### PR TITLE
Add dsh-eval-harness (Development Helpers / 开发与运行时)

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ This list collects community plugins that are installable via `dsh plugin add` (
 - [Qwen-MM-Plugins](https://github.com/omdsh-dev/Qwen-MM-Plugins) - Qwen multi-modal plugin support.
 - [dsh-tps](https://github.com/Small-tailqwq/dsh-tps) - A TPS metrics plugin.
 - [dsh-fail-logger](https://github.com/Areium/dsh-fail-logger) - Auto-log failed tool calls across native tools, PTC run_code, and inline invocations: dedup and count root causes into a skill so repeated mistakes fade.
+- [dsh-eval-harness](https://github.com/BiBoyang/dsh-eval-harness) - Evaluation harness for DSH plugins: YAML cases drive real headless agent runs, assert on tool calls, args, results and token usage, with a baseline gate for CI regression.
 
 
 ### Just for Fun

--- a/README.zh.md
+++ b/README.zh.md
@@ -145,6 +145,7 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 - [Qwen-MM-Plugins](https://github.com/omdsh-dev/Qwen-MM-Plugins) — Qwen 多模态插件支持。
 - [dsh-tps](https://github.com/Small-tailqwq/dsh-tps) — TPS 指标插件。
 - [dsh-fail-logger](https://github.com/Areium/dsh-fail-logger) — 全模式调用工具失败自动实录：把原生工具 / PTC run_code / 代码内嵌工具调用的失败错因去重计数后写入 skill，越用越少错。
+- [dsh-eval-harness](https://github.com/BiBoyang/dsh-eval-harness) — DSH 插件评测框架：YAML 用例驱动真实 headless agent，断言工具调用/参数/返回与 token 用量，baseline 门禁做 CI 回归。
 
 
 ### 🎮 娱乐


### PR DESCRIPTION
Adds [dsh-eval-harness](https://github.com/BiBoyang/dsh-eval-harness) to both README files.

- `README.md` → 开发辅助 / Development Helpers
- `README.zh.md` → 🧑‍💻 开发与运行时

**dsh-eval-harness** — Evaluation harness for DSH plugins: YAML cases drive real headless agent runs, assert on tool calls/args/results and token usage, baseline gate for CI regression.

Requirements:
- [x] declares a `dsh.bundle` manifest in `package.json`
- [x] repo has the `dsh-plugin` topic
