### PR TITLE
Add dsh-testgen (automated unit-test generation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ This list collects community plugins that are installable via `dsh plugin add` (
 
 ### Development & Runtime
 
+- [bujue600-arch/dsh-testgen](https://github.com/bujue600-arch/dsh-testgen) - Automated unit-test generation: a /testgen command and generate_tests tool that scaffold, run, and fix tests until they pass (LLM + offline template generators; vitest/jest/mocha/node:test).
 - [omdsh-dev/fabric](https://github.com/omdsh-dev/fabric) - An MC-Fabric-style hook processor.
 - [LoserFox/dsh-git-identity](https://github.com/LoserFox/dsh-git-identity) - Pin Git commits to the environment's own author identity; env-var injection overrides all `git config` settings.
 - [Zhenyu98/dsh-context-doctor](https://github.com/Zhenyu98/dsh-context-doctor) - Context injection audit: token costs of instruction chains / skill catalogs / tool schemas, duplicate and conflict detection.

--- a/README.zh.md
+++ b/README.zh.md
@@ -258,6 +258,7 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 
 ### 🧑‍💻 开发与运行时
 
+- [bujue600-arch/dsh-testgen](https://github.com/bujue600-arch/dsh-testgen) - 自动化单元测试生成：/testgen 命令与 generate_tests 工具，生成、运行并修复测试直至通过（LLM 与离线模板双生成器；支持 vitest/jest/mocha/node:test）。
 - [omdsh-dev/fabric](https://github.com/omdsh-dev/fabric) — 类似 MC Fabric 的 hook 处理器。
 - [LoserFox/dsh-git-identity](https://github.com/LoserFox/dsh-git-identity) — git 提交固定使用环境自身作者身份，环境变量注入压过一切 `git config` 设置。
 - [Zhenyu98/dsh-context-doctor](https://github.com/Zhenyu98/dsh-context-doctor) — 上下文注入审计：统计指令链/技能目录/工具 schema 的 token 成本，检测重复与冲突。


### PR DESCRIPTION
Adds [dsh-testgen](https://github.com/bujue600-arch/dsh-testgen) under Development & Runtime.

A DeepSeek Harness plugin that generates, runs, and fixes unit tests: /testgen slash command + generate_tests model tool, LLM and offline template generators, hot-reloaded config, 79 unit tests, CI. Repo carries the dsh-plugin topic.