### PR TITLE
docs: add dsh-cost-meter (Sttrevens)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ This list collects community plugins that are installable via `dsh plugin add` (
 - [jiangnanquan/dsh-ux](https://github.com/jiangnanquan/dsh-ux) - Solarized light theme, compact layout, think/tool-chain collapse capsules, and balance, session cost, and usage dashboards for the DSH web UI.
 - [a903067276-rgb/dsh-hud](https://github.com/a903067276-rgb/dsh-hud) - HUD status panel: Git status, MCP servers, skills, model and token usage in a floating side panel.
 - [wsxwj123/dsh-plugins#turn-scrubber](https://github.com/wsxwj123/dsh-plugins/tree/main/packages/turn-scrubber) - Compact right-edge turn rail with hover summaries and click-to-jump navigation.
+- [Sttrevens/dsh-cost-meter](https://github.com/Sttrevens/dsh-cost-meter) - Per-turn USD cost badge in the Web UI: session total in the header and per-turn cost in each message footer, with a hover breakdown.
 
 
 ### Themes & Appearance

--- a/README.zh.md
+++ b/README.zh.md
@@ -74,6 +74,7 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 - [jiangnanquan/dsh-ux](https://github.com/jiangnanquan/dsh-ux) — Solarized 浅色主题、紧凑布局、思考/工具链折叠胶囊，以及余额、本轮成本与用量看板的 DSH Web 界面增强插件。
 - [a903067276-rgb/dsh-hud](https://github.com/a903067276-rgb/dsh-hud) — HUD 状态面板：Git 状态、MCP 服务器、技能列表、模型与 token 用量，悬浮侧栏一览无余。
 - [wsxwj123/dsh-plugins#turn-scrubber](https://github.com/wsxwj123/dsh-plugins/tree/main/packages/turn-scrubber) — 右侧紧凑回合刻度条，悬停显示回合摘要，点击跳转到对应用户回合。
+- [Sttrevens/dsh-cost-meter](https://github.com/Sttrevens/dsh-cost-meter) — Web UI 美元成本徽标：头部显示会话总成本、每条回复结尾显示该轮成本，悬停看分项。
 
 
 ### 🎭 主题与外观


### PR DESCRIPTION
Adds **dsh-cost-meter (Sttrevens)** under UI Enhancements / 🎨 UI 增强 (both README.md and README.zh.md).

Per-turn USD cost badge for the DSH Web UI: session total in the header, per-turn cost in each assistant-message footer, hover breakdown of input/output/cache-read/cache-write.

- Repo: https://github.com/Sttrevens/dsh-cost-meter (declares `dsh.bundle` + `dsh.client`, `dsh-plugin` topic)
- npm: https://www.npmjs.com/package/@steven-wu/dsh-cost-meter
- Install: `dsh plugin --profile web add @steven-wu/dsh-cost-meter`