### PR TITLE
docs: add Code2Skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,7 @@ dsh plugin --profile web add dshmarket
 
 ### Development & Runtime
 
+- [leechen298/Code2Skill](https://github.com/leechen298/Code2Skill) - Generate Functions, MCP tools, workflow Skills, and offline test packages from user-authorized source code.
 - [bujue600-arch/dsh-testgen](https://github.com/bujue600-arch/dsh-testgen) - Automated unit-test generation: a /testgen command and generate_tests tool that scaffold, run, and fix tests until they pass (LLM + offline template generators; vitest/jest/mocha/node:test).
 - [omdsh-dev/fabric](https://github.com/omdsh-dev/fabric) - An MC-Fabric-style hook processor.
 - [LoserFox/dsh-git-identity](https://github.com/LoserFox/dsh-git-identity) - Pin Git commits to the environment's own author identity; env-var injection overrides all `git config` settings.

--- a/README.zh.md
+++ b/README.zh.md
@@ -300,6 +300,7 @@ dsh plugin --profile web add dshmarket
 
 ### 🧑‍💻 开发与运行时
 
+- [leechen298/Code2Skill](https://github.com/leechen298/Code2Skill) — 从用户授权的源码生成 Function、MCP 工具、工作流 Skill 与离线测试包。
 - [bujue600-arch/dsh-testgen](https://github.com/bujue600-arch/dsh-testgen) - 自动化单元测试生成：/testgen 命令与 generate_tests 工具，生成、运行并修复测试直至通过（LLM 与离线模板双生成器；支持 vitest/jest/mocha/node:test）。
 - [omdsh-dev/fabric](https://github.com/omdsh-dev/fabric) — 类似 MC Fabric 的 hook 处理器。
 - [LoserFox/dsh-git-identity](https://github.com/LoserFox/dsh-git-identity) — git 提交固定使用环境自身作者身份，环境变量注入压过一切 `git config` 设置。
@@ -387,4 +388,3 @@ dsh plugin --profile web add dshmarket
 ## 免责声明
 
 本项目是社区维护的索引。插件由各自作者开发与维护，收录不构成背书，亦不对任何插件的安全性、质量或维护状态作出保证。安装插件即在你的机器上运行第三方代码——请自行审阅源码、风险自担。本项目与 DeepSeek 无隶属关系。
-


### PR DESCRIPTION
## Summary

Add Code2Skill v1.1.3 to the English and Chinese Development & Runtime lists. Code2Skill generates Functions, MCP tools, workflow Skills, and offline test packages from user-authorized source code.

## Verification

- [x] The repository's `package.json` declares `dsh.bundle`, with `cordis.patch.yml` present.
- [x] One line was added to both `README.md` and `README.zh.md` under the matching category.
- [x] The descriptions are factual and avoid superlatives.
- [x] The repository has the `dsh-plugin` topic.
- [x] `git diff --check`

Install documentation: `dsh plugin --profile web add github:leechen298/Code2Skill#v1.1.3`
