### PR TITLE
Add liqichen/dsh-plugin-manager to Development & Runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,6 +434,7 @@ dsh plugin --profile web add dshmarket
 - [lsz-asd/dsh-chameleon#bundle](https://github.com/lsz-asd/dsh-chameleon/tree/main/bundle) - Self-editing desktop workbench for DeepSeek Harness: a full dsh web replica with an edit mode in which the agent modifies the workbench (patch layers, plugins, UI) with hot reload.
 - [jiayan-xu/dsh-ocr-review](https://github.com/jiayan-xu/dsh-ocr-review) - Local AI code-review gate: review a workspace/branch/commit diff via the managed ocr.js, returning structured findings with token stats; gate mode fails on findings.
 - [huguangyu666/dsh-store](https://github.com/huguangyu666/dsh-store) - Plugin store: npm authoritative catalog + awesome curated list (550+ plugins, 11 categories), dsh-field quality verification, official `dsh plugin add/remove` one-click install, sidebar + settings entry.
+- [liqichen/dsh-plugin-manager](https://github.com/liqichen/dsh-plugin-manager) - GUI in the DSH settings panel: toggle/delete MCP servers, browse and trash skills, and list built-in plugin packages — hot-applied without restart.
 
 
 ### Just for Fun

--- a/README.zh.md
+++ b/README.zh.md
@@ -432,6 +432,7 @@ dsh plugin --profile web add dshmarket
 - [lsz-asd/dsh-chameleon#bundle](https://github.com/lsz-asd/dsh-chameleon/tree/main/bundle) — 可自修改的 DeepSeek Harness 桌面工作台：完整 dsh web 副本 + 编辑模式，agent 在对话中实时修改工作台（补丁层、插件、UI）并热更新生效。
 - [jiayan-xu/dsh-ocr-review](https://github.com/jiayan-xu/dsh-ocr-review) — 本地 AI 代码评审门禁：对工作区/分支/commit diff 跑评审（托管 ocr.js），返回结构化 findings 与 token 统计；门禁模式发现问题即失败。
 - [huguangyu666/dsh-store](https://github.com/huguangyu666/dsh-store) — dsh 插件商店：npm 权威目录 + awesome 精选（550+ 插件、11 分类）、dsh 字段质量验证、官方 `dsh plugin add/remove` 一键安装，侧边栏与设置页入口。
+- [liqichen/dsh-plugin-manager](https://github.com/liqichen/dsh-plugin-manager) — 在 DSH 设置面板内嵌的图形化管理器：开关/删除 MCP 服务、浏览并回收 Skills、查看内置插件包，改动热生效无需重启。
 
 
 ### 🎮 娱乐


### PR DESCRIPTION
## What

Add [liqichen/dsh-plugin-manager](https://github.com/liqichen/dsh-plugin-manager) to the **Development & Runtime** category (both README.md and README.zh.md).

## Why

A GUI plugin manager embedded in the DSH settings panel:

- Toggle / delete **MCP servers** in `cordis.patch.yml` — hot-applied via host HMR, no restart
- Browse and **trash skills** (move to `.trash-*`, recoverable)
- Read-only list of **built-in plugin packages**
- Every write auto-backs up `cordis.patch.yml` (`.bak-<timestamp>`)

## Checklist

- [x] Repo declares a `dsh.bundle` manifest in `package.json` (`patch: ./cordis.patch.yml`)
- [x] `cordis.patch.yml` present at repo root with the `- insert:` block
- [x] Real working code (node half `index.js` + browser half `client.js`)
- [x] `dsh-plugin` topic added
- [x] One line added to both `README.md` and `README.zh.md`
- [x] Description states what the plugin does, no marketing