### PR TITLE
Add dsh-ultracode to Workflow & Automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ This list collects community plugins that are installable via `dsh plugin add` (
 
 ### Workflow & Automation
 
+- [ParticleLight/dsh-ultracode](https://github.com/ParticleLight/dsh-ultracode) - UltraCode agent preset: max-depth reasoning + plan-execute-verify + parallel subagent orchestration as a one-command-install working mode.
 - [icetomoyo/dsh_workflow](https://github.com/icetomoyo/dsh_workflow) - UltraCode-style multi-agent orchestration: a generatable, savable, governable, observable, resumable workflow layer.
 - [NanmiCoder/dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) - AgentTeams multi-agent teams.
 - [titanwings/dsh-automation](https://github.com/titanwings/dsh-automation) - Scheduled coding runs in fresh agent sessions with auditable history.

--- a/README.zh.md
+++ b/README.zh.md
@@ -194,6 +194,7 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 
 
 ### 🔁 工作流与自动化
+- [ParticleLight/dsh-ultracode](https://github.com/ParticleLight/dsh-ultracode) — UltraCode Agent 预设：最大推理深度 + 规划-执行-验证 + 并行子代理编排，一键安装即得的完整工作模式。
 
 - [icetomoyo/dsh_workflow](https://github.com/icetomoyo/dsh_workflow) — 把 UltraCode 式多 Agent 调度带给 DSH：可生成、可保存、可治理、可观察、可恢复的 Workflow 层。
 - [NanmiCoder/dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) — AgentTeams 多智能体团队。


### PR DESCRIPTION
## What

Adds [ParticleLight/dsh-ultracode](https://github.com/ParticleLight/dsh-ultracode) to the **Workflow & Automation** category (both EN and ZH lists).

## Why

dsh-ultracode is an UltraCode **agent preset** plugin for DeepSeek Harness: a working mode, not just an effort level. It installs the ultracode agent preset into \/.agent-presets/ on first boot (idempotent), giving sessions:

- Max-depth reasoning before acting
- Plan → execute → verify discipline
- Parallel subagent/workflow fan-out
- Complete, verifiable results

It is built on the code (PTC) preset with the UltraCode working-mode guide added to the persona. Install: dsh plugin --profile web add github:ParticleLight/dsh-ultracode.

Tagged dsh-plugin on GitHub.