### PR TITLE
Add Jolly-J/dsh-deepseek-billing (UI Enhancements)

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ This list collects community plugins that are installable via `dsh plugin add` (
 - [dsh-web-attention-badge](https://github.com/Luaphes/dsh-web-attention-badge) - Attention reminders: frame badge, tab-title count, and a status-colored whale favicon for sessions waiting for input or finished unopened.
 - [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) - Plugin and skin collection for the DSH Web UI: task board, Git graph, right-side panel, remote mobile UI, pet, live token stats, and a skin center.
 
+- [dsh-deepseek-billing](https://github.com/Jolly-J/dsh-deepseek-billing) - DeepSeek account balance and per-session cost card in the sidebar foot.
 ### Themes & Appearance
 
 - [dsh-skin](https://github.com/KinGao294/dsh-skin) - Codex-style skin switcher plus a custom wallpaper layer with opacity and blur controls.

--- a/README.zh.md
+++ b/README.zh.md
@@ -67,6 +67,7 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 - [dsh-web-attention-badge](https://github.com/Luaphes/dsh-web-attention-badge) — 会话需要你时三处同时亮起：角标、标签页标题计数、按状态换色的鲸鱼 favicon。
 - [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) — DSH Web UI 插件与皮肤合集：任务看板、git 图、右侧面板、远程移动端 UI、桌宠、实时 token 统计与皮肤中心。
 
+- [dsh-deepseek-billing](https://github.com/Jolly-J/dsh-deepseek-billing) — 侧边栏底部 DeepSeek 账户余额显示与会话费用估算卡片。
 ### 🎭 主题与外观
 
 - [dsh-skin](https://github.com/KinGao294/dsh-skin) — Codex 风格皮肤切换器 + 自定义壁纸层，可调透明度与模糊。
@@ -257,3 +258,4 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 ## 免责声明
 
 本项目是社区维护的索引。插件由各自作者开发与维护，收录不构成背书，亦不对任何插件的安全性、质量或维护状态作出保证。安装插件即在你的机器上运行第三方代码——请自行审阅源码、风险自担。本项目与 DeepSeek 无隶属关系。
+


### PR DESCRIPTION
Adds [Jolly-J/dsh-deepseek-billing](https://github.com/Jolly-J/dsh-deepseek-billing) under **UI Enhancements**, one line in each of README.md and README.zh.md.

Checklist against contributing.md:
- `package.json` declares `dsh.bundle` with `patch: ./cordis.patch.yml` (installable via `dsh plugin --profile web add github:Jolly-J/dsh-deepseek-billing`); zero runtime dependencies and `lib/` is committed, so a git install runs with no build step.
- `cordis.patch.yml` sits at the repo root and inserts the plugin by package name.
- Repo carries the `dsh-plugin` topic (plus deepseek-harness / dsh / deepseek).
- Description states function only: a sidebar-foot card showing the DeepSeek account balance and the current session's token usage with an official-price-table cost estimate.

Verified: built against the DSH v0.1 checkout and running live in the author's deployment; `dsh plugin add` tested end-to-end in a scratch profile (dependency resolution, bundle-layer reconciliation, lib/ present).