### PR TITLE
docs: add dsh-fail-logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ This list collects community plugins that are installable via `dsh plugin add` (
 - [plugin-template](https://github.com/omdsh-dev/plugin-template) - Plugin template repo (based on the official turtle-ui repo).
 - [Qwen-MM-Plugins](https://github.com/omdsh-dev/Qwen-MM-Plugins) - Qwen multi-modal plugin support.
 - [dsh-tps](https://github.com/Small-tailqwq/dsh-tps) - A TPS metrics plugin.
+- [dsh-fail-logger](https://github.com/Areium/dsh-fail-logger) - Auto-log failed tool calls across native tools, PTC run_code, and inline invocations: dedup and count root causes into a skill so repeated mistakes fade.
+
 
 ### Just for Fun
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -141,6 +141,8 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 - [plugin-template](https://github.com/omdsh-dev/plugin-template) — 插件模板仓库（基于 turtle-ui 官方仓库）。
 - [Qwen-MM-Plugins](https://github.com/omdsh-dev/Qwen-MM-Plugins) — Qwen 多模态插件支持。
 - [dsh-tps](https://github.com/Small-tailqwq/dsh-tps) — TPS 指标插件。
+- [dsh-fail-logger](https://github.com/Areium/dsh-fail-logger) — 全模式调用工具失败自动实录：把原生工具 / PTC run_code / 代码内嵌工具调用的失败错因去重计数后写入 skill，越用越少错。
+
 
 ### 🎮 娱乐
 


### PR DESCRIPTION
Add dsh-fail-logger: an all-mode tool failure recorder for DeepSeek Harness.

- npm: https://www.npmjs.com/package/dsh-fail-logger (v0.4.1)
- Install: dsh plugin --profile web add dsh-fail-logger
- 14 test suites + dual-platform CI (Ubuntu/Windows)
- Distinct from distill/dsh-skillport (proactive skill generation) and dsh-trace (external telemetry): this one passively records failures into a local skill for self-healing.