### PR TITLE
Add dsh-webui-market-plugin to Tools & Capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ This list collects community plugins that are installable via `dsh plugin add` (
 - [modsearch](https://github.com/liustack/modsearch) - Web search bridge for text-only agents: ask the web or X, get structured JSON evidence (search, fetch, citations).
 - [argo](https://github.com/taxueseek/argo) - Search built for agents: multilingual coverage across web, academic, code, shopping, finance, news, and encyclopedias.
 - [dsh-browser](https://github.com/Lum1104/dsh-browser) - Chrome sidebar extension that lets DSH operate your browser directly, no vision capabilities required.
+- [dsh-webui-market-plugin](https://github.com/Sanqi-normal/dsh-webui-market-plugin) - In-harness plugin market for the dsh web GUI: browse the awesome-dsh-plugin.com catalog and install/uninstall plugins into a profile from Settings → Plugins → Plugin Market.
 
 ### Workflow & Automation
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -146,6 +146,7 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 - [modsearch](https://github.com/liustack/modsearch) — 纯文本 agent 的联网搜索桥：搜索网页与 X，返回结构化 JSON 证据（search/fetch/引用）。
 - [argo](https://github.com/taxueseek/argo) — 专为 agent 打造的搜索工具：多语言，覆盖中文/英文/学术/代码/购物/金融/新闻/百科。
 - [dsh-browser](https://github.com/Lum1104/dsh-browser) — Chrome 侧边栏扩展，让 DSH 直接操控你的浏览器，无需视觉能力。
+- [dsh-webui-market-plugin](https://github.com/Sanqi-normal/dsh-webui-market-plugin) — dsh Web GUI 内的社区插件市场：浏览 awesome-dsh-plugin.com 目录，从 设置 → 插件 → 插件市场 安装/卸载插件到 profile。
 
 ### 🔁 工作流与自动化
 


### PR DESCRIPTION
# PR title (title)

Add dsh-webui-market-plugin to Tools & Capabilities

# PR body (description)

Adds [dsh-webui-market-plugin](https://github.com/Sanqi-normal/dsh-webui-market-plugin) to the **Tools & Capabilities** section of both READMEs.

An in-harness community plugin market for the dsh web GUI: browse the awesome-dsh-plugin.com catalog and install/uninstall plugins into a profile from **Settings → Plugins → Plugin Market**, with real installed-status sync and live pnpm output for background install tasks.

## Checklist

- [x] `package.json` declares a `dsh.bundle` manifest (`dsh.bundle.patch` → `cordis.patch.yml`)
- [x] Real working code (`lib/`, `tests/`, docs, license)
- [x] Repo has the `dsh-plugin` topic
- [x] Added one line to `README.md` (EN) and `README.zh.md` (中文), both ending with a period/句号
- [x] No marketing language in the descriptions

## Install

```sh
dsh plugin --profile web add github:Sanqi-normal/dsh-webui-market-plugin
# or from npm:
dsh plugin --profile web add @sanqi-normal/dsh-webui-market-plugin
```
