### PR TITLE
Add zoumutou/dsh-cost-balance to UI Enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ dsh plugin --profile web add dshmarket
 - [Noob-stupid/dsh-plugin-hub](https://github.com/Noob-stupid/dsh-plugin-hub) - A plugin management panel: one-click enable/disable for installed plugins plus a GitHub dsh-plugin marketplace with details and one-click installs.
 
 - [Make0209/dsh-usage-stats](https://github.com/Make0209/dsh-usage-stats) - GitHub-style usage heatmap dashboard: per-workspace turn counts and token spend (with cache-hit rate), DeepSeek account balance, and workspace aliases.
+- [zoumutou/dsh-cost-balance](https://github.com/zoumutou/dsh-cost-balance) - Collapsible iOS-style stats pill under the composer: session cost, DeepSeek account balance, cache-hit rate, and token usage in a frosted panel.
 
 - [bowenliang123/dsh-context](https://github.com/bowenliang123/dsh-context) - Context insight panel: see what the model's context window is made of and how it evolves — composition vs. window size, per-request history, compression/injection events, and per-message token stats.
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -49,6 +49,7 @@ dsh plugin --profile web add dshmarket
 - [Noob-stupid/dsh-plugin-hub](https://github.com/Noob-stupid/dsh-plugin-hub) — 插件管理面板：已安装插件一键启用/停用，内置 GitHub dsh-plugin 插件市场，支持详情查看与一键安装。
 
 - [Make0209/dsh-usage-stats](https://github.com/Make0209/dsh-usage-stats) — GitHub 风格用量热力图看板：按工作区统计使用次数与 Token 花费（含缓存命中率）、DeepSeek 账户余额查询、工作区别名管理。
+- [zoumutou/dsh-cost-balance](https://github.com/zoumutou/dsh-cost-balance) — 输入框下方的 iOS 风格统计条：一键展开查看会话花费、DeepSeek 账户余额、缓存命中率与 Token 用量。
 
 - [bowenliang123/dsh-context](https://github.com/bowenliang123/dsh-context) — 上下文洞察面板：一眼看清模型上下文窗口的组成与变化——构成对照窗口大小、按请求历史趋势、压缩/注入事件、消息级 token 统计。
 


### PR DESCRIPTION
Add [zoumutou/dsh-cost-balance](https://github.com/zoumutou/dsh-cost-balance) to the UI Enhancements category.

- Declares `dsh.bundle` (patch: `./cordis.patch.yml`) + `dsh.client` (platform: web) — installable via `dsh plugin --profile web add dsh-cost-balance`
- Published on npm: [dsh-cost-balance@0.1.0](https://www.npmjs.com/package/dsh-cost-balance) (prebuilt installs, no build approval needed)
- MIT license, `dsh-plugin` topic added
- What it does: iOS-style collapsed stats pill under the DSH web composer; tap to open a frosted panel with session cost (official DeepSeek pricing), account balance, cache-hit rate, and token usage.