### PR TITLE
add: dsh-tool-search

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ This list collects community plugins that are installable via `dsh plugin add` (
 
 - [SamXiaBing/dsh-adb](https://github.com/SamXiaBing/dsh-adb) - ADB device & bench operations for DSH: device discovery, structured logcat (background streaming), apk install, file pull/push, and dumpsys performance snapshots.
 - [xiaoyuyu6420/dsh-backup](https://github.com/xiaoyuyu6420/dsh-backup) - One-command backup of DSH user data: /backup, scheduled auto-backup, sha256 checksums and rotation.
+- [Letter2025/dsh-tool-search](https://github.com/Letter2025/dsh-tool-search) - Hermes-style tool search & slimming: progressive disclosure, semantic search, describe, and call long-tail tools on demand while core tools stay eager.
 
 
 - [1na-ko/dsh-hdc-bridge](https://github.com/1na-ko/dsh-hdc-bridge) - HarmonyOS device bridge: hdc screenshot/install/log/crash/UI automation loop with read_image, official-first versioned API knowledge (SDK .d.ts + offline bundled docs), and a DevEco CLI build/sign/lint lane.

--- a/README.zh.md
+++ b/README.zh.md
@@ -184,6 +184,7 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 
 - [SamXiaBing/dsh-adb](https://github.com/SamXiaBing/dsh-adb) — ADB 设备·台架运维工具集：设备发现、结构化 logcat（后台采集）、apk 安装、文件 pull/push、性能快照。
 - [xiaoyuyu6420/dsh-backup](https://github.com/xiaoyuyu6420/dsh-backup) — 一键备份 DSH 用户数据：/backup 命令、定时自动备份、sha256 校验与自动轮换。
+- [Letter2025/dsh-tool-search](https://github.com/Letter2025/dsh-tool-search) — Hermes 风格工具搜索与瘦身：渐进式披露，语义搜索/查看/调用长尾工具，核心工具保持直通。
 
 
 - [1na-ko/dsh-hdc-bridge](https://github.com/1na-ko/dsh-hdc-bridge) — 鸿蒙设备桥：hdc 截图/装包/日志/崩溃/UI 自动化闭环（配 read_image 看图），官方优先版本化 API 知识层（SDK .d.ts + 离线随包文档），以及 DevEco CLI 构建/签名/lint 通道。


### PR DESCRIPTION
Add [Letter2025/dsh-tool-search](https://github.com/Letter2025/dsh-tool-search) to the **Tools & Capabilities / 工具与能力** category (one line in each of `README.md` and `README.zh.md`).

Hermes-style tool search & slimming for DeepSeek Harness: when the tool catalog is large, the model-visible schemas collapse to three bridge tools (`tool_search` / `tool_describe` / `tool_call`) plus a tiered grouped manifest; long-tail tools are discovered through a configured rerank model and invoked by real name. Core tools stay eager. Includes a conversational setup skill for tool grouping and matcher configuration.

- [x] `package.json` declares `dsh.bundle` — `dsh.bundle.patch: ./cordis.patch.yml` (installable via `dsh plugin --profile web add dsh-tool-search`)
- [x] One line added to **both** `README.md` (English) and `README.zh.md` (中文), under the matching category
- [x] Description states what the plugin does, no superlatives
- [x] Repo has the `dsh-plugin` topic
