### PR TITLE
Add dsh-mcp-panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ This list collects community plugins that are installable via `dsh plugin add` (
 - [dsh-tmuxctl](https://github.com/Jesse-njx/dsh-tmuxctl) - Take control of your tmux panes: list/send-keys/capture, run long jobs in a pane with watch mode, and approval-gated destructive commands.
 - [dsh-updater-ui](https://github.com/xingyingyuzhui/dsh-updater-ui) - DSH self-updater in the settings page: one-click check/pull (git pull --ff-only), auto background checks, version diff and changelog preview with a red-dot reminder.
 - [dsh-repro](https://github.com/EvilIrving/dsh-repro) - /repro exports a minimal, secret-scrubbed, replayable problem bundle: the session log, failed commands, and git diff.
+- [dsh-mcp-panel](https://github.com/PerryLink/dsh-mcp-panel) - Read-only runtime management panel for the official DSH MCP client: connection status, registered tools, errors, and reconnect counts through the /mcp command and a Settings tab, with sanitized display and enable/disable patch suggestions.
 
 
 ### Just for Fun

--- a/README.zh.md
+++ b/README.zh.md
@@ -185,6 +185,7 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 - [dsh-tmuxctl](https://github.com/Jesse-njx/dsh-tmuxctl) — 掌控你的 tmux 面板：list/send-keys/capture、在面板中运行长任务并 watch，破坏性命令需审批。
 - [dsh-updater-ui](https://github.com/xingyingyuzhui/dsh-updater-ui) — 设置页中的 DSH 自助更新器：一键检查/拉取（git pull --ff-only）、自动后台检查、版本对比与更新说明预览，带红点提醒。
 - [dsh-repro](https://github.com/EvilIrving/dsh-repro) — /repro 导出最小可复现问题包：去 secret 的会话日志、失败命令与 git diff。
+- [dsh-mcp-panel](https://github.com/PerryLink/dsh-mcp-panel) — 官方 MCP 客户端（dsh-mcp-client）的只读运行时管理面板：/mcp 命令与设置页 MCP 页签展示连接状态、已注册工具、错误与重连计数，脱敏展示并提供启停 patch 建议。
 
 
 ### 🎮 娱乐


### PR DESCRIPTION
Add [dsh-mcp-panel](https://github.com/PerryLink/dsh-mcp-panel) to the **Development & Runtime** category.

One-line summary: read-only runtime management panel for the official DeepSeek Harness MCP client — `/mcp` command plus a Settings → Plugins → MCP tab showing connection status, registered tools, recent errors, and reconnect counts, with sanitized display and controlled enable/disable patch suggestions.

Changes follow `contributing.md`:
- one line added to `README.md` (English) and one line to `README.zh.md` (中文), same entry, matching category;
- the repo declares `dsh.bundle` in `package.json` (installable via `dsh plugin add`), contains real working code, and carries the `dsh-plugin` topic.
