### PR TITLE
Add dsh-reverse-skill to Skills section

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ dsh plugin --profile web add dshmarket
 - [jinguanghai/deepseek-harness-forge-plugins#forge-tcm](https://github.com/jinguanghai/deepseek-harness-forge-plugins/tree/main/plugins/forge-tcm) - Traditional Chinese Medicine toolkit: eight-axes diagnosis and herb-pair lookup.
 
 ### Skills
+- [dhicoc/dsh-reverse-skill](https://github.com/dhicoc/dsh-reverse-skill) - Complete reverse-skill pack (85 SKILL.md) as a DeepSeek Harness Cordis plugin: reverse engineering, authorized pentesting and security-research skill router.
 - [creght-dev/skills](https://github.com/creght-dev/skills) - Skills for building websites on the Creght platform: CLI pull/push sync, page and component conventions, CMS, forms, auth, SEO, publishing and version rollback.
 
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -240,6 +240,7 @@ dsh plugin --profile web add dshmarket
 - [jinguanghai/deepseek-harness-forge-plugins#forge-tcm](https://github.com/jinguanghai/deepseek-harness-forge-plugins/tree/main/plugins/forge-tcm) — 中医工具集：八纲辨证与药对查询。
 
 ### 🧩 技能包
+- [dhicoc/dsh-reverse-skill](https://github.com/dhicoc/dsh-reverse-skill) — 完整 reverse-skill（85 个 SKILL.md）的 DeepSeek Harness 插件：逆向工程、授权渗透测试与安全研究的技能路由包。
 - [creght-dev/skills](https://github.com/creght-dev/skills) — Creght 平台建站技能包：CLI 拉取/推送同步、页面与组件规范、CMS、表单、Auth、SEO、发布与版本回滚。
 
 


### PR DESCRIPTION
Add **dhicoc/dsh-reverse-skill** to the `### Skills` list (EN + ZH).

- Complete reverse-skill pack (85 `SKILL.md` from upstream `zhaoxuya520/reverse-skill`, MIT) packaged as a DeepSeek Harness Cordis plugin.
- Declares a `dsh.bundle` manifest (`cordis.patch.yml`) so it is installable & active via `dsh plugin add github:dhicoc/dsh-reverse-skill`.
- Repo carries the `dsh-plugin` topic.
- Categories covered: reverse engineering, authorized pentesting, security research, and 42 CTF-track skills.

Install: `dsh plugin add github:dhicoc/dsh-reverse-skill`