### PR TITLE
Add dsh-font: font switcher for the DSH Web GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ dsh plugin --profile web add dshmarket
 - [Small-tailqwq/dsh-deep-whale](https://github.com/Small-tailqwq/dsh-deep-whale) - Whale-girl skin series for the DSH Web UI (maid-atelier).
 - [wsxwj123/dsh-plugins#theme-gallery](https://github.com/wsxwj123/dsh-plugins/tree/main/packages/theme-gallery) - Fifteen curated theme families with complete light and dark palettes that follow the native Light, Dark, and Follow system modes.
 - [PAKIKNOWLEDGE/dsh-client-ui-skin-claude](https://github.com/PAKIKNOWLEDGE/dsh-client-ui-skin-claude) - Claude-style skin with a warm-black canvas, clay accent, and serif UI that follows the native light and dark themes.
+- [tianyhjg-lab/dsh-font](https://github.com/tianyhjg-lab/dsh-font) - Font switcher for the DSH Web GUI: 99 UI fonts and 31 code fonts with CJK-Latin pairing stacks, instant apply and localStorage persistence.
 
 
 ### Sessions & Messages

--- a/README.zh.md
+++ b/README.zh.md
@@ -134,6 +134,7 @@ dsh plugin --profile web add dshmarket
 - [Small-tailqwq/dsh-deep-whale](https://github.com/Small-tailqwq/dsh-deep-whale) — DSH Web 鲸鱼娘皮肤系列（深海女仆工坊 maid-atelier）。
 - [wsxwj123/dsh-plugins#theme-gallery](https://github.com/wsxwj123/dsh-plugins/tree/main/packages/theme-gallery) — 15 个精选主题家族，浅深配色完整，跟随 DSH 原生浅色/深色/跟随系统模式。
 - [PAKIKNOWLEDGE/dsh-client-ui-skin-claude](https://github.com/PAKIKNOWLEDGE/dsh-client-ui-skin-claude) — Claude 风格皮肤：暖黑画布、陶橙点缀、衬线 UI，跟随原生亮/暗主题。
+- [tianyhjg-lab/dsh-font](https://github.com/tianyhjg-lab/dsh-font) — DSH Web GUI 字体切换器：99 个界面字体与 31 个代码字体，中西文自动搭配，即选即生效，localStorage 持久化。
 
 
 ### 💬 会话与消息


### PR DESCRIPTION
Adds [tianyhjg-lab/dsh-font](https://github.com/tianyhjg-lab/dsh-font) to the **Themes & Appearance** category in both READMEs.

A font switcher for the DeepSeek Harness Web GUI: 99 UI fonts (CJK sans / serif / kai-fangsong / display + Latin serif / sans / display, WPS classics included) and 31 code fonts, each with CJK-Latin pairing stacks, instant apply and localStorage persistence. No font files are bundled — only system-installed fonts are referenced, and the README carries a license disclaimer.

Install: `dsh plugin --profile web add github:tianyhjg-lab/dsh-font`
