### PR TITLE
Add Bernardxu123/dsh-mobile-gate to UI Enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ dsh plugin --profile web add dshmarket
 
 - [AcidGr/dsh-web-lan-access](https://github.com/AcidGr/dsh-web-lan-access) - LAN/remote access for the Web UI: injects a crypto.randomUUID polyfill on plain-HTTP origins so the frontend survives LAN or Tailscale IP direct links.
 
+- [Bernardxu123/dsh-mobile-gate](https://github.com/Bernardxu123/dsh-mobile-gate) - LAN mobile gateway: isolated child-process reverse proxy with first-visit approval, per-device token binding, rate limiting, and mobile layout injection (compact composer pills, randomUUID polyfill).
+
 - [Noob-stupid/dsh-plugin-hub](https://github.com/Noob-stupid/dsh-plugin-hub) - A plugin management panel: one-click enable/disable for installed plugins plus a GitHub dsh-plugin marketplace with details and one-click installs.
 
 - [Make0209/dsh-usage-stats](https://github.com/Make0209/dsh-usage-stats) - GitHub-style usage heatmap dashboard: per-workspace turn counts and token spend (with cache-hit rate), DeepSeek account balance, and workspace aliases.

--- a/README.zh.md
+++ b/README.zh.md
@@ -44,6 +44,8 @@ dsh plugin --profile web add dshmarket
 
 - [AcidGr/dsh-web-lan-access](https://github.com/AcidGr/dsh-web-lan-access) — Web UI 局域网/远程访问：为纯 HTTP 非安全上下文注入 crypto.randomUUID polyfill，局域网/Tailscale IP 直连时前端不再崩溃。
 
+- [Bernardxu123/dsh-mobile-gate](https://github.com/Bernardxu123/dsh-mobile-gate) — 局域网手机访问网关：独立子进程反向代理 + 首次访问审批 + 设备令牌绑定 + 限流 + 手机端紧凑排版注入（输入区权限/模型小胶囊、randomUUID polyfill）。
+
 - [Noob-stupid/dsh-plugin-hub](https://github.com/Noob-stupid/dsh-plugin-hub) — 插件管理面板：已安装插件一键启用/停用，内置 GitHub dsh-plugin 插件市场，支持详情查看与一键安装。
 
 - [Make0209/dsh-usage-stats](https://github.com/Make0209/dsh-usage-stats) — GitHub 风格用量热力图看板：按工作区统计使用次数与 Token 花费（含缓存命中率）、DeepSeek 账户余额查询、工作区别名管理。


### PR DESCRIPTION
Adds [dsh-mobile-gate](https://github.com/Bernardxu123/dsh-mobile-gate) to the UI Enhancements category.

LAN mobile gateway for DeepSeek Harness (DSH):
- Isolated child-process reverse proxy (0.0.0.0:3088) to the DSH Web UI — host config untouched
- First-visit approval, per-device token + cookie binding, per-IP rate limiting
- Mobile layout injection (compact composer pills for permission/model selectors, randomUUID polyfill)
- Declares a \dsh.bundle\ manifest, installable via \dsh plugin add\
- Bilingual README + llms.txt + AGENTS.md