### PR TITLE
Add superboy911/dsh-model-router to Models & Providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,7 @@ dsh plugin --profile web add dshmarket
 - [omdsh-dev/Qwen-MM-Plugins](https://github.com/omdsh-dev/Qwen-MM-Plugins) - Qwen multi-modal plugin support.
 - [suntianc/dsh-codex-auth](https://github.com/suntianc/dsh-codex-auth) - Reuses the Codex CLI ChatGPT login as an `openai-codex` LLM route and adds GPT Auth controls to DSH Web settings.
 - [feibi-mochi/deepseek-harness-wallet](https://github.com/feibi-mochi/deepseek-harness-wallet) - Multi-provider wallet chip: official DeepSeek balance, per-session cost & tokens, third-party token totals, recharge shortcut, low-balance alerts.
+- [superboy911/dsh-model-router](https://github.com/superboy911/dsh-model-router) - Deterministic keyword routing, allowlisted model switching, and an isolated image_gen channel for DeepSeek Harness.
 
 ### Development & Runtime
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -317,6 +317,7 @@ dsh plugin --profile web add dshmarket
 - [omdsh-dev/Qwen-MM-Plugins](https://github.com/omdsh-dev/Qwen-MM-Plugins) — Qwen 多模态插件支持。
 - [suntianc/dsh-codex-auth](https://github.com/suntianc/dsh-codex-auth) — 复用 Codex CLI 的 ChatGPT 登录态注册 `openai-codex` LLM 路由，并在 DSH Web 设置中提供 GPT Auth 控件。
 - [feibi-mochi/deepseek-harness-wallet](https://github.com/feibi-mochi/deepseek-harness-wallet) — 多供应商钱包标签：官方 DeepSeek 余额、本会话花费与 token、第三方合计 token、一键充值、低余额提醒。
+- [superboy911/dsh-model-router](https://github.com/superboy911/dsh-model-router) — DSH 关键词路由与隔离生图插件：确定性关键词路由、白名单模型切换与隔离的 image_gen 生图通道。
 
 ### 🧑‍💻 开发与运行时
 


### PR DESCRIPTION
Adds [superboy911/dsh-model-router](https://github.com/superboy911/dsh-model-router) to the **Models & Providers** category (both `README.md` and `README.zh.md`).

- Declares a `dsh.bundle` manifest with `cordis.patch.yml` — installable via `dsh plugin add`. ✅
- Has the `dsh-plugin` topic. ✅
- Actively maintained (v0.2.2, CI, tests). ✅
- Functional one-line descriptions, no marketing. ✅

收录 [superboy911/dsh-model-router](https://github.com/superboy911/dsh-model-router) 到「模型与账号接入」分类（中英文 README 均已添加）。