### PR TITLE
Add dsh-memory-vault: cross-session memory vault for DeepSeek Harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ This list collects community plugins that are installable via `dsh plugin add` (
 - [dsh-mneme](https://github.com/modusensus/dsh-mneme) - Cross-session memory: SQLite with a human-editable Markdown mirror, background consolidation (dedup, merge, conflict resolution), and six memory tools.
 - [nowledge-mem-deepseek-harness](https://github.com/nowledge-co/nowledge-mem-deepseek-harness) - One memory layer for every AI tool and agent: Context Bundle injection, prompt-time recall, MCP tools, and turn-end DSH thread capture.
 - [dsh-memory](https://github.com/Jesse-njx/dsh-memory) - Cited memory over DSH's lossless session log: distilled facts carry `(sessionId, eventRange)` citations that expand back to the exact original log excerpt.
+- [dsh-memory-vault](https://github.com/flymysql/dsh-memory) - Cross-session memory vault: remember / recall / forget tools, per-turn prompt injection, and a settings-page entry browser.
 - [dsh-plugin-asmemory](https://github.com/Xplore-LAB/dsh-plugin-asmemory) - Action-state time memory: record typed states and actions, then analyze trends, anomalies, and causality.
 - [dsh-sidechain](https://github.com/Buyi-wsgzg/dsh-sidechain) - `/side` persistent side sessions and `/btw` one-shot side questions, run in a temporary fork without touching main history.
 - [dsh-conversation-share](https://github.com/bill9109/dsh-conversation-share) - Share any excerpt of a conversation.

--- a/README.zh.md
+++ b/README.zh.md
@@ -72,6 +72,7 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 - [dsh-mneme](https://github.com/modusensus/dsh-mneme) — 跨会话记忆：SQLite + 可人工编辑的 Markdown 镜像，后台自动巩固（去重/合并/冲突裁决），提供 6 个记忆工具。
 - [nowledge-mem-deepseek-harness](https://github.com/nowledge-co/nowledge-mem-deepseek-harness) — 给所有 AI 工具和 Agent 共用的一层记忆：注入 Context Bundle、提示时检索、MCP 工具与回合结束 DSH 线程捕获。
 - [dsh-memory](https://github.com/Jesse-njx/dsh-memory) — 基于 DSH 无损会话日志的引用式记忆：蒸馏出的事实带 `(sessionId, eventRange)` 引用，可随时展开回原始日志片段。
+- [dsh-memory-vault](https://github.com/flymysql/dsh-memory) — 跨会话记忆库：remember / recall / forget 工具、每轮提示注入与设置页条目浏览。
 - [dsh-plugin-asmemory](https://github.com/Xplore-LAB/dsh-plugin-asmemory) — 动作-状态时序记忆：记录类型化的状态与动作，做趋势、异常与因果关联分析。
 - [dsh-sidechain](https://github.com/Buyi-wsgzg/dsh-sidechain) — `/side` 持续性侧会话与 `/btw` 一次性侧问，在临时 fork 中运行、不写入主会话历史。
 - [dsh-conversation-share](https://github.com/bill9109/dsh-conversation-share) — 分享任意段落的对话。


### PR DESCRIPTION
Closes #36 (submission issue).

## dsh-memory-vault

Cross-session memory vault for DeepSeek Harness.

- **Repo**: https://github.com/flymysql/dsh-memory
- **npm**: https://www.npmjs.com/package/dsh-memory-vault
- **Topic**: `dsh-plugin`
- **Category**: Sessions & Messages (memory)

### What it does
Three model tools (`memory_remember` / `memory_recall` / `memory_forget`) give agents a persistent second brain: facts, preferences, decisions, and project notes survive across sessions. The most recent entries are injected into every system-prompt assembly, so each session starts already aware of stored context. Records live in a durable storage domain (`dsh_memory`, json backend). A Settings page ("记忆库") lists, adds, and deletes entries through the harness `webServer` JSON route.

### Manifest
The repo declares a `dsh.bundle` manifest in `package.json` (patch at `cordis.patch.yml`), so it installs via `dsh plugin add dsh-memory-vault`.
