### PR TITLE
Add dsh-web-mobile-fix and dsh-web-lan-access under UI Enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ dsh plugin --profile web add dshmarket
 
 ### UI Enhancements
 
+- [AcidGr/dsh-web-mobile-fix](https://github.com/AcidGr/dsh-web-mobile-fix) - Mobile layout fixes for the Web UI on narrow screens: full-screen settings panel, one-row plugin nav, full-screen sidebar, centered popups, icon-only session-log button.
+
+- [AcidGr/dsh-web-lan-access](https://github.com/AcidGr/dsh-web-lan-access) - LAN/remote access for the Web UI: injects a crypto.randomUUID polyfill on plain-HTTP origins so the frontend survives LAN or Tailscale IP direct links.
+
 - [Noob-stupid/dsh-plugin-hub](https://github.com/Noob-stupid/dsh-plugin-hub) - A plugin management panel: one-click enable/disable for installed plugins plus a GitHub dsh-plugin marketplace with details and one-click installs.
 
 - [wjy9902/dsh-web-default-session](https://github.com/wjy9902/dsh-web-default-session) - The generic New Session action opens a default-directory workspace instead of requiring a folder pick, and the workspace picker lists that workspace as a no-folder choice.

--- a/README.zh.md
+++ b/README.zh.md
@@ -40,6 +40,10 @@ dsh plugin --profile web add dshmarket
 
 ### 🎨 UI 增强
 
+- [AcidGr/dsh-web-mobile-fix](https://github.com/AcidGr/dsh-web-mobile-fix) — Web UI 移动端布局修复：窄屏下设置面板全屏化、插件导航单行排满、侧边栏全屏、弹层居中、会话日志按钮图标化。
+
+- [AcidGr/dsh-web-lan-access](https://github.com/AcidGr/dsh-web-lan-access) — Web UI 局域网/远程访问：为纯 HTTP 非安全上下文注入 crypto.randomUUID polyfill，局域网/Tailscale IP 直连时前端不再崩溃。
+
 - [Noob-stupid/dsh-plugin-hub](https://github.com/Noob-stupid/dsh-plugin-hub) — 插件管理面板：已安装插件一键启用/停用，内置 GitHub dsh-plugin 插件市场，支持详情查看与一键安装。
 
 - [wjy9902/dsh-web-default-session](https://github.com/wjy9902/dsh-web-default-session) — 点「新会话」默认打开绑定宿主启动目录的「默认目录」工作区（无需选文件夹），工作区选择菜单中也可选该项。


### PR DESCRIPTION
Add two Web UI plugins / 新增两个 Web UI 插件：

- [AcidGr/dsh-web-mobile-fix](https://github.com/AcidGr/dsh-web-mobile-fix) - Mobile layout fixes for the Web UI on narrow screens: full-screen settings panel, one-row plugin nav, full-screen sidebar, centered popups, icon-only session-log button.
- [AcidGr/dsh-web-lan-access](https://github.com/AcidGr/dsh-web-lan-access) - LAN/remote access for the Web UI: injects a crypto.randomUUID polyfill on plain-HTTP origins so the frontend survives LAN or Tailscale IP direct links.

Both are published on npm: `dsh plugin --profile web add dsh-web-mobile-fix` / `dsh plugin --profile web add dsh-web-lan-access`.

---

- [x] My repo's `package.json` declares **`dsh.bundle`** (not just `dsh.client`)
- [x] One line added to **both** `README.md` and `README.zh.md`, under the matching category
- [x] Description states what the plugin does, no superlatives
- [x] My repo has the `dsh-plugin` topic

**Recommended:**
- [x] 📦 Published to npm (`dsh-web-mobile-fix@1.0.0`, `dsh-web-lan-access@1.0.0`)
- [ ] 🔗 `peerDependencies` — not applicable: neither plugin imports any `@deepseek-ai/*` package