### PR TITLE
Add radres/dsh-plugin-call-me to Notifications & Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ dsh plugin --profile web add dshmarket
 
 ### Notifications & Integrations
 
+- [radres/dsh-plugin-call-me](https://github.com/radres/dsh-plugin-call-me) - Rings your phone over CallKit: `call_me` and `text_me` tools, plus optional turn-end and approval calls whose spoken answer is transcribed back into the session.
 - [omdsh-dev/dsh-open-in-vscode](https://github.com/omdsh-dev/dsh-open-in-vscode) - Open DSH workspace directories in VS Code directly from the web GUI.
 - [omdsh-dev/dsh-notification](https://github.com/omdsh-dev/dsh-notification) - Desktop notifications for turn completions, with per-outcome controls and keyword rules.
 - [bobleer/dsh-acp-for-bitfun](https://github.com/bobleer/dsh-acp-for-bitfun) - ACP bridge between BitFun and DSH.

--- a/README.zh.md
+++ b/README.zh.md
@@ -270,6 +270,7 @@ dsh plugin --profile web add dshmarket
 
 ### 🔔 通知与集成
 
+- [radres/dsh-plugin-call-me](https://github.com/radres/dsh-plugin-call-me) — 通过 CallKit 打电话到你的手机：`call_me` 与 `text_me` 工具，并可在回合结束或等待审批时来电，语音回答转写后送回会话。
 - [omdsh-dev/dsh-open-in-vscode](https://github.com/omdsh-dev/dsh-open-in-vscode) — 从 Web GUI 一键在 VS Code 中打开工作区目录。
 - [omdsh-dev/dsh-notification](https://github.com/omdsh-dev/dsh-notification) — 回合完成桌面通知，按结果分控 + 关键词过滤。
 - [bobleer/dsh-acp-for-bitfun](https://github.com/bobleer/dsh-acp-for-bitfun) — BitFun 与 DSH 的 ACP 交互对接。


### PR DESCRIPTION
- [x] My repo's `package.json` declares **`dsh.bundle`** (not just `dsh.client`) — `{"dsh":{"bundle":{"patch":"./cordis.patch.yml"}}}` with `cordis.patch.yml` at the repo root
- [x] One line added to **both** `README.md` and `README.zh.md`, under Notifications & Integrations
- [x] Description states what the plugin does, no superlatives
- [x] My repo has the `dsh-plugin` topic

**What it does:** places an actual phone call. The agent gets `call_me` (rings the phone, speaks a question, blocks, returns the answer transcribed) and `text_me`. Optionally, a turn ending or an `approval/request` can ring the phone too, and in call mode the spoken answer resumes the run through `agent.followup()` / `agent.steer()`, so an idle run picks itself up from what you said out loud.

I put it first in the category rather than appending, since every other entry there delivers a notification and this one is a voice call, but please move it wherever you think it belongs.

**Verified against dsh 0.1.0-rc.6**, not just unit tests:

- `dsh plugin --profile web add github:radres/dsh-plugin-call-me` installs in about 6s and appends the bundle to the profile itself. `--dump-config` shows the `# == dsh-plugin-call-me` layer.
- A probe plugin injected with `--patch` reports `ctx.tools.schemas()` = `["call_me", "text_me"]`, so the real registry accepts both definitions and the model sees them.
- Booted against a stub service on localhost: it resolves the paired number, long-polls the event stream, and advances its cursor on an inbound message.

**On your two recommendations:**

- No `@deepseek-ai/*` dependency at all, peer or otherwise. The tools are registered as raw JSON-Schema `ToolDefinition`s, which `ctx.tools.register()` accepts, so there is no second copy of any official runtime in the profile.
- Not on npm yet. It is plain ESM with no build step, so a git install needs no `allowBuilds` approval either way (confirmed on a clean profile), and npm publishing is next.

24 offline tests (fake Cordis context, recording `fetch`, no network) run in CI. Nothing contacts anyone until a phone is paired, unsolicited contact is throttled and grace-delayed, and no listener can throw into the agent loop.