### PR TITLE
Add dsh-apple-mode: Xcode AI integration for DSH

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ English | [中文](README.zh.md)
 - [dsh-openmaic](https://github.com/THU-MAIC/dsh-openmaic) - OpenMAIC: classrooms, slides, interactive widgets, and Socratic teaching.
 - [dsh-scholar](https://github.com/lzszq/dsh-scholar) - Academic assistant plugin.
 
+- [dsh-apple-mode](https://github.com/jihongboo/dsh-apple-mode) - Xcode AI integration for DSH: 26 Xcode MCP tools (mcpbridge) + Apple platform skills + Xcode Intelligence-style persona (agent preset or global bundle).
 ## Workflow & Automation
 
 - [dsh_workflow](https://github.com/icetomoyo/dsh_workflow) - UltraCode-style multi-agent orchestration: a generatable, savable, governable, observable, resumable workflow layer.

--- a/README.zh.md
+++ b/README.zh.md
@@ -77,6 +77,7 @@
 - [dsh-openmaic](https://github.com/THU-MAIC/dsh-openmaic) — OpenMAIC 教学：课堂、幻灯片、交互组件与苏格拉底式教学。
 - [dsh-scholar](https://github.com/lzszq/dsh-scholar) — 学术助手插件。
 
+- [dsh-apple-mode](https://github.com/jihongboo/dsh-apple-mode) — DSH 的 Xcode AI 集成：26 个 Xcode MCP 工具（mcpbridge）+ Apple 平台技能 + Xcode Intelligence 风格 persona（agent preset 或全局 bundle）。
 ## 🔁 工作流与自动化
 
 - [dsh_workflow](https://github.com/icetomoyo/dsh_workflow) — 把 UltraCode 式多 Agent 调度带给 DSH：可生成、可保存、可治理、可观察、可恢复的 Workflow 层。


### PR DESCRIPTION
Adds [dsh-apple-mode](https://github.com/jihongboo/dsh-apple-mode) under **Tools & Capabilities**.

It provides Xcode AI integration for DeepSeek Harness: 26 Xcode MCP tools (Apple's `mcpbridge`) plus Apple platform skills and an Xcode Intelligence-style persona, delivered as an agent preset (`./install.sh`) and/or a global MCP bundle.

Requirements met:
- Declares `dsh.bundle` manifest in `package.json` (installable via `dsh plugin --profile web add "github:jihongboo/dsh-apple-mode"`).
- `dsh-plugin` topic added to the repository.
- Description states function only, no superlatives.
