### PR TITLE
Add dsh-trio: browser automation + MCP server + GitHub tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,8 @@ This list collects community plugins that are installable via `dsh plugin add` (
 - [argo](https://github.com/taxueseek/argo) - Search built for agents: multilingual coverage across web, academic, code, shopping, finance, news, and encyclopedias.
 - [dsh-browser](https://github.com/Lum1104/dsh-browser) - Chrome sidebar extension that lets DSH operate your browser directly, no vision capabilities required.
 - [dsh-webui-market-plugin](https://github.com/Sanqi-normal/dsh-webui-market-plugin) - In-harness plugin market for the dsh web GUI: browse the awesome-dsh-plugin.com catalog and install/uninstall plugins into a profile from Settings → Plugins → Plugin Market.
+- [dsh-trio](https://github.com/huey1in/trio) - Browser automation (Playwright) with a live view, an MCP server exposing DSH agents to any MCP client, and GitHub issue/PR/webhook review tools.
+
 
 ### Workflow & Automation
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -150,6 +150,8 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 - [argo](https://github.com/taxueseek/argo) — 专为 agent 打造的搜索工具：多语言，覆盖中文/英文/学术/代码/购物/金融/新闻/百科。
 - [dsh-browser](https://github.com/Lum1104/dsh-browser) — Chrome 侧边栏扩展，让 DSH 直接操控你的浏览器，无需视觉能力。
 - [dsh-webui-market-plugin](https://github.com/Sanqi-normal/dsh-webui-market-plugin) — dsh Web GUI 内的社区插件市场：浏览 awesome-dsh-plugin.com 目录，从 设置 → 插件 → 插件市场 安装/卸载插件到 profile。
+- [dsh-trio](https://github.com/huey1in/trio) — 浏览器自动化（Playwright，带实时画面）+ MCP Server（把 DSH agent 暴露给任何 MCP 客户端）+ GitHub issue/PR/webhook 评审工具。
+
 
 ### 🔁 工作流与自动化
 


### PR DESCRIPTION
Adds [dsh-trio](https://github.com/huey1in/trio) under **Tools & Capabilities** (both README.md and README.zh.md).

- Browser automation (Playwright, auto-detects system Edge/Chrome) with a live-view page
- MCP server (Streamable HTTP) exposing DSH sessions/agents to any MCP client
- GitHub issue/PR tools plus a webhook-driven automatic PR review

Meets the requirements: declares a `dsh.bundle` manifest (installable via `dsh plugin add dsh-trio`), contains real code verified end-to-end on a running DSH instance, and the repo has the `dsh-plugin` topic.