### PR TITLE
Add dsh-ding: conversation-done notification plugin (sound + Windows toast)

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ This list collects community plugins that are installable via `dsh plugin add` (
 - [imetn/dsh-lark-bridge](https://github.com/imetn/dsh-lark-bridge) - Bidirectional Lark/Feishu controller for DeepSeek Harness with project and session routing, interactive cards, approvals, attachments, and task controls.
 - [pc439527/dsh-notify-bark](https://github.com/pc439527/dsh-notify-bark) - Bark push notifications to iPhone: turn completion, waiting-for-input, and approval events sent from the DSH Host.
 
+- [CAOGGL/dsh-ding](https://github.com/CAOGGL/dsh-ding) — Notifies you when a conversation finishes: plays a sound and shows a Windows notification when the agent goes idle (configurable sound file, volume, debounce/throttle).
 
 ### Models & Providers
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -246,6 +246,7 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 - [imetn/dsh-lark-bridge](https://github.com/imetn/dsh-lark-bridge) — DeepSeek Harness 的飞书/Lark 双向控制器，支持 Project 与 Session 路由、交互卡片、审批、附件和任务控制。
 - [pc439527/dsh-notify-bark](https://github.com/pc439527/dsh-notify-bark) — Bark 推送通知到 iPhone：回合完成、等待回答、等待授权等事件由 Host 端发送。
 
+- [CAOGGL/dsh-ding](https://github.com/CAOGGL/dsh-ding) — 对话完成提醒：Agent 空闲（idle）时播放提示音并弹 Windows 原生通知，可配 ding.mp3、音量与防抖节流。
 
 ### 🔌 模型与账号接入
 


### PR DESCRIPTION
Adds [dsh-ding](https://github.com/CAOGGL/dsh-ding) under the notifications category.

- Plays a sound (default `ding.mp3`, configurable) and shows a Windows native notification when the DSH agent finishes a conversation (status back to idle)
- Configurable: sound file, volume 0~1, debounce/throttle, skip-subagents
- Installable as a bundle: `dsh plugin --profile web add github:CAOGGL/dsh-ding`
- MIT licensed, topic `dsh-plugin`