### PR TITLE
feat: add dsh-memoria to Memory section

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ dsh plugin --profile web add dshmarket
 - [ICCuse/dsh-premise-guard](https://github.com/ICCuse/dsh-premise-guard) - Post-compaction premise-drift guard: injects a one-shot notice when a compaction summary drops a critical literal anchor.
 - [freehul/sgme](https://github.com/freehul/sgme) - ShiGuang Memory Engine (SGME) bridge: multi-agent shared long-term memory via HTTP — L0/L1/L1.5/L2 distillation, scenario-based injection, unified search, and proactive care signals (memory_search / wiki_search / signal_pull / signal_claim / signal_ack), installable as `dsh-sgme`.
 - [Phant0Meow/dsh-memory-meow](https://github.com/Phant0Meow/dsh-memory-meow) - Project-scoped cross-session memory: PROJECT.md snapshot injected into the first user message, a memory_remember tool, and auto-reflection after ReAct tasks; each project keeps its own memory file.
+- [jiayan-xu/dsh-memoria](https://github.com/jiayan-xu/dsh-memoria) - Vector + graph memory backend: observe/remember/search/recall tools against a local memoria server, fusing HNSW semantic recall, FTS5 keyword search, and knowledge-graph signals via RRF ranking, with automatic turn-end persistence and per-agent namespace isolation.
 
 
 ### Tools & Capabilities

--- a/README.zh.md
+++ b/README.zh.md
@@ -151,6 +151,7 @@ dsh plugin --profile web add dshmarket
 - [ICCuse/dsh-premise-guard](https://github.com/ICCuse/dsh-premise-guard) — 压缩后前提漂移守卫：摘要丢失关键字面锚点时注入一次性提醒。
 - [freehul/sgme](https://github.com/freehul/sgme) — 拾光记忆引擎（SGME）桥接：多智能体共享长期记忆（HTTP）—— L0/L1/L1.5/L2 分层提炼、按场景注入、统一检索、主动关怀信号（memory_search / wiki_search / signal_pull / signal_claim / signal_ack），npm 包名 `dsh-sgme`。
 - [Phant0Meow/dsh-memory-meow](https://github.com/Phant0Meow/dsh-memory-meow) — 项目级跨会话记忆：PROJECT.md 快照注入首条用户消息（缓存友好）+ memory_remember 工具 + ReAct 任务结束自动反思；各项目独立记忆文件，互不互通。
+- [jiayan-xu/dsh-memoria](https://github.com/jiayan-xu/dsh-memoria) — 向量+图记忆后端：observe/remember/search/recall 四个工具对接本地 memoria 服务，HNSW 语义召回 + FTS5 关键词 + 知识图谱信号经 RRF 融合排序，回合结束自动写入，按 Agent 命名空间隔离。
 
 
 ### 🛠️ 工具与能力


### PR DESCRIPTION
Adds [dsh-memoria](https://github.com/jiayan-xu/dsh-memoria) to the Memory section (both EN and ZH READMEs).

**What it is**: a production-grade vector + graph memory backend (memoria) for DeepSeek Harness. The agent gets 4 tools — `memoria_observe` / `memoria_remember` / `memoria_search` / `memoria_recall` — wired to a real memory server (SQLite + HNSW vectors + FTS5 + knowledge-graph, RRF-fused multi-signal recall).

**Highlights**:
- Semantic recall + keyword search + graph relations fused by RRF ranking
- Auto-write on turn end: positive user feedback escalates to importance-5 opinion memories
- Per-agent namespace isolation with badge-based auth (each agent only sees its own memory)
- Hot-reload settings section (`memoria:` in settings.yaml)
- One-command install with auto-mount bundle patch: `dsh plugin add github:jiayan-xu/dsh-memoria` or `dsh plugin add @jhp830901/dsh-memoria` (also published on npm)
