### PR TITLE
docs: add dsh-chat-import

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ English | [中文](README.zh.md)
 - [dsh-conversation-share](https://github.com/bill9109/dsh-conversation-share) — Share any excerpt of a conversation.
 - [dsh-explain](https://github.com/yuezengwu/dsh-explain) — Local-first learning mode: cross-session learning threads with per-source explanations.
 - [dsh-prompt-studio](https://github.com/Moeblack/dsh-prompt-studio) — Edit user and built-in system-prompt sections with live preview.
+- [dsh-chat-import](https://github.com/Nwflower/dsh-chat-import) — Import Claude Code / Codex / ChatGPT / Cursor chat histories as resumable DeepSeek Harness sessions.
 
 ## 🛠️ Tools & Capabilities
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -50,6 +50,7 @@
 - [dsh-conversation-share](https://github.com/bill9109/dsh-conversation-share) — 分享任意段落的对话。
 - [dsh-explain](https://github.com/yuezengwu/dsh-explain) — 本地优先学习模式：跨会话全局学习线程、按来源讲解。
 - [dsh-prompt-studio](https://github.com/Moeblack/dsh-prompt-studio) — 带实时预览的用户/内置 system prompt 分节编辑器。
+- [dsh-chat-import](https://github.com/Nwflower/dsh-chat-import) — 把 Claude Code / Codex / ChatGPT / Cursor 的聊天记录全保真导入为可续聊的 DSH 会话
 
 ## 🛠️ 工具与能力
 


### PR DESCRIPTION
## 收录请求

- 仓库: https://github.com/Nwflower/dsh-chat-import
- 分类: Sessions & Messages（会话与消息）
- 一句话: Import Claude Code / Codex / ChatGPT / Cursor chat histories as resumable DeepSeek Harness sessions
- 说明: README.md（EN）+ README.zh.md（中文）同 PR 各加一行，符合 Contributing 要求；仓库已带 dsh-plugin topic
- 验证: npm test 42/42；已发布 npm（dsh-chat-import@0.1.0）；dsh 0.1.0-rc.6 headless 加载验证通过