### PR TITLE
Add creght-skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,8 @@ This list collects community plugins that are installable via `dsh plugin add` (
 - [SamXiaBing/dsh-adb](https://github.com/SamXiaBing/dsh-adb) - ADB device & bench operations for DSH: device discovery, structured logcat (background streaming), apk install, file pull/push, and dumpsys performance snapshots.
 
 ### Skills
+- [creght-dev/skills](https://github.com/creght-dev/skills) - Skills for building websites on the Creght platform: CLI pull/push sync, page and component conventions, CMS, forms, auth, SEO, publishing and version rollback.
+
 
 ### Workflow & Automation
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -174,6 +174,8 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 - [SamXiaBing/dsh-adb](https://github.com/SamXiaBing/dsh-adb) — ADB 设备·台架运维工具集：设备发现、结构化 logcat（后台采集）、apk 安装、文件 pull/push、性能快照。
 
 ### 🧩 技能包
+- [creght-dev/skills](https://github.com/creght-dev/skills) — Creght 平台建站技能包：CLI 拉取/推送同步、页面与组件规范、CMS、表单、Auth、SEO、发布与版本回滚。
+
 
 ### 🔁 工作流与自动化
 


### PR DESCRIPTION
Adds [creght-skills](https://github.com/creght-dev/skills) under **Tools & Capabilities** / **🛠️ 工具与能力** — a skill pack for building websites on the Creght platform (CLI sync, page/component conventions, CMS, forms, Auth, Func backend, SEO, publishing and version rollback, plus replicating an existing site onto Creght).

- [x] My repo's `package.json` declares **`dsh.bundle`** (not just `dsh.client`) — [manifest](https://github.com/creght-dev/skills/blob/main/package.json), [`cordis.patch.yml`](https://github.com/creght-dev/skills/blob/main/cordis.patch.yml) / 仓库 `package.json` 已声明 `dsh.bundle`
- [x] One line added to **both** `README.md` (English) and `README.zh.md` (中文), under the matching category / 两个语言文件各加一行，放对分类
- [x] Description states what the plugin does, no superlatives / 描述只说功能，不带营销词
- [x] My repo has the `dsh-plugin` topic / 仓库已打 `dsh-plugin` topic

Install: `npx @deepseek-ai/dsh plugin --profile web add github:creght-dev/skills`

🤖 Generated with [Claude Code](https://claude.com/claude-code)