### PR TITLE
Add LeemanCheung/dsh-task-dag

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ dsh plugin --profile web add dshmarket
 - [liliuCourier/dsh-chat-outline](https://github.com/liliuCourier/dsh-chat-outline) - Persistent left-hand conversation outline: questions and final replies per turn, keyword filter, one-click jump.
 - [LaoYueHanNi/dsh-token-usage](https://github.com/LaoYueHanNi/dsh-token-usage) - Per-request model token usage tracked to per-day JSONL files, with a stats page in Web settings: daily trend chart, per-model breakdown, and date/model filters.
 - [QT-Chen/dsh-mic-input](https://github.com/QT-Chen/dsh-mic-input) - Microphone voice input for the composer: browser Web Speech API live transcription, dedupe/auto-continue, smart punctuation, language and auto-send settings.
+- [LeemanCheung/dsh-task-dag](https://github.com/LeemanCheung/dsh-task-dag) - Displays a Session's subagents and durable workflow runs as a live DAG with status, navigation, and restart-safe history.
 
 
 ### Themes & Appearance

--- a/README.zh.md
+++ b/README.zh.md
@@ -96,6 +96,7 @@ dsh plugin --profile web add dshmarket
 - [liliuCourier/dsh-chat-outline](https://github.com/liliuCourier/dsh-chat-outline) — 对话栏左侧常驻大纲：按轮次列出提问与最后回复，支持关键词过滤与一键跳转。
 - [LaoYueHanNi/dsh-token-usage](https://github.com/LaoYueHanNi/dsh-token-usage) — 按请求持久化模型 token 用量，Web 设置「Token 用量」统计页：按日趋势图、按模型明细表、日期/模型筛选。
 - [QT-Chen/dsh-mic-input](https://github.com/QT-Chen/dsh-mic-input) — 输入框麦克风语音输入：浏览器 Web Speech API 实时转写，自动去重/续听、智能标点，支持语言与自动发送设置。
+- [LeemanCheung/dsh-task-dag](https://github.com/LeemanCheung/dsh-task-dag) — 将会话子代理与持久工作流运行展示为实时 DAG，支持状态展示、节点导航与重启后历史恢复。
 
 
 ### 🎭 主题与外观


### PR DESCRIPTION
Adds [`LeemanCheung/dsh-task-dag`](https://github.com/LeemanCheung/dsh-task-dag) to **UI Enhancements** in both language lists. The awesome-list diff remains exactly one factual line per README.

The plugin displays the current Session, delegated subagents, and durable workflow runs as a live DAG. It uses DSH Client Session projections without Host polling, supports direct subagent navigation, and restores workflow history after restart.

### Reviewer verification

- Root install manifest: [`package.json` declares `dsh.bundle`](https://github.com/LeemanCheung/dsh-task-dag/blob/main/package.json) and the browser client entry.
- Root bundle patch: [`cordis.patch.yml`](https://github.com/LeemanCheung/dsh-task-dag/blob/main/cordis.patch.yml).
- Stable release: [`v1.1.0`](https://github.com/LeemanCheung/dsh-task-dag/releases/tag/v1.1.0).
- CI: [`npm ci`, interaction smoke tests, and committed-bundle reproducibility all pass](https://github.com/LeemanCheung/dsh-task-dag/actions/runs/31800898354).
- Security boundary: [browser-only, read-only visualization](https://github.com/LeemanCheung/dsh-task-dag/blob/main/SECURITY.md); no files, commands, network requests, Host RPC, model tools, or persisted user content.
- Repository topics include [`dsh-plugin`](https://github.com/topics/dsh-plugin); official `@deepseek-ai/*` packages are peer dependencies.

Install command:

```text
dsh plugin --profile web add github:LeemanCheung/dsh-task-dag
```

### Contribution checklist

- [x] The plugin repository declares `dsh.bundle` in `package.json`.
- [x] One line is added to both `README.md` and `README.zh.md` under the matching category.
- [x] Both descriptions are factual, contain no superlatives, and end with punctuation.
- [x] The repository has the `dsh-plugin` topic.
- [x] The repository contains working source, a prebuilt client bundle, bilingual docs, an MIT license, and passing CI.