### PR TITLE
add: dsh-continual-evolve (Tools)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ This list collects community plugins that are installable via `dsh plugin add` (
 - [dsh-openmaic](https://github.com/THU-MAIC/dsh-openmaic) - OpenMAIC: classrooms, slides, interactive widgets, and Socratic teaching.
 - [dsh-scholar](https://github.com/lzszq/dsh-scholar) - Academic assistant plugin.
 - [dsh-apple-mode](https://github.com/jihongboo/dsh-apple-mode) - Xcode AI integration for DSH: 26 Xcode MCP tools (mcpbridge) + Apple platform skills + Xcode Intelligence-style persona (agent preset or global bundle).
+- [dsh-continual-evolve](https://github.com/ZK-Andy/dsh-continual-evolve) - Continual self-evolution: versioned, auditable, rollback-safe harness state (prompts, memory, skills, subagent specs) refined from session trajectories, with review gates and hot-reloaded skills.
+
 
 ### Workflow & Automation
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -93,6 +93,8 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 - [dsh-openmaic](https://github.com/THU-MAIC/dsh-openmaic) — OpenMAIC 教学：课堂、幻灯片、交互组件与苏格拉底式教学。
 - [dsh-scholar](https://github.com/lzszq/dsh-scholar) — 学术助手插件。
 - [dsh-apple-mode](https://github.com/jihongboo/dsh-apple-mode) — DSH 的 Xcode AI 集成：26 个 Xcode MCP 工具（mcpbridge）+ Apple 平台技能 + Xcode Intelligence 风格 persona（agent preset 或全局 bundle）。
+- [dsh-continual-evolve](https://github.com/ZK-Andy/dsh-continual-evolve) — 持续自进化：从会话轨迹沉淀版本化、可审计、可回滚的 harness 状态（提示词/记忆/技能/子代理规格），带审查门禁与技能热加载。
+
 
 ### 🔁 工作流与自动化
 


### PR DESCRIPTION
Add [ZK-Andy/dsh-continual-evolve](https://github.com/ZK-Andy/dsh-continual-evolve) to the Tools section.

**dsh-continual-evolve** — Continual self-evolution plugin for DeepSeek Harness:
- Versioned, auditable, rollback-safe harness state (prompt notes / memories / skills / subagent specs) refined from session trajectories
- Deterministic inverse-op rollback; code-enforced validation, atomic persistence, optimistic concurrency
- Auto-review gate (turn-interval + compaction checkpoints) with a durable `reviews.jsonl` audit trail
- Cross-session edits gated by explicit human approval
- Skill entries materialize to `$DSH_HOME/skills/` (hot-reloaded)
- Benchmark-driven validation loop: evaluation matrix, code-owned scoreboard, non-regressive acceptance rule

Verified installable: declares `dsh.bundle` manifest + `dsh-plugin` topic; 62 tests; MIT.