### PR TITLE
Add dsh-plugin-hub under UI Enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ This list collects community plugins that are installable via `dsh plugin add` (
 
 ### UI Enhancements
 
+- [Noob-stupid/dsh-plugin-hub](https://github.com/Noob-stupid/dsh-plugin-hub) - A plugin management panel: one-click enable/disable for installed plugins plus a GitHub dsh-plugin marketplace with details and one-click installs.
+
+
 - [huiliyi37/dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) - A terminal UI (TUI) for DeepSeek Harness.
 - [openma-ai/deepseek-harness-tui](https://github.com/openma-ai/deepseek-harness-tui) - A Rust/ratatui terminal client that speaks the DSH SDK JSON-RPC protocol directly and runs standalone or as a profile bundle.
 - [omdsh-dev/dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) - Codex-style `@file` mentions: search workspace files in the composer and attach their contents to prompts.

--- a/README.zh.md
+++ b/README.zh.md
@@ -35,6 +35,9 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 ## 插件
 
 ### 🎨 UI 增强
+
+- [Noob-stupid/dsh-plugin-hub](https://github.com/Noob-stupid/dsh-plugin-hub) — 插件管理面板：已安装插件一键启用/停用，内置 GitHub dsh-plugin 插件市场，支持详情查看与一键安装。
+
 - [zealot00/dsh-pet](https://github.com/zealot00/dsh-pet) - DSH Web UI 桌面宠物：精灵图动画、agent 状态联动、拖拽、闹钟（每天/一次）与番茄钟，皮肤下拉选择 + 预览。
 
 - [huiliyi37/dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) — DeepSeek Harness 的终端 UI（TUI）。


### PR DESCRIPTION
Add **dsh-plugin-hub** under UI Enhancements:

A plugin management panel for the DSH web UI: one-click enable/disable for installed plugins plus a GitHub dsh-plugin marketplace with plugin details and one-click installs.

- Declares a `dsh.bundle` manifest (installable via `dsh plugin add`).
- Carries the `dsh-plugin` topic.
- Entry added to both `README.md` and `README.zh.md`.
