### PR TITLE
Add llm-adaptive to Models & Providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ This list collects community plugins that are installable via `dsh plugin add` (
 
 ### Models & Providers
 
+- [llm-adaptive](https://github.com/dylan121322/llm-adaptive) - Adaptive model routing: per-request complexity classification with automatic provider routing.
 - [dsh-llm-fallbacks](https://github.com/btspoony/dsh-llm-fallbacks) - Role-based LLM retry & fallback strategies.
 - [dsh-codex-connect](https://github.com/franksong2702/dsh-codex-connect) - Connect ChatGPT OAuth and OpenAI Codex models to DeepSeek Harness, with opt-in search and image tools.
 - [dsh-everything-oauth](https://github.com/kam74515-boop/dsh-everything-oauth) - Import local Codex, Grok, Claude, OpenCode, and CC Switch logins into DSH; pick sources and enable models in Settings.

--- a/README.zh.md
+++ b/README.zh.md
@@ -200,6 +200,7 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 
 ### 🔌 模型与账号接入
 
+- [llm-adaptive](https://github.com/dylan121322/llm-adaptive) — 自适应模型路由：请求级复杂度分类，按配置链自动选择后端 provider。
 - [dsh-llm-fallbacks](https://github.com/btspoony/dsh-llm-fallbacks) — 基于角色的模型重试与备用策略。
 - [dsh-codex-connect](https://github.com/franksong2702/dsh-codex-connect) — 通过 ChatGPT OAuth 将 OpenAI Codex 模型接入 DeepSeek Harness，并提供可选的搜索与图片工具。
 - [dsh-everything-oauth](https://github.com/kam74515-boop/dsh-everything-oauth) — 把本机 Codex / Grok / Claude / OpenCode / CC Switch 登录态导入 DSH，在设置里自选来源并启用模型。


### PR DESCRIPTION
## What
Add [llm-adaptive](https://github.com/dylan121322/llm-adaptive) to the Models & Providers category in both README.md and README.zh.md.

## Plugin
- **llm-adaptive**: Adaptive model routing for DeepSeek Harness — every LLM request is classified by a flash classifier (low/medium/high/critical) and routed to the matching backend provider through config-driven chains (`pool.json` → `routing.levels`).
- Declares `dsh.bundle` manifest in package.json with a `cordis.patch.yml` (installable via `dsh plugin add`).
- Repo has the `dsh-plugin` topic.