### PR TITLE
Add dsh-prompt-stash

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ This list collects community plugins that are installable via `dsh plugin add` (
 - [dsh-chat-import](https://github.com/Nwflower/dsh-chat-import) - Import Claude Code / Codex / ChatGPT / Cursor / Gemini / Reasonix / opencode chat histories as resumable DeepSeek Harness sessions.
 - [dsh-file-claim](https://github.com/Nwflower/dsh-file-claim) - File claim/release protection for parallel DSH sessions on the same workspace (heartbeat stale takeover, pending 3-way merge area).
 - [dsh-interconnect](https://github.com/Chinesezjc/dsh-interconnect) - Cross-instance message and event handoff between DSH instances via an interconnect server.
+- [dsh-prompt-stash](https://github.com/Wine-Red/dsh-prompt-stash) - Local, per-session LIFO prompt stash for temporarily setting aside unfinished composer text and safely restoring it later.
 
 ### Memory
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -90,6 +90,7 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 - [dsh-chat-import](https://github.com/Nwflower/dsh-chat-import) — 把 Claude Code / Codex / ChatGPT / Cursor / Gemini / Reasonix / opencode 的聊天记录全保真导入为可续聊的 DSH 会话。
 - [dsh-file-claim](https://github.com/Nwflower/dsh-file-claim) — 同一工作区并行多会话的文件认领与写入保护（claim/release、心跳 stale 接管、pending 三路合并）。
 - [dsh-interconnect](https://github.com/Chinesezjc/dsh-interconnect) — 跨实例互联：经 interconnect 服务在多个 DSH 实例间转发消息与事件。
+- [dsh-prompt-stash](https://github.com/Wine-Red/dsh-prompt-stash) — 本地、按会话隔离的 LIFO 输入暂存：临时收起未完成的输入，之后安全恢复并继续编辑。
 
 ### 🧠 记忆
 


### PR DESCRIPTION
## Summary
- Add dsh-prompt-stash to the English Sessions & Messages list.
- Add the matching entry to the Chinese list.

## Why
dsh-prompt-stash provides a local, per-session LIFO prompt stash for temporarily setting aside unfinished composer text and restoring it later.

## Eligibility
- [x] The root package manifest declares dsh.bundle.
- [x] One entry was added to each README under the matching category.
- [x] The repository has the dsh-plugin topic.
- [x] Both descriptions are factual and end with punctuation.

## Validation
- git diff --check
- Verified the repository manifest and dsh-plugin topic.
- Verified the latest published npm package is 0.2.2.