### PR TITLE
Add uagent-sync to Workflow & Automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,7 @@ dsh plugin --profile web add dshmarket
 
 
 - [truelove-dreamer/dsh-plugin-hooks](https://github.com/truelove-dreamer/dsh-plugin-hooks) - Claude-Code-style lifecycle hooks: configured shell commands run before/after model tool calls with a JSON payload on stdin; a non-zero pre-tool exit blocks the call.
+- [severin-ye/uagent-sync#packages/dsh](https://github.com/severin-ye/uagent-sync/tree/master/packages/dsh) - Cross-device workspace backup, restore, and ecosystem update via the uagent-sync CLI.
 ### Notifications & Integrations
 
 - [radres/dsh-plugin-call-me](https://github.com/radres/dsh-plugin-call-me) - Rings your phone over CallKit: `call_me` and `text_me` tools, plus optional turn-end and approval calls whose spoken answer is transcribed back into the session.

--- a/README.zh.md
+++ b/README.zh.md
@@ -323,6 +323,7 @@ dsh plugin --profile web add dshmarket
 
 
 - [truelove-dreamer/dsh-plugin-hooks](https://github.com/truelove-dreamer/dsh-plugin-hooks) — Claude Code 风格生命周期 hooks：工具调用前后自动执行 shell 命令（stdin 收 JSON payload），pre-tool 非零退出即阻断调用。
+- [severin-ye/uagent-sync#packages/dsh](https://github.com/severin-ye/uagent-sync/tree/master/packages/dsh) — 工作区跨设备备份、恢复与扩展更新，经 uagent-sync CLI 桥接执行。
 ### 🔔 通知与集成
 
 - [radres/dsh-plugin-call-me](https://github.com/radres/dsh-plugin-call-me) — 通过 CallKit 打电话到你的手机：`call_me` 与 `text_me` 工具，并可在回合结束或等待审批时来电，语音回答转写后送回会话。


### PR DESCRIPTION
Adds the [uagent-sync](https://github.com/severin-ye/uagent-sync) DeepSeek Harness bundle to the Workflow & Automation section.

**What it does:** cross-device workspace backup, restore, and ecosystem update via the uagent-sync CLI — 16 `sync_*` tools bridged to the CLI, plus 3 shared skills registered as DSH runtime skills.

**Install:**
```sh
dsh plugin --profile <name> add "github:severin-ye/uagent-sync#main&path:packages/dsh"
```

- Declares `dsh.bundle` manifest with `cordis.patch.yml`
- Pure JS bundle (no build/allowBuilds step)
- Repo tagged `dsh-plugin`