### PR TITLE
Add dsh-plugin-automations (Workflow & Automation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This list collects community plugins that are installable via `dsh plugin add` (
 
 > 💡 New here? Install `dsh-find-plugin` first — then just ask your agent to find plugins for you: `dsh plugin --profile web add dsh-find-plugin`
 
-**187** plugins · [PRs welcome](#contributing)
+**188** plugins · [PRs welcome](#contributing)
 
 ## Contents
 
@@ -162,6 +162,7 @@ This list collects community plugins that are installable via `dsh plugin add` (
 - [dsh_workflow](https://github.com/icetomoyo/dsh_workflow) - UltraCode-style multi-agent orchestration: a generatable, savable, governable, observable, resumable workflow layer.
 - [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) - AgentTeams multi-agent teams.
 - [dsh-automation](https://github.com/titanwings/dsh-automation) - Scheduled coding runs in fresh agent sessions with auditable history.
+- [dsh-plugin-automations](https://github.com/Sev7een/dsh-plugin-automations) - Settings-based scheduled tasks that run on time or during DeepSeek off-peak hours, with one-time and daily schedules backed by durable task state.
 - [dsh-routines](https://github.com/Jesse-njx/dsh-routines) - Scheduled agents on a cron: run a prompt on a schedule and get the digest where you already are, with overlap/missed-run/timeout safety defaults.
 - [dsh-plannotator](https://github.com/titanwings/dsh-plannotator) - Plan review with anchored annotations and structured feedback back to the agent.
 - [dsh-loop](https://github.com/vlln/dsh-loop) - Recurring loops: `/loop` command + loop tool + activity status bar.

--- a/README.zh.md
+++ b/README.zh.md
@@ -12,7 +12,7 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 
 > 💡 新来的话，先装 `dsh-find-plugin`——之后想要什么插件，直接问 agent 就行：`dsh plugin --profile web add dsh-find-plugin`
 
-**187** 个插件 · 欢迎 [PR](#贡献)
+**188** 个插件 · 欢迎 [PR](#贡献)
 
 ## 目录
 
@@ -162,6 +162,7 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 - [dsh_workflow](https://github.com/icetomoyo/dsh_workflow) — 把 UltraCode 式多 Agent 调度带给 DSH：可生成、可保存、可治理、可观察、可恢复的 Workflow 层。
 - [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) — AgentTeams 多智能体团队。
 - [dsh-automation](https://github.com/titanwings/dsh-automation) — 定时任务：让 Coding 任务按计划在全新 Agent Session 中运行，保留可审计历史。
+- [dsh-plugin-automations](https://github.com/Sev7een/dsh-plugin-automations) — 设置页定时任务：支持准点或 DeepSeek 谷时段执行、单次/每日重复，并持久化任务状态。
 - [dsh-routines](https://github.com/Jesse-njx/dsh-routines) — 定时 Agent：按 cron 计划运行 prompt，把摘要送到你已有的地方，内置重叠/漏跑/超时安全策略。
 - [dsh-plannotator](https://github.com/titanwings/dsh-plannotator) — 计划批注：选中计划原文逐条批注，结构化反馈送回 Agent。
 - [dsh-loop](https://github.com/vlln/dsh-loop) — 定时循环：`/loop` 命令 + loop 工具 + 活动状态条。


### PR DESCRIPTION
## What changed

- Added `dsh-plugin-automations` to Workflow & Automation in both English and Chinese lists.
- Updated the displayed plugin totals from 187 to 188.

## Why

The plugin adds durable scheduled tasks to the DSH Web Settings page, supporting on-time or DeepSeek off-peak execution and one-time or daily schedules.

## Validation

- Confirmed the repository declares `dsh.bundle` and `dsh.client`.
- Confirmed the repository has the `dsh-plugin` topic.
- `npm run check` passed.
- `npm test` passed: 8 test files, 50 tests.
- `npm run build` and `npm pack --dry-run` passed.
- Confirmed both README files contain 188 plugin entries.
- Ran `git diff --check`.
