### PR TITLE
add: dsh-approval-llm

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,8 @@ This list collects community plugins that are installable via `dsh plugin add` (
 - [EvilIrving/dsh-proof](https://github.com/EvilIrving/dsh-proof) - Independent read-only acceptance layer: spawns a read-only verifier before each top-level turn closes and steers non-pass gaps back into the agent.
 - [PerryLink/dsh-doublecheck](https://github.com/PerryLink/dsh-doublecheck) - Engineering-discipline guard: grill the requirements before the first edit, enforce red/green test evidence gates, and audit the delivery with a forked adversary (grill-requirements skill + tool-policy gates).
 - [btspoony/mstar-harness](https://github.com/btspoony/mstar-harness) - Skill-driven harness/loop engineering workflow agent plugin.
+- [Letter2025/dsh-approval-llm](https://github.com/Letter2025/dsh-approval-llm) - Model-based permission approval: an approval-request answerer backed by a separate reviewer model.
+
 
 ### Notifications & Integrations
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -200,6 +200,8 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 - [EvilIrving/dsh-proof](https://github.com/EvilIrving/dsh-proof) — 独立只读验收层：顶层 turn 收尾前 spawn 只读 verifier，未通过时把缺口注回主 agent。
 - [PerryLink/dsh-doublecheck](https://github.com/PerryLink/dsh-doublecheck) — 工程纪律守门：动笔前审讯需求，红绿测试证据门，交付后对抗评审（grill-requirements 技能 + 工具策略门）。
 - [btspoony/mstar-harness](https://github.com/btspoony/mstar-harness) — 技能驱动的 harness/loop 工程化工作流插件。
+- [Letter2025/dsh-approval-llm](https://github.com/Letter2025/dsh-approval-llm) — 基于模型的权限审批：由独立审查模型自动应答 approval 权限请求。
+
 
 ### 🔔 通知与集成
 


### PR DESCRIPTION
Add [dsh-approval-llm](https://github.com/Letter2025/dsh-approval-llm) to the **Tools & Capabilities / 工具与能力** category (one line in each of `README.md` and `README.zh.md`).

Model-based permission approval (approve-for-me) for DeepSeek Harness: an `approval/request` answerer backed by a separate reviewer model, so permission prompts can be answered automatically by policy instead of a human.

- [x] `package.json` declares `dsh.bundle` — `dsh.bundle.patch: ./cordis.patch.yml` (installable via `dsh plugin --profile web add dsh-approval-llm`)
- [x] One line added to **both** `README.md` (English) and `README.zh.md` (中文), under the matching category
- [x] Description states what the plugin does, no superlatives
- [x] Repo has the `dsh-plugin` topic
