### PR TITLE
Add dsh-mic-input: microphone voice input for the DSH Web UI (Web Speech API)

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ This list collects community plugins that are installable via `dsh plugin add` (
 - [HsiangNianian/dsh-auto-continue](https://github.com/HsiangNianian/dsh-auto-continue) - Auto-resumes interrupted DSH Web requests: sends a queued 「继续」 after network, timeout or host-crash failures, with error classification, adaptive backoff, templated continue text and browser notifications.
 - [liliuCourier/dsh-chat-outline](https://github.com/liliuCourier/dsh-chat-outline) - Persistent left-hand conversation outline: questions and final replies per turn, keyword filter, one-click jump.
 - [LaoYueHanNi/dsh-token-usage](https://github.com/LaoYueHanNi/dsh-token-usage) - Per-request model token usage tracked to per-day JSONL files, with a stats page in Web settings: daily trend chart, per-model breakdown, and date/model filters.
+- [QT-Chen/dsh-mic-input](https://github.com/QT-Chen/dsh-mic-input) - Microphone voice input for the composer: browser Web Speech API live transcription, dedupe/auto-continue, smart punctuation, language and auto-send settings.
 
 
 ### Themes & Appearance

--- a/README.zh.md
+++ b/README.zh.md
@@ -88,6 +88,7 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 - [HsiangNianian/dsh-auto-continue](https://github.com/HsiangNianian/dsh-auto-continue) — DSH Web 请求中断自动续跑：网络、超时或宿主崩溃等非人为失败后自动发送「继续」，支持错误分类、自适应退避、模板化继续文本与浏览器通知。
 - [liliuCourier/dsh-chat-outline](https://github.com/liliuCourier/dsh-chat-outline) — 对话栏左侧常驻大纲：按轮次列出提问与最后回复，支持关键词过滤与一键跳转。
 - [LaoYueHanNi/dsh-token-usage](https://github.com/LaoYueHanNi/dsh-token-usage) — 按请求持久化模型 token 用量，Web 设置「Token 用量」统计页：按日趋势图、按模型明细表、日期/模型筛选。
+- [QT-Chen/dsh-mic-input](https://github.com/QT-Chen/dsh-mic-input) — 输入框麦克风语音输入：浏览器 Web Speech API 实时转写，自动去重/续听、智能标点，支持语言与自动发送设置。
 
 
 ### 🎭 主题与外观


### PR DESCRIPTION
Add [QT-Chen/dsh-mic-input](https://github.com/QT-Chen/dsh-mic-input) to the UI Enhancements category.

**dsh-mic-input** — pure client plugin adding a microphone button to the composer of the DSH Web GUI. Live transcription via the browser's built-in Web Speech API (Edge=Azure, Chrome=Google), zero server, zero keys. Features: no duplicated text (draft rebuilt from session start, interim-echo dedupe), auto-continue on silence, smart punctuation (auto-complete ？/！/。), language selection, optional auto-send, settings row under 设置 → 通用 → 语音输入.

- `dsh.bundle.patch` + `dsh.client` (platform web) declared; installable via `dsh plugin --profile web add github:QT-Chen/dsh-mic-input`
- Repo topic: `dsh-plugin`
- MIT licensed, active maintenance

---

收录 [QT-Chen/dsh-mic-input](https://github.com/QT-Chen/dsh-mic-input)（UI 增强分类）。