### PR TITLE
Add disyli/dsh-tool-call-stats (Development & Runtime)

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ This list collects community plugins that are installable via `dsh plugin add` (
 - [arrow949/dsh-turn-approval](https://github.com/arrow949/dsh-turn-approval) - Turn-scoped “Allow for this task” approvals: automatically allow matching `danger-full-access` escalations only for the current task, then expire.
 - [omdsh-dev/plugin-template](https://github.com/omdsh-dev/plugin-template) - Plugin template repo (based on the official turtle-ui repo).
 - [Small-tailqwq/dsh-tps](https://github.com/Small-tailqwq/dsh-tps) - A TPS metrics plugin.
+- [disyli/dsh-tool-call-stats](https://github.com/disyli/dsh-tool-call-stats) - Per-process tool-call statistics: a `tool_stats` tool reporting per-tool call counts, error counts, and average durations.
 - [Areium/dsh-fail-logger](https://github.com/Areium/dsh-fail-logger) - Auto-log failed tool calls across native tools, PTC run_code, and inline invocations: dedup and count root causes into a skill so repeated mistakes fade.
 - [BiBoyang/dsh-eval-harness](https://github.com/BiBoyang/dsh-eval-harness) - Evaluation harness for DSH plugins: YAML cases drive real headless agent runs, assert on tool calls, args, results and token usage, with a baseline gate for CI regression.
 - [hust-open-atom-club/oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) - Community distribution: TUI, desktop, and Web UI as one bundle with layered installation.

--- a/README.zh.md
+++ b/README.zh.md
@@ -252,6 +252,7 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 - [arrow949/dsh-turn-approval](https://github.com/arrow949/dsh-turn-approval) — DSH「允许本次任务」临时授权：仅在当前任务内自动放行同类 `danger-full-access` 请求，任务结束自动失效。
 - [omdsh-dev/plugin-template](https://github.com/omdsh-dev/plugin-template) — 插件模板仓库（基于 turtle-ui 官方仓库）。
 - [Small-tailqwq/dsh-tps](https://github.com/Small-tailqwq/dsh-tps) — TPS 指标插件。
+- [disyli/dsh-tool-call-stats](https://github.com/disyli/dsh-tool-call-stats) — 进程内工具调用统计：提供 `tool_stats` 工具，按工具汇报调用次数、失败次数与平均耗时。
 - [Areium/dsh-fail-logger](https://github.com/Areium/dsh-fail-logger) — 全模式调用工具失败自动实录：把原生工具 / PTC run_code / 代码内嵌工具调用的失败错因去重计数后写入 skill，越用越少错。
 - [BiBoyang/dsh-eval-harness](https://github.com/BiBoyang/dsh-eval-harness) — DSH 插件评测框架：YAML 用例驱动真实 headless agent，断言工具调用/参数/返回与 token 用量，baseline 门禁做 CI 回归。
 - [hust-open-atom-club/oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) — 社区发行版：TUI、桌面端与 Web UI 统一体验，分层安装、一步到位。


### PR DESCRIPTION
Adds [disyli/dsh-tool-call-stats](https://github.com/disyli/dsh-tool-call-stats) under **Development & Runtime**, one line in each of README.md and README.zh.md.

Checklist against contributing.md:
- `package.json` declares `dsh.bundle` with `patch: ./cordis.patch.yml` (installable via `dsh plugin add github:disyli/dsh-tool-call-stats`); official packages are declared as `peerDependencies`.
- `cordis.patch.yml` sits at the repo root and inserts the plugin by package name.
- Real working code, no build step (~100 lines plain ESM); repo carries the `dsh-plugin` topic.
- Description states function only: per-process tool-call statistics (call counts, error counts, avg durations via a `tool_stats` tool). It counts tool-call dispatches, not tokens — distinct from the token/cost trackers already listed.

Honest status note: built against the v0.1 developer preview; verified to compose into the plugin tree (`--dump-config` / headless boot). The README carries an explicit status note until a full live-session run is confirmed. Happy to hold this PR if you prefer entries only after end-to-end verification.