### PR TITLE
Add dsh-MusicPlayer to Just for Fun

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,6 +447,7 @@ dsh plugin --profile web add dshmarket
 - [anweat/dsh-restart](https://github.com/anweat/dsh-restart) - Restart DSH: configurable restart method (Node native / legacy PowerShell), post-restart continue prompt, optional watchdog auto-relaunch.
 - [yyh-001/dsh-expression](https://github.com/yyh-001/dsh-expression) - Meme search, the fun way: describe the vibe, and the agent finds and sends a real meme that actually fits.
 - [PC2005-cloud/dsh-pet#dsh-pet](https://github.com/PC2005-cloud/dsh-pet/tree/main/dsh-pet) - Desktop pet for the DSH Web UI with 25 transparent animations, screen wandering, click reactions and drag, plus a reproducible asset-generation pipeline.
+- [xiekai886/dsh-MusicPlayer](https://github.com/xiekai886/dsh-MusicPlayer) - A collapsible/expandable draggable floating music player with NetEase Cloud Music playlist import and song/artist search — chat and listen at the same time.
 
 
 ## Contributing

--- a/README.zh.md
+++ b/README.zh.md
@@ -445,6 +445,7 @@ dsh plugin --profile web add dshmarket
 - [anweat/dsh-restart](https://github.com/anweat/dsh-restart) — DSH 重启插件：可配置的重启方式（Node 原生/旧 PowerShell 适配）、重启后自动继续的提示词、可选看门狗自动拉起。
 - [yyh-001/dsh-expression](https://github.com/yyh-001/dsh-expression) — 陪 AI 斗图的搞笑插件：说个感觉，AI 帮你搜到、发出那张恰到好处的真实表情包。
 - [PC2005-cloud/dsh-pet#dsh-pet](https://github.com/PC2005-cloud/dsh-pet/tree/main/dsh-pet) — DSH Web UI 桌面宠物：25 个透明动画、屏幕漫游、点击反应与拖拽，附可复现的素材生成链。
+- [xiekai886/dsh-MusicPlayer](https://github.com/xiekai886/dsh-MusicPlayer) — 可折叠/展开、自由拖动的悬浮音乐播放器，接入网易云音乐，支持歌单导入和按歌名或歌手搜索单曲导入，边对话边听歌。
 
 
 ## 贡献


### PR DESCRIPTION
Add [dsh-MusicPlayer](https://github.com/xiekai886/dsh-MusicPlayer) under **Just for Fun** (娱乐) in both README.md and README.zh.md.

**dsh-MusicPlayer** is an APlayer-inspired floating music player plugin for DeepSeek Harness Web: collapsible/expandable draggable frosted-glass card, NetEase Cloud Music playlist import (link/ID) and song/artist search with one-click add, multi-layer audio source resolution (Meting → outer/url), and an agent-facing music tool — chat and listen at the same time.

Requirements checklist (per contributing.md):
- [x] Declares dsh.bundle manifest in package.json (with cordis.patch.yml)
- [x] Real, working code (host + client halves, zero external front-end deps)
- [x] dsh-plugin topic added to the repo
- [x] Functional one-line descriptions, no marketing
- [x] Added one line to both README.md (EN) and README.zh.md (中文)