### PR TITLE
docs: register dsh-bash-terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ This list collects community plugins that are installable via `dsh plugin add` (
 
 ### Tools & Capabilities
 
+- [dsh-bash-terminal](https://github.com/MAXeaglet/dsh-bash-terminal) - One shell tool for PowerShell / Git Bash / WSL on Windows plus an interactive PTY terminal; the default terminal is chosen by the user in DSH settings.
 - [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) - Vision tasks for text-only models: intent-aware image Q&A, long-screenshot OCR, UI reproduction, grounding, and pixel diff.
 - [dsh-custom-tool](https://github.com/omdsh-dev/dsh-custom-tool) - Create and manage sandboxed JavaScript tools with a Monaco editor and model-driven tool lifecycle.
 - [dsh-computer-use](https://github.com/Anionex/dsh-computer-use) - Accessibility-first macOS computer use: fresh observations, stale-state rejection, scoped permissions, and safe input.

--- a/README.zh.md
+++ b/README.zh.md
@@ -76,6 +76,7 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 
 ### 🛠️ 工具与能力
 
+- [dsh-bash-terminal](https://github.com/MAXeaglet/dsh-bash-terminal) — 一个 shell 工具：Windows 上统一执行 PowerShell / Git Bash / WSL，外加交互式 PTY 终端，默认终端由用户在设置中选择。
 - [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) — 让纯文本模型更好地做视觉任务：带意图的图片问答、长截图 OCR、UI 还原等。
 - [dsh-custom-tool](https://github.com/omdsh-dev/dsh-custom-tool) — 用 Monaco 编辑器创建和管理沙箱化的自定义 JavaScript 工具。
 - [dsh-computer-use](https://github.com/Anionex/dsh-computer-use) — macOS 电脑控制：Accessibility 观测、过期状态拒绝、作用域权限与安全输入。


### PR DESCRIPTION
## What

Registers [dsh-bash-terminal](https://github.com/MAXeaglet/dsh-bash-terminal) under Tools & Capabilities in both README.md and README.zh.md.

## Why

A Windows multi-terminal plugin: one shell tool running PowerShell / Git Bash / WSL (the default terminal is chosen by the user in DSH settings — the AI cannot override), plus an interactive PTY 	erminal tool (official ctx.subprocess.spawnTerminal / node-pty), official sandbox integration, and a native settings row. Installable via dsh plugin add dsh-bash-terminal (ships dsh.bundle + dsh.client manifests; peerDependencies complete; 4 test suites + GitHub Actions CI green).

## Line added (EN)

- [dsh-bash-terminal](https://github.com/MAXeaglet/dsh-bash-terminal) - One shell tool for PowerShell / Git Bash / WSL on Windows plus an interactive PTY terminal; the default terminal is chosen by the user in DSH settings.

Repo already carries the dsh-plugin topic.