### PR TITLE
将 283Gawin/dsh-heatmap 收录至「UI 增强」分类

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ dsh plugin --profile web add dshmarket
 
 
 - [siberiah2o/dsh-plugin-terminal](https://github.com/siberiah2o/dsh-plugin-terminal) - Bottom multi-tab terminal panel (node-pty + xterm.js) pinned to the viewport bottom, always below the input box.
+- [283Gawin/dsh-heatmap](https://github.com/283Gawin/dsh-heatmap) - Activity heatmap in the DSH Web sidebar: GitHub-style grid of daily commits, token usage, and estimated spend, with a today stats line for all-session token totals, cache hit rate, and per-model auto-priced cost.
 ### Themes & Appearance
 
 - [KinGao294/dsh-skin](https://github.com/KinGao294/dsh-skin) - Codex-style skin switcher plus a custom wallpaper layer with opacity and blur controls.

--- a/README.zh.md
+++ b/README.zh.md
@@ -123,6 +123,7 @@ dsh plugin --profile web add dshmarket
 
 
 - [siberiah2o/dsh-plugin-terminal](https://github.com/siberiah2o/dsh-plugin-terminal) — 底部多标签终端面板（node-pty + xterm.js）：贴底全宽，输入框始终在终端上方。
+- [283Gawin/dsh-heatmap](https://github.com/283Gawin/dsh-heatmap) — DSH Web 侧边栏活动热力图：GitHub 风格网格展示每日提交、Token 用量与估算花费，今日统计行显示全会话 Token 总量、缓存命中率与按模型自动计价的花费。
 ### 🎭 主题与外观
 
 - [KinGao294/dsh-skin](https://github.com/KinGao294/dsh-skin) — Codex 风格皮肤切换器 + 自定义壁纸层，可调透明度与模糊。


### PR DESCRIPTION
## 变更内容

在 `README.md` 与 `README.zh.md` 的 **UI Enhancements / 🎨 UI 增强** 分类下各新增一行，收录 [283Gawin/dsh-heatmap](https://github.com/283Gawin/dsh-heatmap)。

**dsh-heatmap** —— DSH Web 侧边栏活动热力图：GitHub 风格网格展示每日提交、Token 用量与估算花费；今日统计行显示全会话 Token 总量、缓存命中率与按模型自动计价的花费。

## 贡献指南要求核对

- ✅ `package.json` 声明了 `dsh.bundle` manifest（含 `cordis.patch.yml`），可通过 `dsh plugin add` 安装
- ✅ 仓库含真实可用代码（完整 src + 14 个 vitest 测试用例通过）
- ✅ 处于活跃维护状态
- ✅ 仓库已添加 [`dsh-plugin`](https://github.com/topics/dsh-plugin) topic（另加 dsh / heatmap / token-usage / activity-tracker）
- ✅ 描述只陈述功能，无营销用语

## 其他说明

- 官方 `@deepseek-ai/*` 包均声明为 `peerDependencies`（符合贡献指南推荐做法）
- 模型定价表参照 [xiufengsun/TokenTracker](https://github.com/xiufengsun/TokenTracker) 的 curated 价格校准