### PR TITLE
Add pack-agent-dsh to Tools & Capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ This list collects community plugins that are installable via `dsh plugin add` (
 - [dsh-plugin-mineru](https://github.com/HuanLinOTO/dsh-plugin-mineru) - Expose MineRU document parsing tools to the model.
 - [dsh-cowork](https://github.com/Jesse-njx/dsh-cowork) - Bounded, cell-addressed `doc_read`/`doc_write` for xlsx / pdf / docx / pptx / ipynb, plus an MCP server and CLI.
 - [dsh-skillport](https://github.com/Jesse-njx/dsh-skillport) - Bring your existing Agent Skills (SKILL.md) library to DSH: discover skills across Claude/Codex/Cursor/Gemini paths, inject a progressive-disclosure index, and load bodies on demand.
+- [pack-agent-dsh](https://github.com/sakikoTGW/pack-agent) - Project .pack.json/.pack.zip into .agent-pack/modpacks/ and expose skills via a workspace allow-list.
 - [dsh-tool-search](https://github.com/vibeinging/dsh-tool-search) - Per-agent on-demand tool discovery and progressive schema disclosure.
 - [dsh-openmaic](https://github.com/THU-MAIC/dsh-openmaic) - OpenMAIC: classrooms, slides, interactive widgets, and Socratic teaching.
 - [dsh-scholar](https://github.com/lzszq/dsh-scholar) - Academic assistant plugin.

--- a/README.zh.md
+++ b/README.zh.md
@@ -130,6 +130,7 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 - [dsh-plugin-mineru](https://github.com/HuanLinOTO/dsh-plugin-mineru) — 向模型暴露 MineRU 文档解析工具。
 - [dsh-cowork](https://github.com/Jesse-njx/dsh-cowork) — doc_read/doc_write：以有界、单元格寻址的方式读写 xlsx / pdf / docx / pptx / ipynb，另附 MCP 服务器与 CLI。
 - [dsh-skillport](https://github.com/Jesse-njx/dsh-skillport) — 把已有的 Agent Skills（SKILL.md）技能库带进 DSH：扫描 Claude/Codex/Cursor/Gemini 技能目录、注入渐进式索引，按需加载技能正文。
+- [pack-agent-dsh](https://github.com/sakikoTGW/pack-agent) — 把 .pack.json/.pack.zip 投影到 .agent-pack/modpacks/，按工作区白名单暴露 skill。
 - [dsh-tool-search](https://github.com/vibeinging/dsh-tool-search) — 按 agent 的按需工具发现与渐进式 schema 披露。
 - [dsh-openmaic](https://github.com/THU-MAIC/dsh-openmaic) — OpenMAIC 教学：课堂、幻灯片、交互组件与苏格拉底式教学。
 - [dsh-scholar](https://github.com/lzszq/dsh-scholar) — 学术助手插件。


### PR DESCRIPTION
## Summary
- Add `pack-agent-dsh` under Tools & Capabilities in `README.md` and `README.zh.md`.

## Plugin
- Repo: https://github.com/sakikoTGW/pack-agent
- npm: https://www.npmjs.com/package/@sakikotgw/pack-agent-dsh (`0.4.2`)
- Topic: `dsh-plugin` already on the repo
- Install: `dsh plugin --profile web add @sakikotgw/pack-agent-dsh`
- Show and tell: https://github.com/deepseek-ai/deepseek-harness/discussions/1071

Projects `.pack.json` / `.pack.zip` into `.agent-pack/modpacks/` and exposes skills through a workspace allow-list. Cursor / Claude / Codex packs can be mapped in with the CLI package `@sakikotgw/pack-agent`.
