### PR TITLE
Add dsh-doublecheck

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ This list collects community plugins that are installable via `dsh plugin add` (
 - [dsh-specflow](https://github.com/lonelymoon87/dsh-specflow) - Adds specification artifacts, skills, commands, goal-backed implementation, and task-progress context.
 - [dsh-science](https://github.com/biociao/dsh-science) - Claude Science-style research workbench: ReAct research-loop engine (research_* tools), versioned artifacts with provenance (artifact_* tools), and 10 science skills for genomics/pathogens/bioinformatics.
 - [dsh-proof](https://github.com/EvilIrving/dsh-proof) - Independent read-only acceptance layer: spawns a read-only verifier before each top-level turn closes and steers non-pass gaps back into the agent.
+- [dsh-doublecheck](https://github.com/PerryLink/dsh-doublecheck) — Engineering-discipline guard: grill the requirements before the first edit, enforce red/green test evidence gates, and audit the delivery with a forked adversary (grill-requirements skill + tool-policy gates).
 
 
 ### Notifications & Integrations

--- a/README.zh.md
+++ b/README.zh.md
@@ -143,6 +143,7 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 - [dsh-specflow](https://github.com/lonelymoon87/dsh-specflow) — 增加规格工件、技能、命令、由 goal 驱动的实施流程和任务进度上下文。
 - [dsh-science](https://github.com/biociao/dsh-science) — 面向 DSH 的 Claude Science 式科研工作台：ReAct 研究循环引擎（research_* 工具）、带溯源的版本化工件（artifact_* 工具）与面向基因组/病原体/生物信息的 10 个科研技能。
 - [dsh-proof](https://github.com/EvilIrving/dsh-proof) — 独立只读验收层：顶层 turn 收尾前 spawn 只读 verifier，未通过时把缺口注回主 agent。
+- [dsh-doublecheck](https://github.com/PerryLink/dsh-doublecheck) — 工程纪律守门：动笔前审讯需求，红绿测试证据门，交付后对抗评审（grill-requirements 技能 + 工具策略门）。
 
 
 ### 🔔 通知与集成


### PR DESCRIPTION
Adds **dsh-doublecheck** to the `Workflow & Automation` category in both `README.md` and `README.zh.md`, per the Contributing section.

- **What it does**: engineering-discipline guard — grill the requirements before the first edit (bundled `grill-requirements` skill), enforce red/green test evidence gates, and audit the delivery with a forked adversary. Native DSH implementation on the skill registry, tool policy pipeline, approval seam, and session log.
- **Repo**: https://github.com/PerryLink/dsh-doublecheck
- **Category choice**: the discipline loop (grill → red → green → review) is an agent-workflow enforcement; siblings `dsh-inspect` (adversarial checkup → fix → review loop) and `dsh-proof` (read-only acceptance layer) already live in `Workflow & Automation`. `Development & Runtime` holds build/runtime/sandbox infrastructure, not workflow discipline.
- The repo carries the [`dsh-plugin`](https://github.com/topics/dsh-plugin) topic, as requested by Contributing.
