### PR TITLE
Add night batch: voice, tmuxctl, docker, plugin-manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ This list collects community plugins that are installable via `dsh plugin add` (
 - [dsh-code-intel](https://github.com/lonelymoon87/dsh-code-intel) - Indexes workspace symbols with Tree-sitter and provides lexical or optional embedding-assisted code search.
 - [dsh-subagent-tools](https://github.com/lynx-gt/dsh-subagent-tools) - Per-call model, provider, persona, and toolFilter overrides for subagent delegation, with @preset: references and provider/model composite ids.
 - [dsh-subagent-cwd](https://github.com/lynx-gt/dsh-subagent-cwd) - dsh-subagent-tools plus a per-call cwd for subagents, shipped with the two in-process provider patches it requires.
+- [dsh-voice](https://github.com/Jesse-njx/dsh-voice) - Voice notes in, spoken answers out: dictate audio that becomes user messages (transcribe), have the agent read replies aloud (speak), local-first under ~/.dsh/voice.
+- [dsh-docker](https://github.com/Jesse-njx/dsh-docker) - Typed, guarded container control: ps/logs/inspect/exec/start/stop and compose up/down with JSON output, project-aware targeting, and approval-gated destructive ops.
 
 
 ### Workflow & Automation
@@ -167,6 +169,8 @@ This list collects community plugins that are installable via `dsh plugin add` (
 - [dsh-revdiff](https://github.com/BrambleXu/dsh-revdiff) - Native interactive Git diff review for DeepSeek Harness with structured annotations sent back to the current Agent session.
 - [dsh-gitflow](https://github.com/lonelymoon87/dsh-gitflow) - Adds approval-gated Git status, diff, log, commit, branch, and optional checkpoint tools.
 - [dsh-guardian](https://github.com/lonelymoon87/dsh-guardian) - Adds dangerous-operation policy checks, output redaction, and a security-review workflow.
+- [dsh-plugin-manager](https://github.com/Jesse-njx/dsh-plugin-manager) - The `dsh pm` plugin manager: multi-source search (awesome list + GitHub + npm), install/remove/update per profile, and a doctor audit of manifests, bundle patches, and version drift.
+- [dsh-tmuxctl](https://github.com/Jesse-njx/dsh-tmuxctl) - Take control of your tmux panes: list/send-keys/capture, run long jobs in a pane with watch mode, and approval-gated destructive commands.
 
 
 ### Just for Fun

--- a/README.zh.md
+++ b/README.zh.md
@@ -108,6 +108,8 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 - [dsh-code-intel](https://github.com/lonelymoon87/dsh-code-intel) — 用 Tree-sitter 建立工作区符号索引，提供词法或可选 embedding 辅助的代码检索。
 - [dsh-subagent-tools](https://github.com/lynx-gt/dsh-subagent-tools) — 子代理委派的按调用覆盖：model/provider/persona/toolFilter、@preset: 引用与 provider/model 组合 id。
 - [dsh-subagent-cwd](https://github.com/lynx-gt/dsh-subagent-cwd) — 在 dsh-subagent-tools 基础上增加子代理按调用 cwd，附带所需的两个 in-process provider 补丁。
+- [dsh-voice](https://github.com/Jesse-njx/dsh-voice) — 语音输入、语音输出：把口述音频转写为用户消息（transcribe），让 agent 朗读回复（speak），本地优先，音频存于 ~/.dsh/voice。
+- [dsh-docker](https://github.com/Jesse-njx/dsh-docker) — 类型安全、带护栏的容器控制：ps/logs/inspect/exec/start/stop 与 compose up/down，JSON 输出、项目感知定位、破坏性操作需审批。
 
 
 ### 🔁 工作流与自动化
@@ -167,6 +169,8 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 - [dsh-revdiff](https://github.com/BrambleXu/dsh-revdiff) — DeepSeek Harness 原生交互式 Git diff 审查，支持结构化批注并回传当前 Agent 会话。
 - [dsh-gitflow](https://github.com/lonelymoon87/dsh-gitflow) — 增加需要审批的 Git 状态、diff、日志、提交、分支和可选检查点工具。
 - [dsh-guardian](https://github.com/lonelymoon87/dsh-guardian) — 增加危险操作策略检查、输出脱敏和安全审查工作流。
+- [dsh-plugin-manager](https://github.com/Jesse-njx/dsh-plugin-manager) — `dsh pm` 插件管理器：多源搜索（awesome 列表 + GitHub + npm）、按 profile 安装/移除/更新，以及 doctor 审计（清单、bundle patch、版本漂移）。
+- [dsh-tmuxctl](https://github.com/Jesse-njx/dsh-tmuxctl) — 掌控你的 tmux 面板：list/send-keys/capture、在面板中运行长任务并 watch，破坏性命令需审批。
 
 
 ### 🎮 娱乐


### PR DESCRIPTION
Adds the **night batch** — four new plugins from the Jesse-njx suite:

| Plugin | Category | What it does |
|---|---|---|
| [dsh-voice](https://github.com/Jesse-njx/dsh-voice) | Tools & Capabilities | Voice notes in, spoken answers out — dictate audio that becomes user messages (transcribe), have the agent read replies aloud (speak). Local-first, audio under `~/.dsh/voice`. |
| [dsh-docker](https://github.com/Jesse-njx/dsh-docker) | Tools & Capabilities | Typed, guarded container control: ps/logs/inspect/exec/start/stop + compose up/down, JSON output, project-aware targeting, approval-gated destructive ops. |
| [dsh-plugin-manager](https://github.com/Jesse-njx/dsh-plugin-manager) | Development & Runtime | The `dsh pm` plugin manager: multi-source search (awesome list + GitHub + npm), install/remove/update per profile, doctor audit of manifests/bundle patches/version drift. |
| [dsh-tmuxctl](https://github.com/Jesse-njx/dsh-tmuxctl) | Development & Runtime | Take control of your tmux panes: list/send-keys/capture, run long jobs with watch mode, approval-gated destructive commands. |

All repos are public, carry the `dsh-plugin` topic, and declare a `dsh.bundle` manifest. Both `README.md` and `README.zh.md` updated; plugin count bumped 122 → 126.

Note: `dsh-plugin-manager` is a CLI lifecycle manager (search/install/update/doctor) — distinct from the web runtime manager published as `dsh-plugin-manager` on npm by hrhgit and from `dsh-plugins` (dsp) by MeCKodo; its differentiators are the `doctor` audit, `update` with drift checks, and multi-source discovery.
