### PR TITLE
Add dsh-passwords — login gateway for the DSH web UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ This list collects community plugins that are installable via `dsh plugin add` (
 - [dsh-multica-runtime](https://github.com/forrestchang/dsh-multica-runtime) - Run the dsh runtime on Multica.
 - [dsh-user-experience](https://github.com/DietCokewithSugar/dsh-user-experience) - Finds potential UX issues in your project: automatically reviews React/TypeScript code, pinpoints each problem, and gives concrete suggestions.
 - [dsh-cost-tracker](https://github.com/yflmq001/dsh-cost-tracker) - Per-model token cost tracking with configurable cache-hit/miss, output and peak-window pricing, a live session cost bar, and unconfigured-model flags.
+- [dsh-passwords](https://github.com/slywalker2006/dsh-passwords) — Login gateway for the DSH web UI: password door with first-run setup, bcrypt + at-rest encryption (AES-256-GCM/HMAC), brute-force lockout, audit log, TLS 1.2+ with 80→443 redirect, CSRF, anti-framing.
 
 ### Just for Fun
 

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ This list collects community plugins that are installable via `dsh plugin add` (
 - [dsh-multica-runtime](https://github.com/forrestchang/dsh-multica-runtime) - Run the dsh runtime on Multica.
 - [dsh-user-experience](https://github.com/DietCokewithSugar/dsh-user-experience) - Finds potential UX issues in your project: automatically reviews React/TypeScript code, pinpoints each problem, and gives concrete suggestions.
 - [dsh-cost-tracker](https://github.com/yflmq001/dsh-cost-tracker) - Per-model token cost tracking with configurable cache-hit/miss, output and peak-window pricing, a live session cost bar, and unconfigured-model flags.
-- [dsh-passwords](https://github.com/slywalker2006/dsh-passwords) — Login gateway for the DSH web UI: password door with first-run setup, bcrypt + at-rest encryption (AES-256-GCM/HMAC), brute-force lockout, audit log, TLS 1.2+ with 80→443 redirect, CSRF, anti-framing.
+- [dsh-passwords](https://github.com/slywalker2006/dsh-passwords) - Login gateway for the DSH web UI: password door with first-run setup, bcrypt + at-rest encryption (AES-256-GCM/HMAC), brute-force lockout, audit log, TLS 1.2+ with 80→443 redirect, CSRF, anti-framing.
 
 ### Just for Fun
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -249,6 +249,7 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 - [dsh-multica-runtime](https://github.com/forrestchang/dsh-multica-runtime) — 让 dsh 运行时跑在 Multica 上。
 - [dsh-user-experience](https://github.com/DietCokewithSugar/dsh-user-experience) — 帮你发现项目中可能存在的用户体验问题：自动走查 React/TypeScript 源码，定位问题并给出具体优化建议。
 - [dsh-cost-tracker](https://github.com/yflmq001/dsh-cost-tracker) — 按模型追踪 token 成本：可配置缓存命中/未命中、输出与高峰时段单价，实时会话花费条，并标记未配置价格的模型。
+- [dsh-passwords](https://github.com/slywalker2006/dsh-passwords) — DSH Web UI 登录网关：首次配置、bcrypt + 静态加密（AES-256-GCM/HMAC）、防爆破、审计日志、TLS 1.2+ 与 80→443 跳转、CSRF 与防嵌框。
 
 ### 🎮 娱乐
 


### PR DESCRIPTION
Adds [dsh-passwords](https://github.com/slywalker2006/dsh-passwords) to Development & Runtime in both README.md and README.zh.md, following the contribution format.

Independent login gateway (password door) in front of the DSH web UI: first-run setup, bcrypt + at-rest encryption (AES-256-GCM/HMAC), brute-force lockout, audit log, TLS 1.2+ with 80→443 redirect, CSRF, anti-framing. BSD-3-Clause. The repo carries the `dsh-plugin` topic.

Compliance notes:
- `package.json` declares the required `dsh.bundle` manifest (`"dsh": { "bundle": { "patch": "./cordis.yml" } }`) — the patch pins the in-app directory picker and is installable via `dsh plugin add`.
- Real, working code (gateway runs in production); actively maintained with versioned releases.
- Entry format follows the CONTRIBUTING templates (single dash for the English entry, em-dash for the Chinese entry, both end with a period).