### PR TITLE
Add dsh-pet — Codex-style desktop pet

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ This list collects community plugins that are installable via `dsh plugin add` (
 - [dsh-plugin-d399](https://github.com/HuanLinOTO/dsh-plugin-d399) - Pops up a mini-game menu (wordle, match-3, extensible) while the model generates.
 - [dsh-auto-chess](https://github.com/omdsh-dev/dsh-auto-chess) - Auto chess: human vs AI, or AI vs AI.
 - [dsh-douyin](https://github.com/AnacondaKC/dsh-douyin) - Short-video sidebar: native player, series navigation, precise history replay.
+- [dsh-pet](https://github.com/minybear/DeepSeek-Harness-Pet) - Codex-style desktop pet: a floating animated sprite in the corner that mirrors the agent's running state (working, waiting, failed, done).
 
 ## Contributing
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -260,6 +260,7 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 - [dsh-plugin-d399](https://github.com/HuanLinOTO/dsh-plugin-d399) — 模型生成时弹出小游戏菜单（wordle/消消乐，可扩展）。
 - [dsh-auto-chess](https://github.com/omdsh-dev/dsh-auto-chess) — 自走棋：人机对战或双 AI 对弈。
 - [dsh-douyin](https://github.com/AnacondaKC/dsh-douyin) — 侧栏短视频：原生播放器、系列导航、精确历史回放。
+- [dsh-pet](https://github.com/minybear/DeepSeek-Harness-Pet) — Codex 风格桌面宠物：右下角悬浮动画精灵，随 agent 运行状态实时变化（工作、等待、报错、完成）。
 
 ## 贡献
 


### PR DESCRIPTION
## What
Add [dsh-pet](https://github.com/minybear/DeepSeek-Harness-Pet) — a Codex-style desktop pet for the DSH web GUI.

## Details
- `dsh.bundle` + `dsh.client` manifest (installable via `dsh plugin --profile web add github:minybear/DeepSeek-Harness-Pet`).
- Floating animated sprite in `shell.overlay`, driven by the agent's running state (working / waiting-for-input / failed / just-finished / idle); click to wave.
- Implements the OpenAI Codex pet package format (pet.json + row-major atlas, 9 animation states).
- MIT licensed; has the `dsh-plugin` topic.

Entry added under "Just for Fun" (`README.md`) and "娱乐" (`README.zh.md`).