### PR TITLE
docs: add dsh-chat-outline to UI Enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ This list collects community plugins that are installable via `dsh plugin add` (
 - [Jolly-J/dsh-deepseek-billing](https://github.com/Jolly-J/dsh-deepseek-billing) - DeepSeek account balance and per-session cost card in the sidebar foot.
 - [AKIRACOD/dsh-drag-and-drop](https://github.com/AKIRACOD/dsh-drag-and-drop) - File-drag fork: drop documents as removable chips above the composer, send without typing.
 - [HsiangNianian/dsh-auto-continue](https://github.com/HsiangNianian/dsh-auto-continue) - Auto-resumes interrupted DSH Web requests: sends a queued 「继续」 after network, timeout or host-crash failures, with error classification, adaptive backoff, templated continue text and browser notifications.
+- [liliuCourier/dsh-chat-outline](https://github.com/liliuCourier/dsh-chat-outline) - Persistent left-hand conversation outline: questions and final replies per turn, keyword filter, one-click jump.
 
 
 ### Themes & Appearance

--- a/README.zh.md
+++ b/README.zh.md
@@ -83,6 +83,7 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 - [Jolly-J/dsh-deepseek-billing](https://github.com/Jolly-J/dsh-deepseek-billing) — 侧边栏底部 DeepSeek 账户余额显示与会话费用估算卡片。
 - [AKIRACOD/dsh-drag-and-drop](https://github.com/AKIRACOD/dsh-drag-and-drop) — 拖放 fork：文档以可删除「文件芯片」挂在输入框上方，不打字也能发送。
 - [HsiangNianian/dsh-auto-continue](https://github.com/HsiangNianian/dsh-auto-continue) — DSH Web 请求中断自动续跑：网络、超时或宿主崩溃等非人为失败后自动发送「继续」，支持错误分类、自适应退避、模板化继续文本与浏览器通知。
+- [liliuCourier/dsh-chat-outline](https://github.com/liliuCourier/dsh-chat-outline) — 对话栏左侧常驻大纲：按轮次列出提问与最后回复，支持关键词过滤与一键跳转。
 
 
 ### 🎭 主题与外观


### PR DESCRIPTION
Add [liliuCourier/dsh-chat-outline](https://github.com/liliuCourier/dsh-chat-outline) to the UI Enhancements section (one line each in README.md and README.zh.md).

- Declares `dsh.bundle` manifest with `cordis.patch.yml` (installable via `dsh plugin add`)
- Published on npm (`dsh-chat-outline`), official `@deepseek-ai/*` packages as `peerDependencies`
- Repo tagged with the `dsh-plugin` topic

The plugin is a persistent left-hand conversation outline: questions and final replies per turn, keyword filter, one-click jump, and a scroll-following position indicator.