### PR TITLE
docs: add task-passport

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ This list collects community plugins that are installable via `dsh plugin add` (
 
 - [Anionex/dsh-turn-rewind](https://github.com/Anionex/dsh-turn-rewind) - Rewind conversation and workspace state, powered by a persistent Change Ledger.
 - [Jesse-njx/dsh-crosstalk](https://github.com/Jesse-njx/dsh-crosstalk) - Cross-session messaging for DSH: any session on the machine can list and message any other, Claude Code-style, via a local heartbeat registry and inbox.
+- [dongsheng123132/task-passport](https://github.com/dongsheng123132/task-passport) - Carry durable task state across DeepSeek Harness, WorkBuddy, Claude Code and Codex with machine-readable checkpoints and optimistic locking.
 - [hellodigua/dsh-share](https://github.com/hellodigua/dsh-share) - Share your conversations with one click.
 - [Moeblack/dsh-message-edit](https://github.com/Moeblack/dsh-message-edit) - Branch-based message editing, reroll, retry, and a version timeline.
 - [Buyi-wsgzg/dsh-sidechain](https://github.com/Buyi-wsgzg/dsh-sidechain) - `/side` persistent side sessions and `/btw` one-shot side questions, run in a temporary fork without touching main history.

--- a/README.zh.md
+++ b/README.zh.md
@@ -105,6 +105,7 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 
 - [Anionex/dsh-turn-rewind](https://github.com/Anionex/dsh-turn-rewind) — 对话回退：基于持久 Change Ledger 回滚会话与工作区状态。
 - [Jesse-njx/dsh-crosstalk](https://github.com/Jesse-njx/dsh-crosstalk) — 跨会话消息：本机任意会话都可像 Claude Code 一样列出并互发消息，基于本地心跳注册表与收件箱。
+- [dongsheng123132/task-passport](https://github.com/dongsheng123132/task-passport) — 通过机器可读检查点与乐观锁，在 DeepSeek Harness、WorkBuddy、Claude Code 和 Codex 之间交接持久任务状态。
 - [hellodigua/dsh-share](https://github.com/hellodigua/dsh-share) — 一键分享你的对话。
 - [Moeblack/dsh-message-edit](https://github.com/Moeblack/dsh-message-edit) — 基于分支的消息编辑、reroll、重试与版本时间线。
 - [Buyi-wsgzg/dsh-sidechain](https://github.com/Buyi-wsgzg/dsh-sidechain) — `/side` 持续性侧会话与 `/btw` 一次性侧问，在临时 fork 中运行、不写入主会话历史。


### PR DESCRIPTION
## What changed

Adds `dongsheng123132/task-passport` to Sessions & Messages in both the English and Chinese READMEs.

## Why

Task Passport carries durable task state across DeepSeek Harness, WorkBuddy, Claude Code and Codex using machine-readable checkpoints and optimistic locking. The repository contains a real installable DSH bundle and working CLI.

## Verification

- Immutable source: https://github.com/dongsheng123132/task-passport/tree/61ab7881e09c23a930e676cd9e450fdef436b14c
- `package.json` declares `dsh.bundle.patch`; the referenced `cordis.patch.yml` exists at that commit
- Fresh checkout: `npm test` (15/15), `npm run check`, and `npm run pack:check` pass
- Both language entries added; `git diff --check` passes