### PR TITLE
docs: add @zhaoolee/dsh-notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This list collects community plugins that are installable via `dsh plugin add` (
 
 > 💡 New here? Install [dsh-find-plugin](https://github.com/awesome-dsh-plugin/dsh-find-plugin) first — then just ask your agent to find plugins for you: `dsh plugin --profile web add dsh-find-plugin`
 
-**143** plugins · [PRs welcome](#contributing)
+**144** plugins · [PRs welcome](#contributing)
 
 ## Contents
 
@@ -117,6 +117,7 @@ This list collects community plugins that are installable via `dsh plugin add` (
 - [dsh-docker](https://github.com/Jesse-njx/dsh-docker) - Typed, guarded container control: ps/logs/inspect/exec/start/stop and compose up/down with JSON output, project-aware targeting, and approval-gated destructive ops.
 - [dsh-excel-vera-plugin](https://github.com/hccccc01333/dsh-excel-vera-plugin) - Detect and repair silent Excel formula errors: pattern validation, semantic Formula IR compilation, deterministic and LLM repair, oracle scoring, and chart validation.
 - [dsh-context-proxy](https://github.com/EvilIrving/dsh-context-proxy) - Thin on-demand context retrieval: context_query / context_slice / context_grep tools that read already-persisted history back with replay-safe citations.
+- [@zhaoolee/dsh-notes](https://github.com/zhaoolee/notes) - Export DSH conversations as Smartisan Notes-style PNGs, or create and update Markdown notes in a configured account-scoped workspace.
 
 
 ### Workflow & Automation

--- a/README.zh.md
+++ b/README.zh.md
@@ -12,7 +12,7 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 
 > 💡 新来的话，先装 [dsh-find-plugin](https://github.com/awesome-dsh-plugin/dsh-find-plugin)——之后想要什么插件，直接问 agent 就行：`dsh plugin --profile web add dsh-find-plugin`
 
-**143** 个插件 · 欢迎 [PR](#贡献)
+**144** 个插件 · 欢迎 [PR](#贡献)
 
 ## 目录
 
@@ -117,6 +117,7 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 - [dsh-docker](https://github.com/Jesse-njx/dsh-docker) — 类型安全、带护栏的容器控制：ps/logs/inspect/exec/start/stop 与 compose up/down，JSON 输出、项目感知定位、破坏性操作需审批。
 - [dsh-excel-vera-plugin](https://github.com/hccccc01333/dsh-excel-vera-plugin) — 检测并修复 Excel 公式静默错误：列 pattern 校验、语义 Formula IR 编译、确定性 + LLM 修复、oracle 判分与图表校验。
 - [dsh-context-proxy](https://github.com/EvilIrving/dsh-context-proxy) — 按需取回薄层：context_query / context_slice / context_grep 三个工具读取已持久化的历史，引用可回放。
+- [@zhaoolee/dsh-notes](https://github.com/zhaoolee/notes) — 将 DSH 对话导出为锤子便签风格 PNG，或在配置的账号工作区中新建和更新 Markdown 便签。
 
 
 ### 🔁 工作流与自动化


### PR DESCRIPTION
Closes #30

## What changed

- Added `@zhaoolee/dsh-notes` to **Tools & Capabilities** in `README.md` and `README.zh.md`.
- Updated the hand-written plugin count from 143 to 144 in both language versions.

## Why

`@zhaoolee/dsh-notes` gives DSH a conversation-export tool with two modes: Smartisan Notes-style PNG export through the public demo endpoint, or Markdown note creation and updates in a configured account-scoped notes workspace.

The source lives in the `dsh-plugin/` subpackage of `zhaoolee/notes`, is published on npm, declares `dsh.bundle.patch`, and the repository carries the `dsh-plugin` topic.

## Validation

- `git diff --check`
- `node scripts/build-site.mjs`: parsed 144 entries across both locales
- Confirmed `@zhaoolee/dsh-notes@0.1.1` on npm
- `npm run test:dsh-plugin` in the source repository: 15/15 passing

Generated site files are intentionally omitted, following the contribution guide; the website rebuilds after merge.
