### PR TITLE
feat: Add Max-Samson/dsh-usage-chart to UI Enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ dsh plugin --profile web add dshmarket
 
 - [siberiah2o/dsh-plugin-terminal](https://github.com/siberiah2o/dsh-plugin-terminal) - Bottom multi-tab terminal panel (node-pty + xterm.js) pinned to the viewport bottom, always below the input box.
 - [283Gawin/dsh-heatmap](https://github.com/283Gawin/dsh-heatmap) - Activity heatmap in the DSH Web sidebar: GitHub-style grid of daily commits, token usage, and estimated spend, with a today stats line for all-session token totals, cache hit rate, and per-model auto-priced cost.
+- [Max-Samson/dsh-usage-chart](https://github.com/Max-Samson/dsh-usage-chart) - Token, cost, and balance dashboard under the composer: live indicator plus zero-dependency SVG charts for per-turn usage, estimated cost, and DeepSeek account balance.
 ### Themes & Appearance
 
 - [KinGao294/dsh-skin](https://github.com/KinGao294/dsh-skin) - Codex-style skin switcher plus a custom wallpaper layer with opacity and blur controls.

--- a/README.zh.md
+++ b/README.zh.md
@@ -126,6 +126,7 @@ dsh plugin --profile web add dshmarket
 
 - [siberiah2o/dsh-plugin-terminal](https://github.com/siberiah2o/dsh-plugin-terminal) — 底部多标签终端面板（node-pty + xterm.js）：贴底全宽，输入框始终在终端上方。
 - [283Gawin/dsh-heatmap](https://github.com/283Gawin/dsh-heatmap) — DSH Web 侧边栏活动热力图：GitHub 风格网格展示每日提交、Token 用量与估算花费，今日统计行显示全会话 Token 总量、缓存命中率与按模型自动计价的花费。
+- [Max-Samson/dsh-usage-chart](https://github.com/Max-Samson/dsh-usage-chart) — 输入框下方的用量/成本/余额仪表盘：实时指标指示器 + 零依赖 SVG 用量图表，按轮次统计用量、估算成本并实时查询 DeepSeek 账户余额。
 ### 🎭 主题与外观
 
 - [KinGao294/dsh-skin](https://github.com/KinGao294/dsh-skin) — Codex 风格皮肤切换器 + 自定义壁纸层，可调透明度与模糊。


### PR DESCRIPTION
Add [Max-Samson/dsh-usage-chart](https://github.com/Max-Samson/dsh-usage-chart) to the **UI Enhancements / 🎨 UI 增强** section.

> Token, cost, and balance dashboard under the composer: live indicator plus zero-dependency SVG charts for per-turn usage, estimated cost, and DeepSeek account balance.
>
> 输入框下方的用量/成本/余额仪表盘：实时指标指示器 + 零依赖 SVG 用量图表，按轮次统计用量、估算成本并实时查询 DeepSeek 账户余额。

**提交前快速自查（六项全部满足 ✅，无未满足项）**

- ✅ `package.json` 声明了 **`dsh.bundle`**（非仅 `dsh.client`）— `dsh.bundle.patch: ./cordis.patch.yml` + `dsh.client.platform: web`，可经 `dsh plugin add` 安装
- ✅ 两个语言文件各加一行，分类正确 — `README.md` / `README.zh.md` 均位于 UI Enhancements / 🎨 UI 增强
- ✅ 描述只说功能，无营销词 — 用量 / 成本 / 余额仪表盘
- ✅ 仓库已打 `dsh-plugin` topic — 已确认（另有 `dsh`、`deepseek-harness`）

**推荐项（同样满足 ✅）**

- ✅ 已发布 npm — `dsh-usage-chart@0.1.1`，`dsh plugin --profile web add dsh-usage-chart` 一键安装，预构建产物免 `allowBuilds` 授权
- ✅ 官方 `@deepseek-ai/*` 均声明为 `peerDependencies`（标记 optional）— 避免 profile 内出现重复运行时

### 本次改动

- `README.md`：UI Enhancements 新增 1 行
- `README.zh.md`：🎨 UI 增强 新增 1 行
- 插件总数 316 → 317 由 CI 自动同步，无需手动修改