### PR TITLE
add dsh-auto-continue to UI Enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ This list collects community plugins that are installable via `dsh plugin add` (
 
 - [Jolly-J/dsh-deepseek-billing](https://github.com/Jolly-J/dsh-deepseek-billing) - DeepSeek account balance and per-session cost card in the sidebar foot.
 - [AKIRACOD/dsh-drag-and-drop](https://github.com/AKIRACOD/dsh-drag-and-drop) - File-drag fork: drop documents as removable chips above the composer, send without typing.
+- [HsiangNianian/dsh-auto-continue](https://github.com/HsiangNianian/dsh-auto-continue) - Auto-resumes interrupted DSH Web requests: sends a queued 「继续」 after network, timeout or host-crash failures, with error classification, adaptive backoff, templated continue text and browser notifications.
 
 
 ### Themes & Appearance

--- a/README.zh.md
+++ b/README.zh.md
@@ -81,6 +81,7 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 
 - [Jolly-J/dsh-deepseek-billing](https://github.com/Jolly-J/dsh-deepseek-billing) — 侧边栏底部 DeepSeek 账户余额显示与会话费用估算卡片。
 - [AKIRACOD/dsh-drag-and-drop](https://github.com/AKIRACOD/dsh-drag-and-drop) — 拖放 fork：文档以可删除「文件芯片」挂在输入框上方，不打字也能发送。
+- [HsiangNianian/dsh-auto-continue](https://github.com/HsiangNianian/dsh-auto-continue) — DSH Web 请求中断自动续跑：网络、超时或宿主崩溃等非人为失败后自动发送「继续」，支持错误分类、自适应退避、模板化继续文本与浏览器通知。
 
 
 ### 🎭 主题与外观


### PR DESCRIPTION
## What

Add [HsiangNianian/dsh-auto-continue](https://github.com/HsiangNianian/dsh-auto-continue) to **UI Enhancements** (one line each in `README.md` and `README.zh.md`).

## Checklist

- [x] `dsh.bundle` manifest declared (`dsh.bundle.patch: ./cordis.patch.yml` + `dsh.client`) — installable via `dsh plugin add`
- [x] Real, working code (browser half engine + host half settings namespace; 12 headless behavioral tests)
- [x] Published on npm (`dsh-client-auto-continue@0.3.0`, prebuilt install — no `allowBuilds` step)
- [x] Official `@deepseek-ai/*` packages declared as `peerDependencies`
- [x] `dsh-plugin` topic set
- [x] One factual line per language, no marketing

## Description

Auto-resumes interrupted DSH Web requests: after network/timeout/host-crash failures it sends a queued 「继续」, with error classification (permanent auth/balance/model errors are skipped), adaptive backoff, templated continue text (`{code}` `{tool}` placeholders) and optional browser notifications. Everything configurable from the plugin settings card.
