### PR TITLE
add: web-search-pro / browser / voice-webspeech / restart plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,11 @@ This list collects community plugins that are installable via `dsh plugin add` (
 - [dsh-auto-chess](https://github.com/omdsh-dev/dsh-auto-chess) - Auto chess: human vs AI, or AI vs AI.
 - [dsh-douyin](https://github.com/AnacondaKC/dsh-douyin) - Short-video sidebar: native player, series navigation, precise history replay.
 - [@minybear/dsh-pet](https://github.com/minybear/DeepSeek-Harness-Pet) - Codex-style desktop pet: a floating animated sprite in the corner that mirrors the agent's running state (working, waiting, failed, done).
+- [dsh-web-search-pro](https://github.com/anweat/dsh-web-search-pro) - Persistent enhanced web search: multi-engine routing (DeepSeek/Exa/DDG/Bing/Jina + GitHub/Bilibili/YouTube/V2EX/Xiaohongshu/Twitter/Reddit/RSS), SQLite+LRU cache, userscript-style extraction, Playwright rendering.
+- [dsh-browser](https://github.com/anweat/dsh-browser) - Self-contained browser runtime: Playwright (chromium) + OpenCLI as plugin-local dependencies (global reuse fallback), exposes a `browser` service and 9 interactive browser tools.
+- [dsh-voice-webspeech](https://github.com/anweat/dsh-voice-webspeech) - Browser Web Speech API voice input: zero server, zero keys, zero model downloads (Edge=Azure, Chrome=Google speech).
+- [dsh-restart](https://github.com/anweat/dsh-restart) - Restart DSH: configurable restart method (Node native / legacy PowerShell), post-restart continue prompt, optional watchdog auto-relaunch.
+
 
 ## Contributing
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -268,6 +268,11 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 - [dsh-auto-chess](https://github.com/omdsh-dev/dsh-auto-chess) — 自走棋：人机对战或双 AI 对弈。
 - [dsh-douyin](https://github.com/AnacondaKC/dsh-douyin) — 侧栏短视频：原生播放器、系列导航、精确历史回放。
 - [@minybear/dsh-pet](https://github.com/minybear/DeepSeek-Harness-Pet) — Codex 风格桌面宠物：右下角悬浮动画精灵，随 agent 运行状态实时变化（工作、等待、报错、完成）。
+- [dsh-web-search-pro](https://github.com/anweat/dsh-web-search-pro) - 增强型、可持久化的网页搜索：多引擎路由（DeepSeek/Exa/DDG/Bing/Jina + GitHub/B站/YouTube/V2EX/小红书/Twitter/Reddit/RSS）、SQLite+LRU 缓存、userscript 风格抽取、Playwright 渲染。
+- [dsh-browser](https://github.com/anweat/dsh-browser) - 自包含浏览器运行时：Playwright（chromium）+ OpenCLI 作为插件本地依赖（全局复用回退），提供 `browser` 服务与 9 个交互式浏览器工具。
+- [dsh-voice-webspeech](https://github.com/anweat/dsh-voice-webspeech) - 浏览器 Web Speech API 语音输入：零服务端、零密钥、零模型下载（Edge=Azure 语音、Chrome=Google 语音）。
+- [dsh-restart](https://github.com/anweat/dsh-restart) - DSH 重启插件：可配置的重启方式（Node 原生/旧 PowerShell 适配）、重启后自动继续的提示词、可选看门狗自动拉起。
+
 
 ## 贡献
 


### PR DESCRIPTION
Add four installable plugins (all declare `dsh.bundle`, npm-published, tagged with the `dsh-plugin` topic):

- [dsh-web-search-pro](https://github.com/anweat/dsh-web-search-pro) — persistent multi-engine web search → Tools & Capabilities
- [dsh-browser](https://github.com/anweat/dsh-browser) — self-contained Playwright+OpenCLI browser runtime → Tools & Capabilities
- [dsh-voice-webspeech](https://github.com/anweat/dsh-voice-webspeech) — browser Web Speech voice input → Tools & Capabilities
- [dsh-restart](https://github.com/anweat/dsh-restart) — restart DSH with watchdog → Development & Runtime

Listed in both README.md and README.zh.md.