### PR TITLE
Add dsh-im-bridge（微信/iLink 双向桥）

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ This list collects community plugins that are installable via `dsh plugin add` (
 - [dsh-session-notification](https://github.com/dingyi222666/dsh-session-notification) - Notifications for four session states, with browser alerts and prompts.
 - [dsh-web-ui-notify](https://github.com/bill9109/dsh-web-ui-notify) - Desktop notification reminders.
 - [dsh-webbridge](https://github.com/bill9109/dsh-webbridge) - DSH meets Kimi WebBridge.
+- [dsh-im-bridge](https://github.com/BiBoyang/dsh-im-bridge) - Two-way WeChat (iLink) bridge: turn-end and approval-request push, in-chat approve/reject and message injection, persistent dedup and convergent long-reply chunking; channel layer extensible to other IMs.
+
 
 ### Development & Runtime
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -121,6 +121,8 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 - [dsh-session-notification](https://github.com/dingyi222666/dsh-session-notification) — 会话完成等四种状态的通知响应，支持浏览器提示。
 - [dsh-web-ui-notify](https://github.com/bill9109/dsh-web-ui-notify) — 桌面通知提醒。
 - [dsh-webbridge](https://github.com/bill9109/dsh-webbridge) — DSH 结合 Kimi WebBridge。
+- [dsh-im-bridge](https://github.com/BiBoyang/dsh-im-bridge) — 微信（iLink）双向桥：turn 完成/批准请求推送、聊天内批准与消息注入、持久去重与长回复收敛分段；通道层为多 IM 预留。
+
 
 ### 🧑‍💻 开发与运行时
 


### PR DESCRIPTION
收录 [dsh-im-bridge](https://github.com/BiBoyang/dsh-im-bridge)：DSH 的微信（iLink）双向桥插件。

- `package.json` 已声明 `dsh.bundle` manifest（`dsh plugin add github:BiBoyang/dsh-im-bridge` 可安装）
- 功能：turn 完成/批准请求推送到微信；微信内回复「批准/拒绝」应答 `approval/request`；文本注入绑定会话；iLink 扫码登录、持久去重、1200 码点收敛分段、`..`/`!!`/超时合并窗口
- 已在真实 web 会话端到端验证（approval 推送 → 微信批准 → 任务继续）
- 描述遵循「只说功能」要求，中英各一行，放在通知分类下

注：我这边没有给仓库加 topic 的 API 权限，`dsh-plugin` topic 我会随后在仓库设置里手动补上。