### PR TITLE
Add dsh-lark-bridge to Notifications & Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,8 @@ This list collects community plugins that are installable via `dsh plugin add` (
 - [dsh-web-ui-notify](https://github.com/bill9109/dsh-web-ui-notify) - Desktop notification reminders.
 - [dsh-webbridge](https://github.com/bill9109/dsh-webbridge) - DSH meets Kimi WebBridge.
 - [dsh-im-bridge](https://github.com/BiBoyang/dsh-im-bridge) - Two-way WeChat (iLink) bridge: turn-end and approval-request push, in-chat approve/reject and message injection, persistent dedup and convergent long-reply chunking; channel layer extensible to other IMs.
+- [dsh-lark-bridge](https://github.com/imetn/dsh-lark-bridge) - Bidirectional Lark/Feishu controller for DeepSeek Harness with project and session routing, interactive cards, approvals, attachments, and task controls.
+
 
 ### Models & Providers
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -195,6 +195,8 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 - [dsh-web-ui-notify](https://github.com/bill9109/dsh-web-ui-notify) — 桌面通知提醒。
 - [dsh-webbridge](https://github.com/bill9109/dsh-webbridge) — DSH 结合 Kimi WebBridge。
 - [dsh-im-bridge](https://github.com/BiBoyang/dsh-im-bridge) — 微信（iLink）双向桥：turn 完成/批准请求推送、聊天内批准与消息注入、持久去重与长回复收敛分段；通道层为多 IM 预留。
+- [dsh-lark-bridge](https://github.com/imetn/dsh-lark-bridge) — DeepSeek Harness 的飞书/Lark 双向控制器，支持 Project 与 Session 路由、交互卡片、审批、附件和任务控制。
+
 
 ### 🔌 模型与账号接入
 


### PR DESCRIPTION
## What changed

- Added `dsh-lark-bridge` to Notifications & Integrations in both English and Chinese lists.
- Updated the displayed plugin total from 190 to 191.

## Why

`dsh-lark-bridge` provides a bidirectional Lark/Feishu control surface for DeepSeek Harness, including project and session routing, native interactive cards, approvals, attachments, and task controls.

## Validation

- [x] The plugin repository declares `dsh.bundle.patch` in `package.json`.
- [x] The plugin repository contains the referenced `cordis.patch.yml`.
- [x] The plugin repository has the `dsh-plugin` topic.
- [x] One factual entry was added to both `README.md` and `README.zh.md`.
- [x] Both plugin sections contain 191 entries.
- [x] `git diff --check` passes.
