### PR TITLE
docs: add dsh-cost-meter

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ This list collects community plugins that are installable via `dsh plugin add` (
 - [dsh-turn-navigator](https://github.com/vibeinging/dsh-turn-navigator) - Turn navigation for the DSH Web UI.
 - [dsh-milestone](https://github.com/SnowCrescenter-tech/dsh-milestone) - Right-side dot-timeline rail: jump between user messages.
 - [dsh-balance-meter](https://github.com/Ghost011118/dsh-balance-meter) - DeepSeek account balance and session cost in the composer dock, with auto-fetched official pricing and peak/off-peak support.
+- [dsh-cost-meter](https://github.com/Han-1413141/dsh-cost-meter) - Per-session and daily API cost, budget with usage %, official balance, history dashboard, and one-click official price sync with peak/off-peak pricing.
 - [dsh-plugin-deepseek-balance](https://github.com/fishxcode/dsh-plugin-deepseek-balance) - DeepSeek API balance, balance trend, and daily usage charts in DSH Web settings.
 - [ds-api-usage](https://github.com/Sev7een/ds-api-usage) - DeepSeek API balance and 24-hour usage dashboard in Settings, with estimated spend, token counts, request counts, and an hourly timeline.
 - [dsh-spend](https://github.com/nonewind/dsh-spend) - Token usage and estimated spend for the dsh web UI: floating panel with per-model, per-day, and per-session stats.

--- a/README.zh.md
+++ b/README.zh.md
@@ -58,6 +58,7 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 - [dsh-turn-navigator](https://github.com/vibeinging/dsh-turn-navigator) — 对话轮次导航。
 - [dsh-milestone](https://github.com/SnowCrescenter-tech/dsh-milestone) — 右侧圆点时间轴导航条，点击跳转到任意用户消息。
 - [dsh-balance-meter](https://github.com/Ghost011118/dsh-balance-meter) — 输入框 dock 显示 DeepSeek 账户余额与会话花费，自动拉取官方定价，支持高峰/低谷计价。
+- [dsh-cost-meter](https://github.com/Han-1413141/dsh-cost-meter) — 会话与当日 API 费用统计、预算图框（已用%）、官方余额、历史看板，支持峰谷计价与官方价格一键同步。
 - [dsh-plugin-deepseek-balance](https://github.com/fishxcode/dsh-plugin-deepseek-balance) — 在 DSH Web 设置中展示 DeepSeek API 余额、余额趋势与每日用量图表。
 - [ds-api-usage](https://github.com/Sev7een/ds-api-usage) — 在设置页展示 DeepSeek API 余额与最近 24 小时用量，包括估算消费、Token、请求次数和按小时时间线。
 - [dsh-spend](https://github.com/nonewind/dsh-spend) — DSH Web 用量与费用统计插件：右下角悬浮窗，按模型/按天/按会话多维聚合与预计花费。


### PR DESCRIPTION
Add **dsh-cost-meter** ([repo](https://github.com/Han-1413141/dsh-cost-meter)) — a session-cost / usage-metering plugin for the DeepSeek Harness Web GUI.

What it does:

- Per-session cost badge in the composer dock or session header, with input / cache / output token breakdown
- Daily cost + official account balance (total / granted / topped-up) in the sidebar
- Budget box with usage %, progress bar and over-budget warnings (today / month / total / custom range)
- Settings dashboard: summary cards, per-session breakdown, day-level history (retention configurable)
- DeepSeek peak/off-peak pricing with effective-time gating and current-tier indicator
- One-click official price sync (parses the official pricing page), manual editing as fallback

Repo is public, non-fork, MIT-licensed, and carries the `dsh-plugin` topic.
Install: `dsh plugin --profile web add github:Han-1413141/dsh-cost-meter`
Screenshots: https://github.com/Han-1413141/dsh-cost-meter#图文演示
Entry added under *UI Enhancements* in both README.md and README.zh.md, right after the related dsh-balance-meter entry.