### PR TITLE
Add dsh-task-relay to Sessions & Messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ dsh plugin --profile web add dshmarket
 - [Anionex/dsh-turn-rewind](https://github.com/Anionex/dsh-turn-rewind) - Rewind conversation and workspace state, powered by a persistent Change Ledger.
 - [Jesse-njx/dsh-crosstalk](https://github.com/Jesse-njx/dsh-crosstalk) - Cross-session messaging for DSH: any session on the machine can list and message any other, Claude Code-style, via a local heartbeat registry and inbox.
 - [dongsheng123132/task-passport](https://github.com/dongsheng123132/task-passport) - Carry durable task state across DeepSeek Harness, WorkBuddy, Claude Code and Codex with machine-readable checkpoints and optimistic locking.
+- [LeslieWylie/dsh-task-relay](https://github.com/LeslieWylie/dsh-task-relay) - Cross-session task queue with handoff notes: sessions and subagents push, claim, complete and cancel tasks on a shared file-backed queue, and leave a handoff summary for whoever picks up next.
 - [hellodigua/dsh-share](https://github.com/hellodigua/dsh-share) - Share your conversations with one click.
 - [Moeblack/dsh-message-edit](https://github.com/Moeblack/dsh-message-edit) - Branch-based message editing, reroll, retry, and a version timeline.
 - [Buyi-wsgzg/dsh-sidechain](https://github.com/Buyi-wsgzg/dsh-sidechain) - `/side` persistent side sessions and `/btw` one-shot side questions, run in a temporary fork without touching main history.

--- a/README.zh.md
+++ b/README.zh.md
@@ -120,6 +120,7 @@ dsh plugin --profile web add dshmarket
 - [Anionex/dsh-turn-rewind](https://github.com/Anionex/dsh-turn-rewind) — 对话回退：基于持久 Change Ledger 回滚会话与工作区状态。
 - [Jesse-njx/dsh-crosstalk](https://github.com/Jesse-njx/dsh-crosstalk) — 跨会话消息：本机任意会话都可像 Claude Code 一样列出并互发消息，基于本地心跳注册表与收件箱。
 - [dongsheng123132/task-passport](https://github.com/dongsheng123132/task-passport) — 通过机器可读检查点与乐观锁，在 DeepSeek Harness、WorkBuddy、Claude Code 和 Codex 之间交接持久任务状态。
+- [LeslieWylie/dsh-task-relay](https://github.com/LeslieWylie/dsh-task-relay) — 跨会话任务队列与交接摘要：会话与子 agent 在共享的文件队列上投递、认领、完成、取消任务，并留下交接摘要供后续会话查看。
 - [hellodigua/dsh-share](https://github.com/hellodigua/dsh-share) — 一键分享你的对话。
 - [Moeblack/dsh-message-edit](https://github.com/Moeblack/dsh-message-edit) — 基于分支的消息编辑、reroll、重试与版本时间线。
 - [Buyi-wsgzg/dsh-sidechain](https://github.com/Buyi-wsgzg/dsh-sidechain) — `/side` 持续性侧会话与 `/btw` 一次性侧问，在临时 fork 中运行、不写入主会话历史。


### PR DESCRIPTION
## dsh-task-relay

A cross-session task queue with handoff notes. Sessions and subagents `push`,
`claim`, `done` and `cancel` tasks on a shared file-backed queue, and leave a
handoff summary for whoever picks up next. Seven tools, no network, no
subprocesses; state is a single JSON file written atomically (temp + rename).

Repo: https://github.com/LeslieWylie/dsh-task-relay — MIT, CI green on `main`.

### Overlap with what's already listed

Placed in Sessions & Messages next to its nearest neighbour rather than in
Workflow & Automation, and it's worth being explicit about the overlap:

- **`dongsheng123132/task-passport`** carries durable task state *across
  runtimes* (DSH, WorkBuddy, Claude Code, Codex) with checkpoints and
  optimistic locking. If you need one task to survive moving between tools,
  that is the better fit and this is not a replacement for it.
- **`Jesse-njx/dsh-crosstalk`** is live session-to-session messaging.

`dsh-task-relay` is narrower than both: one machine, one harness, a queue that
outlives the sessions using it. Tasks are claimed rather than addressed, so
whoever is free next picks up the work instead of the sender choosing a
recipient.

### On verification

I want to be straightforward that this listing is self-reported, as all of
them are — CI here builds the site, it never installs or runs a submitted
plugin. So rather than assert that it works, here is what I actually checked
and what I found, including the parts that were broken until this week.

**v0.0.1 was uninstallable by anyone but me.** `.gitignore` excluded `lib/`,
`main` pointed at `lib/index.js`, and the only build hook was `prepack` —
which pnpm refuses to run for a git dependency:

```
ERR_PNPM_GIT_DEP_PREPARE_NOT_ALLOWED  The git-hosted package "dsh-task-relay@0.0.1"
needs to execute build scripts but is not in the "onlyBuiltDependencies" allowlist.
```

The package never reached `node_modules`. All 26 unit tests were green the
whole time, because they import `src/*.ts` and never touch the entry point the
package publishes. It worked on my machine only because my profile used
`link:` to a locally built copy.

**v0.1.0 fixed that and shipped a second install failure.** With npm inside a
real profile:

```
npm error Found: @deepseek-ai/dsh-tools@0.1.0-rc.6
npm error Conflicting peer dependency: @deepseek-ai/dsh-tools@0.0.1-rc.1
npm error   peerOptional @deepseek-ai/dsh-tools@">=0.0.1-rc.1 <0.2.0"
```

semver only lets a prerelease satisfy a comparator set when some comparator
shares its `major.minor.patch` tuple *and* carries a prerelease tag. The range
`>=0.0.1-rc.1 <0.2.0` has comparators on `0.0.1` and `0.2.0`, so it does not
match `0.1.0-rc.6` — the version shipping harnesses actually run. Two things
made this easy to miss: npm's `latest` tag for `@deepseek-ai/dsh-tools` is the
older `0.0.1-rc.1` (the current line is under `next`), and the intuitive
"allow all prereleases" form `>=0.0.0-0 <0.2.0-0` matches *no* `0.1.0`
prerelease either. An explicit `||` across both lines is required.

**v0.1.1** is what I'm submitting. From a clean clone: typecheck, 26 unit
tests, a `lib/` freshness gate, and 22/22 boot checks that load the built
artifact into a real `cordis` `Context`, register all seven tools, and run
push → claim → handoff → done → cancel through the actual tool registry —
then reopen the file with a fresh store instance to confirm the queue really
does outlive the session that wrote it, since that is the entire product
claim.

Reproducing the install without cloning:

```sh
pnpm install "github:LeslieWylie/dsh-task-relay#v0.1.1"
```

Two caveats a reader should know. `lib/` is committed on purpose — it is the
only way a `github:` install yields a runnable package given the pnpm
restriction above; CI rebuilds and diffs it so it cannot silently drift. And
installing the tarball into an *empty* project resolves but cannot import,
because the harness packages are peers; that is expected, the same way a
webpack plugin needs webpack.

### Note for maintainers

In #136 the blocker was that the package name used the `@deepseek-ai/*`
scope. That's resolved — it's plain `dsh-task-relay` now, no reserved scope.

Happy to move this to Workflow & Automation instead if you'd rather group it
by function than by neighbour.
