### PR TITLE
Add Fishsb/dsh-prompt-enhancer to UI Enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ dsh plugin --profile web add dshmarket
 
 - [wjy9902/dsh-web-default-session](https://github.com/wjy9902/dsh-web-default-session) - The generic New Session action opens a default-directory workspace instead of requiring a folder pick, and the workspace picker lists that workspace as a no-folder choice.
 
+- [Fishsb/dsh-prompt-enhancer](https://github.com/Fishsb/dsh-prompt-enhancer) - One-click prompt enhancement: an independent LLM call rewrites your rough draft in the composer, fully undoable.
 
 - [huiliyi37/dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) - A terminal UI (TUI) for DeepSeek Harness.
 - [openma-ai/deepseek-harness-tui](https://github.com/openma-ai/deepseek-harness-tui) - A Rust/ratatui terminal client that speaks the DSH SDK JSON-RPC protocol directly and runs standalone or as a profile bundle.

--- a/README.zh.md
+++ b/README.zh.md
@@ -46,6 +46,8 @@ dsh plugin --profile web add dshmarket
 
 - [wjy9902/dsh-web-default-session](https://github.com/wjy9902/dsh-web-default-session) — 点「新会话」默认打开绑定宿主启动目录的「默认目录」工作区（无需选文件夹），工作区选择菜单中也可选该项。
 
+- [Fishsb/dsh-prompt-enhancer](https://github.com/Fishsb/dsh-prompt-enhancer) — 一键提示词增强：独立 LLM 调用把模糊草稿改写为更强的提示词，不满意可撤回。
+
 - [zealot00/dsh-pet](https://github.com/zealot00/dsh-pet) - DSH Web UI 桌面宠物：精灵图动画、agent 状态联动、拖拽、闹钟（每天/一次）与番茄钟，皮肤下拉选择 + 预览。
 
 - [huiliyi37/dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) — DeepSeek Harness 的终端 UI（TUI）。


### PR DESCRIPTION
- [x] My repo's package.json declares **dsh.bundle** (not just dsh.client) - verified with a local dsh plugin add github:Fishsb/dsh-prompt-enhancer install and end-to-end test (composer button -> host RPC -> LLM -> draft replacement)
- [x] One line added to **both** README.md (English) and README.zh.md (??), under the matching category
- [x] Description states what the plugin does, no superlatives
- [x] My repo has the dsh-plugin topic

**Recommended:**
- Not published to npm yet (git install path; npm publish planned as a follow-up)