### PR TITLE
feat: add dsh-codex-auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ This list collects community plugins that are installable via `dsh plugin add` (
 - [dsh-updater-ui](https://github.com/xingyingyuzhui/dsh-updater-ui) - DSH self-updater in the settings page: one-click check/pull (git pull --ff-only), auto background checks, version diff and changelog preview with a red-dot reminder.
 - [dsh-repro](https://github.com/EvilIrving/dsh-repro) - /repro exports a minimal, secret-scrubbed, replayable problem bundle: the session log, failed commands, and git diff.
 - [dsh-mcp-panel](https://github.com/PerryLink/dsh-mcp-panel) - Read-only runtime management panel for the official DSH MCP client: connection status, registered tools, errors, and reconnect counts through the /mcp command and a Settings tab, with sanitized display and enable/disable patch suggestions.
+- [dsh-codex-auth](https://github.com/suntianc/dsh-codex-auth) - Reuses the Codex CLI ChatGPT login as an `openai-codex` LLM route and adds GPT Auth controls to DSH Web settings.
 
 
 ### Just for Fun

--- a/README.zh.md
+++ b/README.zh.md
@@ -201,6 +201,9 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 
 
 - [dsh-pain-point-check](https://github.com/ICCuse/dsh-pain-point-check) — 强制痛点检查：同一问题连续 2 个实验未收敛后注入三问、拦截非调查类工具调用直到答出、阻止同方向重试。
+- [dsh-codex-auth](https://github.com/suntianc/dsh-codex-auth) — 复用 Codex CLI 的 ChatGPT 登录态注册 `openai-codex` LLM 路由，并在 DSH Web 设置中提供 GPT Auth 控件。
+
+
 ### 🎮 娱乐
 
 - [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) — 2005 年中文站点风格的整活广告插件：侧栏广告/信息流/角落弹窗 + 假关闭叉，素材全虚构。


### PR DESCRIPTION
## Summary

Add `dsh-codex-auth` to the Development & Runtime category in both English and Chinese lists.

The plugin reuses the Codex CLI ChatGPT login as an `openai-codex` LLM route and adds GPT Auth controls to DSH Web settings.

## Eligibility

- declares a `dsh.bundle` manifest
- published on npm as `dsh-codex-auth`
- contains working plugin and test code
- repository has the `dsh-plugin` topic

## Verification

- bilingual entries use the same repository URL
- `git diff --check`
- README parser compatibility checked with `scripts/build-site.mjs`