### PR TITLE
add dsh-tool-turbo: per-round reasoning_effort optimizer (Tools & Capabilities)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ This list collects community plugins that are installable via `dsh plugin add` (
 
 ### Tools & Capabilities
 
+- [dsh-tool-turbo](https://github.com/Electricitysheep/dsh-tool-turbo) - Per-round reasoning_effort optimizer: auto-downgrades reasoning for simple tool calls, lifts back for heavy work. Cuts thinking time between tool calls.
 - [dsh-bash-terminal](https://github.com/MAXeaglet/dsh-bash-terminal) - One shell tool for PowerShell / Git Bash / WSL on Windows plus an interactive PTY terminal; the default terminal is chosen by the user in DSH settings.
 - [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) - Vision tasks for text-only models: intent-aware image Q&A, long-screenshot OCR, UI reproduction, grounding, and pixel diff.
 - [dsh-custom-tool](https://github.com/omdsh-dev/dsh-custom-tool) - Create and manage sandboxed JavaScript tools with a Monaco editor and model-driven tool lifecycle.


### PR DESCRIPTION
Add [dsh-tool-turbo](https://github.com/Electricitysheep/dsh-tool-turbo) to Tools & Capabilities.

**What it does**: per-round reasoning_effort optimizer for dsh — auto-downgrades reasoning for simple tool calls, lifts back for heavy work. Cuts thinking time between tool calls.

**Validated**: real runs documented in dsh-handbook (ch. 4/6), MIT licensed, installable bundle.