### PR TITLE
Add dsh-md-preview to Tools & Capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ dsh plugin --profile web add dshmarket
 - [LeslieWylie/dsh-fleet-audit](https://github.com/LeslieWylie/dsh-fleet-audit) - Read-only agent-fleet credential hygiene audit: credential-file permissions, embedded credentials in git remotes (masked in output), and provider token literal counts; zero-dependency and deterministic.
 - [whyihaveyou/dsh-suite#plugin-manager](https://github.com/whyihaveyou/dsh-suite/tree/main/packages/plugins/plugin-manager) - In-app plugin store for the DSH Web UI: browse, search, one-click install, compat badges.
 - [loguhan/dsh-workshop](https://github.com/loguhan/dsh-workshop) - Steam Workshop-style plugin store for the DSH Web UI: browse, search, and one-click install community plugins with mirror acceleration, progress UI, security checks, and Chinese descriptions.
+- [LeslieWylie/dsh-md-preview](https://github.com/LeslieWylie/dsh-md-preview) - Render Markdown to a standalone, self-contained HTML page: an `md_html_render` tool that works in a headless profile, plus a web drawer to browse, preview, edit and export local `.md` files; both share one renderer, with no runtime dependencies.
 
 ### Skills
 - [creght-dev/skills](https://github.com/creght-dev/skills) - Skills for building websites on the Creght platform: CLI pull/push sync, page and component conventions, CMS, forms, auth, SEO, publishing and version rollback.

--- a/README.zh.md
+++ b/README.zh.md
@@ -227,6 +227,7 @@ dsh plugin --profile web add dshmarket
 - [LeslieWylie/dsh-fleet-audit](https://github.com/LeslieWylie/dsh-fleet-audit) — 只读的 agent 机群凭据卫生审计：检查凭据文件权限、git remote 内嵌凭据（输出脱敏）与 provider token 字面量计数；零依赖、确定性。
 - [whyihaveyou/dsh-suite#plugin-manager](https://github.com/whyihaveyou/dsh-suite/tree/main/packages/plugins/plugin-manager) — DSH Web UI 内置插件商店：浏览、搜索、一键安装、兼容性徽章。
 - [loguhan/dsh-workshop](https://github.com/loguhan/dsh-workshop) — DSH Web UI 的 Steam 创意工坊式插件商店：浏览、搜索并一键安装社区插件，支持镜像加速、进度 UI、安全检测与中文描述。
+- [LeslieWylie/dsh-md-preview](https://github.com/LeslieWylie/dsh-md-preview) — 把 Markdown 渲染为自包含的独立 HTML 页面：提供在 headless 配置下同样可用的 `md_html_render` 工具，以及在网页端浏览、预览、编辑并导出本地 `.md` 文件的抽屉；两个入口共用同一个渲染器，无运行时依赖。
 
 ### 🧩 技能包
 - [creght-dev/skills](https://github.com/creght-dev/skills) — Creght 平台建站技能包：CLI 拉取/推送同步、页面与组件规范、CMS、表单、Auth、SEO、发布与版本回滚。


### PR DESCRIPTION
Adds [`LeslieWylie/dsh-md-preview`](https://github.com/LeslieWylie/dsh-md-preview) to **Tools & Capabilities** — one line in `README.md`, one in `README.zh.md`, nothing else.

**What it does.** Renders Markdown to a standalone HTML page through two surfaces backed by a single renderer:

- `md_html_render` — a model-facing tool. Give it Markdown, get a complete self-contained document back, optionally written to disk. Works in a headless profile with no GUI.
- An **MD** drawer in the web session header — browse the working directory, click a `.md` file to render it, edit in place, export.

The exported page embeds its own styles and loads no stylesheet, font, script or image from anywhere, so it opens from disk or on an airgapped machine. Writes go through the harness `fs` service rather than a second path to disk, so `save_path` obeys whatever sandbox policy the session already runs under.

**Requirements checklist**

| | |
|---|---|
| `dsh.bundle` manifest in `package.json` | ✅ `{"bundle": {"patch": "./cordis.patch.yml"}}`, with `cordis.patch.yml` at the repo root |
| Real working code, not a placeholder | ✅ see verification below |
| `dsh-plugin` topic set | ✅ |
| `@deepseek-ai/*` as `peerDependencies` | ✅ and marked `optional`, see note below |
| Description states function, no superlatives | ✅ |
| Licence | MIT |

**Verification — installed from GitHub and actually run, not just linted.** The repo ships `tests/boot.test.mjs`, which boots a real cordis `Context` with the harness's own filesystem service, loads the package the way a profile does, then asks the **real** tool registry for the tool and executes it against the real disk:

```
$ cd ~/.dsh/profiles/<p>/node_modules/dsh-md-preview && node tests/boot.test.mjs
  ok    the harness provides a real fs service
  ok    md_html_render reaches the real tool registry
  ok    the registry accepted the parameter schema
  ok    execute reports no error
  ok    execute reports the path it wrote
  ok    the file is really on disk
  ok    what landed is a complete document
  ok    it carries the requested title
  ok    it still loads nothing from the network
PASS — 0 failing check(s)
```

Two more suites run the renderer for real and assert the host and browser halves produce byte-identical output on a 25-case corpus, so the two surfaces cannot drift apart. XSS coverage asserts a structural invariant — no emitted tag ever carries an unterminated attribute or an `on*=` handler — and includes checks that the checker itself goes red on genuinely unsafe markup, so the security assertion cannot quietly rot into one that always passes.

**Risk disclosure, stated plainly.** It reads and writes files in your session, through the harness `fs` service and only there. The drawer's `readFile` refuses anything that is not `.md`, `.markdown`, `.mdx` or `.txt`. It makes no network requests and spawns no processes. It is not on npm yet, so installs are `github:` and unsigned — read the source before trusting it, as you should with any plugin that can write to your disk.

**One note that may be worth folding into the guidelines.** contributing.md recommends declaring `@deepseek-ai/*` as `peerDependencies`. That is right, but a plain `peerDependencies` entry currently breaks installs: the only usable `@deepseek-ai/dsh-tools` is `0.1.0-rc.6`, a prerelease published under the `next` dist-tag while `latest` is still `0.0.1-rc.1`. A range without a prerelease qualifier never matches it, and when pnpm intersects two plugins' ranges the qualifier gets dropped, so installing two such plugins together fails with `ERR_PNPM_NO_MATCHING_VERSION`. Marking them `optional` in `peerDependenciesMeta` fixes it — the harness injects these at runtime anyway. I hit this for real installing two plugins side by side; happy to open a separate PR for contributing.md if that would help others.

---

将 [`LeslieWylie/dsh-md-preview`](https://github.com/LeslieWylie/dsh-md-preview) 收录至 **工具与能力**，`README.md` 与 `README.zh.md` 各加一行，无其他改动。

**功能。** 把 Markdown 渲染为自包含的独立 HTML 页面，两个入口共用同一个渲染器：

- `md_html_render` —— 模型可直接调用的工具，传入 Markdown 返回完整自包含文档，可选写盘；**无图形界面的 headless 配置下同样可用**。
- 网页会话头部的 **MD** 抽屉 —— 浏览当前工作目录，点开 `.md` 即时渲染，可就地编辑与导出。

导出页面内嵌样式，不加载任何外部样式表、字体、脚本或图片，因此在断网机器上打开效果一致。所有写入统一经由 harness 的 `fs` 服务，不另开一条通往磁盘的路，`save_path` 因此遵守会话既有的沙箱策略。

**收录要求对照**

| | |
|---|---|
| `package.json` 声明 `dsh.bundle` | ✅ `{"bundle": {"patch": "./cordis.patch.yml"}}`，根目录含 `cordis.patch.yml` |
| 真实可用代码，非占位仓库 | ✅ 见下方验证 |
| 已添加 `dsh-plugin` topic | ✅ |
| `@deepseek-ai/*` 用 `peerDependencies` | ✅ 且标记为 `optional`，原因见下 |
| 描述只说功能，不带营销词 | ✅ |
| 许可 | MIT |

**验证方式是真装真跑，而非只做静态检查。** 仓库内含 `tests/boot.test.mjs`：启动真实的 cordis `Context`，加载 harness 自己的文件服务，按 profile 的方式装载本包，然后向**真实的**工具注册表索取该工具并对真实磁盘执行一次（输出见上方英文部分，9 项全通过）。

另有两套测试真实执行渲染器，并断言宿主端与浏览器端在 25 个用例上输出**逐字节一致**，确保两个入口不会各自漂移。XSS 断言检查的是结构性不变式——任何生成的标签都不会出现未闭合属性或 `on*=` 事件处理器——并包含"检查器本身遇到危险标记会变红"的元断言，避免安全断言退化成永远通过的摆设。

**风险说明。** 它会在你的会话中读写文件，且仅通过 harness 的 `fs` 服务进行。抽屉的 `readFile` 拒绝 `.md`、`.markdown`、`.mdx`、`.txt` 以外的一切。不发起任何网络请求，不启动任何子进程。目前尚未发布到 npm，因此只能 `github:` 安装且无签名——和任何能写你磁盘的插件一样，请先读源码再信任它。

**另有一条或可补入贡献指南的发现。** contributing.md 建议用 `peerDependencies` 声明 `@deepseek-ai/*`，方向正确，但目前直接这样写会让安装失败：唯一可用的 `@deepseek-ai/dsh-tools` 是 `0.1.0-rc.6`，属发布在 `next` dist-tag 下的预发布版本，而 `latest` 仍停在 `0.0.1-rc.1`。不带预发布限定的 range 永远匹配不到它；当 pnpm 求两个插件 range 的交集时该限定还会被丢弃，于是两个这样的插件装在一起会直接报 `ERR_PNPM_NO_MATCHING_VERSION`。在 `peerDependenciesMeta` 里标记 `optional` 即可解决——这些包本就由 harness 在运行时注入。这是我同时安装两个插件时实际踩到的。如果有帮助，我可以另开一个 PR 修订 contributing.md。
