### PR TITLE
Add dsh-project-organizer conversation title Skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,7 @@ dsh plugin --profile web add dshmarket
 - [jiayan-xu/dsh-nuphus-mcp](https://github.com/jiayan-xu/dsh-nuphus-mcp) - Desktop and browser automation bridge (36 tools): window/screen/mouse/keyboard control with PaddleOCR element perception, Chrome CDP browsing with accessibility snapshots.
 
 ### Skills
+- [caoqinnan-web/dsh-project-organizer](https://github.com/caoqinnan-web/dsh-project-organizer) - Project context engineering skill that distills scattered conversations, files, decisions, and tasks into a minimal actionable workspace and handoff.
 - [dhicoc/dsh-reverse-skill](https://github.com/dhicoc/dsh-reverse-skill) - Complete reverse-skill pack (85 SKILL.md) as a DeepSeek Harness Cordis plugin: reverse engineering, authorized pentesting and security-research skill router.
 - [creght-dev/skills](https://github.com/creght-dev/skills) - Skills for building websites on the Creght platform: CLI pull/push sync, page and component conventions, CMS, forms, auth, SEO, publishing and version rollback.
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -274,6 +274,7 @@ dsh plugin --profile web add dshmarket
 - [jiayan-xu/dsh-nuphus-mcp](https://github.com/jiayan-xu/dsh-nuphus-mcp) — 桌面 + 浏览器自动化桥（36 个工具）：窗口/屏幕/鼠标/键盘控制配 PaddleOCR 元素感知，Chrome CDP 浏览配无障碍快照。
 
 ### 🧩 技能包
+- [caoqinnan-web/dsh-project-organizer](https://github.com/caoqinnan-web/dsh-project-organizer) — 项目上下文工程 Skill：把零散对话、文件、决策和任务提炼为最小但可执行的项目空间与交接上下文。
 - [dhicoc/dsh-reverse-skill](https://github.com/dhicoc/dsh-reverse-skill) — 完整 reverse-skill（85 个 SKILL.md）的 DeepSeek Harness 插件：逆向工程、授权渗透测试与安全研究的技能路由包。
 - [creght-dev/skills](https://github.com/creght-dev/skills) — Creght 平台建站技能包：CLI 拉取/推送同步、页面与组件规范、CMS、表单、Auth、SEO、发布与版本回滚。
 


### PR DESCRIPTION
## Summary

- add `caoqinnan-web/dsh-project-organizer` to the English and Chinese Skill lists;
- describe its actual scope: renaming project conversations from vague AI-generated titles into clear `Category｜Topic` names based on full conversation content;
- disclose the current validation boundary: the workflow is verified by the author in ChatGPT, while DSH end-to-end conversation access and renaming remain experimental.

## Installation

```bash
dsh plugin --profile web add dsh-project-organizer
```

## Validation

- `package.json` declares `dsh.bundle.patch`;
- `cordis.patch.yml` mounts the runtime adapter;
- the adapter registers the bundled `project-organizer` Skill;
- npm package `dsh-project-organizer@0.2.0` is published;
- repository typecheck, build, tests, Skill validation, and package dry run pass.

This PR intentionally remains a draft until the DSH workflow is tested end to end against a host that can list, read, rename, and reread project conversations.
