### PR TITLE
Add AKIRACOD/dsh-drag-and-drop (composer chip fork) to UI Enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ This list collects community plugins that are installable via `dsh plugin add` (
 
 
 - [dsh-deepseek-billing](https://github.com/Jolly-J/dsh-deepseek-billing) - DeepSeek account balance and per-session cost card in the sidebar foot.
+- [AKIRACOD/dsh-drag-and-drop](https://github.com/AKIRACOD/dsh-drag-and-drop) - File-drag fork: drop documents as removable chips above the composer, send without typing.
+
+
 ### Themes & Appearance
 
 - [KinGao294/dsh-skin](https://github.com/KinGao294/dsh-skin) - Codex-style skin switcher plus a custom wallpaper layer with opacity and blur controls.

--- a/README.zh.md
+++ b/README.zh.md
@@ -80,6 +80,9 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 
 
 - [dsh-deepseek-billing](https://github.com/Jolly-J/dsh-deepseek-billing) — 侧边栏底部 DeepSeek 账户余额显示与会话费用估算卡片。
+- [AKIRACOD/dsh-drag-and-drop](https://github.com/AKIRACOD/dsh-drag-and-drop) — 拖放 fork：文档以可删除「文件芯片」挂在输入框上方，不打字也能发送。
+
+
 ### 🎭 主题与外观
 
 - [KinGao294/dsh-skin](https://github.com/KinGao294/dsh-skin) — Codex 风格皮肤切换器 + 自定义壁纸层，可调透明度与模糊。


### PR DESCRIPTION
## What

Add [AKIRACOD/dsh-drag-and-drop](https://github.com/AKIRACOD/dsh-drag-and-drop) to the **UI Enhancements** section (en + zh).

## Why

A maintained fork of omdsh-dev/dsh-drag-and-drop (formerly bill9109/dsh-drag-and-drop) that improves the drop experience:

- Dropped documents/folders appear as **removable chips in a bar above the composer** instead of path text in the input box.
- A **Send button in the chip bar** sends just the files without typing; resolved paths are prepended to the outgoing message automatically.
- Document drops no longer trigger the composer's misleading "images only" toast; image-only drops keep native thumbnails.

The repo carries the dsh-plugin topic and installs via dsh plugin --profile web add github:AKIRACOD/dsh-drag-and-drop.