### PR TITLE
Reword dsh-user-experience entry: value-first one-liner

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ This list collects community plugins that are installable via `dsh plugin add` (
 - [forkprobe](https://github.com/Jayden-X-L/forkprobe) - Compare multiple skills on the same task and pick the winner.
 - [plugin-registry](https://github.com/vlln/plugin-registry) - Ecosystem infrastructure: a thin browser console for managing official repository plugins (zero patches) plus a make-dsh-plugin skill for guided plugin development.
 - [dsh-multica-runtime](https://github.com/forrestchang/dsh-multica-runtime) - Run the dsh runtime on Multica.
-- [dsh-user-experience](https://github.com/DietCokewithSugar/dsh-user-experience) - Persona-driven UX review of React/TypeScript source: nine static rules for microcopy, state coverage, and dark mode, with per-finding confirm/reject cards.
+- [dsh-user-experience](https://github.com/DietCokewithSugar/dsh-user-experience) - Finds potential UX issues in your project: automatically reviews React/TypeScript code, pinpoints each problem, and gives concrete suggestions.
 
 ### Just for Fun
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -229,7 +229,7 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 - [forkprobe](https://github.com/Jayden-X-L/forkprobe) — 同一任务并行试跑多个技能，对比结果选出最优。
 - [plugin-registry](https://github.com/vlln/plugin-registry) — 插件生态基建：浏览器面板管理官方 repository 插件（0 patch）+ make-dsh-plugin 插件开发引导技能。
 - [dsh-multica-runtime](https://github.com/forrestchang/dsh-multica-runtime) — 让 dsh 运行时跑在 Multica 上。
-- [dsh-user-experience](https://github.com/DietCokewithSugar/dsh-user-experience) — 以目标用户画像为前置输入的 React/TypeScript 源码 UX 走查：微文案/状态覆盖/深色模式 9 条规则，逐条定位并可确认/否决。
+- [dsh-user-experience](https://github.com/DietCokewithSugar/dsh-user-experience) — 帮你发现项目中可能存在的用户体验问题：自动走查 React/TypeScript 源码，定位问题并给出具体优化建议。
 
 ### 🎮 娱乐
 


### PR DESCRIPTION
Rewrites the dsh-user-experience entry in both README.md and README.zh.md into a value-first one-liner, in line with the list's no-marketing guideline.

EN: Finds potential UX issues in your project: automatically reviews React/TypeScript code, pinpoints each problem, and gives concrete suggestions.

??:??????????????????:???? React/TypeScript ??,??????????????