### PR TITLE
Add addxing's four skill bundles (Skills section)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ This list collects community plugins that are installable via `dsh plugin add` (
   - [Models & Providers](#models--providers)
   - [Development & Runtime](#development--runtime)
   - [Just for Fun](#just-for-fun)
+  - [Skills](#skills)
 - [Badge](#badge)
 - [Disclaimer](#disclaimer)
 
@@ -276,6 +277,14 @@ This list collects community plugins that are installable via `dsh plugin add` (
 - [@anweat/dsh-browser](https://github.com/anweat/dsh-browser) - Self-contained browser runtime: Playwright (chromium) + OpenCLI as plugin-local dependencies (global reuse fallback), exposes a `browser` service and 9 interactive browser tools.
 - [dsh-voice-webspeech](https://github.com/anweat/dsh-voice-webspeech) - Browser Web Speech API voice input: zero server, zero keys, zero model downloads (Edge=Azure, Chrome=Google speech).
 - [dsh-restart](https://github.com/anweat/dsh-restart) - Restart DSH: configurable restart method (Node native / legacy PowerShell), post-restart continue prompt, optional watchdog auto-relaunch.
+
+
+### Skills
+
+- [conservative-code-edits](https://github.com/addxing/conservative-code-edits) — Conservative code-edit discipline: minimal changes, preserve architecture and style, avoid unrelated refactors and shared-code risks.
+- [function-extraction](https://github.com/addxing/function-extraction) — Extract a feature's full implementation chain into a technical document with data flow, exception handling, and Mermaid diagrams.
+- [function-testing](https://github.com/addxing/function-testing) — Generate functional test cases from PRDs, Git commits, or user stories, with an Excel-style report.
+- [replicate-android-feature](https://github.com/addxing/replicate-android-feature) — Reproduce an Android feature in another project or platform, treating the source implementation as the source of truth.
 
 
 ## Contributing

--- a/README.zh.md
+++ b/README.zh.md
@@ -27,6 +27,7 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
   - [🔌 模型与账号接入](#-模型与账号接入)
   - [🧑‍💻 开发与运行时](#-开发与运行时)
   - [🎮 娱乐](#-娱乐)
+  - [🧩 技能（Skills）](#-技能skills)
 - [徽章](#徽章)
 - [免责声明](#免责声明)
 
@@ -276,6 +277,14 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 - [@anweat/dsh-browser](https://github.com/anweat/dsh-browser) — 自包含浏览器运行时：Playwright（chromium）+ OpenCLI 作为插件本地依赖（全局复用回退），提供 `browser` 服务与 9 个交互式浏览器工具。
 - [dsh-voice-webspeech](https://github.com/anweat/dsh-voice-webspeech) — 浏览器 Web Speech API 语音输入：零服务端、零密钥、零模型下载（Edge=Azure 语音、Chrome=Google 语音）。
 - [dsh-restart](https://github.com/anweat/dsh-restart) — DSH 重启插件：可配置的重启方式（Node 原生/旧 PowerShell 适配）、重启后自动继续的提示词、可选看门狗自动拉起。
+
+
+### 🧩 技能（Skills）
+
+- [conservative-code-edits](https://github.com/addxing/conservative-code-edits) — 保守代码修改守则 skill：最小化改动、保留既有架构与风格、规避无关重构与共享代码风险。
+- [function-extraction](https://github.com/addxing/function-extraction) — 功能链路提取 skill：从代码库提取某功能的完整实现链路，生成含数据流、异常处理与 Mermaid 图表的技术文档。
+- [function-testing](https://github.com/addxing/function-testing) — 功能测试 skill：从 PRD、Git 提交或用户故事生成功能测试用例，输出 Excel 风格报告。
+- [replicate-android-feature](https://github.com/addxing/replicate-android-feature) — Android 功能复刻 skill：以源项目实际实现为准，将指定功能完整迁移到其他项目或平台。
 
 
 ## 贡献


### PR DESCRIPTION
<!-- Thanks for contributing! Quick checklist / 提交前快速自查 -->

- [ ] My repo's `package.json` declares **`dsh.bundle`** (not just `dsh.client`) — [example](../blob/main/contributing.md) / 仓库 `package.json` 已声明 `dsh.bundle`（只有 `dsh.client` 无法安装）
- [ ] One line added to **both** `README.md` (English) and `README.zh.md` (中文), under the matching category / 两个语言文件各加一行，放对分类
- [ ] Description states what the plugin does, no superlatives / 描述只说功能，不带营销词
- [ ] My repo has the `dsh-plugin` topic / 仓库已打 `dsh-plugin` topic
