### PR TITLE
Add dsh-adb: ADB device & bench operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,8 @@ This list collects community plugins that are installable via `dsh plugin add` (
 - [dsh-webui-market-plugin](https://github.com/Sanqi-normal/dsh-webui-market-plugin) - In-harness plugin market for the dsh web GUI: browse the awesome-dsh-plugin.com catalog and install/uninstall plugins into a profile from Settings → Plugins → Plugin Market.
 - [dsh-trio](https://github.com/huey1in/trio) - Browser automation (Playwright) with a live view, an MCP server exposing DSH agents to any MCP client, and GitHub issue/PR/webhook review tools.
 
+- [dsh-adb](https://github.com/SamXiaBing/dsh-adb) - ADB device & bench operations for DSH: device discovery, structured logcat (background streaming), apk install, file pull/push, and dumpsys performance snapshots.
+
 ### Workflow & Automation
 
 - [dsh_workflow](https://github.com/icetomoyo/dsh_workflow) - UltraCode-style multi-agent orchestration: a generatable, savable, governable, observable, resumable workflow layer.

--- a/README.zh.md
+++ b/README.zh.md
@@ -169,6 +169,8 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 - [dsh-webui-market-plugin](https://github.com/Sanqi-normal/dsh-webui-market-plugin) — dsh Web GUI 内的社区插件市场：浏览 awesome-dsh-plugin.com 目录，从 设置 → 插件 → 插件市场 安装/卸载插件到 profile。
 - [dsh-trio](https://github.com/huey1in/trio) — 浏览器自动化（Playwright，带实时画面）+ MCP Server（把 DSH agent 暴露给任何 MCP 客户端）+ GitHub issue/PR/webhook 评审工具。
 
+- [dsh-adb](https://github.com/SamXiaBing/dsh-adb) — ADB 设备·台架运维工具集：设备发现、结构化 logcat（后台采集）、apk 安装、文件 pull/push、性能快照。
+
 ### 🔁 工作流与自动化
 
 - [dsh_workflow](https://github.com/icetomoyo/dsh_workflow) — 把 UltraCode 式多 Agent 调度带给 DSH：可生成、可保存、可治理、可观察、可恢复的 Workflow 层。


### PR DESCRIPTION
Adds [dsh-adb](https://github.com/SamXiaBing/dsh-adb) to the Tools & Capabilities category (both README.md and README.zh.md).

dsh-adb gives DSH agents direct ADB device & bench operations: device discovery, structured logcat with background streaming via jobs, apk install, file pull/push, and dumpsys performance snapshots (meminfo/gfxinfo/battery). Declares \dsh.bundle\ in package.json.