### PR TITLE
add dsh-file-memory, dsh-knowledge, dsh-premise-guard to Development and Runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,9 @@ This list collects community plugins that are installable via `dsh plugin add` (
 - [dsh-git-identity](https://github.com/LoserFox/dsh-git-identity) - Pin Git commits to the environment's own author identity; env-var injection overrides all `git config` settings.
 - [dsh-context-doctor](https://github.com/Zhenyu98/dsh-context-doctor) - Context injection audit: token costs of instruction chains / skill catalogs / tool schemas, duplicate and conflict detection.
 - [dsh-pain-point-check](https://github.com/ICCuse/dsh-pain-point-check) - Enforced pain-point gate: after two non-converged experiments it injects the three questions, denies non-investigative tool calls until answered, and blocks same-direction retries.
+- [dsh-file-memory](https://github.com/ICCuse/dsh-file-memory) - File-backed working memory: memorize/recall key premises verbatim in a session notes file so they survive context compaction losslessly.
+- [dsh-knowledge](https://github.com/ICCuse/dsh-knowledge) - Bridge into a global Markdown knowledge base shared with the Codex kb.cmd CLI: kb_add/kb_search/kb_show/kb_timeline tools with byte-compatible frontmatter.
+- [dsh-premise-guard](https://github.com/ICCuse/dsh-premise-guard) - Post-compaction premise-drift guard: injects a one-shot notice when a compaction summary drops a critical literal anchor.
 - [dsh-plugin-check](https://github.com/omdsh-dev/dsh-plugin-check) - Plugin health checks: manifest protocol / patch format / build traps, zero-dependency and read-only.
 - [dsh-security-audit](https://github.com/omdsh-dev/dsh-security-audit) - Local security audit: config, plugin origins, sessions, network exposure — read-only redacted risk report.
 - [dsh-session-health](https://github.com/omdsh-dev/dsh-session-health) - Frame-level scan diagnostics for session files (torn/corrupt/empty detection).

--- a/README.zh.md
+++ b/README.zh.md
@@ -233,6 +233,9 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 - [dsh-multica-runtime](https://github.com/forrestchang/dsh-multica-runtime) — 让 dsh 运行时跑在 Multica 上。
 - [dsh-user-experience](https://github.com/DietCokewithSugar/dsh-user-experience) — 以目标用户画像为前置输入的 React/TypeScript 源码 UX 走查：微文案/状态覆盖/深色模式 9 条规则，逐条定位并可确认/否决。
 
+- [dsh-file-memory](https://github.com/ICCuse/dsh-file-memory) — 文件型工作记忆：memorize/recall 把关键前提逐字保存在会话笔记文件，无损挺过上下文压缩。
+- [dsh-knowledge](https://github.com/ICCuse/dsh-knowledge) — 全局知识库桥：kb_add/kb_search/kb_show/kb_timeline 读写与 Codex 共享的 D:\knowledge（格式逐字节兼容）。
+- [dsh-premise-guard](https://github.com/ICCuse/dsh-premise-guard) — 压缩后前提漂移守卫：摘要丢失关键字面锚点时注入一次性提醒。
 ### 🎮 娱乐
 
 - [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) — 2005 年中文站点风格的整活广告插件：侧栏广告/信息流/角落弹窗 + 假关闭叉，素材全虚构。


### PR DESCRIPTION
Adds three plugins to **Development & Runtime** in both READMEs:

- [dsh-file-memory](https://github.com/ICCuse/dsh-file-memory) — session-scoped verbatim working memory (`memorize`/`recall`), the lossless complement to prompt-space compaction checkpoints.
- [dsh-knowledge](https://github.com/ICCuse/dsh-knowledge) — bridge into a global Markdown + YAML-frontmatter knowledge base shared with a Codex `kb.cmd` CLI (`kb_add`/`kb_search`/`kb_show`/`kb_timeline`, byte-compatible writes, no shell encodings).
- [dsh-premise-guard](https://github.com/ICCuse/dsh-premise-guard) — post-compaction premise-drift guard: after a summary drops a critical literal anchor, injects a one-shot notice pointing at recovery.

All three are companion pieces to the earlier [dsh-pain-point-check submission](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/pull/48) and ship with tests (10/10, 5/5, 3/3) and bilingual READMEs.
