### PR TITLE
Add yyh-001/dsh-expression to Just for Fun (meme plugin)

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,7 @@ This list collects community plugins that are installable via `dsh plugin add` (
 - [anweat/dsh-browser](https://github.com/anweat/dsh-browser) - Self-contained browser runtime: Playwright (chromium) + OpenCLI as plugin-local dependencies (global reuse fallback), exposes a `browser` service and 9 interactive browser tools.
 - [anweat/dsh-voice-webspeech](https://github.com/anweat/dsh-voice-webspeech) - Browser Web Speech API voice input: zero server, zero keys, zero model downloads (Edge=Azure, Chrome=Google speech).
 - [anweat/dsh-restart](https://github.com/anweat/dsh-restart) - Restart DSH: configurable restart method (Node native / legacy PowerShell), post-restart continue prompt, optional watchdog auto-relaunch.
+- [yyh-001/dsh-expression](https://github.com/yyh-001/dsh-expression) - Meme search, the fun way: describe the vibe, and the agent finds and sends a real meme that actually fits.
 
 
 ## Contributing

--- a/README.zh.md
+++ b/README.zh.md
@@ -312,6 +312,7 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 - [anweat/dsh-browser](https://github.com/anweat/dsh-browser) — 自包含浏览器运行时：Playwright（chromium）+ OpenCLI 作为插件本地依赖（全局复用回退），提供 `browser` 服务与 9 个交互式浏览器工具。
 - [anweat/dsh-voice-webspeech](https://github.com/anweat/dsh-voice-webspeech) — 浏览器 Web Speech API 语音输入：零服务端、零密钥、零模型下载（Edge=Azure 语音、Chrome=Google 语音）。
 - [anweat/dsh-restart](https://github.com/anweat/dsh-restart) — DSH 重启插件：可配置的重启方式（Node 原生/旧 PowerShell 适配）、重启后自动继续的提示词、可选看门狗自动拉起。
+- [yyh-001/dsh-expression](https://github.com/yyh-001/dsh-expression) — 陪 AI 斗图的搞笑插件：说个感觉，AI 帮你搜到、发出那张恰到好处的真实表情包。
 
 
 ## 贡献


### PR DESCRIPTION
Add [yyh-001/dsh-expression](https://github.com/yyh-001/dsh-expression) to **Just for Fun / 娱乐**.\n\nA meme plugin for DeepSeek Harness: describe the vibe/mood and the agent finds and sends a real meme that actually fits.\n\nRequirements check:\n- package.json declares dsh.bundle manifest (with cordis.patch.yml)\n- Real working code (not a placeholder)\n- dsh-plugin topic added\n- Entry added to both README.md (EN) and README.zh.md (中文)