### PR TITLE
Add PC2005-cloud/dsh-pet (desktop pet) to Just for Fun

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,6 +361,7 @@ dsh plugin --profile web add dshmarket
 - [anweat/dsh-voice-webspeech](https://github.com/anweat/dsh-voice-webspeech) - Browser Web Speech API voice input: zero server, zero keys, zero model downloads (Edge=Azure, Chrome=Google speech).
 - [anweat/dsh-restart](https://github.com/anweat/dsh-restart) - Restart DSH: configurable restart method (Node native / legacy PowerShell), post-restart continue prompt, optional watchdog auto-relaunch.
 - [yyh-001/dsh-expression](https://github.com/yyh-001/dsh-expression) - Meme search, the fun way: describe the vibe, and the agent finds and sends a real meme that actually fits.
+- [PC2005-cloud/dsh-pet#dsh-pet](https://github.com/PC2005-cloud/dsh-pet/tree/main/dsh-pet) - Desktop pet for the DSH Web UI with 25 transparent animations, screen wandering, click reactions and drag, plus a reproducible asset-generation pipeline.
 
 
 ## Contributing

--- a/README.zh.md
+++ b/README.zh.md
@@ -359,6 +359,7 @@ dsh plugin --profile web add dshmarket
 - [anweat/dsh-voice-webspeech](https://github.com/anweat/dsh-voice-webspeech) — 浏览器 Web Speech API 语音输入：零服务端、零密钥、零模型下载（Edge=Azure 语音、Chrome=Google 语音）。
 - [anweat/dsh-restart](https://github.com/anweat/dsh-restart) — DSH 重启插件：可配置的重启方式（Node 原生/旧 PowerShell 适配）、重启后自动继续的提示词、可选看门狗自动拉起。
 - [yyh-001/dsh-expression](https://github.com/yyh-001/dsh-expression) — 陪 AI 斗图的搞笑插件：说个感觉，AI 帮你搜到、发出那张恰到好处的真实表情包。
+- [PC2005-cloud/dsh-pet#dsh-pet](https://github.com/PC2005-cloud/dsh-pet/tree/main/dsh-pet) — DSH Web UI 桌面宠物：25 个透明动画、屏幕漫游、点击反应与拖拽，附可复现的素材生成链。
 
 
 ## 贡献


### PR DESCRIPTION
Add [PC2005-cloud/dsh-pet](https://github.com/PC2005-cloud/dsh-pet) to the **Just for Fun** category (both EN/中文 README).

**What it does**: A floating desktop pet for the DeepSeek Harness Web UI — 25 transparent webm animations (idle, sleep, magic cube, singing, startle...), probability-driven animation chain, screen wandering, click reactions and drag. Also ships a full reproducible asset pipeline (prompts → green-screen videos → transparent animations), so anyone can generate their own pet.

**Requirements check**:
- [x] dsh.bundle manifest declared in package.json (installable via \dsh plugin --profile web add dsh-pet\)
- [x] Published on npm: \dsh-pet@0.1.1\
- [x] Official \@deepseek-ai/*\ packages declared as peerDependencies
- [x] \dsh-plugin\ topic added to the repo
- [x] Active maintenance, real working code

Note: there is an existing \zealot00/dsh-pet\ entry — that one is a sprite-sheet pet with alarm/pomodoro widgets; this one is a distinct plugin with transparent-video animations and a reproducible generation pipeline.