### PR TITLE
Add dsh-memento

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ This list collects community plugins that are installable via `dsh plugin add` (
 - [dsh-adhd-copilot](https://github.com/zimai233/dsh-adhd-copilot) - ADHD behavioral coaching skill: task breakdown, overwhelm management, launch rituals, and failure recovery.
 - [dsh-image-search](https://github.com/zimai233/dsh-image-search) - Multi-engine reverse image search aggregator: Google Lens, Baidu, Yandex, TinEye, SauceNAO, IQDB, Ascii2d.
 - [dsh-video-downloader](https://github.com/zimai233/dsh-video-downloader) - Detect and download media from Bilibili/YouTube/Douyin/Xiaohongshu with quality and format analysis.
+- [dsh-memento](https://github.com/PerryLink/dsh-memento) — Bounded, layered, approval-gated, auditable cross-session memory: a typed `ctx.memory` seam with a zero-dependency SQLite provider, a `memory` tool, and frozen snapshot injection; every write passes the approval gate and stays reconstructable from the session log.
 
 
 ### Workflow & Automation

--- a/README.zh.md
+++ b/README.zh.md
@@ -125,6 +125,7 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 - [dsh-adhd-copilot](https://github.com/zimai233/dsh-adhd-copilot) — ADHD 行为辅导技能：任务拆解、事项过载管理、启动仪式与失败重启。
 - [dsh-image-search](https://github.com/zimai233/dsh-image-search) — 多引擎反向识图聚合：Google Lens、百度、Yandex、TinEye、SauceNAO、IQDB、Ascii2d。
 - [dsh-video-downloader](https://github.com/zimai233/dsh-video-downloader) — 检测并下载 B站/YouTube/抖音/小红书视频媒体，带清晰度与格式分析。
+- [dsh-memento](https://github.com/PerryLink/dsh-memento) — 有界、分层、带审批门、可审计的跨会话记忆：`ctx.memory` 服务 + 零依赖 SQLite 存储 + `memory` 工具与冻结快照注入；写入必过审批门，模型可见内容可自会话日志重建。
 
 
 ### 🔁 工作流与自动化


### PR DESCRIPTION
Adds **dsh-memento** to the `Tools & Capabilities` category (both `README.md` and `README.zh.md`, per the Contributing section).

- **What it does**: bounded, layered, approval-gated, auditable cross-session memory for DeepSeek Harness — a typed `ctx.memory` capability seam (Service Definition / local SQLite Provider / `memory` tool + frozen snapshot injection). Every write passes the approval waterfall; everything model-visible is reconstructable from the session log.
- **Repo**: https://github.com/PerryLink/dsh-memento
- **Category choice**: the plugin is a memory/tools capability (sibling entries like dsh-kb-sieve and dsh-continual-evolve live in `Tools & Capabilities`); it is not a scheduling/orchestration workflow, so `Workflow & Automation` was not used.
- The repo already carries the [`dsh-plugin`](https://github.com/topics/dsh-plugin) topic, as requested by Contributing.
