### PR TITLE
Add SaiSenBox/dsh-boot-guard to Development & Runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,6 +378,7 @@ dsh plugin --profile web add dshmarket
 
 ### Development & Runtime
 
+- [SaiSenBox/dsh-boot-guard](https://github.com/SaiSenBox/dsh-boot-guard) - Loader-independent startup recovery for DSH Web that detects likely broken plugins, temporarily skips them, and restores only Boot Guard-managed changes.
 - [leechen298/Code2Skill](https://github.com/leechen298/Code2Skill) - Generate Functions, MCP tools, workflow Skills, and offline test packages from user-authorized source code.
 - [bujue600-arch/dsh-testgen](https://github.com/bujue600-arch/dsh-testgen) - Automated unit-test generation: a /testgen command and generate_tests tool that scaffold, run, and fix tests until they pass (LLM + offline template generators; vitest/jest/mocha/node:test).
 - [omdsh-dev/fabric](https://github.com/omdsh-dev/fabric) - An MC-Fabric-style hook processor.

--- a/README.zh.md
+++ b/README.zh.md
@@ -377,6 +377,7 @@ dsh plugin --profile web add dshmarket
 
 ### 🧑‍💻 开发与运行时
 
+- [SaiSenBox/dsh-boot-guard](https://github.com/SaiSenBox/dsh-boot-guard) — 独立于常规客户端插件加载链的 DSH Web 启动救援工具，可定位疑似故障插件、临时跳过，并且只恢复 Boot Guard 写入的配置。
 - [leechen298/Code2Skill](https://github.com/leechen298/Code2Skill) — 从用户授权的源码生成 Function、MCP 工具、工作流 Skill 与离线测试包。
 - [bujue600-arch/dsh-testgen](https://github.com/bujue600-arch/dsh-testgen) — 自动化单元测试生成：/testgen 命令与 generate_tests 工具，生成、运行并修复测试直至通过（LLM 与离线模板双生成器；支持 vitest/jest/mocha/node:test）。
 - [omdsh-dev/fabric](https://github.com/omdsh-dev/fabric) — 类似 MC Fabric 的 hook 处理器。


### PR DESCRIPTION
## What changed

- Added `SaiSenBox/dsh-boot-guard` to **Development & Runtime** in `README.md`.
- Added the matching Chinese entry to **开发与运行时** in `README.zh.md`.

## Why

`dsh-boot-guard` provides loader-independent startup recovery when a broken plugin prevents DSH Web from loading. It can identify likely failing plugins, temporarily skip selected entries, and restore only configuration changes that Boot Guard created.

## User impact

After merge, users can discover the plugin through the Awesome DSH Plugin list and its generated marketplace.

## Validation

- [x] `package.json` declares `dsh.bundle` and the repository contains `cordis.patch.yml`.
- [x] Published to npm as `dsh-boot-guard@1.1.0`.
- [x] Repository has the `dsh-plugin` topic.
- [x] Added factual one-line descriptions to both language files.
- [x] `git diff --check` passes.
