### PR TITLE
feat: add itr-del/dsh-feishu to Notifications & Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,7 @@ dsh plugin --profile web add dshmarket
 - [xmanrui/dsh-feishu](https://github.com/xmanrui/dsh-feishu) - Connect a Feishu bot to DeepSeek Harness by scanning a QR code.
 - [doncelee229-cmyk/dsh-plugin-approval-alert](https://github.com/doncelee229-cmyk/dsh-plugin-approval-alert) - Native OS notifications for approval and question/plan prompts: the toast names the workspace, click jumps to it, bilingual (zh-CN/zh-TW/en), with chime.
 - [muretai/muretai-dsh-skill](https://github.com/muretai/muretai-dsh-skill) - Puts the agent on the Muretai network: its own identity, invite-based introductions, signed end-to-end encrypted messaging with agents owned by other people, and an inbound-mail wake that lets it reply on its own.
+- [itr-del/dsh-feishu](https://github.com/itr-del/dsh-feishu) - Feishu (Lark) IM bridge for DeepSeek Harness via `dsh plugin add`; one DM user to one persistent dsh session, with full debugging docs.
 
 ### Models & Providers
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -347,6 +347,7 @@ dsh plugin --profile web add dshmarket
 - [xmanrui/dsh-feishu](https://github.com/xmanrui/dsh-feishu) — 通过扫码把飞书机器人接入DeepSeek Harness。
 - [doncelee229-cmyk/dsh-plugin-approval-alert](https://github.com/doncelee229-cmyk/dsh-plugin-approval-alert) — 审批与选择方案的系统级桌面通知：通知显示所属工作区、点击跳转到对应工作区，多语言（简中/繁中/英文），附提示音。
 - [muretai/muretai-dsh-skill](https://github.com/muretai/muretai-dsh-skill) — 让智能体加入 Muretai 网络：拥有自己的身份，通过邀请相识，与属于其他人的智能体进行签名、端到端加密的通信；来信唤醒后可自行回复。
+- [itr-del/dsh-feishu](https://github.com/itr-del/dsh-feishu) — DeepSeek Harness 的飞书/Lark 私聊桥接插件，支持 `dsh plugin add` 一键安装，配套完整调试文档。
 
 ### 🔌 模型与账号接入
 


### PR DESCRIPTION
Adds **dsh-feishu** under "Notifications & Integrations".

- Repo: https://github.com/itr-del/dsh-feishu
- Description: Feishu (Lark) IM bridge for DeepSeek Harness — a cordis plugin that wires a Feishu self-built bot into a running `dsh web` profile.
- Highlights: scoped `agent/status` listener, `installModelSelection()` setup, DSML tool-call marker filter, one Feishu user ↔ one persistent dsh session.
- License: MIT
- Author: itr-del (13918029394@163.com)
- Disclosure: I wrote and maintain dsh-feishu.

Companion to imetn/dsh-lark-bridge — same target (Feishu), different design:
this one focuses on the *minimal viable* path that documents every gotcha
(agents.create meta, scoped events, env var inheritance) so newcomers can
debug their own bridges without rediscovering them.

Topic tags added on the repo: `dsh`, `dsh-plugin`, `feishu`, `lark`, `im-bridge`, `cordis`.