### PR TITLE
Add dsh-excel-vera-plugin (VERA)

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ This list collects community plugins that are installable via `dsh plugin add` (
 - [dsh-subagent-cwd](https://github.com/lynx-gt/dsh-subagent-cwd) - dsh-subagent-tools plus a per-call cwd for subagents, shipped with the two in-process provider patches it requires.
 - [dsh-voice](https://github.com/Jesse-njx/dsh-voice) - Voice notes in, spoken answers out: dictate audio that becomes user messages (transcribe), have the agent read replies aloud (speak), local-first under ~/.dsh/voice.
 - [dsh-docker](https://github.com/Jesse-njx/dsh-docker) - Typed, guarded container control: ps/logs/inspect/exec/start/stop and compose up/down with JSON output, project-aware targeting, and approval-gated destructive ops.
+- [dsh-excel-vera-plugin](https://github.com/hccccc01333/dsh-excel-vera-plugin) - Detect and repair silent Excel formula errors: pattern validation, semantic Formula IR compilation, deterministic and LLM repair, oracle scoring, and chart validation.
 
 
 ### Workflow & Automation

--- a/README.zh.md
+++ b/README.zh.md
@@ -111,6 +111,7 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 - [dsh-subagent-cwd](https://github.com/lynx-gt/dsh-subagent-cwd) — 在 dsh-subagent-tools 基础上增加子代理按调用 cwd，附带所需的两个 in-process provider 补丁。
 - [dsh-voice](https://github.com/Jesse-njx/dsh-voice) — 语音输入、语音输出：把口述音频转写为用户消息（transcribe），让 agent 朗读回复（speak），本地优先，音频存于 ~/.dsh/voice。
 - [dsh-docker](https://github.com/Jesse-njx/dsh-docker) — 类型安全、带护栏的容器控制：ps/logs/inspect/exec/start/stop 与 compose up/down，JSON 输出、项目感知定位、破坏性操作需审批。
+- [dsh-excel-vera-plugin](https://github.com/hccccc01333/dsh-excel-vera-plugin) — 检测并修复 Excel 公式静默错误：列 pattern 校验、语义 Formula IR 编译、确定性 + LLM 修复、oracle 判分与图表校验。
 
 
 ### 🔁 工作流与自动化


### PR DESCRIPTION
Adds [dsh-excel-vera-plugin](https://github.com/hccccc01333/dsh-excel-vera-plugin) to Tools & Capabilities in README.md and README.zh.md.

VERA is a verified Excel reasoning agent for DSH:

- Silent-error detection for Excel formulas: per-column reference-pattern anomalies, structure mismatches, hardcoded values in formula columns, empty gaps, and circular references.
- Semantic Formula IR (binary / ratio / aggregate) compiled to deterministic Excel formulas.
- Deterministic repair (reference offsets, range endpoints, empty-gap fill) plus optional LLM repair via DeepSeek, with auto table-header detection.
- Oracle scoring against ground-truth workbooks and a Pass@1 benchmark (11/11 with real DeepSeek, meanAccuracy 1.000; 85 unit tests).
- Chart structure and visual validation, workbook diff, and chart PNG export.

The repo declares a \dsh.bundle\ manifest, is published on npm as \dsh-excel-vera-plugin\ (0.12.0), and carries the \dsh-plugin\ topic. Per the contributing guide, only the two README lines were changed; the site rebuilds automatically.