### PR TITLE
Add muretai/muretai-dsh-skill (Notifications & Integrations)

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,7 @@ dsh plugin --profile web add dshmarket
 - [whyihaveyou/dsh-suite#plugin-notify](https://github.com/whyihaveyou/dsh-suite/tree/main/packages/plugins/plugin-notify) - IM webhook and local notifications on turn completion, errors, or approval (Feishu/WeCom/DingTalk/Slack/Discord/custom).
 - [xmanrui/dsh-feishu](https://github.com/xmanrui/dsh-feishu) - Connect a Feishu bot to DeepSeek Harness by scanning a QR code.
 - [doncelee229-cmyk/dsh-plugin-approval-alert](https://github.com/doncelee229-cmyk/dsh-plugin-approval-alert) - Native OS notifications for approval and question/plan prompts: the toast names the workspace, click jumps to it, bilingual (zh-CN/zh-TW/en), with chime.
+- [muretai/muretai-dsh-skill](https://github.com/muretai/muretai-dsh-skill) - Puts the agent on the Muretai network: its own identity, invite-based introductions, signed end-to-end encrypted messaging with agents owned by other people, and an inbound-mail wake that lets it reply on its own.
 
 ### Models & Providers
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -306,6 +306,7 @@ dsh plugin --profile web add dshmarket
 - [whyihaveyou/dsh-suite#plugin-notify](https://github.com/whyihaveyou/dsh-suite/tree/main/packages/plugins/plugin-notify) — 回合完成、错误或待审批时推送 IM webhook（飞书/企微/钉钉/Slack/Discord/自定义）与本地通知。
 - [xmanrui/dsh-feishu](https://github.com/xmanrui/dsh-feishu) — 通过扫码把飞书机器人接入DeepSeek Harness。
 - [doncelee229-cmyk/dsh-plugin-approval-alert](https://github.com/doncelee229-cmyk/dsh-plugin-approval-alert) — 审批与选择方案的系统级桌面通知：通知显示所属工作区、点击跳转到对应工作区，多语言（简中/繁中/英文），附提示音。
+- [muretai/muretai-dsh-skill](https://github.com/muretai/muretai-dsh-skill) — 让智能体加入 Muretai 网络：拥有自己的身份，通过邀请相识，与属于其他人的智能体进行签名、端到端加密的通信；来信唤醒后可自行回复。
 
 ### 🔌 模型与账号接入
 


### PR DESCRIPTION
Adds [muretai/muretai-dsh-skill](https://github.com/muretai/muretai-dsh-skill) — join the Muretai agent network from DeepSeek Harness: the agent gets its own identity, meets agents owned by other people through invite-based introductions, exchanges signed end-to-end encrypted messages, and an inbound-mail wake starts a one-shot `dsh --profile headless` session so it reads and replies on its own.

Requirements checklist:
- `package.json` declares `dsh.bundle` → root `cordis.patch.yml` (installable via `dsh plugin --profile <p> add github:muretai/muretai-dsh-skill`; the patch row resolves the node directory and identity at runtime, nothing machine-specific baked in). Verified on a clean box against dsh 0.1.0-rc.6: github-install, row composition, and the MCP server spawning per profile.
- `@deepseek-ai/dsh-mcp-client` is declared as an (optional) peerDependency — it resolves from the dsh installation.
- Real, working, maintained code (MIT): the pack is rendered from the Muretai core adapter, has a byte-drift CI gate (`tools/check_render.sh`), EN/中文 READMEs, and was end-to-end verified live (invite join + signed greeting + unattended wake reply over the relay).
- `dsh-plugin` topic is set.

One line added to each of README.md / README.zh.md under Notifications & Integrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)