### PR TITLE
Add bwndlct/dsh-session-export (Sessions & Messages)

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ This list collects community plugins that are installable via `dsh plugin add` (
 - [Chinesezjc/dsh-interconnect](https://github.com/Chinesezjc/dsh-interconnect) - Cross-instance message and event handoff between DSH instances via an interconnect server.
 - [Wine-Red/dsh-prompt-stash](https://github.com/Wine-Red/dsh-prompt-stash) - Local, per-session LIFO prompt stash for temporarily setting aside unfinished composer text and safely restoring it later.
 - [heartmove/dsh-side-chat](https://github.com/heartmove/dsh-side-chat) - Select part of a conversation and ask about it in a right-side side chat; bring AI replies back to the main chat directly or as a summary.
-
+- [bwndlct/dsh-session-export](https://github.com/bwndlct/dsh-session-export) - Export the current session to portable, schema-versioned Markdown and JSON files via the `session_export` tool and slash commands, with cross-platform-safe filenames.
 
 ### Memory
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -112,7 +112,7 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 - [Chinesezjc/dsh-interconnect](https://github.com/Chinesezjc/dsh-interconnect) — 跨实例互联：经 interconnect 服务在多个 DSH 实例间转发消息与事件。
 - [Wine-Red/dsh-prompt-stash](https://github.com/Wine-Red/dsh-prompt-stash) — 本地、按会话隔离的 LIFO 输入暂存：临时收起未完成的输入，之后安全恢复并继续编辑。
 - [heartmove/dsh-side-chat](https://github.com/heartmove/dsh-side-chat) — 选中对话片段，在右侧面板的侧边聊天中提问（按会话隔离）；AI 回复可原文或摘要后带回主会话。
-
+- [bwndlct/dsh-session-export](https://github.com/bwndlct/dsh-session-export) — 把当前会话导出为可移植、带 schema 版本的 Markdown 与 JSON 文件，提供 `session_export` 工具与斜杠命令两种入口，文件名跨平台安全。
 
 ### 🧠 记忆
 


### PR DESCRIPTION
Adds one line to each of README.md and README.zh.md under Sessions & Messages / 会话与消息.

**Plugin**: https://github.com/bwndlct/dsh-session-export
**Category**: Sessions & Messages

Checklist per contributing.md:
- [x] `dsh.bundle` manifest declared in `package.json` (with `cordis.patch.yml` at repo root)
- [x] Real, working code (31 tests, verified live against dsh 0.1.0-rc.6 in web + headless profiles)
- [x] `dsh-plugin` topic added to the repo
- [x] Official `@deepseek-ai/*` packages declared as `peerDependencies`
- [x] Descriptions state what the plugin does (EN + ZH), no marketing
- [ ] npm publish — skipped for now; GitHub install (`dsh plugin add github:bwndlct/dsh-session-export`) verified working with committed build output