### PR TITLE
Add dsh-media-preview: audio/video preview for better-sidebar

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ dsh plugin --profile web add dshmarket
 - [ccch1mneyyy/dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) - Claude Code-style full-screen terminal UI: pixel-whale header, live status line, and streaming thought expansion.
 - [omdsh-dev/DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) - Full sidebar workbench with file rendering and editing, terminal, Git, and subagents; third-party plugins can register new tabs.
 - [tsonglew/dsh-workspace-search](https://github.com/tsonglew/dsh-workspace-search) - VS Code-style workspace keyword search tab for dsh-better-sidebar: matches file names and content, grouped by file with line numbers, opens in the sidebar editor.
+- [tsonglew/dsh-media-preview](https://github.com/tsonglew/dsh-media-preview) - Audio/video FileViewer for dsh-better-sidebar: native inline playback for mp4/webm/mkv/mov and mp3/flac/wav, served by a Range-capable streaming media route.
 - [Han-1413141/dsh-sticky-disclosure](https://github.com/Han-1413141/dsh-sticky-disclosure) - One-click collapse of every expanded section (Think rows, tool cards) with a live-count pill and a customizable hotkey.
 - [Meredith2328/dsh-sticky-note](https://github.com/Meredith2328/dsh-sticky-note) - Quick sticky notes on the composer toolbar: jot ideas or TODOs, auto-saved as Markdown, one click to send into the chat.
 - [Luaphes/dsh-web-attention-badge](https://github.com/Luaphes/dsh-web-attention-badge) - Attention reminders: frame badge, tab-title count, and a status-colored whale favicon for sessions waiting for input or finished unopened.

--- a/README.zh.md
+++ b/README.zh.md
@@ -83,6 +83,7 @@ dsh plugin --profile web add dshmarket
 - [ccch1mneyyy/dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) — Claude Code 风格全屏终端 UI：像素鲸鱼顶栏、实时工作状态行、思考流式展开。
 - [omdsh-dev/DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) — 侧边栏完整工作台：内置文件渲染编辑、终端、Git 与子代理，支持三方插件注册新 Tab。
 - [tsonglew/dsh-workspace-search](https://github.com/tsonglew/dsh-workspace-search) — VS Code 式工作区关键词搜索 Tab（better-sidebar 扩展）：同时匹配文件名与文件内容，结果按文件分组带行号，点击在侧栏编辑器打开。
+- [tsonglew/dsh-media-preview](https://github.com/tsonglew/dsh-media-preview) — better-sidebar 音视频预览器：原生播放器内联播放 mp4/webm/mkv/mov 等视频与 mp3/flac/wav 等音频，自带支持 HTTP Range 拖动的流式媒体路由。
 - [Han-1413141/dsh-sticky-disclosure](https://github.com/Han-1413141/dsh-sticky-disclosure) — 一键收起会话中所有展开的区块（Think、工具卡等），常驻计数按钮 + 自定义快捷键。
 - [Meredith2328/dsh-sticky-note](https://github.com/Meredith2328/dsh-sticky-note) — 编辑框工具栏便签，随手记点子和 TODO，自动保存为 Markdown，一键发送到对话。
 - [Luaphes/dsh-web-attention-badge](https://github.com/Luaphes/dsh-web-attention-badge) — 会话需要你时三处同时亮起：角标、标签页标题计数、按状态换色的鲸鱼 favicon。


### PR DESCRIPTION
## What

Adds [tsonglew/dsh-media-preview](https://github.com/tsonglew/dsh-media-preview) to the UI enhancement section (both `README.md` and `README.zh.md`).

## About the plugin

Audio/video **FileViewer** for [dsh-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar), registered via its official `ctx.betterSidebar.registerFileViewer` API.

- Native inline playback for video (`mp4 webm mov m4v mkv avi ogv ts 3gp flv`) and audio (`mp3 wav ogg oga m4a aac flac opus weba wma`)
- Served by its own **Range-capable streaming route** (`/media-preview/file`) — better-sidebar's built-in media route has no HTTP Range support, so this package ships 206-seeking and `fs.createReadStream` streaming
- Magic-byte sniffing claims extension-less media (`ftyp`/EBML/`OggS`/`fLaC`/RIFF/ID3)
- Whole-filesystem scope behind the same browser trust fence the built-in `/api` documents, matching the directory-picker browse backend
- Dual-face bundle (`dsh.bundle` + `dsh.client`), MIT licensed: `dsh plugin --profile web add github:tsonglew/dsh-media-preview`

The repo carries the `dsh-plugin` GitHub topic.