### PR TITLE
Add dsh-skill-manager to Skills category

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ dsh plugin --profile web add dshmarket
 - [creght-dev/skills](https://github.com/creght-dev/skills) - Skills for building websites on the Creght platform: CLI pull/push sync, page and component conventions, CMS, forms, auth, SEO, publishing and version rollback.
 
 
+- [YTxue/dsh-skill-manager](https://github.com/YTxue/dsh-skill-manager) - Skill pool manager in the Settings sidebar: enable/disable, folder batch import with rename-conflict prompts, state-driven one-click DSH-spec check & auto-fix, system/project scope labels.
 ### Workflow & Automation
 
 - [icetomoyo/dsh_workflow](https://github.com/icetomoyo/dsh_workflow) - UltraCode-style multi-agent orchestration: a generatable, savable, governable, observable, resumable workflow layer.

--- a/README.zh.md
+++ b/README.zh.md
@@ -217,6 +217,7 @@ dsh plugin --profile web add dshmarket
 - [creght-dev/skills](https://github.com/creght-dev/skills) — Creght 平台建站技能包：CLI 拉取/推送同步、页面与组件规范、CMS、表单、Auth、SEO、发布与版本回滚。
 
 
+- [YTxue/dsh-skill-manager](https://github.com/YTxue/dsh-skill-manager) — 设置侧边栏的 Skill 管理器：池与启用目录启停、文件夹批量导入（重名询问）、状态驱动一键规范检查与自动修复、系统级/项目级来源标识。
 ### 🔁 工作流与自动化
 
 - [icetomoyo/dsh_workflow](https://github.com/icetomoyo/dsh_workflow) — 把 UltraCode 式多 Agent 调度带给 DSH：可生成、可保存、可治理、可观察、可恢复的 Workflow 层。


### PR DESCRIPTION
Add [dsh-skill-manager](https://github.com/YTxue/dsh-skill-manager) to the Skills category in `README.md` and `README.zh.md`.

- A Skill manager in the DSH Settings sidebar: enable/disable between skill-pool and skills, folder batch import with rename-conflict prompts, state-driven one-click DSH-spec check & auto-fix, system/project scope labels, current-project auto detection.
- Repo has the `dsh-plugin` topic and declares a `dsh.bundle` manifest (installable via `dsh plugin add`).
- MIT licensed, zero third-party runtime dependencies.