### PR TITLE
add dsh-pain-point-check to Development and Runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ This list collects community plugins that are installable via `dsh plugin add` (
 - [fabric](https://github.com/omdsh-dev/fabric) - An MC-Fabric-style hook processor.
 - [dsh-git-identity](https://github.com/LoserFox/dsh-git-identity) - Pin Git commits to the environment's own author identity; env-var injection overrides all `git config` settings.
 - [dsh-context-doctor](https://github.com/Zhenyu98/dsh-context-doctor) - Context injection audit: token costs of instruction chains / skill catalogs / tool schemas, duplicate and conflict detection.
+- [dsh-pain-point-check](https://github.com/ICCuse/dsh-pain-point-check) - Enforced pain-point gate: after two non-converged experiments it injects the three questions, denies non-investigative tool calls until answered, and blocks same-direction retries.
 - [dsh-plugin-check](https://github.com/omdsh-dev/dsh-plugin-check) - Plugin health checks: manifest protocol / patch format / build traps, zero-dependency and read-only.
 - [dsh-security-audit](https://github.com/omdsh-dev/dsh-security-audit) - Local security audit: config, plugin origins, sessions, network exposure — read-only redacted risk report.
 - [dsh-session-health](https://github.com/omdsh-dev/dsh-session-health) - Frame-level scan diagnostics for session files (torn/corrupt/empty detection).

--- a/README.zh.md
+++ b/README.zh.md
@@ -196,6 +196,7 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 - [dsh-mcp-panel](https://github.com/PerryLink/dsh-mcp-panel) — 官方 MCP 客户端（dsh-mcp-client）的只读运行时管理面板：/mcp 命令与设置页 MCP 页签展示连接状态、已注册工具、错误与重连计数，脱敏展示并提供启停 patch 建议。
 
 
+- [dsh-pain-point-check](https://github.com/ICCuse/dsh-pain-point-check) — 强制痛点检查：同一问题连续 2 个实验未收敛后注入三问、拦截非调查类工具调用直到答出、阻止同方向重试。
 ### 🎮 娱乐
 
 - [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) — 2005 年中文站点风格的整活广告插件：侧栏广告/信息流/角落弹窗 + 假关闭叉，素材全虚构。


### PR DESCRIPTION
Adds [dsh-pain-point-check](https://github.com/ICCuse/dsh-pain-point-check) to **Development & Runtime** in both READMEs.

An enforced pain-point-check guard for DeepSeek Harness: after two non-converged experiments on one problem it injects the three questions, denies non-investigative tool calls until they are answered in the reply text, and blocks same-direction retries. Tested end-to-end (8 tests) against a real agent loop with a scripted mock adapter. Tagged `dsh-plugin`. See also the official discussion: https://github.com/deepseek-ai/deepseek-harness/discussions/895