### PR TITLE
Add dsh-sgme (SGME memory engine bridge) to Memory category

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ This list collects community plugins that are installable via `dsh plugin add` (
 - [ICCuse/dsh-file-memory](https://github.com/ICCuse/dsh-file-memory) - File-backed working memory: memorize/recall key premises verbatim in a session notes file so they survive context compaction losslessly.
 - [ICCuse/dsh-knowledge](https://github.com/ICCuse/dsh-knowledge) - Bridge into a global Markdown knowledge base shared with the Codex kb.cmd CLI: kb_add/kb_search/kb_show/kb_timeline tools with byte-compatible frontmatter.
 - [ICCuse/dsh-premise-guard](https://github.com/ICCuse/dsh-premise-guard) - Post-compaction premise-drift guard: injects a one-shot notice when a compaction summary drops a critical literal anchor.
+- [freehul/sgme](https://github.com/freehul/sgme) - ShiGuang Memory Engine (SGME) bridge: multi-agent shared long-term memory via HTTP — L0/L1/L1.5/L2 distillation, scenario-based injection, unified search, and proactive care signals (memory_search / wiki_search / signal_pull / signal_claim / signal_ack), installable as `dsh-sgme`.
 
 ### Tools & Capabilities
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -119,6 +119,7 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 - [ICCuse/dsh-file-memory](https://github.com/ICCuse/dsh-file-memory) — 文件型工作记忆：memorize/recall 把关键前提逐字保存在会话笔记文件，无损挺过上下文压缩。
 - [ICCuse/dsh-knowledge](https://github.com/ICCuse/dsh-knowledge) — 全局知识库桥：kb_add/kb_search/kb_show/kb_timeline 读写与 Codex 共享的 D:\knowledge（格式逐字节兼容）。
 - [ICCuse/dsh-premise-guard](https://github.com/ICCuse/dsh-premise-guard) — 压缩后前提漂移守卫：摘要丢失关键字面锚点时注入一次性提醒。
+- [freehul/sgme](https://github.com/freehul/sgme) — 拾光记忆引擎（SGME）桥接：多智能体共享长期记忆（HTTP）—— L0/L1/L1.5/L2 分层提炼、按场景注入、统一检索、主动关怀信号（memory_search / wiki_search / signal_pull / signal_claim / signal_ack），npm 包名 `dsh-sgme`。
 
 ### 🛠️ 工具与能力
 


### PR DESCRIPTION
## 新增插件

**dsh-sgme** — 拾光记忆引擎（SGME）桥接，为 DeepSeek Harness 提供多智能体共享长期记忆。

- 仓库：https://github.com/freehul/sgme
- npm：https://www.npmjs.com/package/dsh-sgme（\dsh plugin add dsh-sgme\ 可安装）
- 已加 \dsh-plugin\ topic ✅

## 能力

- L0/L1/L1.5/L2 四层记忆提炼（去重/合并/冲突裁决）
- 按场景注入（零 LLM 成本，纯结构化查询）
- 统一检索（BM25 + 向量 + 标签三重融合）
- 主动关怀信号（signal_pull/claim/ack，谁消费谁标记）
- 5 个工具：memory_search / wiki_search / signal_pull / signal_claim / signal_ack

## 改动

在 Memory 分类下中英 README 各加一行。