### PR TITLE
Add dsh-cowork — doc_read/doc_write for office documents & notebooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ English | [中文](README.zh.md)
 - [dsh-tool-time](https://github.com/omdsh-dev/dsh-tool-time) — Strict ISO 8601 parsing, IANA timezone conversion, and UTC calendar arithmetic.
 - [dsh-kb-sieve](https://github.com/omdsh-dev/dsh-kb-sieve) — Build auditable KB packs (SQLite FTS5) from md/txt/docx/pdf with deterministic retrieval and original-text reading.
 - [dsh-plugin-mineru](https://github.com/HuanLinOTO/dsh-plugin-mineru) — Expose MineRU document parsing tools to the model.
+- [dsh-cowork](https://github.com/Jesse-njx/dsh-cowork) — doc_read/doc_write: bounded, cell-addressed reading and editing of xlsx / pdf / docx / pptx / ipynb, plus an MCP server and CLI.
 - [dsh-tool-search](https://github.com/vibeinging/dsh-tool-search) — Per-agent on-demand tool discovery and progressive schema disclosure.
 - [dsh-openmaic](https://github.com/THU-MAIC/dsh-openmaic) — OpenMAIC: classrooms, slides, interactive widgets, and Socratic teaching.
 - [dsh-scholar](https://github.com/lzszq/dsh-scholar) — Academic assistant plugin.

--- a/README.zh.md
+++ b/README.zh.md
@@ -71,6 +71,7 @@
 - [dsh-tool-time](https://github.com/omdsh-dev/dsh-tool-time) — 严格 ISO 8601 解析、IANA 时区转换、UTC 日历运算。
 - [dsh-kb-sieve](https://github.com/omdsh-dev/dsh-kb-sieve) — 从 md/txt/docx/pdf 构建可审计知识库包（SQLite FTS5），确定性检索与原文阅读。
 - [dsh-plugin-mineru](https://github.com/HuanLinOTO/dsh-plugin-mineru) — 向模型暴露 MineRU 文档解析工具。
+- [dsh-cowork](https://github.com/Jesse-njx/dsh-cowork) — doc_read/doc_write：以有界、单元格寻址的方式读写 xlsx / pdf / docx / pptx / ipynb，另附 MCP 服务器与 CLI。
 - [dsh-tool-search](https://github.com/vibeinging/dsh-tool-search) — 按 agent 的按需工具发现与渐进式 schema 披露。
 - [dsh-openmaic](https://github.com/THU-MAIC/dsh-openmaic) — OpenMAIC 教学：课堂、幻灯片、交互组件与苏格拉底式教学。
 - [dsh-scholar](https://github.com/lzszq/dsh-scholar) — 学术助手插件。


### PR DESCRIPTION
Adds [dsh-cowork](https://github.com/Jesse-njx/dsh-cowork) under 🛠️ Tools & Capabilities in both README.md and README.zh.md.

dsh-cowork is a `dsh-plugin`-topic repo: a DeepSeek Harness bundle providing `doc_read` / `doc_write` tools for xlsx / pdf / docx / pptx / ipynb (bounded, cell-addressed windows; zip-bomb/macro safety; guarded atomic writes), plus an MCP server and CLI.