### PR TITLE
docs: add dsh-recommend to tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ This list collects community plugins that are installable via `dsh plugin add` (
 - [dsh-scholar](https://github.com/lzszq/dsh-scholar) - Academic assistant plugin.
 - [dsh-apple-mode](https://github.com/jihongboo/dsh-apple-mode) - Xcode AI integration for DSH: 26 Xcode MCP tools (mcpbridge) + Apple platform skills + Xcode Intelligence-style persona (agent preset or global bundle).
 - [dsh-continual-evolve](https://github.com/ZK-Andy/dsh-continual-evolve) - Continual self-evolution: versioned, auditable, rollback-safe harness state (prompts, memory, skills, subagent specs) refined from session trajectories, with review gates and hot-reloaded skills.
+- [dsh-recommend](https://github.com/zp-home/dsh-recommend) - Transparent rankings and recommendations for the DSH plugin ecosystem: daily auto-fetched topic data, an open scoring model, and rank/search/recommend tools with a settings-page leaderboard.
 
 
 ### Workflow & Automation

--- a/README.zh.md
+++ b/README.zh.md
@@ -94,6 +94,7 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 - [dsh-scholar](https://github.com/lzszq/dsh-scholar) — 学术助手插件。
 - [dsh-apple-mode](https://github.com/jihongboo/dsh-apple-mode) — DSH 的 Xcode AI 集成：26 个 Xcode MCP 工具（mcpbridge）+ Apple 平台技能 + Xcode Intelligence 风格 persona（agent preset 或全局 bundle）。
 - [dsh-continual-evolve](https://github.com/ZK-Andy/dsh-continual-evolve) — 持续自进化：从会话轨迹沉淀版本化、可审计、可回滚的 harness 状态（提示词/记忆/技能/子代理规格），带审查门禁与技能热加载。
+- [dsh-recommend](https://github.com/zp-home/dsh-recommend) — DSH 插件透明排行与推荐：每日自动抓取 `dsh-plugin` 话题生态，公开评分模型，提供 rank/search/recommend 工具与设置页榜单。
 
 
 ### 🔁 工作流与自动化


### PR DESCRIPTION
Add [dsh-recommend](https://github.com/zp-home/dsh-recommend) — transparent plugin rankings & recommendations for the DSH ecosystem: open scoring model, daily auto-fetched `dsh-plugin` topic data, rank/search/recommend tools and a settings-page leaderboard. Declares `dsh.bundle` and carries the `dsh-plugin` topic. Both READMEs updated under the tools category.