### PR TITLE
Add dsh-balance-meter to UI Enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ This list collects community plugins that are installable via `dsh plugin add` (
 - [web-components](https://github.com/omdsh-dev/web-components) - Web Components support.
 - [dsh-turn-navigator](https://github.com/vibeinging/dsh-turn-navigator) - Turn navigation for the DSH Web UI.
 - [dsh-milestone](https://github.com/SnowCrescenter-tech/dsh-milestone) - Right-side dot-timeline rail: jump between user messages.
+- [dsh-balance-meter](https://github.com/Ghost011118/dsh-balance-meter) - DeepSeek account balance and session cost in the composer dock, with auto-fetched official pricing and peak/off-peak support.
 
 ### Sessions & Messages
 


### PR DESCRIPTION
Adds dsh-balance-meter to the UI Enhancements section.

dsh-balance-meter shows the live DeepSeek account balance and current session cost in the DSH Web composer dock, with auto-fetched official pricing (refreshed every 6h) and peak/off-peak hour support. Install via `dsh plugin --profile web add dsh-balance-meter` (npm) or from the GitHub repo. npm: dsh-balance-meter@0.1.0