### PR TITLE
docs: add dsh-file-uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ This list collects community plugins that are installable via `dsh plugin add` (
 - [dsh-spotlight](https://github.com/0xsline/dsh-spotlight) - Keyboard-first command palette for the DSH Web UI.
 - [dsh-101](https://github.com/bill9109/dsh-101) - Document reading mode for DSH.
 - [dsh-drag-and-drop](https://github.com/bill9109/dsh-drag-and-drop) - Cross-platform file drag-and-drop with raw path insertion, no file copying.
+- [dsh-file-uploads](https://github.com/l541402398/dsh-file-uploads) - Upload arbitrary local files from the Web composer, show pending cards, and manage stored files in Settings.
 - [dsh-deeplink](https://github.com/qyw233/dsh-deeplink) - Deep links: open a specific session or workspace via `?session=` / `?workspace=`.
 - [dsh-diff-viewer](https://github.com/lehhair/dsh-diff-viewer) - PiUI-style diff viewer replacing the stock DiffBlock for write/edit tool calls.
 - [ex-setting](https://github.com/omdsh-dev/ex-setting) - Settings extensions for DSH.

--- a/README.zh.md
+++ b/README.zh.md
@@ -47,6 +47,7 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 - [dsh-spotlight](https://github.com/0xsline/dsh-spotlight) — 键盘优先的命令面板（command palette）。
 - [dsh-101](https://github.com/bill9109/dsh-101) — DSH 文档阅读模式。
 - [dsh-drag-and-drop](https://github.com/bill9109/dsh-drag-and-drop) — 跨平台文件拖拽与原始路径插入，无需复制文件。
+- [dsh-file-uploads](https://github.com/l541402398/dsh-file-uploads) — 从 Web 输入框上传任意本地文件，以待发送卡片展示，并在设置中管理已存文件。
 - [dsh-deeplink](https://github.com/qyw233/dsh-deeplink) — `?session=` / `?workspace=` 深链直达指定项目对话。
 - [dsh-diff-viewer](https://github.com/lehhair/dsh-diff-viewer) — PiUI 风格 diff 查看器，替换 write/edit 工具调用的默认 DiffBlock。
 - [ex-setting](https://github.com/omdsh-dev/ex-setting) — DSH 的设置扩展。


### PR DESCRIPTION
Adds `dsh-file-uploads` to the UI Enhancements section in both English and Chinese.

The plugin:
- declares an installable `dsh.bundle` manifest;
- contains working Host and Client code plus regression tests;
- is released under MIT as v1.0.0;
- has the `dsh-plugin` GitHub topic.

Repository: https://github.com/l541402398/dsh-file-uploads