### PR TITLE
Add dsh-files: file upload + content-sniffing read_document

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ dsh plugin --profile web add dshmarket
 - [0xsline/dsh-spotlight](https://github.com/0xsline/dsh-spotlight) - Keyboard-first command palette for the DSH Web UI.
 - [bill9109/dsh-101](https://github.com/bill9109/dsh-101) - Document reading mode for DSH.
 - [bill9109/dsh-drag-and-drop](https://github.com/bill9109/dsh-drag-and-drop) - Cross-platform file drag-and-drop with raw path insertion, no file copying.
+- [taxueseek/dsh-files](https://github.com/taxueseek/dsh-files) - File upload with color-coded attachment cards (session-isolated storage, sha256 dedup, TTL sweep) plus a content-sniffing read_document tool for PDF/DOCX/XLSX/TXT.
 - [l541402398/dsh-file-uploads](https://github.com/l541402398/dsh-file-uploads) - Upload arbitrary local files from the Web composer, show pending cards, and manage stored files in Settings.
 - [qyw233/dsh-deeplink](https://github.com/qyw233/dsh-deeplink) - Deep links: open a specific session or workspace via `?session=` / `?workspace=`.
 - [lehhair/dsh-diff-viewer](https://github.com/lehhair/dsh-diff-viewer) - PiUI-style diff viewer replacing the stock DiffBlock for write/edit tool calls.

--- a/README.zh.md
+++ b/README.zh.md
@@ -62,6 +62,7 @@ dsh plugin --profile web add dshmarket
 - [0xsline/dsh-spotlight](https://github.com/0xsline/dsh-spotlight) — 键盘优先的命令面板（command palette）。
 - [bill9109/dsh-101](https://github.com/bill9109/dsh-101) — DSH 文档阅读模式。
 - [bill9109/dsh-drag-and-drop](https://github.com/bill9109/dsh-drag-and-drop) — 跨平台文件拖拽与原始路径插入，无需复制文件。
+- [taxueseek/dsh-files](https://github.com/taxueseek/dsh-files) — 文件上传（彩色附件卡片、会话隔离存储、sha256 去重、TTL 清扫）+ 内容嗅探的 read_document 文档读取（PDF/DOCX/XLSX/TXT）。
 - [l541402398/dsh-file-uploads](https://github.com/l541402398/dsh-file-uploads) — 从 Web 输入框上传任意本地文件，以待发送卡片展示，并在设置中管理已存文件。
 - [qyw233/dsh-deeplink](https://github.com/qyw233/dsh-deeplink) — `?session=` / `?workspace=` 深链直达指定项目对话。
 - [lehhair/dsh-diff-viewer](https://github.com/lehhair/dsh-diff-viewer) — PiUI 风格 diff 查看器，替换 write/edit 工具调用的默认 DiffBlock。


### PR DESCRIPTION
Add [taxueseek/dsh-files](https://github.com/taxueseek/dsh-files) to the UI Enhancements section.

A dual-face plugin:
- **Upload**: paperclip button in the Web composer, files shown as color-coded floating cards (PDF red / DOC blue / XLS green / TXT gray / ZIP purple), paths auto-attached to the outgoing message; session-isolated storage under `<workspace>/.dsh-filess/<sessionId>/`, sha256 content dedup, TTL sweep.
- **Document reading**: `read_document` tool for text / PDF / DOCX / XLSX with byte-level content sniffing (never trusts extensions, rejects disguised executables), encoding chain UTF-16 BOM → UTF-8 → GB18030, paginated reads, LRU parse cache.

Install: `dsh plugin --profile web add dsh-files`

Added one line to both README.md and README.zh.md per the contributing rule; repo already carries the `dsh-plugin` topic.