### PR TITLE
Add deepseek-harness-tui

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ This list collects community plugins that are installable via `dsh plugin add` (
 ### UI Enhancements
 
 - [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) - A terminal UI (TUI) for DeepSeek Harness.
+- [deepseek-harness-tui](https://github.com/openma-ai/deepseek-harness-tui) - A Rust/ratatui terminal client that speaks the DSH SDK JSON-RPC protocol directly and runs standalone or as a profile bundle.
 - [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) - Codex-style `@file` mentions: search workspace files in the composer and attach their contents to prompts.
 - [ui-status-label](https://github.com/alingalingling/ui-status-label) - Customize the "deep diving" thinking status label to anything you like.
 - [dsh-openpencil](https://github.com/ZSeven-W/dsh-openpencil) - OpenPencil design preview and editing plugin.

--- a/README.zh.md
+++ b/README.zh.md
@@ -30,6 +30,7 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 ### 🎨 UI 增强
 
 - [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) — DeepSeek Harness 的终端 UI（TUI）。
+- [deepseek-harness-tui](https://github.com/openma-ai/deepseek-harness-tui) — Rust/ratatui 终端客户端，直接使用 DSH SDK JSON-RPC 协议，支持独立运行或作为 profile bundle 加载。
 - [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) — Codex 风格的 `@file` 文件引用，输入框里直接搜索并引用工作区文件。
 - [ui-status-label](https://github.com/alingalingling/ui-status-label) — 把鲸鱼娘思考时的 "deep diving" 状态文案自定义成任意你想要的样子。
 - [dsh-openpencil](https://github.com/ZSeven-W/dsh-openpencil) — OpenPencil 设计预览与编辑插件。


### PR DESCRIPTION
## What changed

Adds `openma-ai/deepseek-harness-tui` to the English and Chinese **UI Enhancements** sections.

## Why

The project is a Rust/ratatui terminal client that consumes the DeepSeek Harness SDK JSON-RPC protocol directly. It runs standalone or as an installable `dsh` profile bundle.

## User impact

Readers can discover another terminal-native DSH interface with streamed reasoning, tool events, subagent activity, and durable sessions.

## Checks

- Confirmed `npm/package.json` declares `dsh.bundle.patch`.
- Confirmed the repository carries the `dsh-plugin` topic.
- Updated both language versions.
- `git diff --check` passes.
