### PR TITLE
Add dsh-evidence-memory: Git-backed evidence memory plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ dsh plugin --profile web add dshmarket
 - [ICCuse/dsh-premise-guard](https://github.com/ICCuse/dsh-premise-guard) - Post-compaction premise-drift guard: injects a one-shot notice when a compaction summary drops a critical literal anchor.
 - [freehul/sgme](https://github.com/freehul/sgme) - ShiGuang Memory Engine (SGME) bridge: multi-agent shared long-term memory via HTTP — L0/L1/L1.5/L2 distillation, scenario-based injection, unified search, and proactive care signals (memory_search / wiki_search / signal_pull / signal_claim / signal_ack), installable as `dsh-sgme`.
 - [Phant0Meow/dsh-memory-meow](https://github.com/Phant0Meow/dsh-memory-meow) - Project-scoped cross-session memory: PROJECT.md snapshot injected into the first user message, a memory_remember tool, and auto-reflection after ReAct tasks; each project keeps its own memory file.
+- [LeslieWylie/dsh-tool-rlvr-memory](https://github.com/LeslieWylie/dsh-tool-rlvr-memory) - Git-backed evidence memory: auditable, line-addressable citations with commit hash, freshness, and status; provides doctor/search/get/sync tools.
 
 
 ### Tools & Capabilities

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ dsh plugin --profile web add dshmarket
 - [ICCuse/dsh-premise-guard](https://github.com/ICCuse/dsh-premise-guard) - Post-compaction premise-drift guard: injects a one-shot notice when a compaction summary drops a critical literal anchor.
 - [freehul/sgme](https://github.com/freehul/sgme) - ShiGuang Memory Engine (SGME) bridge: multi-agent shared long-term memory via HTTP — L0/L1/L1.5/L2 distillation, scenario-based injection, unified search, and proactive care signals (memory_search / wiki_search / signal_pull / signal_claim / signal_ack), installable as `dsh-sgme`.
 - [Phant0Meow/dsh-memory-meow](https://github.com/Phant0Meow/dsh-memory-meow) - Project-scoped cross-session memory: PROJECT.md snapshot injected into the first user message, a memory_remember tool, and auto-reflection after ReAct tasks; each project keeps its own memory file.
-- [LeslieWylie/dsh-tool-rlvr-memory](https://github.com/LeslieWylie/dsh-tool-rlvr-memory) - Git-backed evidence memory: auditable, line-addressable citations with commit hash, freshness, and status; provides doctor/search/get/sync tools.
+- [LeslieWylie/dsh-evidence-memory](https://github.com/LeslieWylie/dsh-evidence-memory) - Git-backed evidence memory: auditable, line-addressable citations with commit hash, freshness, and status; provides doctor/search/get/sync tools. (wraps a local CLI dependency not yet published standalone)
 
 
 ### Tools & Capabilities

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 English | [中文](README.zh.md)
 
+> 📌 **Fork notice:** this is a personal mirror of the upstream [awesome-dsh-plugin/awesome-dsh-plugin](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin) list, kept in sync for reference. It is not an independently curated list — please star and send PRs to the upstream (or to [AdamPlatin123/awesome-dsh-plugins](https://github.com/AdamPlatin123/awesome-dsh-plugins)) rather than this fork.
+
 > A curated list of plugins for [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) (`dsh`).
 
 DeepSeek Harness is DeepSeek's open-source agent harness — a runnable coding agent (Web and headless), built on a framework where everything is a plugin: models, tools, sandboxes, session storage, UI, even the agent loop itself. Plugins can extend the official coding agent, swap out its core parts, or assemble something entirely different.
@@ -18,7 +20,7 @@ dsh plugin --profile web add dshmarket
 
 > 💡 Prefer chat? [dsh-find-plugin](https://github.com/awesome-dsh-plugin/dsh-find-plugin#readme) lets your agent find plugins for you (`dsh plugin --profile web add dsh-find-plugin`).
 
-**252** plugins · [PRs welcome](#contributing)
+**260** plugins · [PRs welcome](#contributing)
 
 ## Contents
 
@@ -97,6 +99,7 @@ dsh plugin --profile web add dshmarket
 - [liliuCourier/dsh-chat-outline](https://github.com/liliuCourier/dsh-chat-outline) - Persistent left-hand conversation outline: questions and final replies per turn, keyword filter, one-click jump.
 - [LaoYueHanNi/dsh-token-usage](https://github.com/LaoYueHanNi/dsh-token-usage) - Per-request model token usage tracked to per-day JSONL files, with a stats page in Web settings: daily trend chart, per-model breakdown, and date/model filters.
 - [QT-Chen/dsh-mic-input](https://github.com/QT-Chen/dsh-mic-input) - Microphone voice input for the composer: browser Web Speech API live transcription, dedupe/auto-continue, smart punctuation, language and auto-send settings.
+- [LeslieWylie/dsh-md-preview](https://github.com/LeslieWylie/dsh-md-preview) - Markdown preview drawer for the DSH web GUI: browse, render, edit, and export to standalone HTML without leaving the session. Zero runtime dependencies.
 
 
 ### Themes & Appearance
@@ -214,6 +217,9 @@ dsh plugin --profile web add dshmarket
 - [PicGo/dsh-plugin](https://github.com/PicGo/dsh-plugin) - Upload local images and files to your image host through PicGo's existing configuration (PicGo Cloud, GitHub, S3, COS, Qiniu, or any installed uploader plugin), via a `picgo_upload` tool and a `/picgo` command.
 - [mafeis/dsh-net-proxy](https://github.com/mafeis/dsh-net-proxy) - Route agent network requests through a local HTTP/CONNECT/SOCKS5 proxy.
 - [bwndlct/dsh-session-audit](https://github.com/bwndlct/dsh-session-audit) - Session execution analytics: steps, tool calls, failures, repeated actions, token usage and verification signals, rendered as text/Markdown/JSON reports.
+- [LeslieWylie/dsh-ops-kit](https://github.com/LeslieWylie/dsh-ops-kit) - Evidence-driven memory, multi-agent orchestration, benchmark operations, and plugin-release workflow bundled as one reusable DSH toolkit: capability catalog, workflow planner, skill reader, memory search, repository audit, and release checklist tools.
+- [LeslieWylie/dsh-fleet-audit](https://github.com/LeslieWylie/dsh-fleet-audit) - Read-only agent-fleet hygiene audit: credential-file permissions, embedded git-remote credentials (masked), and provider token literals. Zero-dependency, deterministic.
+- [LeslieWylie/dsh-md-html-render](https://github.com/LeslieWylie/dsh-md-html-render) - Markdown→HTML rendering tool: renders Markdown into a standalone styled web page, returned inline or written to disk. Zero dependencies.
 
 ### Skills
 - [creght-dev/skills](https://github.com/creght-dev/skills) - Skills for building websites on the Creght platform: CLI pull/push sync, page and component conventions, CMS, forms, auth, SEO, publishing and version rollback.
@@ -240,6 +246,9 @@ dsh plugin --profile web add dshmarket
 - [btspoony/mstar-harness](https://github.com/btspoony/mstar-harness) - Skill-driven harness/loop engineering workflow agent plugin.
 - [Letter2025/dsh-approval-llm](https://github.com/Letter2025/dsh-approval-llm) - Model-based permission approval: an approval-request answerer backed by a separate reviewer model.
 - [Letter2025/dsh-model-failover](https://github.com/Letter2025/dsh-model-failover) - Two-level model circuit breaker with failover: trip a model or a whole provider after repeated request failures and route the next request to a configured fallback.
+- [LeslieWylie/dsh-task-relay](https://github.com/LeslieWylie/dsh-task-relay) - Cross-session task relay board: task push/list/claim/done plus handoff write/read, for coordinating agents and subagents across sessions.
+- [LeslieWylie/review-workflow](https://github.com/LeslieWylie/review-workflow) - Multi-panelist review workflow skill: independent panelist scoring, chair calibration, and a critic re-review pass, with a 6-step/6-checkpoint control flow.
+- [LeslieWylie/agent-loop-workflow](https://github.com/LeslieWylie/agent-loop-workflow) - Generic multi-agent collaboration workflow skeleton: loop guard, handoff format, three-tier risk triage, delivery ordering, and a review-to-close protocol.
 
 
 ### Notifications & Integrations

--- a/README.zh.md
+++ b/README.zh.md
@@ -139,6 +139,7 @@ dsh plugin --profile web add dshmarket
 - [ICCuse/dsh-premise-guard](https://github.com/ICCuse/dsh-premise-guard) — 压缩后前提漂移守卫：摘要丢失关键字面锚点时注入一次性提醒。
 - [freehul/sgme](https://github.com/freehul/sgme) — 拾光记忆引擎（SGME）桥接：多智能体共享长期记忆（HTTP）—— L0/L1/L1.5/L2 分层提炼、按场景注入、统一检索、主动关怀信号（memory_search / wiki_search / signal_pull / signal_claim / signal_ack），npm 包名 `dsh-sgme`。
 - [Phant0Meow/dsh-memory-meow](https://github.com/Phant0Meow/dsh-memory-meow) — 项目级跨会话记忆：PROJECT.md 快照注入首条用户消息（缓存友好）+ memory_remember 工具 + ReAct 任务结束自动反思；各项目独立记忆文件，互不互通。
+- [LeslieWylie/dsh-tool-rlvr-memory](https://github.com/LeslieWylie/dsh-tool-rlvr-memory) — Git 证据记忆：可审计的 Git 回溯查询，返回行级引用、提交哈希、新鲜度与状态，支持 doctor/search/get/sync 四个工具。
 
 
 ### 🛠️ 工具与能力

--- a/README.zh.md
+++ b/README.zh.md
@@ -4,6 +4,8 @@
 
 [English](README.md) | 中文
 
+> 📌 **Fork 说明：** 本仓库是上游 [awesome-dsh-plugin/awesome-dsh-plugin](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin) 列表的个人镜像，仅用于个人参考同步，并非独立维护的列表。如需 star 或提 PR，请前往上游仓库或 [AdamPlatin123/awesome-dsh-plugins](https://github.com/AdamPlatin123/awesome-dsh-plugins)，而非本 fork。
+
 > [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)（`dsh`）插件精选列表。
 
 DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行的 Coding Agent（提供 Web 与 headless 两种形式），底层又是一套「一切皆插件」的框架：模型、工具、沙箱、会话存储、UI、乃至 Agent Loop 本身都是插件。插件既可以扩展官方 Coding Agent，也可以替换其核心部件，甚至组装出完全不同的东西。
@@ -18,7 +20,7 @@ dsh plugin --profile web add dshmarket
 
 > 💡 更喜欢对话式？装 [dsh-find-plugin](https://github.com/awesome-dsh-plugin/dsh-find-plugin#readme)，想要什么插件直接问 agent（`dsh plugin --profile web add dsh-find-plugin`）。
 
-**252** 个插件 · 欢迎 [PR](#贡献)
+**260** 个插件 · 欢迎 [PR](#贡献)
 
 ## 目录
 
@@ -96,6 +98,7 @@ dsh plugin --profile web add dshmarket
 - [liliuCourier/dsh-chat-outline](https://github.com/liliuCourier/dsh-chat-outline) — 对话栏左侧常驻大纲：按轮次列出提问与最后回复，支持关键词过滤与一键跳转。
 - [LaoYueHanNi/dsh-token-usage](https://github.com/LaoYueHanNi/dsh-token-usage) — 按请求持久化模型 token 用量，Web 设置「Token 用量」统计页：按日趋势图、按模型明细表、日期/模型筛选。
 - [QT-Chen/dsh-mic-input](https://github.com/QT-Chen/dsh-mic-input) — 输入框麦克风语音输入：浏览器 Web Speech API 实时转写，自动去重/续听、智能标点，支持语言与自动发送设置。
+- [LeslieWylie/dsh-md-preview](https://github.com/LeslieWylie/dsh-md-preview) — DSH Web GUI 的 Markdown 预览抽屉：浏览、渲染、编辑并导出为独立 HTML，无需离开当前会话。零运行时依赖。
 
 
 ### 🎭 主题与外观
@@ -213,6 +216,9 @@ dsh plugin --profile web add dshmarket
 - [PicGo/dsh-plugin](https://github.com/PicGo/dsh-plugin) — 通过 PicGo 已有配置（PicGo Cloud、GitHub、S3、腾讯云 COS、七牛，或任意已安装的上传插件）把本地图片和文件上传到图床，提供 `picgo_upload` 工具与 `/picgo` 命令。
 - [mafeis/dsh-net-proxy](https://github.com/mafeis/dsh-net-proxy) — 让 agent 的网络请求走本机 HTTP/CONNECT/SOCKS5 代理。
 - [bwndlct/dsh-session-audit](https://github.com/bwndlct/dsh-session-audit) — 会话执行分析：步骤、工具调用、失败、重复动作、token 用量与验证信号，输出 text/Markdown/JSON 报告。
+- [LeslieWylie/dsh-ops-kit](https://github.com/LeslieWylie/dsh-ops-kit) — 证据驱动的记忆、多智能体编排、基准评测与插件发布工作流打包成的可复用 DSH 工具包：能力目录、工作流规划器、技能阅读器、记忆搜索、仓库审计与发布检查单工具。
+- [LeslieWylie/dsh-fleet-audit](https://github.com/LeslieWylie/dsh-fleet-audit) — 只读的 agent 集群卫生审计：凭据文件权限、git remote 中嵌入的凭据（已脱敏）、供应商 token 字面量。零依赖，确定性输出。
+- [LeslieWylie/dsh-md-html-render](https://github.com/LeslieWylie/dsh-md-html-render) — Markdown→HTML 渲染工具：把 Markdown 渲染成独立样式化网页，可直接返回或写入磁盘。零依赖。
 
 ### 🧩 技能包
 - [creght-dev/skills](https://github.com/creght-dev/skills) — Creght 平台建站技能包：CLI 拉取/推送同步、页面与组件规范、CMS、表单、Auth、SEO、发布与版本回滚。
@@ -239,6 +245,9 @@ dsh plugin --profile web add dshmarket
 - [btspoony/mstar-harness](https://github.com/btspoony/mstar-harness) — 技能驱动的 harness/loop 工程化工作流插件。
 - [Letter2025/dsh-approval-llm](https://github.com/Letter2025/dsh-approval-llm) — 基于模型的权限审批：由独立审查模型自动应答 approval 权限请求。
 - [Letter2025/dsh-model-failover](https://github.com/Letter2025/dsh-model-failover) — 两级模型熔断与回退：模型或平台连续失败后自动熔断，并把下一个请求路由到配置好的备用模型。
+- [LeslieWylie/dsh-task-relay](https://github.com/LeslieWylie/dsh-task-relay) — 跨会话任务接力板：task push/list/claim/done 加 handoff write/read，用于跨会话协调 agent 与子 agent。
+- [LeslieWylie/review-workflow](https://github.com/LeslieWylie/review-workflow) — 通用多评委评审工作流：N 评委独立打分 + Chair 校准 + Critic 复核，带 6 步 6 checkpoint 流程控制。
+- [LeslieWylie/agent-loop-workflow](https://github.com/LeslieWylie/agent-loop-workflow) — 通用多 agent 协作工作流骨架：Loop Guard、handoff 格式、风险三档分流、交付顺序、review→收口协议。
 
 
 ### 🔔 通知与集成

--- a/README.zh.md
+++ b/README.zh.md
@@ -139,7 +139,7 @@ dsh plugin --profile web add dshmarket
 - [ICCuse/dsh-premise-guard](https://github.com/ICCuse/dsh-premise-guard) — 压缩后前提漂移守卫：摘要丢失关键字面锚点时注入一次性提醒。
 - [freehul/sgme](https://github.com/freehul/sgme) — 拾光记忆引擎（SGME）桥接：多智能体共享长期记忆（HTTP）—— L0/L1/L1.5/L2 分层提炼、按场景注入、统一检索、主动关怀信号（memory_search / wiki_search / signal_pull / signal_claim / signal_ack），npm 包名 `dsh-sgme`。
 - [Phant0Meow/dsh-memory-meow](https://github.com/Phant0Meow/dsh-memory-meow) — 项目级跨会话记忆：PROJECT.md 快照注入首条用户消息（缓存友好）+ memory_remember 工具 + ReAct 任务结束自动反思；各项目独立记忆文件，互不互通。
-- [LeslieWylie/dsh-tool-rlvr-memory](https://github.com/LeslieWylie/dsh-tool-rlvr-memory) — Git 证据记忆：可审计的 Git 回溯查询，返回行级引用、提交哈希、新鲜度与状态，支持 doctor/search/get/sync 四个工具。
+- [LeslieWylie/dsh-evidence-memory](https://github.com/LeslieWylie/dsh-evidence-memory) — Git 证据记忆：可审计的 Git 回溯查询，返回行级引用、提交哈希、新鲜度与状态，支持 doctor/search/get/sync 四个工具。（依赖的本地 CLI 尚未独立发布）
 
 
 ### 🛠️ 工具与能力


### PR DESCRIPTION
Add [dsh-evidence-memory](https://github.com/LeslieWylie/dsh-evidence-memory) to the Memory section.

A DSH plugin that wraps a Git-backed project memory CLI into four deterministic tools: memory_doctor, memory_search, memory_get, memory_sync. Provides Git-backed project memory with line-addressable evidence, freshness tracking, and audit trail.