### PR TITLE
Add Nowledge Mem DeepSeek Harness plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ English | [中文](README.zh.md)
 - [dsh-share](https://github.com/hellodigua/dsh-share) — Share your conversations with one click.
 - [dsh-message-edit](https://github.com/Moeblack/dsh-message-edit) — Branch-based message editing, reroll, retry, and a version timeline.
 - [dsh-mnemon](https://github.com/omdsh-dev/dsh-mnemon) — Deep Mnemon integration: local three-tier memory (Runtime Memory, retrievable Documents, supervised Memory Spaces).
-- [nowledge-mem-deepseek-harness](https://github.com/nowledge-co/nowledge-mem-deepseek-harness) — Nowledge Mem integration: Context Bundle injection, prompt-time memory recall, MCP tools, and turn-end DSH thread capture.
+- [nowledge-mem-deepseek-harness](https://github.com/nowledge-co/nowledge-mem-deepseek-harness) — One memory layer for every AI tool and agent: Context Bundle injection, prompt-time recall, MCP tools, and turn-end DSH thread capture.
 - [dsh-sidechain](https://github.com/Buyi-wsgzg/dsh-sidechain) — `/side` persistent side sessions and `/btw` one-shot side questions, run in a temporary fork without touching main history.
 - [dsh-conversation-share](https://github.com/bill9109/dsh-conversation-share) — Share any excerpt of a conversation.
 - [dsh-explain](https://github.com/yuezengwu/dsh-explain) — Local-first learning mode: cross-session learning threads with per-source explanations.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ English | [中文](README.zh.md)
 
 > A curated list of plugins for [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) (`dsh`).
 
-**95** plugins · [Website](https://awesome-dsh-plugin.com/) · [PRs welcome](#contributing)
+**96** plugins · [Website](https://awesome-dsh-plugin.com/) · [PRs welcome](#contributing)
 
 ## Contents
 
@@ -46,6 +46,7 @@ English | [中文](README.zh.md)
 - [dsh-share](https://github.com/hellodigua/dsh-share) — Share your conversations with one click.
 - [dsh-message-edit](https://github.com/Moeblack/dsh-message-edit) — Branch-based message editing, reroll, retry, and a version timeline.
 - [dsh-mnemon](https://github.com/omdsh-dev/dsh-mnemon) — Deep Mnemon integration: local three-tier memory (Runtime Memory, retrievable Documents, supervised Memory Spaces).
+- [nowledge-mem-deepseek-harness](https://github.com/nowledge-co/nowledge-mem-deepseek-harness) — Nowledge Mem integration: Context Bundle injection, prompt-time memory recall, MCP tools, and turn-end DSH thread capture.
 - [dsh-sidechain](https://github.com/Buyi-wsgzg/dsh-sidechain) — `/side` persistent side sessions and `/btw` one-shot side questions, run in a temporary fork without touching main history.
 - [dsh-conversation-share](https://github.com/bill9109/dsh-conversation-share) — Share any excerpt of a conversation.
 - [dsh-explain](https://github.com/yuezengwu/dsh-explain) — Local-first learning mode: cross-session learning threads with per-source explanations.

--- a/README.zh.md
+++ b/README.zh.md
@@ -4,7 +4,7 @@
 
 > [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)（`dsh`）插件精选列表。
 
-**95** 个插件 · [网站](https://awesome-dsh-plugin.com/zh/) · 欢迎 [PR](#贡献)
+**96** 个插件 · [网站](https://awesome-dsh-plugin.com/zh/) · 欢迎 [PR](#贡献)
 
 ## 目录
 
@@ -46,6 +46,7 @@
 - [dsh-share](https://github.com/hellodigua/dsh-share) — 一键分享你的对话。
 - [dsh-message-edit](https://github.com/Moeblack/dsh-message-edit) — 基于分支的消息编辑、reroll、重试与版本时间线。
 - [dsh-mnemon](https://github.com/omdsh-dev/dsh-mnemon) — Mnemon 深度集成：本地三层记忆（Runtime Memory、可检索 Documents、受监督 Memory Spaces）。
+- [nowledge-mem-deepseek-harness](https://github.com/nowledge-co/nowledge-mem-deepseek-harness) — Nowledge Mem 集成：注入 Context Bundle、提示时记忆检索、MCP 工具与回合结束 DSH 线程捕获。
 - [dsh-sidechain](https://github.com/Buyi-wsgzg/dsh-sidechain) — `/side` 持续性侧会话与 `/btw` 一次性侧问，在临时 fork 中运行、不写入主会话历史。
 - [dsh-conversation-share](https://github.com/bill9109/dsh-conversation-share) — 分享任意段落的对话。
 - [dsh-explain](https://github.com/yuezengwu/dsh-explain) — 本地优先学习模式：跨会话全局学习线程、按来源讲解。

--- a/README.zh.md
+++ b/README.zh.md
@@ -46,7 +46,7 @@
 - [dsh-share](https://github.com/hellodigua/dsh-share) — 一键分享你的对话。
 - [dsh-message-edit](https://github.com/Moeblack/dsh-message-edit) — 基于分支的消息编辑、reroll、重试与版本时间线。
 - [dsh-mnemon](https://github.com/omdsh-dev/dsh-mnemon) — Mnemon 深度集成：本地三层记忆（Runtime Memory、可检索 Documents、受监督 Memory Spaces）。
-- [nowledge-mem-deepseek-harness](https://github.com/nowledge-co/nowledge-mem-deepseek-harness) — Nowledge Mem 集成：注入 Context Bundle、提示时记忆检索、MCP 工具与回合结束 DSH 线程捕获。
+- [nowledge-mem-deepseek-harness](https://github.com/nowledge-co/nowledge-mem-deepseek-harness) — 给所有 AI 工具和 Agent 共用的一层记忆：注入 Context Bundle、提示时检索、MCP 工具与回合结束 DSH 线程捕获。
 - [dsh-sidechain](https://github.com/Buyi-wsgzg/dsh-sidechain) — `/side` 持续性侧会话与 `/btw` 一次性侧问，在临时 fork 中运行、不写入主会话历史。
 - [dsh-conversation-share](https://github.com/bill9109/dsh-conversation-share) — 分享任意段落的对话。
 - [dsh-explain](https://github.com/yuezengwu/dsh-explain) — 本地优先学习模式：跨会话全局学习线程、按来源讲解。

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,13 +4,13 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Awesome DSH Plugin — Curated DeepSeek Harness (dsh) Plugin List</title>
-<meta name="description" content="A curated list of 95 DeepSeek Harness (dsh) plugins: UI enhancements, sessions, tools, workflow, notifications, development, and fun. Updated continuously.">
+<meta name="description" content="A curated list of 96 DeepSeek Harness (dsh) plugins: UI enhancements, sessions, tools, workflow, notifications, development, and fun. Updated continuously.">
 <link rel="canonical" href="https://awesome-dsh-plugin.com/">
 <link rel="alternate" hreflang="en" href="https://awesome-dsh-plugin.com/">
 <link rel="alternate" hreflang="zh" href="https://awesome-dsh-plugin.com/zh/">
 <link rel="alternate" hreflang="x-default" href="https://awesome-dsh-plugin.com/">
 <meta property="og:title" content="Awesome DSH Plugin — Curated DeepSeek Harness (dsh) Plugin List">
-<meta property="og:description" content="A curated list of 95 DeepSeek Harness (dsh) plugins: UI enhancements, sessions, tools, workflow, notifications, development, and fun. Updated continuously.">
+<meta property="og:description" content="A curated list of 96 DeepSeek Harness (dsh) plugins: UI enhancements, sessions, tools, workflow, notifications, development, and fun. Updated continuously.">
 <meta property="og:url" content="https://awesome-dsh-plugin.com/">
 <meta property="og:image" content="https://awesome-dsh-plugin.com/og.png">
 <meta property="og:image:width" content="1200">
@@ -25,7 +25,7 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,400..800;1,6..72,400..600&display=swap" rel="stylesheet">
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"ItemList","name":"Awesome DSH Plugin","url":"https://awesome-dsh-plugin.com/","numberOfItems":95,"itemListElement":[{"@type":"ListItem","position":1,"name":"dsh-tianshu-tui","url":"https://github.com/huiliyi37/dsh-tianshu-tui"},{"@type":"ListItem","position":2,"name":"dsh-at-file","url":"https://github.com/omdsh-dev/dsh-at-file"},{"@type":"ListItem","position":3,"name":"ui-status-label","url":"https://github.com/alingalingling/ui-status-label"},{"@type":"ListItem","position":4,"name":"dsh-openpencil","url":"https://github.com/ZSeven-W/dsh-openpencil"},{"@type":"ListItem","position":5,"name":"dsh-visualize","url":"https://github.com/Nagi-ovo/dsh-visualize"},{"@type":"ListItem","position":6,"name":"dsh-side-panel","url":"https://github.com/ccq1/dsh-side-panel"},{"@type":"ListItem","position":7,"name":"dsh-focus-chat","url":"https://github.com/dingyi222666/dsh-focus-chat"},{"@type":"ListItem","position":8,"name":"dsh-genui","url":"https://github.com/omdsh-dev/dsh-genui"},{"@type":"ListItem","position":9,"name":"dsh-annotation","url":"https://github.com/omdsh-dev/dsh-annotation"},{"@type":"ListItem","position":10,"name":"dsh-navbar","url":"https://github.com/vlln/dsh-navbar"},{"@type":"ListItem","position":11,"name":"dsh-task-status","url":"https://github.com/vlln/dsh-task-status"},{"@type":"ListItem","position":12,"name":"dsh-web-archive","url":"https://github.com/renat3u/dsh-web-archive"},{"@type":"ListItem","position":13,"name":"dsh-spotlight","url":"https://github.com/0xsline/dsh-spotlight"},{"@type":"ListItem","position":14,"name":"dsh-101","url":"https://github.com/bill9109/dsh-101"},{"@type":"ListItem","position":15,"name":"dsh-drag-and-drop","url":"https://github.com/bill9109/dsh-drag-and-drop"},{"@type":"ListItem","position":16,"name":"dsh-deeplink","url":"https://github.com/qyw233/dsh-deeplink"},{"@type":"ListItem","position":17,"name":"dsh-diff-viewer","url":"https://github.com/lehhair/dsh-diff-viewer"},{"@type":"ListItem","position":18,"name":"ex-setting","url":"https://github.com/omdsh-dev/ex-setting"},{"@type":"ListItem","position":19,"name":"web-components","url":"https://github.com/omdsh-dev/web-components"},{"@type":"ListItem","position":20,"name":"dsh-turn-navigator","url":"https://github.com/vibeinging/dsh-turn-navigator"},{"@type":"ListItem","position":21,"name":"dsh-turn-rewind","url":"https://github.com/Anionex/dsh-turn-rewind"},{"@type":"ListItem","position":22,"name":"distill","url":"https://github.com/LoserFox/distill"},{"@type":"ListItem","position":23,"name":"dsh-share","url":"https://github.com/hellodigua/dsh-share"},{"@type":"ListItem","position":24,"name":"dsh-message-edit","url":"https://github.com/Moeblack/dsh-message-edit"},{"@type":"ListItem","position":25,"name":"dsh-mnemon","url":"https://github.com/omdsh-dev/dsh-mnemon"},{"@type":"ListItem","position":26,"name":"dsh-sidechain","url":"https://github.com/Buyi-wsgzg/dsh-sidechain"},{"@type":"ListItem","position":27,"name":"dsh-conversation-share","url":"https://github.com/bill9109/dsh-conversation-share"},{"@type":"ListItem","position":28,"name":"dsh-explain","url":"https://github.com/yuezengwu/dsh-explain"},{"@type":"ListItem","position":29,"name":"dsh-prompt-studio","url":"https://github.com/Moeblack/dsh-prompt-studio"},{"@type":"ListItem","position":30,"name":"dsh-chat-import","url":"https://github.com/Nwflower/dsh-chat-import"},{"@type":"ListItem","position":31,"name":"dsh-vision-toolkit","url":"https://github.com/Anionex/dsh-vision-toolkit"},{"@type":"ListItem","position":32,"name":"dsh-custom-tool","url":"https://github.com/omdsh-dev/dsh-custom-tool"},{"@type":"ListItem","position":33,"name":"dsh-computer-use","url":"https://github.com/Anionex/dsh-computer-use"},{"@type":"ListItem","position":34,"name":"dsh-data-agent","url":"https://github.com/omdsh-dev/dsh-data-agent"},{"@type":"ListItem","position":35,"name":"dsh-toolkit","url":"https://github.com/omdsh-dev/dsh-toolkit"},{"@type":"ListItem","position":36,"name":"dsh-tool-csv","url":"https://github.com/omdsh-dev/dsh-tool-csv"},{"@type":"ListItem","position":37,"name":"dsh-tool-calculator","url":"https://github.com/omdsh-dev/dsh-tool-calculator"},{"@type":"ListItem","position":38,"name":"dsh-tool-diff","url":"https://github.com/omdsh-dev/dsh-tool-diff"},{"@type":"ListItem","position":39,"name":"dsh-tool-encoding","url":"https://github.com/omdsh-dev/dsh-tool-encoding"},{"@type":"ListItem","position":40,"name":"dsh-tool-json","url":"https://github.com/omdsh-dev/dsh-tool-json"},{"@type":"ListItem","position":41,"name":"dsh-tool-markdown","url":"https://github.com/omdsh-dev/dsh-tool-markdown"},{"@type":"ListItem","position":42,"name":"dsh-tool-regex","url":"https://github.com/omdsh-dev/dsh-tool-regex"},{"@type":"ListItem","position":43,"name":"dsh-tool-schema","url":"https://github.com/omdsh-dev/dsh-tool-schema"},{"@type":"ListItem","position":44,"name":"dsh-tool-stat","url":"https://github.com/omdsh-dev/dsh-tool-stat"},{"@type":"ListItem","position":45,"name":"dsh-tool-time","url":"https://github.com/omdsh-dev/dsh-tool-time"},{"@type":"ListItem","position":46,"name":"dsh-kb-sieve","url":"https://github.com/omdsh-dev/dsh-kb-sieve"},{"@type":"ListItem","position":47,"name":"dsh-plugin-mineru","url":"https://github.com/HuanLinOTO/dsh-plugin-mineru"},{"@type":"ListItem","position":48,"name":"dsh-tool-search","url":"https://github.com/vibeinging/dsh-tool-search"},{"@type":"ListItem","position":49,"name":"dsh-openmaic","url":"https://github.com/THU-MAIC/dsh-openmaic"},{"@type":"ListItem","position":50,"name":"dsh-scholar","url":"https://github.com/lzszq/dsh-scholar"},{"@type":"ListItem","position":51,"name":"dsh_workflow","url":"https://github.com/icetomoyo/dsh_workflow"},{"@type":"ListItem","position":52,"name":"dsh-agent-teams","url":"https://github.com/NanmiCoder/dsh-agent-teams"},{"@type":"ListItem","position":53,"name":"dsh-automation","url":"https://github.com/titanwings/dsh-automation"},{"@type":"ListItem","position":54,"name":"dsh-plannotator","url":"https://github.com/titanwings/dsh-plannotator"},{"@type":"ListItem","position":55,"name":"dsh-loop","url":"https://github.com/vlln/dsh-loop"},{"@type":"ListItem","position":56,"name":"dsh-sentinel","url":"https://github.com/fuhefei/dsh-sentinel"},{"@type":"ListItem","position":57,"name":"dsh-deep-research","url":"https://github.com/omdsh-dev/dsh-deep-research"},{"@type":"ListItem","position":58,"name":"dsh-inspect","url":"https://github.com/omdsh-dev/dsh-inspect"},{"@type":"ListItem","position":59,"name":"dsh-track","url":"https://github.com/fakechris/dsh-track"},{"@type":"ListItem","position":60,"name":"dsh-advisor","url":"https://github.com/btspoony/dsh-advisor"},{"@type":"ListItem","position":61,"name":"dsh-open-in-vscode","url":"https://github.com/omdsh-dev/dsh-open-in-vscode"},{"@type":"ListItem","position":62,"name":"dsh-notification","url":"https://github.com/omdsh-dev/dsh-notification"},{"@type":"ListItem","position":63,"name":"dsh-acp-for-bitfun","url":"https://github.com/bobleer/dsh-acp-for-bitfun"},{"@type":"ListItem","position":64,"name":"telegram","url":"https://github.com/LoserFox/telegram"},{"@type":"ListItem","position":65,"name":"dsh-session-notification","url":"https://github.com/dingyi222666/dsh-session-notification"},{"@type":"ListItem","position":66,"name":"dsh-web-ui-notify","url":"https://github.com/bill9109/dsh-web-ui-notify"},{"@type":"ListItem","position":67,"name":"dsh-webbridge","url":"https://github.com/bill9109/dsh-webbridge"},{"@type":"ListItem","position":68,"name":"fabric","url":"https://github.com/omdsh-dev/fabric"},{"@type":"ListItem","position":69,"name":"dsh-git-identity","url":"https://github.com/LoserFox/dsh-git-identity"},{"@type":"ListItem","position":70,"name":"dsh-context-doctor","url":"https://github.com/Zhenyu98/dsh-context-doctor"},{"@type":"ListItem","position":71,"name":"dsh-plugin-check","url":"https://github.com/omdsh-dev/dsh-plugin-check"},{"@type":"ListItem","position":72,"name":"dsh-security-audit","url":"https://github.com/omdsh-dev/dsh-security-audit"},{"@type":"ListItem","position":73,"name":"dsh-session-health","url":"https://github.com/omdsh-dev/dsh-session-health"},{"@type":"ListItem","position":74,"name":"dsh-evolve","url":"https://github.com/william-jin-cmu/dsh-evolve"},{"@type":"ListItem","position":75,"name":"dsh-trace","url":"https://github.com/vibeinging/dsh-trace"},{"@type":"ListItem","position":76,"name":"sandbox-micro","url":"https://github.com/omdsh-dev/sandbox-micro"},{"@type":"ListItem","position":77,"name":"sandbox-mxc","url":"https://github.com/omdsh-dev/sandbox-mxc"},{"@type":"ListItem","position":78,"name":"sandbox-nono","url":"https://github.com/omdsh-dev/sandbox-nono"},{"@type":"ListItem","position":79,"name":"dsh-agent-budget","url":"https://github.com/vibeinging/dsh-agent-budget"},{"@type":"ListItem","position":80,"name":"dsh-llm-fallbacks","url":"https://github.com/btspoony/dsh-llm-fallbacks"},{"@type":"ListItem","position":81,"name":"dsh-tool-approval","url":"https://github.com/ilharp/dsh-tool-approval"},{"@type":"ListItem","position":82,"name":"plugin-template","url":"https://github.com/omdsh-dev/plugin-template"},{"@type":"ListItem","position":83,"name":"Qwen-MM-Plugins","url":"https://github.com/omdsh-dev/Qwen-MM-Plugins"},{"@type":"ListItem","position":84,"name":"dsh-tps","url":"https://github.com/Small-tailqwq/dsh-tps"},{"@type":"ListItem","position":85,"name":"dsh-ads","url":"https://github.com/Nagi-ovo/dsh-ads"},{"@type":"ListItem","position":86,"name":"dsh-gomoku","url":"https://github.com/omdsh-dev/dsh-gomoku"},{"@type":"ListItem","position":87,"name":"dsh-stock-market","url":"https://github.com/AnacondaKC/dsh-stock-market"},{"@type":"ListItem","position":88,"name":"dsh-emoji","url":"https://github.com/hellodigua/dsh-emoji"},{"@type":"ListItem","position":89,"name":"dsh-minigames","url":"https://github.com/lhh010/dsh-minigames"},{"@type":"ListItem","position":90,"name":"dsh-stickers","url":"https://github.com/william-jin-cmu/dsh-stickers"},{"@type":"ListItem","position":91,"name":"whale-girl","url":"https://github.com/vlln/whale-girl"},{"@type":"ListItem","position":92,"name":"deepseek-manners","url":"https://github.com/Moeblack/deepseek-manners"},{"@type":"ListItem","position":93,"name":"dsh-plugin-d399","url":"https://github.com/HuanLinOTO/dsh-plugin-d399"},{"@type":"ListItem","position":94,"name":"dsh-auto-chess","url":"https://github.com/omdsh-dev/dsh-auto-chess"},{"@type":"ListItem","position":95,"name":"dsh-douyin","url":"https://github.com/AnacondaKC/dsh-douyin"}]}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"ItemList","name":"Awesome DSH Plugin","url":"https://awesome-dsh-plugin.com/","numberOfItems":96,"itemListElement":[{"@type":"ListItem","position":1,"name":"dsh-tianshu-tui","url":"https://github.com/huiliyi37/dsh-tianshu-tui"},{"@type":"ListItem","position":2,"name":"dsh-at-file","url":"https://github.com/omdsh-dev/dsh-at-file"},{"@type":"ListItem","position":3,"name":"ui-status-label","url":"https://github.com/alingalingling/ui-status-label"},{"@type":"ListItem","position":4,"name":"dsh-openpencil","url":"https://github.com/ZSeven-W/dsh-openpencil"},{"@type":"ListItem","position":5,"name":"dsh-visualize","url":"https://github.com/Nagi-ovo/dsh-visualize"},{"@type":"ListItem","position":6,"name":"dsh-side-panel","url":"https://github.com/ccq1/dsh-side-panel"},{"@type":"ListItem","position":7,"name":"dsh-focus-chat","url":"https://github.com/dingyi222666/dsh-focus-chat"},{"@type":"ListItem","position":8,"name":"dsh-genui","url":"https://github.com/omdsh-dev/dsh-genui"},{"@type":"ListItem","position":9,"name":"dsh-annotation","url":"https://github.com/omdsh-dev/dsh-annotation"},{"@type":"ListItem","position":10,"name":"dsh-navbar","url":"https://github.com/vlln/dsh-navbar"},{"@type":"ListItem","position":11,"name":"dsh-task-status","url":"https://github.com/vlln/dsh-task-status"},{"@type":"ListItem","position":12,"name":"dsh-web-archive","url":"https://github.com/renat3u/dsh-web-archive"},{"@type":"ListItem","position":13,"name":"dsh-spotlight","url":"https://github.com/0xsline/dsh-spotlight"},{"@type":"ListItem","position":14,"name":"dsh-101","url":"https://github.com/bill9109/dsh-101"},{"@type":"ListItem","position":15,"name":"dsh-drag-and-drop","url":"https://github.com/bill9109/dsh-drag-and-drop"},{"@type":"ListItem","position":16,"name":"dsh-deeplink","url":"https://github.com/qyw233/dsh-deeplink"},{"@type":"ListItem","position":17,"name":"dsh-diff-viewer","url":"https://github.com/lehhair/dsh-diff-viewer"},{"@type":"ListItem","position":18,"name":"ex-setting","url":"https://github.com/omdsh-dev/ex-setting"},{"@type":"ListItem","position":19,"name":"web-components","url":"https://github.com/omdsh-dev/web-components"},{"@type":"ListItem","position":20,"name":"dsh-turn-navigator","url":"https://github.com/vibeinging/dsh-turn-navigator"},{"@type":"ListItem","position":21,"name":"dsh-turn-rewind","url":"https://github.com/Anionex/dsh-turn-rewind"},{"@type":"ListItem","position":22,"name":"distill","url":"https://github.com/LoserFox/distill"},{"@type":"ListItem","position":23,"name":"dsh-share","url":"https://github.com/hellodigua/dsh-share"},{"@type":"ListItem","position":24,"name":"dsh-message-edit","url":"https://github.com/Moeblack/dsh-message-edit"},{"@type":"ListItem","position":25,"name":"dsh-mnemon","url":"https://github.com/omdsh-dev/dsh-mnemon"},{"@type":"ListItem","position":26,"name":"nowledge-mem-deepseek-harness","url":"https://github.com/nowledge-co/nowledge-mem-deepseek-harness"},{"@type":"ListItem","position":27,"name":"dsh-sidechain","url":"https://github.com/Buyi-wsgzg/dsh-sidechain"},{"@type":"ListItem","position":28,"name":"dsh-conversation-share","url":"https://github.com/bill9109/dsh-conversation-share"},{"@type":"ListItem","position":29,"name":"dsh-explain","url":"https://github.com/yuezengwu/dsh-explain"},{"@type":"ListItem","position":30,"name":"dsh-prompt-studio","url":"https://github.com/Moeblack/dsh-prompt-studio"},{"@type":"ListItem","position":31,"name":"dsh-chat-import","url":"https://github.com/Nwflower/dsh-chat-import"},{"@type":"ListItem","position":32,"name":"dsh-vision-toolkit","url":"https://github.com/Anionex/dsh-vision-toolkit"},{"@type":"ListItem","position":33,"name":"dsh-custom-tool","url":"https://github.com/omdsh-dev/dsh-custom-tool"},{"@type":"ListItem","position":34,"name":"dsh-computer-use","url":"https://github.com/Anionex/dsh-computer-use"},{"@type":"ListItem","position":35,"name":"dsh-data-agent","url":"https://github.com/omdsh-dev/dsh-data-agent"},{"@type":"ListItem","position":36,"name":"dsh-toolkit","url":"https://github.com/omdsh-dev/dsh-toolkit"},{"@type":"ListItem","position":37,"name":"dsh-tool-csv","url":"https://github.com/omdsh-dev/dsh-tool-csv"},{"@type":"ListItem","position":38,"name":"dsh-tool-calculator","url":"https://github.com/omdsh-dev/dsh-tool-calculator"},{"@type":"ListItem","position":39,"name":"dsh-tool-diff","url":"https://github.com/omdsh-dev/dsh-tool-diff"},{"@type":"ListItem","position":40,"name":"dsh-tool-encoding","url":"https://github.com/omdsh-dev/dsh-tool-encoding"},{"@type":"ListItem","position":41,"name":"dsh-tool-json","url":"https://github.com/omdsh-dev/dsh-tool-json"},{"@type":"ListItem","position":42,"name":"dsh-tool-markdown","url":"https://github.com/omdsh-dev/dsh-tool-markdown"},{"@type":"ListItem","position":43,"name":"dsh-tool-regex","url":"https://github.com/omdsh-dev/dsh-tool-regex"},{"@type":"ListItem","position":44,"name":"dsh-tool-schema","url":"https://github.com/omdsh-dev/dsh-tool-schema"},{"@type":"ListItem","position":45,"name":"dsh-tool-stat","url":"https://github.com/omdsh-dev/dsh-tool-stat"},{"@type":"ListItem","position":46,"name":"dsh-tool-time","url":"https://github.com/omdsh-dev/dsh-tool-time"},{"@type":"ListItem","position":47,"name":"dsh-kb-sieve","url":"https://github.com/omdsh-dev/dsh-kb-sieve"},{"@type":"ListItem","position":48,"name":"dsh-plugin-mineru","url":"https://github.com/HuanLinOTO/dsh-plugin-mineru"},{"@type":"ListItem","position":49,"name":"dsh-tool-search","url":"https://github.com/vibeinging/dsh-tool-search"},{"@type":"ListItem","position":50,"name":"dsh-openmaic","url":"https://github.com/THU-MAIC/dsh-openmaic"},{"@type":"ListItem","position":51,"name":"dsh-scholar","url":"https://github.com/lzszq/dsh-scholar"},{"@type":"ListItem","position":52,"name":"dsh_workflow","url":"https://github.com/icetomoyo/dsh_workflow"},{"@type":"ListItem","position":53,"name":"dsh-agent-teams","url":"https://github.com/NanmiCoder/dsh-agent-teams"},{"@type":"ListItem","position":54,"name":"dsh-automation","url":"https://github.com/titanwings/dsh-automation"},{"@type":"ListItem","position":55,"name":"dsh-plannotator","url":"https://github.com/titanwings/dsh-plannotator"},{"@type":"ListItem","position":56,"name":"dsh-loop","url":"https://github.com/vlln/dsh-loop"},{"@type":"ListItem","position":57,"name":"dsh-sentinel","url":"https://github.com/fuhefei/dsh-sentinel"},{"@type":"ListItem","position":58,"name":"dsh-deep-research","url":"https://github.com/omdsh-dev/dsh-deep-research"},{"@type":"ListItem","position":59,"name":"dsh-inspect","url":"https://github.com/omdsh-dev/dsh-inspect"},{"@type":"ListItem","position":60,"name":"dsh-track","url":"https://github.com/fakechris/dsh-track"},{"@type":"ListItem","position":61,"name":"dsh-advisor","url":"https://github.com/btspoony/dsh-advisor"},{"@type":"ListItem","position":62,"name":"dsh-open-in-vscode","url":"https://github.com/omdsh-dev/dsh-open-in-vscode"},{"@type":"ListItem","position":63,"name":"dsh-notification","url":"https://github.com/omdsh-dev/dsh-notification"},{"@type":"ListItem","position":64,"name":"dsh-acp-for-bitfun","url":"https://github.com/bobleer/dsh-acp-for-bitfun"},{"@type":"ListItem","position":65,"name":"telegram","url":"https://github.com/LoserFox/telegram"},{"@type":"ListItem","position":66,"name":"dsh-session-notification","url":"https://github.com/dingyi222666/dsh-session-notification"},{"@type":"ListItem","position":67,"name":"dsh-web-ui-notify","url":"https://github.com/bill9109/dsh-web-ui-notify"},{"@type":"ListItem","position":68,"name":"dsh-webbridge","url":"https://github.com/bill9109/dsh-webbridge"},{"@type":"ListItem","position":69,"name":"fabric","url":"https://github.com/omdsh-dev/fabric"},{"@type":"ListItem","position":70,"name":"dsh-git-identity","url":"https://github.com/LoserFox/dsh-git-identity"},{"@type":"ListItem","position":71,"name":"dsh-context-doctor","url":"https://github.com/Zhenyu98/dsh-context-doctor"},{"@type":"ListItem","position":72,"name":"dsh-plugin-check","url":"https://github.com/omdsh-dev/dsh-plugin-check"},{"@type":"ListItem","position":73,"name":"dsh-security-audit","url":"https://github.com/omdsh-dev/dsh-security-audit"},{"@type":"ListItem","position":74,"name":"dsh-session-health","url":"https://github.com/omdsh-dev/dsh-session-health"},{"@type":"ListItem","position":75,"name":"dsh-evolve","url":"https://github.com/william-jin-cmu/dsh-evolve"},{"@type":"ListItem","position":76,"name":"dsh-trace","url":"https://github.com/vibeinging/dsh-trace"},{"@type":"ListItem","position":77,"name":"sandbox-micro","url":"https://github.com/omdsh-dev/sandbox-micro"},{"@type":"ListItem","position":78,"name":"sandbox-mxc","url":"https://github.com/omdsh-dev/sandbox-mxc"},{"@type":"ListItem","position":79,"name":"sandbox-nono","url":"https://github.com/omdsh-dev/sandbox-nono"},{"@type":"ListItem","position":80,"name":"dsh-agent-budget","url":"https://github.com/vibeinging/dsh-agent-budget"},{"@type":"ListItem","position":81,"name":"dsh-llm-fallbacks","url":"https://github.com/btspoony/dsh-llm-fallbacks"},{"@type":"ListItem","position":82,"name":"dsh-tool-approval","url":"https://github.com/ilharp/dsh-tool-approval"},{"@type":"ListItem","position":83,"name":"plugin-template","url":"https://github.com/omdsh-dev/plugin-template"},{"@type":"ListItem","position":84,"name":"Qwen-MM-Plugins","url":"https://github.com/omdsh-dev/Qwen-MM-Plugins"},{"@type":"ListItem","position":85,"name":"dsh-tps","url":"https://github.com/Small-tailqwq/dsh-tps"},{"@type":"ListItem","position":86,"name":"dsh-ads","url":"https://github.com/Nagi-ovo/dsh-ads"},{"@type":"ListItem","position":87,"name":"dsh-gomoku","url":"https://github.com/omdsh-dev/dsh-gomoku"},{"@type":"ListItem","position":88,"name":"dsh-stock-market","url":"https://github.com/AnacondaKC/dsh-stock-market"},{"@type":"ListItem","position":89,"name":"dsh-emoji","url":"https://github.com/hellodigua/dsh-emoji"},{"@type":"ListItem","position":90,"name":"dsh-minigames","url":"https://github.com/lhh010/dsh-minigames"},{"@type":"ListItem","position":91,"name":"dsh-stickers","url":"https://github.com/william-jin-cmu/dsh-stickers"},{"@type":"ListItem","position":92,"name":"whale-girl","url":"https://github.com/vlln/whale-girl"},{"@type":"ListItem","position":93,"name":"deepseek-manners","url":"https://github.com/Moeblack/deepseek-manners"},{"@type":"ListItem","position":94,"name":"dsh-plugin-d399","url":"https://github.com/HuanLinOTO/dsh-plugin-d399"},{"@type":"ListItem","position":95,"name":"dsh-auto-chess","url":"https://github.com/omdsh-dev/dsh-auto-chess"},{"@type":"ListItem","position":96,"name":"dsh-douyin","url":"https://github.com/AnacondaKC/dsh-douyin"}]}</script>
 <style>
 :root{
   /* canvas — warm paper */
@@ -204,9 +204,9 @@ footer a{color:var(--text-2)}
       <span class="count" id="count" aria-live="polite">0 / 0</span>
     </div>
     <div class="filters" id="filters">
-      <button class="chip active" type="button" data-cat="all">All <small>95</small></button>
+      <button class="chip active" type="button" data-cat="all">All <small>96</small></button>
       <button class="chip" type="button" data-cat="ui">🎨 UI Enhancements <small>20</small></button>
-      <button class="chip" type="button" data-cat="session">💬 Sessions & Messages <small>10</small></button>
+      <button class="chip" type="button" data-cat="session">💬 Sessions & Messages <small>11</small></button>
       <button class="chip" type="button" data-cat="tools">🛠️ Tools & Capabilities <small>20</small></button>
       <button class="chip" type="button" data-cat="workflow">🔁 Workflow & Automation <small>10</small></button>
       <button class="chip" type="button" data-cat="notify">🔔 Notifications & Integrations <small>7</small></button>
@@ -401,7 +401,7 @@ footer a{color:var(--text-2)}
       <button class="copy" type="button" data-cmd="dsh plugin --profile web add github:vibeinging/dsh-turn-navigator" aria-label="Copy install command">copy install</button>
     </li>
 
-    <li class="sec" data-sec="session"><h2 id="session">💬 Sessions & Messages <small>10</small></h2></li>
+    <li class="sec" data-sec="session"><h2 id="session">💬 Sessions & Messages <small>11</small></h2></li>
 
     <li class="item" data-cat="session" style="animation-delay:0.40s">
       <span class="no" aria-hidden="true">№ 21</span>
@@ -451,6 +451,15 @@ footer a{color:var(--text-2)}
     <li class="item" data-cat="session" style="animation-delay:0.40s">
       <span class="no" aria-hidden="true">№ 26</span>
       <div>
+        <h3><a href="https://github.com/nowledge-co/nowledge-mem-deepseek-harness" rel="noopener" translate="no">nowledge-mem-deepseek-harness</a><span class="by" translate="no">nowledge-co</span></h3>
+        <p>Nowledge Mem integration: Context Bundle injection, prompt-time memory recall, MCP tools, and turn-end DSH thread capture.</p>
+      </div>
+      <button class="copy" type="button" data-cmd="dsh plugin --profile web add github:nowledge-co/nowledge-mem-deepseek-harness" aria-label="Copy install command">copy install</button>
+    </li>
+
+    <li class="item" data-cat="session" style="animation-delay:0.40s">
+      <span class="no" aria-hidden="true">№ 27</span>
+      <div>
         <h3><a href="https://github.com/Buyi-wsgzg/dsh-sidechain" rel="noopener" translate="no">dsh-sidechain</a><span class="by" translate="no">Buyi-wsgzg</span></h3>
         <p>`/side` persistent side sessions and `/btw` one-shot side questions, run in a temporary fork without touching main history.</p>
       </div>
@@ -458,7 +467,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="session" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 27</span>
+      <span class="no" aria-hidden="true">№ 28</span>
       <div>
         <h3><a href="https://github.com/bill9109/dsh-conversation-share" rel="noopener" translate="no">dsh-conversation-share</a><span class="by" translate="no">bill9109</span></h3>
         <p>Share any excerpt of a conversation.</p>
@@ -467,7 +476,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="session" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 28</span>
+      <span class="no" aria-hidden="true">№ 29</span>
       <div>
         <h3><a href="https://github.com/yuezengwu/dsh-explain" rel="noopener" translate="no">dsh-explain</a><span class="by" translate="no">yuezengwu</span></h3>
         <p>Local-first learning mode: cross-session learning threads with per-source explanations.</p>
@@ -476,7 +485,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="session" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 29</span>
+      <span class="no" aria-hidden="true">№ 30</span>
       <div>
         <h3><a href="https://github.com/Moeblack/dsh-prompt-studio" rel="noopener" translate="no">dsh-prompt-studio</a><span class="by" translate="no">Moeblack</span></h3>
         <p>Edit user and built-in system-prompt sections with live preview.</p>
@@ -485,7 +494,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="session" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 30</span>
+      <span class="no" aria-hidden="true">№ 31</span>
       <div>
         <h3><a href="https://github.com/Nwflower/dsh-chat-import" rel="noopener" translate="no">dsh-chat-import</a><span class="by" translate="no">Nwflower</span></h3>
         <p>Import Claude Code / Codex / ChatGPT / Cursor chat histories as resumable DeepSeek Harness sessions.</p>
@@ -496,7 +505,7 @@ footer a{color:var(--text-2)}
     <li class="sec" data-sec="tools"><h2 id="tools">🛠️ Tools & Capabilities <small>20</small></h2></li>
 
     <li class="item" data-cat="tools" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 31</span>
+      <span class="no" aria-hidden="true">№ 32</span>
       <div>
         <h3><a href="https://github.com/Anionex/dsh-vision-toolkit" rel="noopener" translate="no">dsh-vision-toolkit</a><span class="by" translate="no">Anionex</span></h3>
         <p>Vision tasks for text-only models: intent-aware image Q&amp;A, long-screenshot OCR, UI reproduction, grounding, and pixel diff.</p>
@@ -505,7 +514,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="tools" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 32</span>
+      <span class="no" aria-hidden="true">№ 33</span>
       <div>
         <h3><a href="https://github.com/omdsh-dev/dsh-custom-tool" rel="noopener" translate="no">dsh-custom-tool</a><span class="by" translate="no">omdsh-dev</span></h3>
         <p>Create and manage sandboxed JavaScript tools with a Monaco editor and model-driven tool lifecycle.</p>
@@ -514,7 +523,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="tools" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 33</span>
+      <span class="no" aria-hidden="true">№ 34</span>
       <div>
         <h3><a href="https://github.com/Anionex/dsh-computer-use" rel="noopener" translate="no">dsh-computer-use</a><span class="by" translate="no">Anionex</span></h3>
         <p>Accessibility-first macOS computer use: fresh observations, stale-state rejection, scoped permissions, and safe input.</p>
@@ -523,7 +532,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="tools" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 34</span>
+      <span class="no" aria-hidden="true">№ 35</span>
       <div>
         <h3><a href="https://github.com/omdsh-dev/dsh-data-agent" rel="noopener" translate="no">dsh-data-agent</a><span class="by" translate="no">omdsh-dev</span></h3>
         <p>Let the AI connect to databases and write SQL for you.</p>
@@ -532,7 +541,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="tools" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 35</span>
+      <span class="no" aria-hidden="true">№ 36</span>
       <div>
         <h3><a href="https://github.com/omdsh-dev/dsh-toolkit" rel="noopener" translate="no">dsh-toolkit</a><span class="by" translate="no">omdsh-dev</span></h3>
         <p>Zero-dependency toolkit: time / encoding / json / calculator / csv / regex / markdown / diff / stat / schema — ten deterministic tools in one install.</p>
@@ -541,7 +550,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="tools" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 36</span>
+      <span class="no" aria-hidden="true">№ 37</span>
       <div>
         <h3><a href="https://github.com/omdsh-dev/dsh-tool-csv" rel="noopener" translate="no">dsh-tool-csv</a><span class="by" translate="no">omdsh-dev</span></h3>
         <p>Parse/query/aggregate/convert CSV (RFC 4180) with a zero-dependency state-machine parser.</p>
@@ -550,7 +559,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="tools" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 37</span>
+      <span class="no" aria-hidden="true">№ 38</span>
       <div>
         <h3><a href="https://github.com/omdsh-dev/dsh-tool-calculator" rel="noopener" translate="no">dsh-tool-calculator</a><span class="by" translate="no">omdsh-dev</span></h3>
         <p>Safe math expression evaluator, zero-dependency recursive-descent parser.</p>
@@ -559,7 +568,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="tools" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 38</span>
+      <span class="no" aria-hidden="true">№ 39</span>
       <div>
         <h3><a href="https://github.com/omdsh-dev/dsh-tool-diff" rel="noopener" translate="no">dsh-tool-diff</a><span class="by" translate="no">omdsh-dev</span></h3>
         <p>Structured comparison and unified diffs for text/JSON/CSV/Markdown.</p>
@@ -568,7 +577,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="tools" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 39</span>
+      <span class="no" aria-hidden="true">№ 40</span>
       <div>
         <h3><a href="https://github.com/omdsh-dev/dsh-tool-encoding" rel="noopener" translate="no">dsh-tool-encoding</a><span class="by" translate="no">omdsh-dev</span></h3>
         <p>base64/url/hex encoding, common hashes, and UUID generation.</p>
@@ -577,7 +586,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="tools" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 40</span>
+      <span class="no" aria-hidden="true">№ 41</span>
       <div>
         <h3><a href="https://github.com/omdsh-dev/dsh-tool-json" rel="noopener" translate="no">dsh-tool-json</a><span class="by" translate="no">omdsh-dev</span></h3>
         <p>JSON queries with a JMESPath subset.</p>
@@ -586,7 +595,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="tools" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 41</span>
+      <span class="no" aria-hidden="true">№ 42</span>
       <div>
         <h3><a href="https://github.com/omdsh-dev/dsh-tool-markdown" rel="noopener" translate="no">dsh-tool-markdown</a><span class="by" translate="no">omdsh-dev</span></h3>
         <p>HTML↔Markdown conversion, GFM table normalization, and TOC generation.</p>
@@ -595,7 +604,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="tools" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 42</span>
+      <span class="no" aria-hidden="true">№ 43</span>
       <div>
         <h3><a href="https://github.com/omdsh-dev/dsh-tool-regex" rel="noopener" translate="no">dsh-tool-regex</a><span class="by" translate="no">omdsh-dev</span></h3>
         <p>Test/extract/safe-replace/statically explain regexes without executing code.</p>
@@ -604,7 +613,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="tools" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 43</span>
+      <span class="no" aria-hidden="true">№ 44</span>
       <div>
         <h3><a href="https://github.com/omdsh-dev/dsh-tool-schema" rel="noopener" translate="no">dsh-tool-schema</a><span class="by" translate="no">omdsh-dev</span></h3>
         <p>JSON Schema validation: validate/paths/explain/normalize.</p>
@@ -613,7 +622,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="tools" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 44</span>
+      <span class="no" aria-hidden="true">№ 45</span>
       <div>
         <h3><a href="https://github.com/omdsh-dev/dsh-tool-stat" rel="noopener" translate="no">dsh-tool-stat</a><span class="by" translate="no">omdsh-dev</span></h3>
         <p>Descriptive statistics, percentiles, frequency distributions, and correlation.</p>
@@ -622,7 +631,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="tools" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 45</span>
+      <span class="no" aria-hidden="true">№ 46</span>
       <div>
         <h3><a href="https://github.com/omdsh-dev/dsh-tool-time" rel="noopener" translate="no">dsh-tool-time</a><span class="by" translate="no">omdsh-dev</span></h3>
         <p>Strict ISO 8601 parsing, IANA timezone conversion, and UTC calendar arithmetic.</p>
@@ -631,7 +640,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="tools" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 46</span>
+      <span class="no" aria-hidden="true">№ 47</span>
       <div>
         <h3><a href="https://github.com/omdsh-dev/dsh-kb-sieve" rel="noopener" translate="no">dsh-kb-sieve</a><span class="by" translate="no">omdsh-dev</span></h3>
         <p>Build auditable KB packs (SQLite FTS5) from md/txt/docx/pdf with deterministic retrieval and original-text reading.</p>
@@ -640,7 +649,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="tools" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 47</span>
+      <span class="no" aria-hidden="true">№ 48</span>
       <div>
         <h3><a href="https://github.com/HuanLinOTO/dsh-plugin-mineru" rel="noopener" translate="no">dsh-plugin-mineru</a><span class="by" translate="no">HuanLinOTO</span></h3>
         <p>Expose MineRU document parsing tools to the model.</p>
@@ -649,7 +658,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="tools" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 48</span>
+      <span class="no" aria-hidden="true">№ 49</span>
       <div>
         <h3><a href="https://github.com/vibeinging/dsh-tool-search" rel="noopener" translate="no">dsh-tool-search</a><span class="by" translate="no">vibeinging</span></h3>
         <p>Per-agent on-demand tool discovery and progressive schema disclosure.</p>
@@ -658,7 +667,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="tools" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 49</span>
+      <span class="no" aria-hidden="true">№ 50</span>
       <div>
         <h3><a href="https://github.com/THU-MAIC/dsh-openmaic" rel="noopener" translate="no">dsh-openmaic</a><span class="by" translate="no">THU-MAIC</span></h3>
         <p>OpenMAIC: classrooms, slides, interactive widgets, and Socratic teaching.</p>
@@ -667,7 +676,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="tools" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 50</span>
+      <span class="no" aria-hidden="true">№ 51</span>
       <div>
         <h3><a href="https://github.com/lzszq/dsh-scholar" rel="noopener" translate="no">dsh-scholar</a><span class="by" translate="no">lzszq</span></h3>
         <p>Academic assistant plugin.</p>
@@ -678,7 +687,7 @@ footer a{color:var(--text-2)}
     <li class="sec" data-sec="workflow"><h2 id="workflow">🔁 Workflow & Automation <small>10</small></h2></li>
 
     <li class="item" data-cat="workflow" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 51</span>
+      <span class="no" aria-hidden="true">№ 52</span>
       <div>
         <h3><a href="https://github.com/icetomoyo/dsh_workflow" rel="noopener" translate="no">dsh_workflow</a><span class="by" translate="no">icetomoyo</span></h3>
         <p>UltraCode-style multi-agent orchestration: a generatable, savable, governable, observable, resumable workflow layer.</p>
@@ -687,7 +696,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="workflow" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 52</span>
+      <span class="no" aria-hidden="true">№ 53</span>
       <div>
         <h3><a href="https://github.com/NanmiCoder/dsh-agent-teams" rel="noopener" translate="no">dsh-agent-teams</a><span class="by" translate="no">NanmiCoder</span></h3>
         <p>AgentTeams multi-agent teams.</p>
@@ -696,7 +705,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="workflow" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 53</span>
+      <span class="no" aria-hidden="true">№ 54</span>
       <div>
         <h3><a href="https://github.com/titanwings/dsh-automation" rel="noopener" translate="no">dsh-automation</a><span class="by" translate="no">titanwings</span></h3>
         <p>Scheduled coding runs in fresh agent sessions with auditable history.</p>
@@ -705,7 +714,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="workflow" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 54</span>
+      <span class="no" aria-hidden="true">№ 55</span>
       <div>
         <h3><a href="https://github.com/titanwings/dsh-plannotator" rel="noopener" translate="no">dsh-plannotator</a><span class="by" translate="no">titanwings</span></h3>
         <p>Plan review with anchored annotations and structured feedback back to the agent.</p>
@@ -714,7 +723,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="workflow" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 55</span>
+      <span class="no" aria-hidden="true">№ 56</span>
       <div>
         <h3><a href="https://github.com/vlln/dsh-loop" rel="noopener" translate="no">dsh-loop</a><span class="by" translate="no">vlln</span></h3>
         <p>Recurring loops: `/loop` command + loop tool + activity status bar.</p>
@@ -723,7 +732,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="workflow" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 56</span>
+      <span class="no" aria-hidden="true">№ 57</span>
       <div>
         <h3><a href="https://github.com/fuhefei/dsh-sentinel" rel="noopener" translate="no">dsh-sentinel</a><span class="by" translate="no">fuhefei</span></h3>
         <p>Condition-driven wakeup: durable file/command/http/process/webhook watches that wake the agent.</p>
@@ -732,7 +741,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="workflow" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 57</span>
+      <span class="no" aria-hidden="true">№ 58</span>
       <div>
         <h3><a href="https://github.com/omdsh-dev/dsh-deep-research" rel="noopener" translate="no">dsh-deep-research</a><span class="by" translate="no">omdsh-dev</span></h3>
         <p>Adaptive deep-research orchestrator built on the official workflow engine.</p>
@@ -741,7 +750,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="workflow" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 58</span>
+      <span class="no" aria-hidden="true">№ 59</span>
       <div>
         <h3><a href="https://github.com/omdsh-dev/dsh-inspect" rel="noopener" translate="no">dsh-inspect</a><span class="by" translate="no">omdsh-dev</span></h3>
         <p>Adversarial checkup → fix → review loop toolset.</p>
@@ -750,7 +759,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="workflow" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 59</span>
+      <span class="no" aria-hidden="true">№ 60</span>
       <div>
         <h3><a href="https://github.com/fakechris/dsh-track" rel="noopener" translate="no">dsh-track</a><span class="by" translate="no">fakechris</span></h3>
         <p>Embedded task management engine: decision-point protocol, idea capture wall, Linear-style issue store.</p>
@@ -759,7 +768,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="workflow" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 60</span>
+      <span class="no" aria-hidden="true">№ 61</span>
       <div>
         <h3><a href="https://github.com/btspoony/dsh-advisor" rel="noopener" translate="no">dsh-advisor</a><span class="by" translate="no">btspoony</span></h3>
         <p>Pair a second model that passively reviews each turn and injects notes.</p>
@@ -770,7 +779,7 @@ footer a{color:var(--text-2)}
     <li class="sec" data-sec="notify"><h2 id="notify">🔔 Notifications & Integrations <small>7</small></h2></li>
 
     <li class="item" data-cat="notify" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 61</span>
+      <span class="no" aria-hidden="true">№ 62</span>
       <div>
         <h3><a href="https://github.com/omdsh-dev/dsh-open-in-vscode" rel="noopener" translate="no">dsh-open-in-vscode</a><span class="by" translate="no">omdsh-dev</span></h3>
         <p>Open DSH workspace directories in VS Code directly from the web GUI.</p>
@@ -779,7 +788,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="notify" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 62</span>
+      <span class="no" aria-hidden="true">№ 63</span>
       <div>
         <h3><a href="https://github.com/omdsh-dev/dsh-notification" rel="noopener" translate="no">dsh-notification</a><span class="by" translate="no">omdsh-dev</span></h3>
         <p>Desktop notifications for turn completions, with per-outcome controls and keyword rules.</p>
@@ -788,7 +797,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="notify" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 63</span>
+      <span class="no" aria-hidden="true">№ 64</span>
       <div>
         <h3><a href="https://github.com/bobleer/dsh-acp-for-bitfun" rel="noopener" translate="no">dsh-acp-for-bitfun</a><span class="by" translate="no">bobleer</span></h3>
         <p>ACP bridge between BitFun and DSH.</p>
@@ -797,7 +806,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="notify" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 64</span>
+      <span class="no" aria-hidden="true">№ 65</span>
       <div>
         <h3><a href="https://github.com/LoserFox/telegram" rel="noopener" translate="no">telegram</a><span class="by" translate="no">LoserFox</span></h3>
         <p>Telegram Bot API bridge: long polling, per-chat sessions, HTML formatting.</p>
@@ -806,7 +815,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="notify" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 65</span>
+      <span class="no" aria-hidden="true">№ 66</span>
       <div>
         <h3><a href="https://github.com/dingyi222666/dsh-session-notification" rel="noopener" translate="no">dsh-session-notification</a><span class="by" translate="no">dingyi222666</span></h3>
         <p>Notifications for four session states, with browser alerts and prompts.</p>
@@ -815,7 +824,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="notify" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 66</span>
+      <span class="no" aria-hidden="true">№ 67</span>
       <div>
         <h3><a href="https://github.com/bill9109/dsh-web-ui-notify" rel="noopener" translate="no">dsh-web-ui-notify</a><span class="by" translate="no">bill9109</span></h3>
         <p>Desktop notification reminders.</p>
@@ -824,7 +833,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="notify" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 67</span>
+      <span class="no" aria-hidden="true">№ 68</span>
       <div>
         <h3><a href="https://github.com/bill9109/dsh-webbridge" rel="noopener" translate="no">dsh-webbridge</a><span class="by" translate="no">bill9109</span></h3>
         <p>DSH meets Kimi WebBridge.</p>
@@ -835,7 +844,7 @@ footer a{color:var(--text-2)}
     <li class="sec" data-sec="dev"><h2 id="dev">🧑‍💻 Development & Runtime <small>17</small></h2></li>
 
     <li class="item" data-cat="dev" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 68</span>
+      <span class="no" aria-hidden="true">№ 69</span>
       <div>
         <h3><a href="https://github.com/omdsh-dev/fabric" rel="noopener" translate="no">fabric</a><span class="by" translate="no">omdsh-dev</span></h3>
         <p>An MC-Fabric-style hook processor.</p>
@@ -844,7 +853,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="dev" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 69</span>
+      <span class="no" aria-hidden="true">№ 70</span>
       <div>
         <h3><a href="https://github.com/LoserFox/dsh-git-identity" rel="noopener" translate="no">dsh-git-identity</a><span class="by" translate="no">LoserFox</span></h3>
         <p>Pin git commits to the environment's own author identity; env-var injection overrides all git config.</p>
@@ -853,7 +862,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="dev" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 70</span>
+      <span class="no" aria-hidden="true">№ 71</span>
       <div>
         <h3><a href="https://github.com/Zhenyu98/dsh-context-doctor" rel="noopener" translate="no">dsh-context-doctor</a><span class="by" translate="no">Zhenyu98</span></h3>
         <p>Context injection audit: token costs of instruction chains / skill catalogs / tool schemas, duplicate and conflict detection.</p>
@@ -862,7 +871,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="dev" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 71</span>
+      <span class="no" aria-hidden="true">№ 72</span>
       <div>
         <h3><a href="https://github.com/omdsh-dev/dsh-plugin-check" rel="noopener" translate="no">dsh-plugin-check</a><span class="by" translate="no">omdsh-dev</span></h3>
         <p>Plugin health checks: manifest protocol / patch format / build traps, zero-dependency and read-only.</p>
@@ -871,7 +880,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="dev" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 72</span>
+      <span class="no" aria-hidden="true">№ 73</span>
       <div>
         <h3><a href="https://github.com/omdsh-dev/dsh-security-audit" rel="noopener" translate="no">dsh-security-audit</a><span class="by" translate="no">omdsh-dev</span></h3>
         <p>Local security audit: config, plugin origins, sessions, network exposure — read-only redacted risk report.</p>
@@ -880,7 +889,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="dev" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 73</span>
+      <span class="no" aria-hidden="true">№ 74</span>
       <div>
         <h3><a href="https://github.com/omdsh-dev/dsh-session-health" rel="noopener" translate="no">dsh-session-health</a><span class="by" translate="no">omdsh-dev</span></h3>
         <p>Frame-level scan diagnostics for session files (torn/corrupt/empty detection).</p>
@@ -889,7 +898,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="dev" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 74</span>
+      <span class="no" aria-hidden="true">№ 75</span>
       <div>
         <h3><a href="https://github.com/william-jin-cmu/dsh-evolve" rel="noopener" translate="no">dsh-evolve</a><span class="by" translate="no">william-jin-cmu</span></h3>
         <p>Self-evolution: the agent hot-mounts/removes persistent plugins on itself mid-session.</p>
@@ -898,7 +907,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="dev" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 75</span>
+      <span class="no" aria-hidden="true">№ 76</span>
       <div>
         <h3><a href="https://github.com/vibeinging/dsh-trace" rel="noopener" translate="no">dsh-trace</a><span class="by" translate="no">vibeinging</span></h3>
         <p>Telemetry backend exporting turns, model steps, and tool calls to yiTrace.</p>
@@ -907,7 +916,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="dev" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 76</span>
+      <span class="no" aria-hidden="true">№ 77</span>
       <div>
         <h3><a href="https://github.com/omdsh-dev/sandbox-micro" rel="noopener" translate="no">sandbox-micro</a><span class="by" translate="no">omdsh-dev</span></h3>
         <p>microsandbox support.</p>
@@ -916,7 +925,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="dev" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 77</span>
+      <span class="no" aria-hidden="true">№ 78</span>
       <div>
         <h3><a href="https://github.com/omdsh-dev/sandbox-mxc" rel="noopener" translate="no">sandbox-mxc</a><span class="by" translate="no">omdsh-dev</span></h3>
         <p>Microsoft cross-platform sandbox support.</p>
@@ -925,7 +934,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="dev" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 78</span>
+      <span class="no" aria-hidden="true">№ 79</span>
       <div>
         <h3><a href="https://github.com/omdsh-dev/sandbox-nono" rel="noopener" translate="no">sandbox-nono</a><span class="by" translate="no">omdsh-dev</span></h3>
         <p>nono sandbox support.</p>
@@ -934,7 +943,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="dev" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 79</span>
+      <span class="no" aria-hidden="true">№ 80</span>
       <div>
         <h3><a href="https://github.com/vibeinging/dsh-agent-budget" rel="noopener" translate="no">dsh-agent-budget</a><span class="by" translate="no">vibeinging</span></h3>
         <p>Agent-tree token budget management.</p>
@@ -943,7 +952,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="dev" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 80</span>
+      <span class="no" aria-hidden="true">№ 81</span>
       <div>
         <h3><a href="https://github.com/btspoony/dsh-llm-fallbacks" rel="noopener" translate="no">dsh-llm-fallbacks</a><span class="by" translate="no">btspoony</span></h3>
         <p>Role-based LLM retry &amp; fallback strategies.</p>
@@ -952,7 +961,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="dev" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 81</span>
+      <span class="no" aria-hidden="true">№ 82</span>
       <div>
         <h3><a href="https://github.com/ilharp/dsh-tool-approval" rel="noopener" translate="no">dsh-tool-approval</a><span class="by" translate="no">ilharp</span></h3>
         <p>Manual approval mode (&quot;Manual Mode&quot; / &quot;Ask Mode&quot;).</p>
@@ -961,7 +970,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="dev" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 82</span>
+      <span class="no" aria-hidden="true">№ 83</span>
       <div>
         <h3><a href="https://github.com/omdsh-dev/plugin-template" rel="noopener" translate="no">plugin-template</a><span class="by" translate="no">omdsh-dev</span></h3>
         <p>Plugin template repo (based on the official turtle-ui repo).</p>
@@ -970,7 +979,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="dev" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 83</span>
+      <span class="no" aria-hidden="true">№ 84</span>
       <div>
         <h3><a href="https://github.com/omdsh-dev/Qwen-MM-Plugins" rel="noopener" translate="no">Qwen-MM-Plugins</a><span class="by" translate="no">omdsh-dev</span></h3>
         <p>Qwen multi-modal plugin support.</p>
@@ -979,7 +988,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="dev" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 84</span>
+      <span class="no" aria-hidden="true">№ 85</span>
       <div>
         <h3><a href="https://github.com/Small-tailqwq/dsh-tps" rel="noopener" translate="no">dsh-tps</a><span class="by" translate="no">Small-tailqwq</span></h3>
         <p>A TPS metrics plugin.</p>
@@ -990,7 +999,7 @@ footer a{color:var(--text-2)}
     <li class="sec" data-sec="fun"><h2 id="fun">🎮 Just for Fun <small>11</small></h2></li>
 
     <li class="item" data-cat="fun" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 85</span>
+      <span class="no" aria-hidden="true">№ 86</span>
       <div>
         <h3><a href="https://github.com/Nagi-ovo/dsh-ads" rel="noopener" translate="no">dsh-ads</a><span class="by" translate="no">Nagi-ovo</span></h3>
         <p>Parody ads in 2005-Chinese-web style: sidebar banners, in-chat feeds, corner popups, and a close button whose hit area is smaller than it looks. All fictional.</p>
@@ -999,7 +1008,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="fun" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 86</span>
+      <span class="no" aria-hidden="true">№ 87</span>
       <div>
         <h3><a href="https://github.com/omdsh-dev/dsh-gomoku" rel="noopener" translate="no">dsh-gomoku</a><span class="by" translate="no">omdsh-dev</span></h3>
         <p>Play Gomoku against the AI, or let two AIs battle it out.</p>
@@ -1008,7 +1017,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="fun" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 87</span>
+      <span class="no" aria-hidden="true">№ 88</span>
       <div>
         <h3><a href="https://github.com/AnacondaKC/dsh-stock-market" rel="noopener" translate="no">dsh-stock-market</a><span class="by" translate="no">AnacondaKC</span></h3>
         <p>Fixes the bug where your account can't lose money while you code.</p>
@@ -1017,7 +1026,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="fun" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 88</span>
+      <span class="no" aria-hidden="true">№ 89</span>
       <div>
         <h3><a href="https://github.com/hellodigua/dsh-emoji" rel="noopener" translate="no">dsh-emoji</a><span class="by" translate="no">hellodigua</span></h3>
         <p>Automatically add emojis to AI replies.</p>
@@ -1026,7 +1035,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="fun" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 89</span>
+      <span class="no" aria-hidden="true">№ 90</span>
       <div>
         <h3><a href="https://github.com/lhh010/dsh-minigames" rel="noopener" translate="no">dsh-minigames</a><span class="by" translate="no">lhh010</span></h3>
         <p>Side-panel arcade: 18 offline mini-games to play while the model thinks.</p>
@@ -1035,7 +1044,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="fun" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 90</span>
+      <span class="no" aria-hidden="true">№ 91</span>
       <div>
         <h3><a href="https://github.com/william-jin-cmu/dsh-stickers" rel="noopener" translate="no">dsh-stickers</a><span class="by" translate="no">william-jin-cmu</span></h3>
         <p>Bidirectional sticker reactions between user and agent.</p>
@@ -1044,7 +1053,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="fun" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 91</span>
+      <span class="no" aria-hidden="true">№ 92</span>
       <div>
         <h3><a href="https://github.com/vlln/whale-girl" rel="noopener" translate="no">whale-girl</a><span class="by" translate="no">vlln</span></h3>
         <p>Desktop pet (QQ-pet style): floats in the corner, draggable, feedable, playable.</p>
@@ -1053,7 +1062,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="fun" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 92</span>
+      <span class="no" aria-hidden="true">№ 93</span>
       <div>
         <h3><a href="https://github.com/Moeblack/deepseek-manners" rel="noopener" translate="no">deepseek-manners</a><span class="by" translate="no">Moeblack</span></h3>
         <p>Append a thank-you note after every message. Mind your manners.</p>
@@ -1062,7 +1071,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="fun" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 93</span>
+      <span class="no" aria-hidden="true">№ 94</span>
       <div>
         <h3><a href="https://github.com/HuanLinOTO/dsh-plugin-d399" rel="noopener" translate="no">dsh-plugin-d399</a><span class="by" translate="no">HuanLinOTO</span></h3>
         <p>Pops up a mini-game menu (wordle, match-3, extensible) while the model generates.</p>
@@ -1071,7 +1080,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="fun" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 94</span>
+      <span class="no" aria-hidden="true">№ 95</span>
       <div>
         <h3><a href="https://github.com/omdsh-dev/dsh-auto-chess" rel="noopener" translate="no">dsh-auto-chess</a><span class="by" translate="no">omdsh-dev</span></h3>
         <p>Auto chess: human vs AI, or AI vs AI.</p>
@@ -1080,7 +1089,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="fun" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 95</span>
+      <span class="no" aria-hidden="true">№ 96</span>
       <div>
         <h3><a href="https://github.com/AnacondaKC/dsh-douyin" rel="noopener" translate="no">dsh-douyin</a><span class="by" translate="no">AnacondaKC</span></h3>
         <p>Short-video sidebar: native player, series navigation, precise history replay.</p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -452,7 +452,7 @@ footer a{color:var(--text-2)}
       <span class="no" aria-hidden="true">№ 26</span>
       <div>
         <h3><a href="https://github.com/nowledge-co/nowledge-mem-deepseek-harness" rel="noopener" translate="no">nowledge-mem-deepseek-harness</a><span class="by" translate="no">nowledge-co</span></h3>
-        <p>Nowledge Mem integration: Context Bundle injection, prompt-time memory recall, MCP tools, and turn-end DSH thread capture.</p>
+        <p>One memory layer for every AI tool and agent: Context Bundle injection, prompt-time recall, MCP tools, and turn-end DSH thread capture.</p>
       </div>
       <button class="copy" type="button" data-cmd="dsh plugin --profile web add github:nowledge-co/nowledge-mem-deepseek-harness" aria-label="Copy install command">copy install</button>
     </li>

--- a/docs/zh/index.html
+++ b/docs/zh/index.html
@@ -4,13 +4,13 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Awesome DSH Plugin — DeepSeek Harness（dsh）插件精选列表</title>
-<meta name="description" content="DeepSeek Harness（dsh）插件精选列表，收录 95 个：UI 增强、会话与消息、工具、工作流与自动化、通知与集成、开发与娱乐，持续更新。">
+<meta name="description" content="DeepSeek Harness（dsh）插件精选列表，收录 96 个：UI 增强、会话与消息、工具、工作流与自动化、通知与集成、开发与娱乐，持续更新。">
 <link rel="canonical" href="https://awesome-dsh-plugin.com/zh/">
 <link rel="alternate" hreflang="en" href="https://awesome-dsh-plugin.com/">
 <link rel="alternate" hreflang="zh" href="https://awesome-dsh-plugin.com/zh/">
 <link rel="alternate" hreflang="x-default" href="https://awesome-dsh-plugin.com/">
 <meta property="og:title" content="Awesome DSH Plugin — DeepSeek Harness（dsh）插件精选列表">
-<meta property="og:description" content="DeepSeek Harness（dsh）插件精选列表，收录 95 个：UI 增强、会话与消息、工具、工作流与自动化、通知与集成、开发与娱乐，持续更新。">
+<meta property="og:description" content="DeepSeek Harness（dsh）插件精选列表，收录 96 个：UI 增强、会话与消息、工具、工作流与自动化、通知与集成、开发与娱乐，持续更新。">
 <meta property="og:url" content="https://awesome-dsh-plugin.com/zh/">
 <meta property="og:image" content="https://awesome-dsh-plugin.com/og.png">
 <meta property="og:image:width" content="1200">
@@ -25,7 +25,7 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,400..800;1,6..72,400..600&display=swap" rel="stylesheet">
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"ItemList","name":"Awesome DSH Plugin","url":"https://awesome-dsh-plugin.com/zh/","numberOfItems":95,"itemListElement":[{"@type":"ListItem","position":1,"name":"dsh-tianshu-tui","url":"https://github.com/huiliyi37/dsh-tianshu-tui"},{"@type":"ListItem","position":2,"name":"dsh-at-file","url":"https://github.com/omdsh-dev/dsh-at-file"},{"@type":"ListItem","position":3,"name":"ui-status-label","url":"https://github.com/alingalingling/ui-status-label"},{"@type":"ListItem","position":4,"name":"dsh-openpencil","url":"https://github.com/ZSeven-W/dsh-openpencil"},{"@type":"ListItem","position":5,"name":"dsh-visualize","url":"https://github.com/Nagi-ovo/dsh-visualize"},{"@type":"ListItem","position":6,"name":"dsh-side-panel","url":"https://github.com/ccq1/dsh-side-panel"},{"@type":"ListItem","position":7,"name":"dsh-focus-chat","url":"https://github.com/dingyi222666/dsh-focus-chat"},{"@type":"ListItem","position":8,"name":"dsh-genui","url":"https://github.com/omdsh-dev/dsh-genui"},{"@type":"ListItem","position":9,"name":"dsh-annotation","url":"https://github.com/omdsh-dev/dsh-annotation"},{"@type":"ListItem","position":10,"name":"dsh-navbar","url":"https://github.com/vlln/dsh-navbar"},{"@type":"ListItem","position":11,"name":"dsh-task-status","url":"https://github.com/vlln/dsh-task-status"},{"@type":"ListItem","position":12,"name":"dsh-web-archive","url":"https://github.com/renat3u/dsh-web-archive"},{"@type":"ListItem","position":13,"name":"dsh-spotlight","url":"https://github.com/0xsline/dsh-spotlight"},{"@type":"ListItem","position":14,"name":"dsh-101","url":"https://github.com/bill9109/dsh-101"},{"@type":"ListItem","position":15,"name":"dsh-drag-and-drop","url":"https://github.com/bill9109/dsh-drag-and-drop"},{"@type":"ListItem","position":16,"name":"dsh-deeplink","url":"https://github.com/qyw233/dsh-deeplink"},{"@type":"ListItem","position":17,"name":"dsh-diff-viewer","url":"https://github.com/lehhair/dsh-diff-viewer"},{"@type":"ListItem","position":18,"name":"ex-setting","url":"https://github.com/omdsh-dev/ex-setting"},{"@type":"ListItem","position":19,"name":"web-components","url":"https://github.com/omdsh-dev/web-components"},{"@type":"ListItem","position":20,"name":"dsh-turn-navigator","url":"https://github.com/vibeinging/dsh-turn-navigator"},{"@type":"ListItem","position":21,"name":"dsh-turn-rewind","url":"https://github.com/Anionex/dsh-turn-rewind"},{"@type":"ListItem","position":22,"name":"distill","url":"https://github.com/LoserFox/distill"},{"@type":"ListItem","position":23,"name":"dsh-share","url":"https://github.com/hellodigua/dsh-share"},{"@type":"ListItem","position":24,"name":"dsh-message-edit","url":"https://github.com/Moeblack/dsh-message-edit"},{"@type":"ListItem","position":25,"name":"dsh-mnemon","url":"https://github.com/omdsh-dev/dsh-mnemon"},{"@type":"ListItem","position":26,"name":"dsh-sidechain","url":"https://github.com/Buyi-wsgzg/dsh-sidechain"},{"@type":"ListItem","position":27,"name":"dsh-conversation-share","url":"https://github.com/bill9109/dsh-conversation-share"},{"@type":"ListItem","position":28,"name":"dsh-explain","url":"https://github.com/yuezengwu/dsh-explain"},{"@type":"ListItem","position":29,"name":"dsh-prompt-studio","url":"https://github.com/Moeblack/dsh-prompt-studio"},{"@type":"ListItem","position":30,"name":"dsh-chat-import","url":"https://github.com/Nwflower/dsh-chat-import"},{"@type":"ListItem","position":31,"name":"dsh-vision-toolkit","url":"https://github.com/Anionex/dsh-vision-toolkit"},{"@type":"ListItem","position":32,"name":"dsh-custom-tool","url":"https://github.com/omdsh-dev/dsh-custom-tool"},{"@type":"ListItem","position":33,"name":"dsh-computer-use","url":"https://github.com/Anionex/dsh-computer-use"},{"@type":"ListItem","position":34,"name":"dsh-data-agent","url":"https://github.com/omdsh-dev/dsh-data-agent"},{"@type":"ListItem","position":35,"name":"dsh-toolkit","url":"https://github.com/omdsh-dev/dsh-toolkit"},{"@type":"ListItem","position":36,"name":"dsh-tool-csv","url":"https://github.com/omdsh-dev/dsh-tool-csv"},{"@type":"ListItem","position":37,"name":"dsh-tool-calculator","url":"https://github.com/omdsh-dev/dsh-tool-calculator"},{"@type":"ListItem","position":38,"name":"dsh-tool-diff","url":"https://github.com/omdsh-dev/dsh-tool-diff"},{"@type":"ListItem","position":39,"name":"dsh-tool-encoding","url":"https://github.com/omdsh-dev/dsh-tool-encoding"},{"@type":"ListItem","position":40,"name":"dsh-tool-json","url":"https://github.com/omdsh-dev/dsh-tool-json"},{"@type":"ListItem","position":41,"name":"dsh-tool-markdown","url":"https://github.com/omdsh-dev/dsh-tool-markdown"},{"@type":"ListItem","position":42,"name":"dsh-tool-regex","url":"https://github.com/omdsh-dev/dsh-tool-regex"},{"@type":"ListItem","position":43,"name":"dsh-tool-schema","url":"https://github.com/omdsh-dev/dsh-tool-schema"},{"@type":"ListItem","position":44,"name":"dsh-tool-stat","url":"https://github.com/omdsh-dev/dsh-tool-stat"},{"@type":"ListItem","position":45,"name":"dsh-tool-time","url":"https://github.com/omdsh-dev/dsh-tool-time"},{"@type":"ListItem","position":46,"name":"dsh-kb-sieve","url":"https://github.com/omdsh-dev/dsh-kb-sieve"},{"@type":"ListItem","position":47,"name":"dsh-plugin-mineru","url":"https://github.com/HuanLinOTO/dsh-plugin-mineru"},{"@type":"ListItem","position":48,"name":"dsh-tool-search","url":"https://github.com/vibeinging/dsh-tool-search"},{"@type":"ListItem","position":49,"name":"dsh-openmaic","url":"https://github.com/THU-MAIC/dsh-openmaic"},{"@type":"ListItem","position":50,"name":"dsh-scholar","url":"https://github.com/lzszq/dsh-scholar"},{"@type":"ListItem","position":51,"name":"dsh_workflow","url":"https://github.com/icetomoyo/dsh_workflow"},{"@type":"ListItem","position":52,"name":"dsh-agent-teams","url":"https://github.com/NanmiCoder/dsh-agent-teams"},{"@type":"ListItem","position":53,"name":"dsh-automation","url":"https://github.com/titanwings/dsh-automation"},{"@type":"ListItem","position":54,"name":"dsh-plannotator","url":"https://github.com/titanwings/dsh-plannotator"},{"@type":"ListItem","position":55,"name":"dsh-loop","url":"https://github.com/vlln/dsh-loop"},{"@type":"ListItem","position":56,"name":"dsh-sentinel","url":"https://github.com/fuhefei/dsh-sentinel"},{"@type":"ListItem","position":57,"name":"dsh-deep-research","url":"https://github.com/omdsh-dev/dsh-deep-research"},{"@type":"ListItem","position":58,"name":"dsh-inspect","url":"https://github.com/omdsh-dev/dsh-inspect"},{"@type":"ListItem","position":59,"name":"dsh-track","url":"https://github.com/fakechris/dsh-track"},{"@type":"ListItem","position":60,"name":"dsh-advisor","url":"https://github.com/btspoony/dsh-advisor"},{"@type":"ListItem","position":61,"name":"dsh-open-in-vscode","url":"https://github.com/omdsh-dev/dsh-open-in-vscode"},{"@type":"ListItem","position":62,"name":"dsh-notification","url":"https://github.com/omdsh-dev/dsh-notification"},{"@type":"ListItem","position":63,"name":"dsh-acp-for-bitfun","url":"https://github.com/bobleer/dsh-acp-for-bitfun"},{"@type":"ListItem","position":64,"name":"telegram","url":"https://github.com/LoserFox/telegram"},{"@type":"ListItem","position":65,"name":"dsh-session-notification","url":"https://github.com/dingyi222666/dsh-session-notification"},{"@type":"ListItem","position":66,"name":"dsh-web-ui-notify","url":"https://github.com/bill9109/dsh-web-ui-notify"},{"@type":"ListItem","position":67,"name":"dsh-webbridge","url":"https://github.com/bill9109/dsh-webbridge"},{"@type":"ListItem","position":68,"name":"fabric","url":"https://github.com/omdsh-dev/fabric"},{"@type":"ListItem","position":69,"name":"dsh-git-identity","url":"https://github.com/LoserFox/dsh-git-identity"},{"@type":"ListItem","position":70,"name":"dsh-context-doctor","url":"https://github.com/Zhenyu98/dsh-context-doctor"},{"@type":"ListItem","position":71,"name":"dsh-plugin-check","url":"https://github.com/omdsh-dev/dsh-plugin-check"},{"@type":"ListItem","position":72,"name":"dsh-security-audit","url":"https://github.com/omdsh-dev/dsh-security-audit"},{"@type":"ListItem","position":73,"name":"dsh-session-health","url":"https://github.com/omdsh-dev/dsh-session-health"},{"@type":"ListItem","position":74,"name":"dsh-evolve","url":"https://github.com/william-jin-cmu/dsh-evolve"},{"@type":"ListItem","position":75,"name":"dsh-trace","url":"https://github.com/vibeinging/dsh-trace"},{"@type":"ListItem","position":76,"name":"sandbox-micro","url":"https://github.com/omdsh-dev/sandbox-micro"},{"@type":"ListItem","position":77,"name":"sandbox-mxc","url":"https://github.com/omdsh-dev/sandbox-mxc"},{"@type":"ListItem","position":78,"name":"sandbox-nono","url":"https://github.com/omdsh-dev/sandbox-nono"},{"@type":"ListItem","position":79,"name":"dsh-agent-budget","url":"https://github.com/vibeinging/dsh-agent-budget"},{"@type":"ListItem","position":80,"name":"dsh-llm-fallbacks","url":"https://github.com/btspoony/dsh-llm-fallbacks"},{"@type":"ListItem","position":81,"name":"dsh-tool-approval","url":"https://github.com/ilharp/dsh-tool-approval"},{"@type":"ListItem","position":82,"name":"plugin-template","url":"https://github.com/omdsh-dev/plugin-template"},{"@type":"ListItem","position":83,"name":"Qwen-MM-Plugins","url":"https://github.com/omdsh-dev/Qwen-MM-Plugins"},{"@type":"ListItem","position":84,"name":"dsh-tps","url":"https://github.com/Small-tailqwq/dsh-tps"},{"@type":"ListItem","position":85,"name":"dsh-ads","url":"https://github.com/Nagi-ovo/dsh-ads"},{"@type":"ListItem","position":86,"name":"dsh-gomoku","url":"https://github.com/omdsh-dev/dsh-gomoku"},{"@type":"ListItem","position":87,"name":"dsh-stock-market","url":"https://github.com/AnacondaKC/dsh-stock-market"},{"@type":"ListItem","position":88,"name":"dsh-emoji","url":"https://github.com/hellodigua/dsh-emoji"},{"@type":"ListItem","position":89,"name":"dsh-minigames","url":"https://github.com/lhh010/dsh-minigames"},{"@type":"ListItem","position":90,"name":"dsh-stickers","url":"https://github.com/william-jin-cmu/dsh-stickers"},{"@type":"ListItem","position":91,"name":"whale-girl","url":"https://github.com/vlln/whale-girl"},{"@type":"ListItem","position":92,"name":"deepseek-manners","url":"https://github.com/Moeblack/deepseek-manners"},{"@type":"ListItem","position":93,"name":"dsh-plugin-d399","url":"https://github.com/HuanLinOTO/dsh-plugin-d399"},{"@type":"ListItem","position":94,"name":"dsh-auto-chess","url":"https://github.com/omdsh-dev/dsh-auto-chess"},{"@type":"ListItem","position":95,"name":"dsh-douyin","url":"https://github.com/AnacondaKC/dsh-douyin"}]}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"ItemList","name":"Awesome DSH Plugin","url":"https://awesome-dsh-plugin.com/zh/","numberOfItems":96,"itemListElement":[{"@type":"ListItem","position":1,"name":"dsh-tianshu-tui","url":"https://github.com/huiliyi37/dsh-tianshu-tui"},{"@type":"ListItem","position":2,"name":"dsh-at-file","url":"https://github.com/omdsh-dev/dsh-at-file"},{"@type":"ListItem","position":3,"name":"ui-status-label","url":"https://github.com/alingalingling/ui-status-label"},{"@type":"ListItem","position":4,"name":"dsh-openpencil","url":"https://github.com/ZSeven-W/dsh-openpencil"},{"@type":"ListItem","position":5,"name":"dsh-visualize","url":"https://github.com/Nagi-ovo/dsh-visualize"},{"@type":"ListItem","position":6,"name":"dsh-side-panel","url":"https://github.com/ccq1/dsh-side-panel"},{"@type":"ListItem","position":7,"name":"dsh-focus-chat","url":"https://github.com/dingyi222666/dsh-focus-chat"},{"@type":"ListItem","position":8,"name":"dsh-genui","url":"https://github.com/omdsh-dev/dsh-genui"},{"@type":"ListItem","position":9,"name":"dsh-annotation","url":"https://github.com/omdsh-dev/dsh-annotation"},{"@type":"ListItem","position":10,"name":"dsh-navbar","url":"https://github.com/vlln/dsh-navbar"},{"@type":"ListItem","position":11,"name":"dsh-task-status","url":"https://github.com/vlln/dsh-task-status"},{"@type":"ListItem","position":12,"name":"dsh-web-archive","url":"https://github.com/renat3u/dsh-web-archive"},{"@type":"ListItem","position":13,"name":"dsh-spotlight","url":"https://github.com/0xsline/dsh-spotlight"},{"@type":"ListItem","position":14,"name":"dsh-101","url":"https://github.com/bill9109/dsh-101"},{"@type":"ListItem","position":15,"name":"dsh-drag-and-drop","url":"https://github.com/bill9109/dsh-drag-and-drop"},{"@type":"ListItem","position":16,"name":"dsh-deeplink","url":"https://github.com/qyw233/dsh-deeplink"},{"@type":"ListItem","position":17,"name":"dsh-diff-viewer","url":"https://github.com/lehhair/dsh-diff-viewer"},{"@type":"ListItem","position":18,"name":"ex-setting","url":"https://github.com/omdsh-dev/ex-setting"},{"@type":"ListItem","position":19,"name":"web-components","url":"https://github.com/omdsh-dev/web-components"},{"@type":"ListItem","position":20,"name":"dsh-turn-navigator","url":"https://github.com/vibeinging/dsh-turn-navigator"},{"@type":"ListItem","position":21,"name":"dsh-turn-rewind","url":"https://github.com/Anionex/dsh-turn-rewind"},{"@type":"ListItem","position":22,"name":"distill","url":"https://github.com/LoserFox/distill"},{"@type":"ListItem","position":23,"name":"dsh-share","url":"https://github.com/hellodigua/dsh-share"},{"@type":"ListItem","position":24,"name":"dsh-message-edit","url":"https://github.com/Moeblack/dsh-message-edit"},{"@type":"ListItem","position":25,"name":"dsh-mnemon","url":"https://github.com/omdsh-dev/dsh-mnemon"},{"@type":"ListItem","position":26,"name":"nowledge-mem-deepseek-harness","url":"https://github.com/nowledge-co/nowledge-mem-deepseek-harness"},{"@type":"ListItem","position":27,"name":"dsh-sidechain","url":"https://github.com/Buyi-wsgzg/dsh-sidechain"},{"@type":"ListItem","position":28,"name":"dsh-conversation-share","url":"https://github.com/bill9109/dsh-conversation-share"},{"@type":"ListItem","position":29,"name":"dsh-explain","url":"https://github.com/yuezengwu/dsh-explain"},{"@type":"ListItem","position":30,"name":"dsh-prompt-studio","url":"https://github.com/Moeblack/dsh-prompt-studio"},{"@type":"ListItem","position":31,"name":"dsh-chat-import","url":"https://github.com/Nwflower/dsh-chat-import"},{"@type":"ListItem","position":32,"name":"dsh-vision-toolkit","url":"https://github.com/Anionex/dsh-vision-toolkit"},{"@type":"ListItem","position":33,"name":"dsh-custom-tool","url":"https://github.com/omdsh-dev/dsh-custom-tool"},{"@type":"ListItem","position":34,"name":"dsh-computer-use","url":"https://github.com/Anionex/dsh-computer-use"},{"@type":"ListItem","position":35,"name":"dsh-data-agent","url":"https://github.com/omdsh-dev/dsh-data-agent"},{"@type":"ListItem","position":36,"name":"dsh-toolkit","url":"https://github.com/omdsh-dev/dsh-toolkit"},{"@type":"ListItem","position":37,"name":"dsh-tool-csv","url":"https://github.com/omdsh-dev/dsh-tool-csv"},{"@type":"ListItem","position":38,"name":"dsh-tool-calculator","url":"https://github.com/omdsh-dev/dsh-tool-calculator"},{"@type":"ListItem","position":39,"name":"dsh-tool-diff","url":"https://github.com/omdsh-dev/dsh-tool-diff"},{"@type":"ListItem","position":40,"name":"dsh-tool-encoding","url":"https://github.com/omdsh-dev/dsh-tool-encoding"},{"@type":"ListItem","position":41,"name":"dsh-tool-json","url":"https://github.com/omdsh-dev/dsh-tool-json"},{"@type":"ListItem","position":42,"name":"dsh-tool-markdown","url":"https://github.com/omdsh-dev/dsh-tool-markdown"},{"@type":"ListItem","position":43,"name":"dsh-tool-regex","url":"https://github.com/omdsh-dev/dsh-tool-regex"},{"@type":"ListItem","position":44,"name":"dsh-tool-schema","url":"https://github.com/omdsh-dev/dsh-tool-schema"},{"@type":"ListItem","position":45,"name":"dsh-tool-stat","url":"https://github.com/omdsh-dev/dsh-tool-stat"},{"@type":"ListItem","position":46,"name":"dsh-tool-time","url":"https://github.com/omdsh-dev/dsh-tool-time"},{"@type":"ListItem","position":47,"name":"dsh-kb-sieve","url":"https://github.com/omdsh-dev/dsh-kb-sieve"},{"@type":"ListItem","position":48,"name":"dsh-plugin-mineru","url":"https://github.com/HuanLinOTO/dsh-plugin-mineru"},{"@type":"ListItem","position":49,"name":"dsh-tool-search","url":"https://github.com/vibeinging/dsh-tool-search"},{"@type":"ListItem","position":50,"name":"dsh-openmaic","url":"https://github.com/THU-MAIC/dsh-openmaic"},{"@type":"ListItem","position":51,"name":"dsh-scholar","url":"https://github.com/lzszq/dsh-scholar"},{"@type":"ListItem","position":52,"name":"dsh_workflow","url":"https://github.com/icetomoyo/dsh_workflow"},{"@type":"ListItem","position":53,"name":"dsh-agent-teams","url":"https://github.com/NanmiCoder/dsh-agent-teams"},{"@type":"ListItem","position":54,"name":"dsh-automation","url":"https://github.com/titanwings/dsh-automation"},{"@type":"ListItem","position":55,"name":"dsh-plannotator","url":"https://github.com/titanwings/dsh-plannotator"},{"@type":"ListItem","position":56,"name":"dsh-loop","url":"https://github.com/vlln/dsh-loop"},{"@type":"ListItem","position":57,"name":"dsh-sentinel","url":"https://github.com/fuhefei/dsh-sentinel"},{"@type":"ListItem","position":58,"name":"dsh-deep-research","url":"https://github.com/omdsh-dev/dsh-deep-research"},{"@type":"ListItem","position":59,"name":"dsh-inspect","url":"https://github.com/omdsh-dev/dsh-inspect"},{"@type":"ListItem","position":60,"name":"dsh-track","url":"https://github.com/fakechris/dsh-track"},{"@type":"ListItem","position":61,"name":"dsh-advisor","url":"https://github.com/btspoony/dsh-advisor"},{"@type":"ListItem","position":62,"name":"dsh-open-in-vscode","url":"https://github.com/omdsh-dev/dsh-open-in-vscode"},{"@type":"ListItem","position":63,"name":"dsh-notification","url":"https://github.com/omdsh-dev/dsh-notification"},{"@type":"ListItem","position":64,"name":"dsh-acp-for-bitfun","url":"https://github.com/bobleer/dsh-acp-for-bitfun"},{"@type":"ListItem","position":65,"name":"telegram","url":"https://github.com/LoserFox/telegram"},{"@type":"ListItem","position":66,"name":"dsh-session-notification","url":"https://github.com/dingyi222666/dsh-session-notification"},{"@type":"ListItem","position":67,"name":"dsh-web-ui-notify","url":"https://github.com/bill9109/dsh-web-ui-notify"},{"@type":"ListItem","position":68,"name":"dsh-webbridge","url":"https://github.com/bill9109/dsh-webbridge"},{"@type":"ListItem","position":69,"name":"fabric","url":"https://github.com/omdsh-dev/fabric"},{"@type":"ListItem","position":70,"name":"dsh-git-identity","url":"https://github.com/LoserFox/dsh-git-identity"},{"@type":"ListItem","position":71,"name":"dsh-context-doctor","url":"https://github.com/Zhenyu98/dsh-context-doctor"},{"@type":"ListItem","position":72,"name":"dsh-plugin-check","url":"https://github.com/omdsh-dev/dsh-plugin-check"},{"@type":"ListItem","position":73,"name":"dsh-security-audit","url":"https://github.com/omdsh-dev/dsh-security-audit"},{"@type":"ListItem","position":74,"name":"dsh-session-health","url":"https://github.com/omdsh-dev/dsh-session-health"},{"@type":"ListItem","position":75,"name":"dsh-evolve","url":"https://github.com/william-jin-cmu/dsh-evolve"},{"@type":"ListItem","position":76,"name":"dsh-trace","url":"https://github.com/vibeinging/dsh-trace"},{"@type":"ListItem","position":77,"name":"sandbox-micro","url":"https://github.com/omdsh-dev/sandbox-micro"},{"@type":"ListItem","position":78,"name":"sandbox-mxc","url":"https://github.com/omdsh-dev/sandbox-mxc"},{"@type":"ListItem","position":79,"name":"sandbox-nono","url":"https://github.com/omdsh-dev/sandbox-nono"},{"@type":"ListItem","position":80,"name":"dsh-agent-budget","url":"https://github.com/vibeinging/dsh-agent-budget"},{"@type":"ListItem","position":81,"name":"dsh-llm-fallbacks","url":"https://github.com/btspoony/dsh-llm-fallbacks"},{"@type":"ListItem","position":82,"name":"dsh-tool-approval","url":"https://github.com/ilharp/dsh-tool-approval"},{"@type":"ListItem","position":83,"name":"plugin-template","url":"https://github.com/omdsh-dev/plugin-template"},{"@type":"ListItem","position":84,"name":"Qwen-MM-Plugins","url":"https://github.com/omdsh-dev/Qwen-MM-Plugins"},{"@type":"ListItem","position":85,"name":"dsh-tps","url":"https://github.com/Small-tailqwq/dsh-tps"},{"@type":"ListItem","position":86,"name":"dsh-ads","url":"https://github.com/Nagi-ovo/dsh-ads"},{"@type":"ListItem","position":87,"name":"dsh-gomoku","url":"https://github.com/omdsh-dev/dsh-gomoku"},{"@type":"ListItem","position":88,"name":"dsh-stock-market","url":"https://github.com/AnacondaKC/dsh-stock-market"},{"@type":"ListItem","position":89,"name":"dsh-emoji","url":"https://github.com/hellodigua/dsh-emoji"},{"@type":"ListItem","position":90,"name":"dsh-minigames","url":"https://github.com/lhh010/dsh-minigames"},{"@type":"ListItem","position":91,"name":"dsh-stickers","url":"https://github.com/william-jin-cmu/dsh-stickers"},{"@type":"ListItem","position":92,"name":"whale-girl","url":"https://github.com/vlln/whale-girl"},{"@type":"ListItem","position":93,"name":"deepseek-manners","url":"https://github.com/Moeblack/deepseek-manners"},{"@type":"ListItem","position":94,"name":"dsh-plugin-d399","url":"https://github.com/HuanLinOTO/dsh-plugin-d399"},{"@type":"ListItem","position":95,"name":"dsh-auto-chess","url":"https://github.com/omdsh-dev/dsh-auto-chess"},{"@type":"ListItem","position":96,"name":"dsh-douyin","url":"https://github.com/AnacondaKC/dsh-douyin"}]}</script>
 <style>
 :root{
   /* canvas — warm paper */
@@ -204,9 +204,9 @@ footer a{color:var(--text-2)}
       <span class="count" id="count" aria-live="polite">0 / 0</span>
     </div>
     <div class="filters" id="filters">
-      <button class="chip active" type="button" data-cat="all">全部 <small>95</small></button>
+      <button class="chip active" type="button" data-cat="all">全部 <small>96</small></button>
       <button class="chip" type="button" data-cat="ui">🎨 UI 增强 <small>20</small></button>
-      <button class="chip" type="button" data-cat="session">💬 会话与消息 <small>10</small></button>
+      <button class="chip" type="button" data-cat="session">💬 会话与消息 <small>11</small></button>
       <button class="chip" type="button" data-cat="tools">🛠️ 工具与能力 <small>20</small></button>
       <button class="chip" type="button" data-cat="workflow">🔁 工作流与自动化 <small>10</small></button>
       <button class="chip" type="button" data-cat="notify">🔔 通知与集成 <small>7</small></button>
@@ -401,7 +401,7 @@ footer a{color:var(--text-2)}
       <button class="copy" type="button" data-cmd="dsh plugin --profile web add github:vibeinging/dsh-turn-navigator" aria-label="复制安装命令">复制安装命令</button>
     </li>
 
-    <li class="sec" data-sec="session"><h2 id="session">💬 会话与消息 <small>10</small></h2></li>
+    <li class="sec" data-sec="session"><h2 id="session">💬 会话与消息 <small>11</small></h2></li>
 
     <li class="item" data-cat="session" style="animation-delay:0.40s">
       <span class="no" aria-hidden="true">№ 21</span>
@@ -451,6 +451,15 @@ footer a{color:var(--text-2)}
     <li class="item" data-cat="session" style="animation-delay:0.40s">
       <span class="no" aria-hidden="true">№ 26</span>
       <div>
+        <h3><a href="https://github.com/nowledge-co/nowledge-mem-deepseek-harness" rel="noopener" translate="no">nowledge-mem-deepseek-harness</a><span class="by" translate="no">nowledge-co</span></h3>
+        <p>Nowledge Mem 集成：注入 Context Bundle、提示时记忆检索、MCP 工具与回合结束 DSH 线程捕获。</p>
+      </div>
+      <button class="copy" type="button" data-cmd="dsh plugin --profile web add github:nowledge-co/nowledge-mem-deepseek-harness" aria-label="复制安装命令">复制安装命令</button>
+    </li>
+
+    <li class="item" data-cat="session" style="animation-delay:0.40s">
+      <span class="no" aria-hidden="true">№ 27</span>
+      <div>
         <h3><a href="https://github.com/Buyi-wsgzg/dsh-sidechain" rel="noopener" translate="no">dsh-sidechain</a><span class="by" translate="no">Buyi-wsgzg</span></h3>
         <p>`/side` 持续性侧会话与 `/btw` 一次性侧问，在临时 fork 中运行、不写入主会话历史。</p>
       </div>
@@ -458,7 +467,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="session" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 27</span>
+      <span class="no" aria-hidden="true">№ 28</span>
       <div>
         <h3><a href="https://github.com/bill9109/dsh-conversation-share" rel="noopener" translate="no">dsh-conversation-share</a><span class="by" translate="no">bill9109</span></h3>
         <p>分享任意段落的对话。</p>
@@ -467,7 +476,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="session" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 28</span>
+      <span class="no" aria-hidden="true">№ 29</span>
       <div>
         <h3><a href="https://github.com/yuezengwu/dsh-explain" rel="noopener" translate="no">dsh-explain</a><span class="by" translate="no">yuezengwu</span></h3>
         <p>本地优先学习模式：跨会话全局学习线程、按来源讲解。</p>
@@ -476,7 +485,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="session" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 29</span>
+      <span class="no" aria-hidden="true">№ 30</span>
       <div>
         <h3><a href="https://github.com/Moeblack/dsh-prompt-studio" rel="noopener" translate="no">dsh-prompt-studio</a><span class="by" translate="no">Moeblack</span></h3>
         <p>带实时预览的用户/内置 system prompt 分节编辑器。</p>
@@ -485,7 +494,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="session" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 30</span>
+      <span class="no" aria-hidden="true">№ 31</span>
       <div>
         <h3><a href="https://github.com/Nwflower/dsh-chat-import" rel="noopener" translate="no">dsh-chat-import</a><span class="by" translate="no">Nwflower</span></h3>
         <p>把 Claude Code / Codex / ChatGPT / Cursor 的聊天记录全保真导入为可续聊的 DSH 会话。</p>
@@ -496,7 +505,7 @@ footer a{color:var(--text-2)}
     <li class="sec" data-sec="tools"><h2 id="tools">🛠️ 工具与能力 <small>20</small></h2></li>
 
     <li class="item" data-cat="tools" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 31</span>
+      <span class="no" aria-hidden="true">№ 32</span>
       <div>
         <h3><a href="https://github.com/Anionex/dsh-vision-toolkit" rel="noopener" translate="no">dsh-vision-toolkit</a><span class="by" translate="no">Anionex</span></h3>
         <p>让纯文本模型更好地做视觉任务：带意图的图片问答、长截图 OCR、UI 还原等。</p>
@@ -505,7 +514,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="tools" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 32</span>
+      <span class="no" aria-hidden="true">№ 33</span>
       <div>
         <h3><a href="https://github.com/omdsh-dev/dsh-custom-tool" rel="noopener" translate="no">dsh-custom-tool</a><span class="by" translate="no">omdsh-dev</span></h3>
         <p>用 Monaco 编辑器创建和管理沙箱化的自定义 JavaScript 工具。</p>
@@ -514,7 +523,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="tools" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 33</span>
+      <span class="no" aria-hidden="true">№ 34</span>
       <div>
         <h3><a href="https://github.com/Anionex/dsh-computer-use" rel="noopener" translate="no">dsh-computer-use</a><span class="by" translate="no">Anionex</span></h3>
         <p>macOS 电脑控制：Accessibility 观测、过期状态拒绝、作用域权限与安全输入。</p>
@@ -523,7 +532,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="tools" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 34</span>
+      <span class="no" aria-hidden="true">№ 35</span>
       <div>
         <h3><a href="https://github.com/omdsh-dev/dsh-data-agent" rel="noopener" translate="no">dsh-data-agent</a><span class="by" translate="no">omdsh-dev</span></h3>
         <p>让 AI 帮你连数据库、写 SQL。</p>
@@ -532,7 +541,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="tools" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 35</span>
+      <span class="no" aria-hidden="true">№ 36</span>
       <div>
         <h3><a href="https://github.com/omdsh-dev/dsh-toolkit" rel="noopener" translate="no">dsh-toolkit</a><span class="by" translate="no">omdsh-dev</span></h3>
         <p>零依赖工具包：time / encoding / json / calculator / csv / regex / markdown / diff / stat / schema 十件套一键安装。</p>
@@ -541,7 +550,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="tools" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 36</span>
+      <span class="no" aria-hidden="true">№ 37</span>
       <div>
         <h3><a href="https://github.com/omdsh-dev/dsh-tool-csv" rel="noopener" translate="no">dsh-tool-csv</a><span class="by" translate="no">omdsh-dev</span></h3>
         <p>CSV 解析/查询/统计/转换（RFC 4180），零依赖状态机解析器。</p>
@@ -550,7 +559,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="tools" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 37</span>
+      <span class="no" aria-hidden="true">№ 38</span>
       <div>
         <h3><a href="https://github.com/omdsh-dev/dsh-tool-calculator" rel="noopener" translate="no">dsh-tool-calculator</a><span class="by" translate="no">omdsh-dev</span></h3>
         <p>安全的数学表达式求值器，零依赖递归下降解析器。</p>
@@ -559,7 +568,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="tools" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 38</span>
+      <span class="no" aria-hidden="true">№ 39</span>
       <div>
         <h3><a href="https://github.com/omdsh-dev/dsh-tool-diff" rel="noopener" translate="no">dsh-tool-diff</a><span class="by" translate="no">omdsh-dev</span></h3>
         <p>文本/JSON/CSV/Markdown 结构化比较与 unified diff。</p>
@@ -568,7 +577,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="tools" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 39</span>
+      <span class="no" aria-hidden="true">№ 40</span>
       <div>
         <h3><a href="https://github.com/omdsh-dev/dsh-tool-encoding" rel="noopener" translate="no">dsh-tool-encoding</a><span class="by" translate="no">omdsh-dev</span></h3>
         <p>base64/url/hex 编解码、常用哈希、UUID 生成。</p>
@@ -577,7 +586,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="tools" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 40</span>
+      <span class="no" aria-hidden="true">№ 41</span>
       <div>
         <h3><a href="https://github.com/omdsh-dev/dsh-tool-json" rel="noopener" translate="no">dsh-tool-json</a><span class="by" translate="no">omdsh-dev</span></h3>
         <p>JMESPath 子集 JSON 查询。</p>
@@ -586,7 +595,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="tools" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 41</span>
+      <span class="no" aria-hidden="true">№ 42</span>
       <div>
         <h3><a href="https://github.com/omdsh-dev/dsh-tool-markdown" rel="noopener" translate="no">dsh-tool-markdown</a><span class="by" translate="no">omdsh-dev</span></h3>
         <p>HTML↔Markdown 转换、GFM 表格规范化、目录生成。</p>
@@ -595,7 +604,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="tools" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 42</span>
+      <span class="no" aria-hidden="true">№ 43</span>
       <div>
         <h3><a href="https://github.com/omdsh-dev/dsh-tool-regex" rel="noopener" translate="no">dsh-tool-regex</a><span class="by" translate="no">omdsh-dev</span></h3>
         <p>正则测试/提取/安全替换/静态解释（不执行代码）。</p>
@@ -604,7 +613,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="tools" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 43</span>
+      <span class="no" aria-hidden="true">№ 44</span>
       <div>
         <h3><a href="https://github.com/omdsh-dev/dsh-tool-schema" rel="noopener" translate="no">dsh-tool-schema</a><span class="by" translate="no">omdsh-dev</span></h3>
         <p>JSON Schema 验证：validate/paths/explain/normalize。</p>
@@ -613,7 +622,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="tools" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 44</span>
+      <span class="no" aria-hidden="true">№ 45</span>
       <div>
         <h3><a href="https://github.com/omdsh-dev/dsh-tool-stat" rel="noopener" translate="no">dsh-tool-stat</a><span class="by" translate="no">omdsh-dev</span></h3>
         <p>描述统计/百分位数/频数分布/相关性。</p>
@@ -622,7 +631,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="tools" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 45</span>
+      <span class="no" aria-hidden="true">№ 46</span>
       <div>
         <h3><a href="https://github.com/omdsh-dev/dsh-tool-time" rel="noopener" translate="no">dsh-tool-time</a><span class="by" translate="no">omdsh-dev</span></h3>
         <p>严格 ISO 8601 解析、IANA 时区转换、UTC 日历运算。</p>
@@ -631,7 +640,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="tools" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 46</span>
+      <span class="no" aria-hidden="true">№ 47</span>
       <div>
         <h3><a href="https://github.com/omdsh-dev/dsh-kb-sieve" rel="noopener" translate="no">dsh-kb-sieve</a><span class="by" translate="no">omdsh-dev</span></h3>
         <p>从 md/txt/docx/pdf 构建可审计知识库包（SQLite FTS5），确定性检索与原文阅读。</p>
@@ -640,7 +649,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="tools" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 47</span>
+      <span class="no" aria-hidden="true">№ 48</span>
       <div>
         <h3><a href="https://github.com/HuanLinOTO/dsh-plugin-mineru" rel="noopener" translate="no">dsh-plugin-mineru</a><span class="by" translate="no">HuanLinOTO</span></h3>
         <p>向模型暴露 MineRU 文档解析工具。</p>
@@ -649,7 +658,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="tools" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 48</span>
+      <span class="no" aria-hidden="true">№ 49</span>
       <div>
         <h3><a href="https://github.com/vibeinging/dsh-tool-search" rel="noopener" translate="no">dsh-tool-search</a><span class="by" translate="no">vibeinging</span></h3>
         <p>按 agent 的按需工具发现与渐进式 schema 披露。</p>
@@ -658,7 +667,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="tools" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 49</span>
+      <span class="no" aria-hidden="true">№ 50</span>
       <div>
         <h3><a href="https://github.com/THU-MAIC/dsh-openmaic" rel="noopener" translate="no">dsh-openmaic</a><span class="by" translate="no">THU-MAIC</span></h3>
         <p>OpenMAIC 教学：课堂、幻灯片、交互组件与苏格拉底式教学。</p>
@@ -667,7 +676,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="tools" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 50</span>
+      <span class="no" aria-hidden="true">№ 51</span>
       <div>
         <h3><a href="https://github.com/lzszq/dsh-scholar" rel="noopener" translate="no">dsh-scholar</a><span class="by" translate="no">lzszq</span></h3>
         <p>学术助手插件。</p>
@@ -678,7 +687,7 @@ footer a{color:var(--text-2)}
     <li class="sec" data-sec="workflow"><h2 id="workflow">🔁 工作流与自动化 <small>10</small></h2></li>
 
     <li class="item" data-cat="workflow" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 51</span>
+      <span class="no" aria-hidden="true">№ 52</span>
       <div>
         <h3><a href="https://github.com/icetomoyo/dsh_workflow" rel="noopener" translate="no">dsh_workflow</a><span class="by" translate="no">icetomoyo</span></h3>
         <p>把 UltraCode 式多 Agent 调度带给 DSH：可生成、可保存、可治理、可观察、可恢复的 Workflow 层。</p>
@@ -687,7 +696,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="workflow" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 52</span>
+      <span class="no" aria-hidden="true">№ 53</span>
       <div>
         <h3><a href="https://github.com/NanmiCoder/dsh-agent-teams" rel="noopener" translate="no">dsh-agent-teams</a><span class="by" translate="no">NanmiCoder</span></h3>
         <p>AgentTeams 多智能体团队。</p>
@@ -696,7 +705,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="workflow" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 53</span>
+      <span class="no" aria-hidden="true">№ 54</span>
       <div>
         <h3><a href="https://github.com/titanwings/dsh-automation" rel="noopener" translate="no">dsh-automation</a><span class="by" translate="no">titanwings</span></h3>
         <p>定时任务：让 Coding 任务按计划在全新 Agent Session 中运行，保留可审计历史。</p>
@@ -705,7 +714,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="workflow" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 54</span>
+      <span class="no" aria-hidden="true">№ 55</span>
       <div>
         <h3><a href="https://github.com/titanwings/dsh-plannotator" rel="noopener" translate="no">dsh-plannotator</a><span class="by" translate="no">titanwings</span></h3>
         <p>计划批注：选中计划原文逐条批注，结构化反馈送回 Agent。</p>
@@ -714,7 +723,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="workflow" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 55</span>
+      <span class="no" aria-hidden="true">№ 56</span>
       <div>
         <h3><a href="https://github.com/vlln/dsh-loop" rel="noopener" translate="no">dsh-loop</a><span class="by" translate="no">vlln</span></h3>
         <p>定时循环：`/loop` 命令 + loop 工具 + 活动状态条。</p>
@@ -723,7 +732,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="workflow" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 56</span>
+      <span class="no" aria-hidden="true">№ 57</span>
       <div>
         <h3><a href="https://github.com/fuhefei/dsh-sentinel" rel="noopener" translate="no">dsh-sentinel</a><span class="by" translate="no">fuhefei</span></h3>
         <p>条件驱动唤醒：file/command/http/process/webhook 持久监视，触发即唤醒 agent。</p>
@@ -732,7 +741,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="workflow" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 57</span>
+      <span class="no" aria-hidden="true">№ 58</span>
       <div>
         <h3><a href="https://github.com/omdsh-dev/dsh-deep-research" rel="noopener" translate="no">dsh-deep-research</a><span class="by" translate="no">omdsh-dev</span></h3>
         <p>自适应深度研究编排器（基于官方 workflow 引擎）。</p>
@@ -741,7 +750,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="workflow" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 58</span>
+      <span class="no" aria-hidden="true">№ 59</span>
       <div>
         <h3><a href="https://github.com/omdsh-dev/dsh-inspect" rel="noopener" translate="no">dsh-inspect</a><span class="by" translate="no">omdsh-dev</span></h3>
         <p>发现问题→修复交付→质量复查的对抗式闭环工具集。</p>
@@ -750,7 +759,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="workflow" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 59</span>
+      <span class="no" aria-hidden="true">№ 60</span>
       <div>
         <h3><a href="https://github.com/fakechris/dsh-track" rel="noopener" translate="no">dsh-track</a><span class="by" translate="no">fakechris</span></h3>
         <p>嵌入式任务管理引擎：决策点协议、念头捕获墙、Linear 形 issue 存储。</p>
@@ -759,7 +768,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="workflow" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 60</span>
+      <span class="no" aria-hidden="true">№ 61</span>
       <div>
         <h3><a href="https://github.com/btspoony/dsh-advisor" rel="noopener" translate="no">dsh-advisor</a><span class="by" translate="no">btspoony</span></h3>
         <p>搭配一个副模型，每轮被动审查并注入见解。</p>
@@ -770,7 +779,7 @@ footer a{color:var(--text-2)}
     <li class="sec" data-sec="notify"><h2 id="notify">🔔 通知与集成 <small>7</small></h2></li>
 
     <li class="item" data-cat="notify" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 61</span>
+      <span class="no" aria-hidden="true">№ 62</span>
       <div>
         <h3><a href="https://github.com/omdsh-dev/dsh-open-in-vscode" rel="noopener" translate="no">dsh-open-in-vscode</a><span class="by" translate="no">omdsh-dev</span></h3>
         <p>从 Web GUI 一键在 VS Code 中打开工作区目录。</p>
@@ -779,7 +788,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="notify" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 62</span>
+      <span class="no" aria-hidden="true">№ 63</span>
       <div>
         <h3><a href="https://github.com/omdsh-dev/dsh-notification" rel="noopener" translate="no">dsh-notification</a><span class="by" translate="no">omdsh-dev</span></h3>
         <p>回合完成桌面通知，按结果分控 + 关键词过滤。</p>
@@ -788,7 +797,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="notify" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 63</span>
+      <span class="no" aria-hidden="true">№ 64</span>
       <div>
         <h3><a href="https://github.com/bobleer/dsh-acp-for-bitfun" rel="noopener" translate="no">dsh-acp-for-bitfun</a><span class="by" translate="no">bobleer</span></h3>
         <p>BitFun 与 DSH 的 ACP 交互对接。</p>
@@ -797,7 +806,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="notify" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 64</span>
+      <span class="no" aria-hidden="true">№ 65</span>
       <div>
         <h3><a href="https://github.com/LoserFox/telegram" rel="noopener" translate="no">telegram</a><span class="by" translate="no">LoserFox</span></h3>
         <p>Telegram Bot API 桥接：长轮询、per-chat 会话、HTML 格式化。</p>
@@ -806,7 +815,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="notify" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 65</span>
+      <span class="no" aria-hidden="true">№ 66</span>
       <div>
         <h3><a href="https://github.com/dingyi222666/dsh-session-notification" rel="noopener" translate="no">dsh-session-notification</a><span class="by" translate="no">dingyi222666</span></h3>
         <p>会话完成等四种状态的通知响应，支持浏览器提示。</p>
@@ -815,7 +824,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="notify" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 66</span>
+      <span class="no" aria-hidden="true">№ 67</span>
       <div>
         <h3><a href="https://github.com/bill9109/dsh-web-ui-notify" rel="noopener" translate="no">dsh-web-ui-notify</a><span class="by" translate="no">bill9109</span></h3>
         <p>桌面通知提醒。</p>
@@ -824,7 +833,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="notify" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 67</span>
+      <span class="no" aria-hidden="true">№ 68</span>
       <div>
         <h3><a href="https://github.com/bill9109/dsh-webbridge" rel="noopener" translate="no">dsh-webbridge</a><span class="by" translate="no">bill9109</span></h3>
         <p>DSH 结合 Kimi WebBridge。</p>
@@ -835,7 +844,7 @@ footer a{color:var(--text-2)}
     <li class="sec" data-sec="dev"><h2 id="dev">🧑‍💻 开发与运行时 <small>17</small></h2></li>
 
     <li class="item" data-cat="dev" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 68</span>
+      <span class="no" aria-hidden="true">№ 69</span>
       <div>
         <h3><a href="https://github.com/omdsh-dev/fabric" rel="noopener" translate="no">fabric</a><span class="by" translate="no">omdsh-dev</span></h3>
         <p>类似 MC Fabric 的 hook 处理器。</p>
@@ -844,7 +853,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="dev" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 69</span>
+      <span class="no" aria-hidden="true">№ 70</span>
       <div>
         <h3><a href="https://github.com/LoserFox/dsh-git-identity" rel="noopener" translate="no">dsh-git-identity</a><span class="by" translate="no">LoserFox</span></h3>
         <p>git 提交固定使用环境自身作者身份，环境变量注入压过一切 git config。</p>
@@ -853,7 +862,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="dev" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 70</span>
+      <span class="no" aria-hidden="true">№ 71</span>
       <div>
         <h3><a href="https://github.com/Zhenyu98/dsh-context-doctor" rel="noopener" translate="no">dsh-context-doctor</a><span class="by" translate="no">Zhenyu98</span></h3>
         <p>上下文注入审计：统计指令链/技能目录/工具 schema 的 token 成本，检测重复与冲突。</p>
@@ -862,7 +871,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="dev" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 71</span>
+      <span class="no" aria-hidden="true">№ 72</span>
       <div>
         <h3><a href="https://github.com/omdsh-dev/dsh-plugin-check" rel="noopener" translate="no">dsh-plugin-check</a><span class="by" translate="no">omdsh-dev</span></h3>
         <p>插件健康检查：扫描清单协议/patch 格式/构建陷阱，零依赖只读。</p>
@@ -871,7 +880,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="dev" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 72</span>
+      <span class="no" aria-hidden="true">№ 73</span>
       <div>
         <h3><a href="https://github.com/omdsh-dev/dsh-security-audit" rel="noopener" translate="no">dsh-security-audit</a><span class="by" translate="no">omdsh-dev</span></h3>
         <p>本机安全审计：配置/插件来源/会话/网络暴露面，只读脱敏风险报告。</p>
@@ -880,7 +889,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="dev" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 73</span>
+      <span class="no" aria-hidden="true">№ 74</span>
       <div>
         <h3><a href="https://github.com/omdsh-dev/dsh-session-health" rel="noopener" translate="no">dsh-session-health</a><span class="by" translate="no">omdsh-dev</span></h3>
         <p>会话文件帧级扫描诊断（torn/损坏/空会话检测）。</p>
@@ -889,7 +898,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="dev" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 74</span>
+      <span class="no" aria-hidden="true">№ 75</span>
       <div>
         <h3><a href="https://github.com/william-jin-cmu/dsh-evolve" rel="noopener" translate="no">dsh-evolve</a><span class="by" translate="no">william-jin-cmu</span></h3>
         <p>自进化：agent 在会话内给自己热挂载/卸载持久化插件。</p>
@@ -898,7 +907,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="dev" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 75</span>
+      <span class="no" aria-hidden="true">№ 76</span>
       <div>
         <h3><a href="https://github.com/vibeinging/dsh-trace" rel="noopener" translate="no">dsh-trace</a><span class="by" translate="no">vibeinging</span></h3>
         <p>遥测后端：把 turns、model steps、tool calls 导出到 yiTrace。</p>
@@ -907,7 +916,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="dev" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 76</span>
+      <span class="no" aria-hidden="true">№ 77</span>
       <div>
         <h3><a href="https://github.com/omdsh-dev/sandbox-micro" rel="noopener" translate="no">sandbox-micro</a><span class="by" translate="no">omdsh-dev</span></h3>
         <p>microsandbox 沙箱支持。</p>
@@ -916,7 +925,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="dev" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 77</span>
+      <span class="no" aria-hidden="true">№ 78</span>
       <div>
         <h3><a href="https://github.com/omdsh-dev/sandbox-mxc" rel="noopener" translate="no">sandbox-mxc</a><span class="by" translate="no">omdsh-dev</span></h3>
         <p>微软跨平台沙盒支持。</p>
@@ -925,7 +934,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="dev" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 78</span>
+      <span class="no" aria-hidden="true">№ 79</span>
       <div>
         <h3><a href="https://github.com/omdsh-dev/sandbox-nono" rel="noopener" translate="no">sandbox-nono</a><span class="by" translate="no">omdsh-dev</span></h3>
         <p>nono 沙盒支持。</p>
@@ -934,7 +943,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="dev" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 79</span>
+      <span class="no" aria-hidden="true">№ 80</span>
       <div>
         <h3><a href="https://github.com/vibeinging/dsh-agent-budget" rel="noopener" translate="no">dsh-agent-budget</a><span class="by" translate="no">vibeinging</span></h3>
         <p>agent 树 token 预算管理。</p>
@@ -943,7 +952,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="dev" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 80</span>
+      <span class="no" aria-hidden="true">№ 81</span>
       <div>
         <h3><a href="https://github.com/btspoony/dsh-llm-fallbacks" rel="noopener" translate="no">dsh-llm-fallbacks</a><span class="by" translate="no">btspoony</span></h3>
         <p>基于角色的模型重试与备用策略。</p>
@@ -952,7 +961,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="dev" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 81</span>
+      <span class="no" aria-hidden="true">№ 82</span>
       <div>
         <h3><a href="https://github.com/ilharp/dsh-tool-approval" rel="noopener" translate="no">dsh-tool-approval</a><span class="by" translate="no">ilharp</span></h3>
         <p>手动审批模式（Manual/Ask Mode）。</p>
@@ -961,7 +970,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="dev" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 82</span>
+      <span class="no" aria-hidden="true">№ 83</span>
       <div>
         <h3><a href="https://github.com/omdsh-dev/plugin-template" rel="noopener" translate="no">plugin-template</a><span class="by" translate="no">omdsh-dev</span></h3>
         <p>插件模板仓库（基于 turtle-ui 官方仓库）。</p>
@@ -970,7 +979,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="dev" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 83</span>
+      <span class="no" aria-hidden="true">№ 84</span>
       <div>
         <h3><a href="https://github.com/omdsh-dev/Qwen-MM-Plugins" rel="noopener" translate="no">Qwen-MM-Plugins</a><span class="by" translate="no">omdsh-dev</span></h3>
         <p>Qwen 多模态插件支持。</p>
@@ -979,7 +988,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="dev" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 84</span>
+      <span class="no" aria-hidden="true">№ 85</span>
       <div>
         <h3><a href="https://github.com/Small-tailqwq/dsh-tps" rel="noopener" translate="no">dsh-tps</a><span class="by" translate="no">Small-tailqwq</span></h3>
         <p>TPS 指标插件。</p>
@@ -990,7 +999,7 @@ footer a{color:var(--text-2)}
     <li class="sec" data-sec="fun"><h2 id="fun">🎮 娱乐 <small>11</small></h2></li>
 
     <li class="item" data-cat="fun" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 85</span>
+      <span class="no" aria-hidden="true">№ 86</span>
       <div>
         <h3><a href="https://github.com/Nagi-ovo/dsh-ads" rel="noopener" translate="no">dsh-ads</a><span class="by" translate="no">Nagi-ovo</span></h3>
         <p>2005 年中文站点风格的整活广告插件：侧栏广告/信息流/角落弹窗 + 假关闭叉，素材全虚构。</p>
@@ -999,7 +1008,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="fun" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 86</span>
+      <span class="no" aria-hidden="true">№ 87</span>
       <div>
         <h3><a href="https://github.com/omdsh-dev/dsh-gomoku" rel="noopener" translate="no">dsh-gomoku</a><span class="by" translate="no">omdsh-dev</span></h3>
         <p>与 AI 下五子棋，也可让 AI 对局比棋力。</p>
@@ -1008,7 +1017,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="fun" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 87</span>
+      <span class="no" aria-hidden="true">№ 88</span>
       <div>
         <h3><a href="https://github.com/AnacondaKC/dsh-stock-market" rel="noopener" translate="no">dsh-stock-market</a><span class="by" translate="no">AnacondaKC</span></h3>
         <p>有效解决了写代码的时候账户不能同时亏钱的 BUG。</p>
@@ -1017,7 +1026,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="fun" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 88</span>
+      <span class="no" aria-hidden="true">№ 89</span>
       <div>
         <h3><a href="https://github.com/hellodigua/dsh-emoji" rel="noopener" translate="no">dsh-emoji</a><span class="by" translate="no">hellodigua</span></h3>
         <p>为 AI 回复自动添加表情。</p>
@@ -1026,7 +1035,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="fun" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 89</span>
+      <span class="no" aria-hidden="true">№ 90</span>
       <div>
         <h3><a href="https://github.com/lhh010/dsh-minigames" rel="noopener" translate="no">dsh-minigames</a><span class="by" translate="no">lhh010</span></h3>
         <p>右侧小游戏面板：18 款离线小游戏，等模型回复时的摸鱼神器。</p>
@@ -1035,7 +1044,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="fun" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 90</span>
+      <span class="no" aria-hidden="true">№ 91</span>
       <div>
         <h3><a href="https://github.com/william-jin-cmu/dsh-stickers" rel="noopener" translate="no">dsh-stickers</a><span class="by" translate="no">william-jin-cmu</span></h3>
         <p>用户与 agent 双向表情贴纸互动。</p>
@@ -1044,7 +1053,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="fun" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 91</span>
+      <span class="no" aria-hidden="true">№ 92</span>
       <div>
         <h3><a href="https://github.com/vlln/whale-girl" rel="noopener" translate="no">whale-girl</a><span class="by" translate="no">vlln</span></h3>
         <p>桌面宠物（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍。</p>
@@ -1053,7 +1062,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="fun" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 92</span>
+      <span class="no" aria-hidden="true">№ 93</span>
       <div>
         <h3><a href="https://github.com/Moeblack/deepseek-manners" rel="noopener" translate="no">deepseek-manners</a><span class="by" translate="no">Moeblack</span></h3>
         <p>给每次消息后注入感谢语，做个有礼貌的人。</p>
@@ -1062,7 +1071,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="fun" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 93</span>
+      <span class="no" aria-hidden="true">№ 94</span>
       <div>
         <h3><a href="https://github.com/HuanLinOTO/dsh-plugin-d399" rel="noopener" translate="no">dsh-plugin-d399</a><span class="by" translate="no">HuanLinOTO</span></h3>
         <p>模型生成时弹出小游戏菜单（wordle/消消乐，可扩展）。</p>
@@ -1071,7 +1080,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="fun" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 94</span>
+      <span class="no" aria-hidden="true">№ 95</span>
       <div>
         <h3><a href="https://github.com/omdsh-dev/dsh-auto-chess" rel="noopener" translate="no">dsh-auto-chess</a><span class="by" translate="no">omdsh-dev</span></h3>
         <p>自走棋：人机对战或双 AI 对弈。</p>
@@ -1080,7 +1089,7 @@ footer a{color:var(--text-2)}
     </li>
 
     <li class="item" data-cat="fun" style="animation-delay:0.40s">
-      <span class="no" aria-hidden="true">№ 95</span>
+      <span class="no" aria-hidden="true">№ 96</span>
       <div>
         <h3><a href="https://github.com/AnacondaKC/dsh-douyin" rel="noopener" translate="no">dsh-douyin</a><span class="by" translate="no">AnacondaKC</span></h3>
         <p>侧栏短视频：原生播放器、系列导航、精确历史回放。</p>

--- a/docs/zh/index.html
+++ b/docs/zh/index.html
@@ -452,7 +452,7 @@ footer a{color:var(--text-2)}
       <span class="no" aria-hidden="true">№ 26</span>
       <div>
         <h3><a href="https://github.com/nowledge-co/nowledge-mem-deepseek-harness" rel="noopener" translate="no">nowledge-mem-deepseek-harness</a><span class="by" translate="no">nowledge-co</span></h3>
-        <p>Nowledge Mem 集成：注入 Context Bundle、提示时记忆检索、MCP 工具与回合结束 DSH 线程捕获。</p>
+        <p>给所有 AI 工具和 Agent 共用的一层记忆：注入 Context Bundle、提示时检索、MCP 工具与回合结束 DSH 线程捕获。</p>
       </div>
       <button class="copy" type="button" data-cmd="dsh plugin --profile web add github:nowledge-co/nowledge-mem-deepseek-harness" aria-label="复制安装命令">复制安装命令</button>
     </li>


### PR DESCRIPTION
Adds the Nowledge Mem community plugin bundle for DeepSeek Harness to the Sessions & Messages section.

Nowledge Mem is a powerful memory layer for AI work: one memory system across AI tools and agents. The DSH bundle brings that into DeepSeek Harness with Context Bundle injection, prompt-time recall, Mem MCP tools, and turn-end DSH thread capture. The plugin repo is tagged `dsh-plugin` and declares a `dsh.bundle` manifest.

Updated:
- `README.md`
- `README.zh.md`
- generated `docs/index.html`
- generated `docs/zh/index.html`

Validation:
- `node scripts/build-site.mjs` -> `96 entries parsed`; `site built: 96 rows × 2 locales + sitemap, README counts synced`
- `git diff --check` -> passed