### PR TITLE
add: dsh-model-failover

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ This list collects community plugins that are installable via `dsh plugin add` (
 - [PerryLink/dsh-doublecheck](https://github.com/PerryLink/dsh-doublecheck) - Engineering-discipline guard: grill the requirements before the first edit, enforce red/green test evidence gates, and audit the delivery with a forked adversary (grill-requirements skill + tool-policy gates).
 - [btspoony/mstar-harness](https://github.com/btspoony/mstar-harness) - Skill-driven harness/loop engineering workflow agent plugin.
 - [Letter2025/dsh-approval-llm](https://github.com/Letter2025/dsh-approval-llm) - Model-based permission approval: an approval-request answerer backed by a separate reviewer model.
+- [Letter2025/dsh-model-failover](https://github.com/Letter2025/dsh-model-failover) - Two-level model circuit breaker with failover: trip a model or a whole provider after repeated request failures and route the next request to a configured fallback.
 
 
 ### Notifications & Integrations

--- a/README.zh.md
+++ b/README.zh.md
@@ -211,6 +211,7 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 - [PerryLink/dsh-doublecheck](https://github.com/PerryLink/dsh-doublecheck) — 工程纪律守门：动笔前审讯需求，红绿测试证据门，交付后对抗评审（grill-requirements 技能 + 工具策略门）。
 - [btspoony/mstar-harness](https://github.com/btspoony/mstar-harness) — 技能驱动的 harness/loop 工程化工作流插件。
 - [Letter2025/dsh-approval-llm](https://github.com/Letter2025/dsh-approval-llm) — 基于模型的权限审批：由独立审查模型自动应答 approval 权限请求。
+- [Letter2025/dsh-model-failover](https://github.com/Letter2025/dsh-model-failover) — 两级模型熔断与回退：模型或平台连续失败后自动熔断，并把下一个请求路由到配置好的备用模型。
 
 
 ### 🔔 通知与集成


### PR DESCRIPTION
Add [Letter2025/dsh-model-failover](https://github.com/Letter2025/dsh-model-failover) to the **Models & Providers / 模型与账号接入** category (one line in each of `README.md` and `README.zh.md`).

Two-level model circuit breaker with failover for DeepSeek Harness: decorates the official `agent/request` + `agent/request-error` waterfalls, trips a model circuit (or a whole provider circuit) after repeated request failures, probes open models after cooldown, and routes the next request to the first healthy configured fallback. Companion to `dsh-approval-llm`.

- [x] `package.json` declares `dsh.bundle` — `dsh.bundle.patch: ./cordis.patch.yml` (installable via `dsh plugin --profile web add dsh-model-failover`)
- [x] One line added to **both** `README.md` (English) and `README.zh.md` (中文), under the matching category
- [x] Description states what the plugin does, no superlatives
- [x] Repo has the `dsh-plugin` topic
