### PR TITLE
Add shopline-ai-toolkit-dsh to Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ dsh plugin --profile web add dshmarket
 
 
 - [YTxue/dsh-skill-manager-ytxue](https://github.com/YTxue/dsh-skill-manager-ytxue) - Skill pool manager in the Settings sidebar: enable/disable, folder batch import with rename-conflict prompts, state-driven one-click DSH-spec check & auto-fix, system/project scope labels.
+- [lunw/shopline-ai-toolkit-dsh](https://github.com/lunw/shopline-ai-toolkit-dsh) - SHOPLINE AI Toolkit: bridges the official SHOPLINE Developer MCP server and ships seven SHOPLINE agent skills (Admin REST, GraphQL, OAuth, webhooks, Sline) — the SHOPLINE counterpart of the Shopify AI Toolkit.
 ### Workflow & Automation
 
 - [ztl34245881-commits/dsh-task-planner](https://github.com/ztl34245881-commits/dsh-task-planner) - Task planning with experience muscle-memory: condition-reflex recall of past solutions, LLM capability matching, and auto-persisted lessons.

--- a/README.zh.md
+++ b/README.zh.md
@@ -274,6 +274,7 @@ dsh plugin --profile web add dshmarket
 
 
 - [YTxue/dsh-skill-manager-ytxue](https://github.com/YTxue/dsh-skill-manager-ytxue) — 设置侧边栏的 Skill 管理器：池与启用目录启停、文件夹批量导入（重名询问）、状态驱动一键规范检查与自动修复、系统级/项目级来源标识。
+- [lunw/shopline-ai-toolkit-dsh](https://github.com/lunw/shopline-ai-toolkit-dsh) — SHOPLINE AI 工具包：接入 SHOPLINE 官方开发者 MCP 服务器，内置七个 SHOPLINE 平台技能（Admin REST、GraphQL、OAuth、Webhook、Sline），是 Shopify AI Toolkit 的 SHOPLINE 对应版。
 ### 🔁 工作流与自动化
 
 - [ztl34245881-commits/dsh-task-planner](https://github.com/ztl34245881-commits/dsh-task-planner) — 带经验肌肉记忆的任务规划：条件反射检索历史方案 + LLM 能力匹配 + 经验自动沉淀。


### PR DESCRIPTION
Adds [shopline-ai-toolkit-dsh](https://github.com/lunw/shopline-ai-toolkit-dsh) to the **Skills** category in both `README.md` and `README.zh.md`.

**What it is:** SHOPLINE AI Toolkit for DeepSeek Harness — bridges the official SHOPLINE Developer MCP server (`mcp__shopline__*` tools, local stdio, no auth) and ships seven SHOPLINE agent skills (onboarding, Admin REST, GraphQL, OAuth, webhooks, Sline, dev-MCP usage), mirroring the Shopify AI Toolkit architecture. Installable via `dsh plugin --profile web add github:lunw/shopline-ai-toolkit-dsh`; declares a `dsh.bundle` manifest and carries the `dsh-plugin` topic.

- [x] Added one line under the matching category in both README.md and README.zh.md
- [x] Repo has the `dsh-plugin` topic