### PR TITLE
feat: add dsh-enhance (jiangnanquan/dsh-ux)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ This list collects community plugins that are installable via `dsh plugin add` (
 - [dsh-web-attention-badge](https://github.com/Luaphes/dsh-web-attention-badge) - Attention reminders: frame badge, tab-title count, and a status-colored whale favicon for sessions waiting for input or finished unopened.
 - [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) - Plugin and skin collection for the DSH Web UI: task board, Git graph, right-side panel, remote mobile UI, pet, live token stats, and a skin center.
 - [dsh-builtin-toggles](https://github.com/Starfie1d1272/dsh-builtin-toggles) - Adds a built-in plugin catalog to DSH Web with search, status explanations, and safe toggles for audited UI plugins.
+- [dsh-enhance](https://github.com/jiangnanquan/dsh-ux) - Solarized light theme, compact layout, think/tool-chain collapse capsules, and balance, session cost, and usage dashboards for the DSH web UI.
 
 ### Themes & Appearance
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -69,6 +69,7 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 - [dsh-web-attention-badge](https://github.com/Luaphes/dsh-web-attention-badge) — 会话需要你时三处同时亮起：角标、标签页标题计数、按状态换色的鲸鱼 favicon。
 - [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) — DSH Web UI 插件与皮肤合集：任务看板、git 图、右侧面板、远程移动端 UI、桌宠、实时 token 统计与皮肤中心。
 - [dsh-builtin-toggles](https://github.com/Starfie1d1272/dsh-builtin-toggles) — 为 DSH Web 添加官方内置插件目录、搜索与状态说明，并提供经过审核的安全 UI 插件开关。
+- [dsh-enhance](https://github.com/jiangnanquan/dsh-ux) — Solarized 浅色主题、紧凑布局、思考/工具链折叠胶囊，以及余额、本轮成本与用量看板的 DSH Web 界面增强插件。
 
 ### 🎭 主题与外观
 


### PR DESCRIPTION
收录 [dsh-enhance](https://github.com/jiangnanquan/dsh-ux):DSH Web 界面增强插件,Solarized 浅色主题、紧凑布局、思考/工具链折叠胶囊,以及余额、本轮成本与近 30 天用量看板。

- ✅ 仓库根 package.json 声明 `dsh.bundle.patch` + `dsh.client`,可通过 `dsh plugin --profile web add github:jiangnanquan/dsh-ux#main` 安装
- ✅ 已加 `dsh-plugin` topic
- ✅ 已提供 INSTALL.md 机器可读安装契约,供 AI agent 自动化安装
- ✅ 仓库内另含 dsh-desktop 无边框 Electron 桌面壳(desktop/ 子目录)

🤖 Generated with [Claude Code](https://claude.com/claude-code)