### PR TITLE
docs: add dsh-subagent-tools and dsh-subagent-cwd

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ This list collects community plugins that are installable via `dsh plugin add` (
 - [modlens](https://github.com/liustack/modlens) - Vision bridge for text-only models: paste an image, get structured JSON evidence (OCR, layout, semantics).
 - [dsh-find-plugin](https://github.com/awesome-dsh-plugin/dsh-find-plugin) - Find plugins without leaving the agent: search this curated registry by keyword or category, with ready-to-run install commands.
 - [dsh-code-intel](https://github.com/lonelymoon87/dsh-code-intel) - Indexes workspace symbols with Tree-sitter and provides lexical or optional embedding-assisted code search.
+- [dsh-subagent-tools](https://github.com/lynx-gt/dsh-subagent-tools) - Per-call model, provider, persona, and toolFilter overrides for subagent delegation, with @preset: references and provider/model composite ids.
+- [dsh-subagent-cwd](https://github.com/lynx-gt/dsh-subagent-cwd) - dsh-subagent-tools plus a per-call cwd for subagents, shipped with the two in-process provider patches it requires.
 
 
 ### Workflow & Automation

--- a/README.zh.md
+++ b/README.zh.md
@@ -105,6 +105,8 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 - [modlens](https://github.com/liustack/modlens) — 为纯文本模型架起视觉桥梁：粘贴图片，输出结构化 JSON 证据（OCR、版面、语义）。
 - [dsh-find-plugin](https://github.com/awesome-dsh-plugin/dsh-find-plugin) — 会话内直接找插件：按关键词/分类搜索本精选 registry，返回描述与可直接执行的安装命令。
 - [dsh-code-intel](https://github.com/lonelymoon87/dsh-code-intel) — 用 Tree-sitter 建立工作区符号索引，提供词法或可选 embedding 辅助的代码检索。
+- [dsh-subagent-tools](https://github.com/lynx-gt/dsh-subagent-tools) — 子代理委派的按调用覆盖：model/provider/persona/toolFilter、@preset: 引用与 provider/model 组合 id。
+- [dsh-subagent-cwd](https://github.com/lynx-gt/dsh-subagent-cwd) — 在 dsh-subagent-tools 基础上增加子代理按调用 cwd，附带所需的两个 in-process provider 补丁。
 
 
 ### 🔁 工作流与自动化


### PR DESCRIPTION
Add two subagent-delegation enhancement bundles to Tools & Capabilities:

- [dsh-subagent-tools](https://github.com/lynx-gt/dsh-subagent-tools) - per-call model/provider/persona/toolFilter overrides, @preset: references, provider/model composite ids (bundle, no patched official files)
- [dsh-subagent-cwd](https://github.com/lynx-gt/dsh-subagent-cwd) - the above plus per-call cwd for subagents, shipped with the two in-process provider patches it requires

Both verified against stock dsh 0.1.0-rc.6 (headless + web).