### PR TITLE
Add `dsh-context` to UI Enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ dsh plugin --profile web add dshmarket
 
 
 - [siberiah2o/dsh-plugin-terminal](https://github.com/siberiah2o/dsh-plugin-terminal) - Bottom multi-tab terminal panel (node-pty + xterm.js) pinned to the viewport bottom, always below the input box.
+- [bowenliang123/dsh-context](https://github.com/bowenliang123/dsh-context) - Context insight panel: a Context tab beside Chat and Trajectory showing what the model's context window is made of — six categories scaled against the window, per-request history bars with provider-reported token usage, and compaction/prune/injection events.
 ### Themes & Appearance
 
 - [KinGao294/dsh-skin](https://github.com/KinGao294/dsh-skin) - Codex-style skin switcher plus a custom wallpaper layer with opacity and blur controls.

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ dsh plugin --profile web add dshmarket
 
 
 - [siberiah2o/dsh-plugin-terminal](https://github.com/siberiah2o/dsh-plugin-terminal) - Bottom multi-tab terminal panel (node-pty + xterm.js) pinned to the viewport bottom, always below the input box.
-- [bowenliang123/dsh-context](https://github.com/bowenliang123/dsh-context) - Context insight panel: a Context tab beside Chat and Trajectory showing what the model's context window is made of — six categories scaled against the window, per-request history bars with provider-reported token usage, and compaction/prune/injection events.
+- [bowenliang123/dsh-context](https://github.com/bowenliang123/dsh-context) - Context insight panel: a Context tab beside Chat/Trajectory to understand what the model's context window is made of and how it evolves — composition, history, events, and per-message stats.
 ### Themes & Appearance
 
 - [KinGao294/dsh-skin](https://github.com/KinGao294/dsh-skin) - Codex-style skin switcher plus a custom wallpaper layer with opacity and blur controls.

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ dsh plugin --profile web add dshmarket
 
 - [Make0209/dsh-usage-stats](https://github.com/Make0209/dsh-usage-stats) - GitHub-style usage heatmap dashboard: per-workspace turn counts and token spend (with cache-hit rate), DeepSeek account balance, and workspace aliases.
 
+- [bowenliang123/dsh-context](https://github.com/bowenliang123/dsh-context) - Context insight panel: see what the model's context window is made of and how it evolves — composition vs. window size, per-request history, compression/injection events, and per-message token stats.
+
 - [wjy9902/dsh-web-default-session](https://github.com/wjy9902/dsh-web-default-session) - The generic New Session action opens a default-directory workspace instead of requiring a folder pick, and the workspace picker lists that workspace as a no-folder choice.
 
 
@@ -116,7 +118,6 @@ dsh plugin --profile web add dshmarket
 
 
 - [siberiah2o/dsh-plugin-terminal](https://github.com/siberiah2o/dsh-plugin-terminal) - Bottom multi-tab terminal panel (node-pty + xterm.js) pinned to the viewport bottom, always below the input box.
-- [bowenliang123/dsh-context](https://github.com/bowenliang123/dsh-context) - Context insight panel: a Context tab beside Chat/Trajectory to understand what the model's context window is made of and how it evolves — composition, history, events, and per-message stats.
 ### Themes & Appearance
 
 - [KinGao294/dsh-skin](https://github.com/KinGao294/dsh-skin) - Codex-style skin switcher plus a custom wallpaper layer with opacity and blur controls.

--- a/README.zh.md
+++ b/README.zh.md
@@ -115,6 +115,7 @@ dsh plugin --profile web add dshmarket
 
 
 - [siberiah2o/dsh-plugin-terminal](https://github.com/siberiah2o/dsh-plugin-terminal) — 底部多标签终端面板（node-pty + xterm.js）：贴底全宽，输入框始终在终端上方。
+- [bowenliang123/dsh-context](https://github.com/bowenliang123/dsh-context) — 上下文洞察面板：在 Chat 与 Trajectory 旁新增「上下文」标签页，按六大类别对照窗口大小拆解模型上下文窗口构成，提供按请求粒度的历史柱状图（含服务商实际 token 用量）与压缩/裁剪/注入事件。
 ### 🎭 主题与外观
 
 - [KinGao294/dsh-skin](https://github.com/KinGao294/dsh-skin) — Codex 风格皮肤切换器 + 自定义壁纸层，可调透明度与模糊。

--- a/README.zh.md
+++ b/README.zh.md
@@ -115,7 +115,7 @@ dsh plugin --profile web add dshmarket
 
 
 - [siberiah2o/dsh-plugin-terminal](https://github.com/siberiah2o/dsh-plugin-terminal) — 底部多标签终端面板（node-pty + xterm.js）：贴底全宽，输入框始终在终端上方。
-- [bowenliang123/dsh-context](https://github.com/bowenliang123/dsh-context) — 上下文洞察面板：在 Chat 与 Trajectory 旁新增「上下文」标签页，按六大类别对照窗口大小拆解模型上下文窗口构成，提供按请求粒度的历史柱状图（含服务商实际 token 用量）与压缩/裁剪/注入事件。
+- [bowenliang123/dsh-context](https://github.com/bowenliang123/dsh-context) — 上下文洞察面板：在 Chat/Trajectory 旁新增「上下文」标签页，了解上下文窗口的组成与变化，掌握上下文信息统计（构成、历史趋势、事件、消息级 token 统计）。
 ### 🎭 主题与外观
 
 - [KinGao294/dsh-skin](https://github.com/KinGao294/dsh-skin) — Codex 风格皮肤切换器 + 自定义壁纸层，可调透明度与模糊。

--- a/README.zh.md
+++ b/README.zh.md
@@ -44,6 +44,8 @@ dsh plugin --profile web add dshmarket
 
 - [Make0209/dsh-usage-stats](https://github.com/Make0209/dsh-usage-stats) — GitHub 风格用量热力图看板：按工作区统计使用次数与 Token 花费（含缓存命中率）、DeepSeek 账户余额查询、工作区别名管理。
 
+- [bowenliang123/dsh-context](https://github.com/bowenliang123/dsh-context) — 上下文洞察面板：一眼看清模型上下文窗口的组成与变化——构成对照窗口大小、按请求历史趋势、压缩/注入事件、消息级 token 统计。
+
 - [wjy9902/dsh-web-default-session](https://github.com/wjy9902/dsh-web-default-session) — 点「新会话」默认打开绑定宿主启动目录的「默认目录」工作区（无需选文件夹），工作区选择菜单中也可选该项。
 
 - [zealot00/dsh-pet](https://github.com/zealot00/dsh-pet) - DSH Web UI 桌面宠物：精灵图动画、agent 状态联动、拖拽、闹钟（每天/一次）与番茄钟，皮肤下拉选择 + 预览。
@@ -115,7 +117,6 @@ dsh plugin --profile web add dshmarket
 
 
 - [siberiah2o/dsh-plugin-terminal](https://github.com/siberiah2o/dsh-plugin-terminal) — 底部多标签终端面板（node-pty + xterm.js）：贴底全宽，输入框始终在终端上方。
-- [bowenliang123/dsh-context](https://github.com/bowenliang123/dsh-context) — 上下文洞察面板：在 Chat/Trajectory 旁新增「上下文」标签页，了解上下文窗口的组成与变化，掌握上下文信息统计（构成、历史趋势、事件、消息级 token 统计）。
 ### 🎭 主题与外观
 
 - [KinGao294/dsh-skin](https://github.com/KinGao294/dsh-skin) — Codex 风格皮肤切换器 + 自定义壁纸层，可调透明度与模糊。


### PR DESCRIPTION
Adds [dsh-context](https://github.com/bowenliang123/dsh-context) under UI Enhancements.

**Context insight panel** for DeepSeek Harness: adds a Context tab beside Chat/Trajectory, to understand what the model's context window is made of and how it evolves — composition, history, events, and per-message stats.

Install:

```sh
dsh plugin --profile web add dsh-context
```

- dsh.bundle manifest (installable via `dsh plugin add`) + dsh.client manifest for the web UI half
- `dsh-plugin` topic already set; MIT licensed