### PR TITLE
Add dsh-cost-tracker to Development & Runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ This list collects community plugins that are installable via `dsh plugin add` (
 - [plugin-registry](https://github.com/vlln/plugin-registry) - Ecosystem infrastructure: a thin browser console for managing official repository plugins (zero patches) plus a make-dsh-plugin skill for guided plugin development.
 - [dsh-multica-runtime](https://github.com/forrestchang/dsh-multica-runtime) - Run the dsh runtime on Multica.
 - [dsh-user-experience](https://github.com/DietCokewithSugar/dsh-user-experience) - Finds potential UX issues in your project: automatically reviews React/TypeScript code, pinpoints each problem, and gives concrete suggestions.
+- [dsh-cost-tracker](https://github.com/yflmq001/dsh-cost-tracker) - Per-model token cost tracking with configurable cache-hit/miss, output and peak-window pricing, a live session cost bar, and unconfigured-model flags.
 
 ### Just for Fun
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -237,6 +237,7 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 - [plugin-registry](https://github.com/vlln/plugin-registry) — 插件生态基建：浏览器面板管理官方 repository 插件（0 patch）+ make-dsh-plugin 插件开发引导技能。
 - [dsh-multica-runtime](https://github.com/forrestchang/dsh-multica-runtime) — 让 dsh 运行时跑在 Multica 上。
 - [dsh-user-experience](https://github.com/DietCokewithSugar/dsh-user-experience) — 帮你发现项目中可能存在的用户体验问题：自动走查 React/TypeScript 源码，定位问题并给出具体优化建议。
+- [dsh-cost-tracker](https://github.com/yflmq001/dsh-cost-tracker) — 按模型追踪 token 成本：可配置缓存命中/未命中、输出与高峰时段单价，实时会话花费条，并标记未配置价格的模型。
 
 ### 🎮 娱乐
 


### PR DESCRIPTION
Add [dsh-cost-tracker](https://github.com/yflmq001/dsh-cost-tracker) to the Development & Runtime section (both README.md and README.zh.md).

- Repo declares a `dsh.bundle` manifest (`cordis.patch.yml`), installable via `dsh plugin add github:yflmq001/dsh-cost-tracker`.
- Real working code: TypeScript plugin with per-model configurable pricing (cache-hit/miss, output, peak-window), per-session cost projection, Web UI cost bar, `/cost` command, cross-session bill, and unit tests.
- Repo tagged with `dsh-plugin` topic.

Per-model token cost tracking: configurable cache-hit/miss, output and peak-window pricing, a live session cost bar, and unconfigured-model flags.