### PR TITLE
Add dsh-session-search-pro to Sessions & Messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ dsh plugin --profile web add dshmarket
 - [bwndlct/dsh-session-export](https://github.com/bwndlct/dsh-session-export) - Export the current session to portable, schema-versioned Markdown and JSON files via the `session_export` tool and slash commands, with cross-platform-safe filenames.
 - [LeemanCheung/dsh-token-usage](https://github.com/LeemanCheung/dsh-token-usage) - Persistent per-session Token usage records and a settings dashboard with provider/model breakdowns and a 52-week activity heatmap.
 - [whyihaveyou/dsh-suite#plugin-session-export](https://github.com/whyihaveyou/dsh-suite/tree/main/packages/plugins/plugin-session-export) - Export the append-only session log as human-readable Markdown or HTML, grouped by trajectory source.
+- [LeslieWylie/dsh-session-search-pro](https://github.com/LeslieWylie/dsh-session-search-pro) - Search, list and read past and current sessions through the harness's own `sessionQuery` service: uses the SQLite FTS5 index where a deployment enables it, and falls back to a bounded newest-first scan where it does not.
 
 ### Memory
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -136,6 +136,7 @@ dsh plugin --profile web add dshmarket
 - [bwndlct/dsh-session-export](https://github.com/bwndlct/dsh-session-export) — 把当前会话导出为可移植、带 schema 版本的 Markdown 与 JSON 文件，提供 `session_export` 工具与斜杠命令两种入口，文件名跨平台安全。
 - [LeemanCheung/dsh-token-usage](https://github.com/LeemanCheung/dsh-token-usage) — 持久化记录每个会话的 Token 用量，在设置页提供 provider/model 统计与最近 52 周活跃度热力图。
 - [whyihaveyou/dsh-suite#plugin-session-export](https://github.com/whyihaveyou/dsh-suite/tree/main/packages/plugins/plugin-session-export) — 把 append-only 会话日志导出为按轨迹来源分组的可读 Markdown 或 HTML。
+- [LeslieWylie/dsh-session-search-pro](https://github.com/LeslieWylie/dsh-session-search-pro) — 通过 harness 自带的 `sessionQuery` 服务搜索、列出、读取历史与当前会话：部署启用了 SQLite FTS5 索引时走索引，未启用时回退到有上限的倒序扫描。
 
 ### 🧠 记忆
 


### PR DESCRIPTION
Three tools — `agent_session_search`, `agent_session_list`, `agent_session_read` — over the harness's own `sessionQuery` service. Because it goes through the service rather than parsing session files, the current in-progress session is searchable too.

- [x] `package.json` declares **`dsh.bundle`** (`{"dsh": {"bundle": {"patch": "./cordis.patch.yml"}}}`)
- [x] One line added to **both** `README.md` and `README.zh.md`, under Sessions & Messages
- [x] Description states what the plugin does, no superlatives
- [x] Repo has the `dsh-plugin` topic

### On the "works out of the box" bar

Applying the standard you set on #136 to my own plugin first: **v0.1.0 did not meet it**, so I fixed it before submitting rather than asking you to.

Its search tool called `sq.searchSessions()` unconditionally. That method is real — it lives on `@deepseek-ai/dsh-session-query-sqlite` — but `dsh-base` wires that backend `path: ':memory:', openAt: 'never'`, and the engine throws `SESSION_QUERY_SEARCH_DISABLED` for exactly that setting. Content search is opt-in. The call sat inside a `try/catch` that returned the error as data, so nothing ever threw and the tool looked healthy while answering every query on every default install with `{"error": "session search is disabled…"}`.

v0.2.0 picks an engine at call time: the FTS5 index where a deployment enables it (`engine: "index"`), and a bounded newest-first scan over `listSessions()` + `filterEvents()` — primitives every `sessionQuery` backend has — where it doesn't (`engine: "scan"`). A failure that is *not* an unavailable index is reported as an error rather than reinterpreted as "no index" and answered with a slower scan of the same broken store.

Measured on a real 24-session corpus, searching a term that matches nothing: **17 ms** warm index vs **3,042 ms** scan. The index is worth having; it just can't be the only path.

### Why the tests didn't catch it

The unit fixture defined its own `searchSessions` stub, so it faithfully verified that the plugin called a method the shipped service would refuse. A stub you write yourself will confirm your own misconception.

So there's now a `tests/boot.test.mjs` that boots a real cordis `Context`, loads the harness's session services, loads the package the way a profile does, and executes through the real tool registry. It also checks every `sq.<method>()` call site against the shipped service — unguarded calls must exist, guarded ones may be absent, and a guarded method must still be real on *some* shipped backend so the fast path can't quietly become dead code. I verified it goes red on the original bug before trusting it.

I'd rather you take the code's word than mine, so: 27 unit + 21 boot assertions, and the boot run below is from a clean `pnpm install github:LeslieWylie/dsh-session-search-pro#v0.2.0` — not from my working tree.

```
  ok — ctx.sessionQuery is a real service
  ok — sq.searchSessions() is optional and properly guarded before use
  ok — sq.searchSessions() is a real method on some shipped backend, not an invention
  ok — sq.listSessions() exists on the real service (called unguarded)
  ok — sq.filterEvents() exists on the real service (called unguarded)
  ok — agent_session_search is in the real tool registry
  ok — search does not report an error
  ok — a blank query is refused by the tool, not the backend
  ok — reading an unknown id is a clean error, not a raw exception

  21 passed, 0 failed
```

I know that transcript is self-reported and CI here never re-runs it — happy to answer anything you'd rather verify yourself.

### Note on a plugin not listed here

The README compares against [Tieboyh/dsh-session-search](https://github.com/Tieboyh/dsh-session-search), which isn't in the list. It searches Codex, Claude Code, PI and OpenCode sessions as well, so for anyone working across several agent CLIs it's the better choice, and the README says so. Mine is DSH-only. Mentioning it in case it's worth a look on its own merits.