### PR TITLE
Add dsh-store: npm authoritative catalog + dsh-field verification plugin store

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,6 +425,7 @@ dsh plugin --profile web add dshmarket
 - [Leon0555/dsh-lan-access](https://github.com/Leon0555/dsh-lan-access) - LAN access for the Web GUI: 0.0.0.0 bind plus a crypto.randomUUID polyfill for non-secure (LAN HTTP) contexts.
 - [lsz-asd/dsh-chameleon#bundle](https://github.com/lsz-asd/dsh-chameleon/tree/main/bundle) - Self-editing desktop workbench for DeepSeek Harness: a full dsh web replica with an edit mode in which the agent modifies the workbench (patch layers, plugins, UI) with hot reload.
 - [jiayan-xu/dsh-ocr-review](https://github.com/jiayan-xu/dsh-ocr-review) - Local AI code-review gate: review a workspace/branch/commit diff via the managed ocr.js, returning structured findings with token stats; gate mode fails on findings.
+- [huguangyu666/dsh-store](https://github.com/huguangyu666/dsh-store) - Plugin store: npm authoritative catalog + awesome curated list (550+ plugins, 11 categories), dsh-field quality verification, official `dsh plugin add/remove` one-click install, sidebar + settings entry.
 
 
 ### Just for Fun

--- a/README.zh.md
+++ b/README.zh.md
@@ -423,6 +423,7 @@ dsh plugin --profile web add dshmarket
 - [Leon0555/dsh-lan-access](https://github.com/Leon0555/dsh-lan-access) — 局域网访问：Web GUI 绑定 0.0.0.0 + crypto.randomUUID polyfill（修复非安全上下文下 RPC 崩溃）。
 - [lsz-asd/dsh-chameleon#bundle](https://github.com/lsz-asd/dsh-chameleon/tree/main/bundle) — 可自修改的 DeepSeek Harness 桌面工作台：完整 dsh web 副本 + 编辑模式，agent 在对话中实时修改工作台（补丁层、插件、UI）并热更新生效。
 - [jiayan-xu/dsh-ocr-review](https://github.com/jiayan-xu/dsh-ocr-review) — 本地 AI 代码评审门禁：对工作区/分支/commit diff 跑评审（托管 ocr.js），返回结构化 findings 与 token 统计；门禁模式发现问题即失败。
+- [huguangyu666/dsh-store](https://github.com/huguangyu666/dsh-store) - dsh 插件商店：npm 权威目录 + awesome 精选（550+ 插件、11 分类）、dsh 字段质量验证、官方 `dsh plugin add/remove` 一键安装，侧边栏与设置页入口。
 
 
 ### 🎮 娱乐


### PR DESCRIPTION
Adds [dsh-store](https://github.com/huguangyu666/dsh-store) to Development & Runtime.

What makes it different from existing stores (dsh-market, plugin-hub, workshops):
- **npm registry as authoritative source** (the actual install location) + awesome curated list merge — 550+ plugins, 11 categories
- **dsh-field background verification** — filters out noise packages that merely tag dsh-plugin keyword
- **Official \dsh plugin add/remove\ install path** (dsh.profile.bundles layer) with fallback
- Sidebar button + settings section entry

Repo has the dsh-plugin topic.