### PR TITLE
docs: add dsh-science

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ This list collects community plugins that are installable via `dsh plugin add` (
 - [dsh-track](https://github.com/fakechris/dsh-track) - Embedded task management engine: decision-point protocol, idea capture wall, Linear-style issue store.
 - [dsh-advisor](https://github.com/btspoony/dsh-advisor) - Pair a second model that passively reviews each turn and injects notes.
 - [dsh-specflow](https://github.com/lonelymoon87/dsh-specflow) - Adds specification artifacts, skills, commands, goal-backed implementation, and task-progress context.
+- [dsh-science](https://github.com/biociao/dsh-science) - Claude Science-style research workbench: ReAct research-loop engine (research_* tools), versioned artifacts with provenance (artifact_* tools), and 10 science skills for genomics/pathogens/bioinformatics.
 
 ### Notifications & Integrations
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -131,6 +131,7 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 - [dsh-track](https://github.com/fakechris/dsh-track) — 嵌入式任务管理引擎：决策点协议、念头捕获墙、Linear 形 issue 存储。
 - [dsh-advisor](https://github.com/btspoony/dsh-advisor) — 搭配一个副模型，每轮被动审查并注入见解。
 - [dsh-specflow](https://github.com/lonelymoon87/dsh-specflow) — 增加规格工件、技能、命令、由 goal 驱动的实施流程和任务进度上下文。
+- [dsh-science](https://github.com/biociao/dsh-science) — 面向 DSH 的 Claude Science 式科研工作台：ReAct 研究循环引擎（research_* 工具）、带溯源的版本化工件（artifact_* 工具）与面向基因组/病原体/生物信息的 10 个科研技能。
 
 ### 🔔 通知与集成
 


### PR DESCRIPTION
Add [dsh-science](https://github.com/biociao/dsh-science) to the **Workflow & Automation** category (EN + ZH).

A Claude Science–style research workbench for DeepSeek Harness:
- `dsh.bundle` manifest in `package.json` — installable via `dsh plugin add` (verified: `dsh plugin --profile web add "github:biociao/dsh-science"`).
- ReAct research-loop engine (`research_*` tools) + versioned artifacts with provenance (`artifact_*` tools), both zero-dependency cordis plugins.
- 10 science skills for genomics / pathogens / bioinformatics.
- `dsh-plugin` topic added. Smoke test 23/23 + isolated bundle install/boot verification pass.