### PR TITLE
docs: add dsh-hud

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ This list collects community plugins that are installable via `dsh plugin add` (
 - [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) - Plugin and skin collection for the DSH Web UI: task board, Git graph, right-side panel, remote mobile UI, pet, live token stats, and a skin center.
 - [dsh-builtin-toggles](https://github.com/Starfie1d1272/dsh-builtin-toggles) - Adds a built-in plugin catalog to DSH Web with search, status explanations, and safe toggles for audited UI plugins.
 - [dsh-enhance](https://github.com/jiangnanquan/dsh-ux) - Solarized light theme, compact layout, think/tool-chain collapse capsules, and balance, session cost, and usage dashboards for the DSH web UI.
+- [dsh-hud](https://github.com/a903067276-rgb/dsh-hud) - HUD status panel: git status, MCP servers, skills, model and token usage in a floating side panel.
 
 ### Themes & Appearance
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -70,6 +70,7 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 - [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) — DSH Web UI 插件与皮肤合集：任务看板、git 图、右侧面板、远程移动端 UI、桌宠、实时 token 统计与皮肤中心。
 - [dsh-builtin-toggles](https://github.com/Starfie1d1272/dsh-builtin-toggles) — 为 DSH Web 添加官方内置插件目录、搜索与状态说明，并提供经过审核的安全 UI 插件开关。
 - [dsh-enhance](https://github.com/jiangnanquan/dsh-ux) — Solarized 浅色主题、紧凑布局、思考/工具链折叠胶囊，以及余额、本轮成本与用量看板的 DSH Web 界面增强插件。
+- [dsh-hud](https://github.com/a903067276-rgb/dsh-hud) — HUD 状态面板：Git 状态、MCP 服务器、技能列表、模型与 token 用量，悬浮侧栏一览无余。
 
 ### 🎭 主题与外观
 


### PR DESCRIPTION
Add [dsh-hud](https://github.com/a903067276-rgb/dsh-hud): HUD status panel for DSH web — git status, MCP servers, skills, model & token usage in a floating side panel.

- Declares `dsh.bundle` + `dsh.client` (installable via `dsh plugin --profile web add github:a903067276-rgb/dsh-hud#main`)
- Has the `dsh-plugin` topic
- Category: UI Enhancements (both EN and ZH README updated)