### PR TITLE
Add dsh-user-experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ This list collects community plugins that are installable via `dsh plugin add` (
 - [forkprobe](https://github.com/Jayden-X-L/forkprobe) - Compare multiple skills on the same task and pick the winner.
 - [plugin-registry](https://github.com/vlln/plugin-registry) - Ecosystem infrastructure: a thin browser console for managing official repository plugins (zero patches) plus a make-dsh-plugin skill for guided plugin development.
 - [dsh-multica-runtime](https://github.com/forrestchang/dsh-multica-runtime) - Run the dsh runtime on Multica.
+- [dsh-user-experience](https://github.com/DietCokewithSugar/dsh-user-experience) - Persona-driven UX review of React/TypeScript source: nine static rules for microcopy, state coverage, and dark mode, with per-finding confirm/reject cards.
 
 ### Just for Fun
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -225,6 +225,7 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 - [forkprobe](https://github.com/Jayden-X-L/forkprobe) — 同一任务并行试跑多个技能，对比结果选出最优。
 - [plugin-registry](https://github.com/vlln/plugin-registry) — 插件生态基建：浏览器面板管理官方 repository 插件（0 patch）+ make-dsh-plugin 插件开发引导技能。
 - [dsh-multica-runtime](https://github.com/forrestchang/dsh-multica-runtime) — 让 dsh 运行时跑在 Multica 上。
+- [dsh-user-experience](https://github.com/DietCokewithSugar/dsh-user-experience) — 以目标用户画像为前置输入的 React/TypeScript 源码 UX 走查：微文案/状态覆盖/深色模式 9 条规则，逐条定位并可确认/否决。
 
 ### 🎮 娱乐
 


### PR DESCRIPTION
Adds [dsh-user-experience](https://github.com/DietCokewithSugar/dsh-user-experience) to Development & Runtime (README.md + README.zh.md).

Persona-driven UX review for React/TypeScript source: nine static rules across microcopy, state coverage, and dark mode, with per-finding confirm/reject cards and locator-grounded reports. The repo declares a dsh.bundle manifest and carries the dsh-plugin topic.