### PR TITLE
Add dsh-vision-bridge: composer-attached images auto-transcribed for text-only DeepSeek models

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ dsh plugin --profile web add dshmarket
 
 - [ysr666/dsh-vision-router](https://github.com/ysr666/dsh-vision-router) - Free vision for text-only agents: built-in keyless vision chain plus pixel tools (Q&A, grounding, crop, pixel diff, colors, OCR, SVG trace, cutout, screenshots); paste an image to use it.
 - [Flyvhidbwo/dsh-vision-proxy](https://github.com/Flyvhidbwo/dsh-vision-proxy) - DeepSeek brain + automatic image transcription: attach images in the GUI and each one is transcribed to text via any OpenAI-compatible VLM (qwen3.7-flash by default) before reaching the text-only DeepSeek.
+- [ximengxiaolan/dsh-vision-bridge](https://github.com/ximengxiaolan/dsh-vision-bridge) - Composer-attached images are transcribed to text by an OpenAI-compatible vision model before reaching text-only DeepSeek models.
 - [lire1131/dsh-undo-plugin](https://github.com/lire1131/dsh-undo-plugin) - Undo/redo & rollback system for DSH: every config change is auto-snapshotted; undo/redo/restore to any version from the WebUI or the offline CLI/GUI tools (works even when DSH fails to boot).
 - [MAXeaglet/dsh-bash-terminal](https://github.com/MAXeaglet/dsh-bash-terminal) - One shell tool for PowerShell / Git Bash / WSL on Windows plus an interactive PTY terminal; the default terminal is chosen by the user in DSH settings.
 - [Anionex/dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) - Vision tasks for text-only models: intent-aware image Q&A, long-screenshot OCR, UI reproduction, grounding, and pixel diff.

--- a/README.zh.md
+++ b/README.zh.md
@@ -145,6 +145,7 @@ dsh plugin --profile web add dshmarket
 
 - [ysr666/dsh-vision-router](https://github.com/ysr666/dsh-vision-router) — 为纯文本 Agent 提供视觉能力：内置免 Key 视觉链 + 像素级视觉工具（看图问答、定位、裁剪、像素对比、取色、OCR、矢量化、抠图、截图）；粘贴图片即可用。
 - [Flyvhidbwo/dsh-vision-proxy](https://github.com/Flyvhidbwo/dsh-vision-proxy) — DeepSeek 大脑 + 自动识图：GUI 附加的每张图片自动经 OpenAI 兼容 VLM（默认 qwen3.7-flash）转译成文字，再交给纯文本的 DeepSeek 作答。
+- [ximengxiaolan/dsh-vision-bridge](https://github.com/ximengxiaolan/dsh-vision-bridge) — 输入框贴图自动识别：由 OpenAI 兼容视觉模型转成文字描述后，再交给纯文本 DeepSeek 模型处理。
 - [lire1131/dsh-undo-plugin](https://github.com/lire1131/dsh-undo-plugin) — DSH 撤销/回退系统：配置变更自动存档，一键撤销/恢复/回退到任意版本，支持 WebUI 与离线 CLI/GUI 工具（DSH 启动失败也能救）。
 - [MAXeaglet/dsh-bash-terminal](https://github.com/MAXeaglet/dsh-bash-terminal) — 一个 shell 工具：Windows 上统一执行 PowerShell / Git Bash / WSL，外加交互式 PTY 终端，默认终端由用户在设置中选择。
 - [Anionex/dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) — 让纯文本模型更好地做视觉任务：带意图的图片问答、长截图 OCR、UI 还原等。


### PR DESCRIPTION
<!-- Thanks for contributing! Quick checklist / ??????? -->

- [x] My repo's `package.json` declares **`dsh.bundle`** (not just `dsh.client`) - `dsh.bundle.patch: ./cordis.patch.yml` / ?? `package.json` ??? `dsh.bundle`(? `cordis.patch.yml`)
- [x] One line added to **both** `README.md` (English) and `README.zh.md` (??), under the matching category (Tools & Capabilities / ?????) / ??????????,???????????
- [x] Description states what the plugin does, no superlatives / ??????
- [x] My repo has the `dsh-plugin` topic / ???? `dsh-plugin` topic

**What it does / ??**

`dsh-vision-bridge` lets text-only DeepSeek models "see" pasted images: when you attach an image in the composer and send it, the plugin transcribes each image to text via an OpenAI-compatible vision model (e.g. Qwen-VL) before the request reaches DeepSeek. The image stays visible in the conversation; only the model-visible request carries the description.

?????????:???? OpenAI ??????(? Qwen-VL)?????????,?????? DeepSeek ??;??????????

**Repo / ??**: https://github.com/ximengxiaolan/dsh-vision-bridge