### PR TITLE
Add PicGo/dsh-plugin (Tools & Capabilities)

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ This list collects community plugins that are installable via `dsh plugin add` (
 
 
 - [1na-ko/dsh-hdc-bridge](https://github.com/1na-ko/dsh-hdc-bridge) - HarmonyOS device bridge: hdc screenshot/install/log/crash/UI automation loop with read_image, official-first versioned API knowledge (SDK .d.ts + offline bundled docs), and a DevEco CLI build/sign/lint lane.
+- [PicGo/dsh-plugin](https://github.com/PicGo/dsh-plugin) - Upload local images and files to your image host through PicGo's existing configuration (PicGo Cloud, GitHub, S3, COS, Qiniu, or any installed uploader plugin), via a `picgo_upload` tool and a `/picgo` command.
 ### Skills
 - [creght-dev/skills](https://github.com/creght-dev/skills) - Skills for building websites on the Creght platform: CLI pull/push sync, page and component conventions, CMS, forms, auth, SEO, publishing and version rollback.
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -187,6 +187,7 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 
 
 - [1na-ko/dsh-hdc-bridge](https://github.com/1na-ko/dsh-hdc-bridge) — 鸿蒙设备桥：hdc 截图/装包/日志/崩溃/UI 自动化闭环（配 read_image 看图），官方优先版本化 API 知识层（SDK .d.ts + 离线随包文档），以及 DevEco CLI 构建/签名/lint 通道。
+- [PicGo/dsh-plugin](https://github.com/PicGo/dsh-plugin) — 通过 PicGo 已有配置（PicGo Cloud、GitHub、S3、腾讯云 COS、七牛，或任意已安装的上传插件）把本地图片和文件上传到图床，提供 `picgo_upload` 工具与 `/picgo` 命令。
 ### 🧩 技能包
 - [creght-dev/skills](https://github.com/creght-dev/skills) — Creght 平台建站技能包：CLI 拉取/推送同步、页面与组件规范、CMS、表单、Auth、SEO、发布与版本回滚。
 


### PR DESCRIPTION
Adds [PicGo/dsh-plugin](https://github.com/PicGo/dsh-plugin) — published on npm as [`@picgo/dsh-plugin`](https://www.npmjs.com/package/@picgo/dsh-plugin).

Harness can show the agent a screenshot, but it has no way to turn a local file into a link — so `![](./out.png)` becomes a dead link the moment you push. This plugin uploads through whatever image host the user already configured in PicGo (PicGo Cloud, GitHub, S3, Tencent COS, Qiniu, or any installed third-party uploader plugin), exposing a `picgo_upload` tool and a `/picgo` command.

- [x] My repo's `package.json` declares **`dsh.bundle`** (not just `dsh.client`) — with `cordis.patch.yml` at the repo root
- [x] One line added to **both** `README.md` (English) and `README.zh.md` (中文), under Tools & Capabilities / 🛠️ 工具与能力
- [x] Description states what the plugin does, no superlatives
- [x] My repo has the `dsh-plugin` topic

**Recommended / 推荐项：**

- [x] 📦 Published to npm — `dsh plugin --profile web add @picgo/dsh-plugin`
- [x] 🔗 `@deepseek-ai/dsh-tools` declared as a `peerDependency`