### PR TITLE
Add dsh-mneme cross-session memory plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ This list collects community plugins that are installable via `dsh plugin add` (
 - [dsh-share](https://github.com/hellodigua/dsh-share) - Share your conversations with one click.
 - [dsh-message-edit](https://github.com/Moeblack/dsh-message-edit) - Branch-based message editing, reroll, retry, and a version timeline.
 - [dsh-mnemon](https://github.com/omdsh-dev/dsh-mnemon) - Deep Mnemon integration: local three-tier memory (Runtime Memory, retrievable Documents, supervised Memory Spaces).
+- [dsh-mneme](https://github.com/modusensus/dsh-mneme) - Cross-session memory with memory sovereignty: SQLite + human-editable Markdown mirror, autoDream background consolidation (dedup/merge/conflict resolution), 6 memory tools, 106 tests.
 - [nowledge-mem-deepseek-harness](https://github.com/nowledge-co/nowledge-mem-deepseek-harness) - One memory layer for every AI tool and agent: Context Bundle injection, prompt-time recall, MCP tools, and turn-end DSH thread capture.
 - [dsh-memory](https://github.com/Jesse-njx/dsh-memory) - Cited memory over DSH's lossless session log: distilled facts carry `(sessionId, eventRange)` citations that expand back to the exact original log excerpt.
 - [dsh-sidechain](https://github.com/Buyi-wsgzg/dsh-sidechain) - `/side` persistent side sessions and `/btw` one-shot side questions, run in a temporary fork without touching main history.

--- a/README.zh.md
+++ b/README.zh.md
@@ -68,6 +68,7 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 - [dsh-share](https://github.com/hellodigua/dsh-share) — 一键分享你的对话。
 - [dsh-message-edit](https://github.com/Moeblack/dsh-message-edit) — 基于分支的消息编辑、reroll、重试与版本时间线。
 - [dsh-mnemon](https://github.com/omdsh-dev/dsh-mnemon) — Mnemon 深度集成：本地三层记忆（Runtime Memory、可检索 Documents、受监督 Memory Spaces）。
+- [dsh-mneme](https://github.com/modusensus/dsh-mneme) — 跨会话记忆，记忆主权归还于人：SQLite + 可人工编辑的 Markdown 镜像，autoDream 后台巩固（去重/合并/冲突裁决），6 个记忆工具，106 个测试护航。
 - [nowledge-mem-deepseek-harness](https://github.com/nowledge-co/nowledge-mem-deepseek-harness) — 给所有 AI 工具和 Agent 共用的一层记忆：注入 Context Bundle、提示时检索、MCP 工具与回合结束 DSH 线程捕获。
 - [dsh-memory](https://github.com/Jesse-njx/dsh-memory) — 基于 DSH 无损会话日志的引用式记忆：蒸馏出的事实带 `(sessionId, eventRange)` 引用，可随时展开回原始日志片段。
 - [dsh-sidechain](https://github.com/Buyi-wsgzg/dsh-sidechain) — `/side` 持续性侧会话与 `/btw` 一次性侧问，在临时 fork 中运行、不写入主会话历史。


### PR DESCRIPTION
Add [dsh-mneme](https://github.com/modusensus/dsh-mneme) to the Sessions & Messages section.

**dsh-mneme** is a cross-session memory plugin for DeepSeek Harness:
- SQLite + human-editable Markdown mirror (memory sovereignty stays with the user)
- autoDream background consolidation: dedup/merge/conflict resolution
- 6 memory tools, session summaries, Web memory panel
- 106 tests passing, MIT licensed

Both README.md and README.zh.md updated.