### PR TITLE
Add dsh-sticky-disclosure (UI Enhancements)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ This list collects community plugins that are installable via `dsh plugin add` (
 - [DHS API Usage](https://github.com/Sev7een/ds-api-usage) - DeepSeek API balance and 24-hour usage dashboard in Settings, with estimated spend, token counts, request counts, and an hourly timeline.
 - [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) - Claude Code-style full-screen terminal UI: pixel-whale header, live status line, and streaming thought expansion.
 - [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) - Full sidebar workbench with file rendering and editing, terminal, Git, and subagents; third-party plugins can register new tabs.
+- [dsh-sticky-disclosure](https://github.com/Han-1413141/dsh-sticky-disclosure) - One-click collapse of every expanded section (Think rows, tool cards) with a live-count pill and a customizable hotkey.
 
 
 ### Sessions & Messages

--- a/README.zh.md
+++ b/README.zh.md
@@ -55,6 +55,7 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 - [DHS API Usage](https://github.com/Sev7een/ds-api-usage) — 在设置页展示 DeepSeek API 余额与最近 24 小时用量，包括估算消费、Token、请求次数和按小时时间线。
 - [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) — Claude Code 风格全屏终端 UI：像素鲸鱼顶栏、实时工作状态行、思考流式展开。
 - [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) — 侧边栏完整工作台：内置文件渲染编辑、终端、Git 与子代理，支持三方插件注册新 Tab。
+- [dsh-sticky-disclosure](https://github.com/Han-1413141/dsh-sticky-disclosure) — 一键收起会话中所有展开的区块（Think、工具卡等），常驻计数按钮 + 自定义快捷键。
 
 
 ### 💬 会话与消息


### PR DESCRIPTION
Adds [dsh-sticky-disclosure](https://github.com/Han-1413141/dsh-sticky-disclosure) under UI Enhancements in both README.md and README.zh.md, and bumps the plugin count to 123.

It is a dsh-installable bundle (declares \dsh.bundle\ + \dsh.client\), carries the \dsh-plugin\ topic, and ships a Playwright test suite (48 assertions) plus bilingual docs.