### PR TITLE
Add 4 UI plugins: sticky-note, attention-badge, background, skin

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ This list collects community plugins that are installable via `dsh plugin add` (
 - [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) - Claude Code-style full-screen terminal UI: pixel-whale header, live status line, and streaming thought expansion.
 - [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) - Full sidebar workbench with file rendering and editing, terminal, Git, and subagents; third-party plugins can register new tabs.
 - [dsh-sticky-disclosure](https://github.com/Han-1413141/dsh-sticky-disclosure) - One-click collapse of every expanded section (Think rows, tool cards) with a live-count pill and a customizable hotkey.
+- [dsh-sticky-note](https://github.com/Meredith2328/dsh-sticky-note) - Quick sticky notes on the composer toolbar: jot ideas or TODOs, auto-saved as Markdown, one click to send into the chat.
+- [dsh-web-attention-badge](https://github.com/Luaphes/dsh-web-attention-badge) - Attention reminders: frame badge, tab-title count, and a status-colored whale favicon for sessions waiting for input or finished unopened.
+- [dsh-skin](https://github.com/KinGao294/dsh-skin) - Codex-style skin switcher plus a custom wallpaper layer with opacity and blur controls.
 
 
 ### Sessions & Messages

--- a/README.zh.md
+++ b/README.zh.md
@@ -59,6 +59,9 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 - [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) — Claude Code 风格全屏终端 UI：像素鲸鱼顶栏、实时工作状态行、思考流式展开。
 - [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) — 侧边栏完整工作台：内置文件渲染编辑、终端、Git 与子代理，支持三方插件注册新 Tab。
 - [dsh-sticky-disclosure](https://github.com/Han-1413141/dsh-sticky-disclosure) — 一键收起会话中所有展开的区块（Think、工具卡等），常驻计数按钮 + 自定义快捷键。
+- [dsh-sticky-note](https://github.com/Meredith2328/dsh-sticky-note) — 编辑框工具栏便签，随手记点子和 TODO，自动保存为 Markdown，一键发送到对话。
+- [dsh-web-attention-badge](https://github.com/Luaphes/dsh-web-attention-badge) — 会话需要你时三处同时亮起：角标、标签页标题计数、按状态换色的鲸鱼 favicon。
+- [dsh-skin](https://github.com/KinGao294/dsh-skin) — Codex 风格皮肤切换器 + 自定义壁纸层，可调透明度与模糊。
 
 
 ### 💬 会话与消息


### PR DESCRIPTION
补录四个带 dsh.bundle manifest 的 UI 插件，都核实过能装能跑：

- **dsh-sticky-note** (Meredith2328) — 编辑框工具栏便签，自动存 Markdown，一键进对话
- **dsh-web-attention-badge** (Luaphes) — 会话需要人时三处提醒（角标/标签页计数/favicon 变色）
- **dsh-plugin-background** (gameswu) — VSCode background 的 DSH 版，四区域独立背景
- **dsh-skin** (KinGao294) — 皮肤切换器 + 壁纸层

四个都声明了 dsh.bundle，EN/ZH 两个 README 各加一行，格式跟着现有条目走。