### PR TITLE
Add dsh-feishu-bridge (Feishu/Lark channel, fail-closed)

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,6 +350,7 @@ dsh plugin --profile web add dshmarket
 - [doncelee229-cmyk/dsh-plugin-approval-alert](https://github.com/doncelee229-cmyk/dsh-plugin-approval-alert) - Native OS notifications for approval and question/plan prompts: the toast names the workspace, click jumps to it, bilingual (zh-CN/zh-TW/en), with chime.
 - [muretai/muretai-dsh-skill](https://github.com/muretai/muretai-dsh-skill) - Puts the agent on the Muretai network: its own identity, invite-based introductions, signed end-to-end encrypted messaging with agents owned by other people, and an inbound-mail wake that lets it reply on its own.
 - [itr-del/dsh-feishu](https://github.com/itr-del/dsh-feishu) - Feishu (Lark) IM bridge for DeepSeek Harness via `dsh plugin add`; one DM user to one persistent dsh session, with full debugging docs.
+- [wz-heng/dsh-feishu-bridge](https://github.com/wz-heng/dsh-feishu-bridge) - Fail-closed Feishu (Lark) channel bridge: chat with a bot, get dsh agent turns back. Official-Python-SDK-only integration (exact-pinned); deny-by-default allowlist, webhook signature/timestamp/replay verification, per-chat sticky sessions; bilingual docs.
 
 ### Models & Providers
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -348,6 +348,7 @@ dsh plugin --profile web add dshmarket
 - [doncelee229-cmyk/dsh-plugin-approval-alert](https://github.com/doncelee229-cmyk/dsh-plugin-approval-alert) — 审批与选择方案的系统级桌面通知：通知显示所属工作区、点击跳转到对应工作区，多语言（简中/繁中/英文），附提示音。
 - [muretai/muretai-dsh-skill](https://github.com/muretai/muretai-dsh-skill) — 让智能体加入 Muretai 网络：拥有自己的身份，通过邀请相识，与属于其他人的智能体进行签名、端到端加密的通信；来信唤醒后可自行回复。
 - [itr-del/dsh-feishu](https://github.com/itr-del/dsh-feishu) — DeepSeek Harness 的飞书/Lark 私聊桥接插件，支持 `dsh plugin add` 一键安装，配套完整调试文档。
+- [wz-heng/dsh-feishu-bridge](https://github.com/wz-heng/dsh-feishu-bridge) — Fail-closed 的飞书（Lark）channel 桥：和机器人聊天即驱动 dsh agent turn。仅经官方 Python SDK 集成（精确锁版）；白名单默认全拒、webhook 验签/时间窗/防重放、按 chat 粘性会话；中英双语文档。
 
 ### 🔌 模型与账号接入
 


### PR DESCRIPTION
Adds **[wz-heng/dsh-feishu-bridge](https://github.com/wz-heng/dsh-feishu-bridge)** under *Notifications & Integrations*, one line in both README.md and README.zh.md per the contributing convention. Repo carries the `dsh-plugin` topic.

Community project (not DeepSeek-official, stated in its README). Highlights: fail-closed security posture — deny-by-default allowlist; webhook signature, timestamp-window and replay verification enforced at the bridge's own boundary rather than delegated to lark-channel-sdk (gaps we found there are reported upstream: larksuite/channel-sdk-python#11, #12); official-Python-SDK-only integration with an exact version pin; per-chat sticky sessions; verified end-to-end against real Feishu; bilingual README with a 5-minute quickstart; 131 tests, none spending API quota by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)