### PR TITLE
Add dsh-calculator: DeepSeek API spend + balance aside panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ This list collects community plugins that are installable via `dsh plugin add` (
 - [wsxwj123/dsh-plugins#turn-scrubber](https://github.com/wsxwj123/dsh-plugins/tree/main/packages/turn-scrubber) - Compact right-edge turn rail with hover summaries and click-to-jump navigation.
 - [Sttrevens/dsh-cost-meter](https://github.com/Sttrevens/dsh-cost-meter) - Per-turn USD cost badge in the Web UI: session total in the header and per-turn cost in each message footer, with a hover breakdown.
 - [a903067276-rgb/dsh-file-mentions](https://github.com/a903067276-rgb/dsh-file-mentions) - Clickable file paths in DSH replies: Codex-style inline open, reveal in file manager, and a mentioned-files chip list at the turn tail.
+- [bobcat848/dsh-calculator](https://github.com/bobcat848/dsh-calculator) - DeepSeek API spend (current session and all sessions) and account balance in the aside panel, with official pricing and peak/off-peak support.
 
 
 ### Themes & Appearance

--- a/README.zh.md
+++ b/README.zh.md
@@ -76,6 +76,7 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 - [wsxwj123/dsh-plugins#turn-scrubber](https://github.com/wsxwj123/dsh-plugins/tree/main/packages/turn-scrubber) — 右侧紧凑回合刻度条，悬停显示回合摘要，点击跳转到对应用户回合。
 - [Sttrevens/dsh-cost-meter](https://github.com/Sttrevens/dsh-cost-meter) — Web UI 美元成本徽标：头部显示会话总成本、每条回复结尾显示该轮成本，悬停看分项。
 - [a903067276-rgb/dsh-file-mentions](https://github.com/a903067276-rgb/dsh-file-mentions) — DSH 回复中的文件路径可点击：Codex 风格行内打开、文件管理器定位、回合尾部文件 chip 列表。
+- [bobcat848/dsh-calculator](https://github.com/bobcat848/dsh-calculator) — 右侧面板展示 DeepSeek API 费用（当前会话 + 全部会话累计）与账户余额，内置官方计价与峰谷计价支持。
 
 
 ### 🎭 主题与外观


### PR DESCRIPTION
Adds [dsh-calculator](https://github.com/bobcat848/dsh-calculator) to the **UI Enhancements** category.

**What it does**: right-hand aside panel showing DeepSeek API spend (current session + all sessions, per model) and live account balance. Only \deepseek-official\ routes are billed; third-party models are listed as unbilled. Uses official pricing with cache-hit/cache-miss/output buckets and automatic Beijing peak/off-peak pricing after 2026-08-17.

**Requirements met**:
- Declares \dsh.bundle\ manifest (\cordis.patch.yml\ in repo root) - installable via \dsh plugin add\
- Real working code (host + browser halves), actively maintained
- \dsh-plugin\ topic added to the repo