### PR TITLE
Map dsh-desktop-windowos#plugin to npm: dsh-desktop-plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ dsh plugin --profile web add dshmarket
 - [urzeye/dsh-outline](https://github.com/urzeye/dsh-outline) - Real-time outline panel for the DSH Web session page: user questions plus a Markdown heading tree (H1–H6) that updates live during streaming, with click-to-locate highlighting, expand-depth control, search, and per-session favorites.
 - [283Gawin/dsh-heatmap](https://github.com/283Gawin/dsh-heatmap) - Activity heatmap in the DSH Web sidebar: GitHub-style grid of daily commits, token usage, and estimated spend, with a today stats line for all-session token totals, cache hit rate, and per-model auto-priced cost.
 - [Max-Samson/dsh-usage-chart](https://github.com/Max-Samson/dsh-usage-chart) - Token, cost, and balance dashboard under the composer: live indicator plus zero-dependency SVG charts for per-turn usage, estimated cost, and DeepSeek account balance.
+- [RAFOLIE/dsh-desktop-windowos#plugin](https://github.com/RAFOLIE/dsh-desktop-windowos/tree/main/plugin) - Windows tray desktop shell for DSH: auto-installs the exe from GitHub Releases, creates a desktop shortcut, and adds a desktop_launch tool to start it from chat.
 ### Themes & Appearance
 
 - [KinGao294/dsh-skin](https://github.com/KinGao294/dsh-skin) - Codex-style skin switcher plus a custom wallpaper layer with opacity and blur controls.

--- a/README.zh.md
+++ b/README.zh.md
@@ -130,6 +130,7 @@ dsh plugin --profile web add dshmarket
 - [urzeye/dsh-outline](https://github.com/urzeye/dsh-outline) — DSH Web 会话页实时大纲面板：「用户问题 + Markdown 标题（1~6 级）」大纲树，流式生成时实时更新，点击节点滚动定位并高亮，支持展开深度调节、搜索与会话级收藏。
 - [283Gawin/dsh-heatmap](https://github.com/283Gawin/dsh-heatmap) — DSH Web 侧边栏活动热力图：GitHub 风格网格展示每日提交、Token 用量与估算花费，今日统计行显示全会话 Token 总量、缓存命中率与按模型自动计价的花费。
 - [Max-Samson/dsh-usage-chart](https://github.com/Max-Samson/dsh-usage-chart) — 输入框下方的用量/成本/余额仪表盘：实时指标指示器 + 零依赖 SVG 用量图表，按轮次统计用量、估算成本并实时查询 DeepSeek 账户余额。
+- [RAFOLIE/dsh-desktop-windowos#plugin](https://github.com/RAFOLIE/dsh-desktop-windowos/tree/main/plugin) — DSH 的 Windows 托盘桌面壳：自动从 GitHub Releases 安装 exe、创建桌面快捷方式，并提供 desktop_launch 工具在对话中一键启动。
 ### 🎭 主题与外观
 
 - [KinGao294/dsh-skin](https://github.com/KinGao294/dsh-skin) — Codex 风格皮肤切换器 + 自定义壁纸层，可调透明度与模糊。

--- a/data/npm-map.json
+++ b/data/npm-map.json
@@ -31,11 +31,7 @@
   "npm": null,
   "checkedAt": "2026-08-14"
  },
- "https://github.com/a903067276-rgb/dsh-file-mentions": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/a903067276-rgb/dsh-hud": {
+ "https://github.com/AKIRACOD/dsh-drag-and-drop": {
   "npm": null,
   "checkedAt": "2026-08-14"
  },
@@ -45,14 +41,6 @@
  },
  "https://github.com/AcidGr/dsh-web-mobile-fix": {
   "npm": "dsh-web-mobile-fix",
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/AKIRACOD/dsh-drag-and-drop": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/alingalingling/ui-status-label": {
-  "npm": null,
   "checkedAt": "2026-08-14"
  },
  "https://github.com/AnacondaKC/dsh-douyin": {
@@ -75,36 +63,8 @@
   "npm": "@dsh-external/dsh-vision-toolkit",
   "checkedAt": "2026-08-14"
  },
- "https://github.com/anweat/dsh-browser": {
-  "npm": "@anweat/dsh-browser",
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/anweat/dsh-restart": {
-  "npm": "dsh-restart",
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/anweat/dsh-voice-webspeech": {
-  "npm": "dsh-voice-webspeech",
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/anweat/dsh-web-search-pro": {
-  "npm": "dsh-web-search-pro",
-  "checkedAt": "2026-08-14"
- },
  "https://github.com/Areium/dsh-fail-logger": {
   "npm": null,
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/arrow949/dsh-turn-approval": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/asukasec/dsh-message-preview": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/awesome-dsh-plugin/dsh-find-plugin": {
-  "npm": "dsh-find-plugin",
   "checkedAt": "2026-08-14"
  },
  "https://github.com/BiBoyang/dsh-eval-harness": {
@@ -113,42 +73,6 @@
  },
  "https://github.com/BiBoyang/dsh-im-bridge": {
   "npm": null,
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/bill9109/dsh-101": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/bill9109/dsh-conversation-share": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/bill9109/dsh-drag-and-drop": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/bill9109/dsh-web-ui-notify": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/bill9109/dsh-webbridge": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/biociao/dsh-science": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/bobcat848/dsh-calculator": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/bobleer/dsh-acp-for-bitfun": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/bowenliang123/dsh-context": {
-  "npm": "dsh-context",
   "checkedAt": "2026-08-14"
  },
  "https://github.com/BrambleXu/dsh-annotate": {
@@ -163,31 +87,7 @@
   "npm": null,
   "checkedAt": "2026-08-14"
  },
- "https://github.com/btspoony/dsh-advisor": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/btspoony/dsh-llm-fallbacks": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/btspoony/mstar-harness": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/bujue600-arch/dsh-testgen": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
  "https://github.com/Buyi-wsgzg/dsh-sidechain": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/bwndlct/dsh-session-audit": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/bwndlct/dsh-session-export": {
   "npm": null,
   "checkedAt": "2026-08-14"
  },
@@ -195,15 +95,7 @@
   "npm": null,
   "checkedAt": "2026-08-14"
  },
- "https://github.com/causebefore/dsh-pomodoro": {
-  "npm": "dsh-pomodoro",
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/ccch1mneyyy/dsh-TUI": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/ccq1/dsh-side-panel": {
+ "https://github.com/CZX2244/dsh-bilibili": {
   "npm": null,
   "checkedAt": "2026-08-14"
  },
@@ -215,59 +107,7 @@
   "npm": null,
   "checkedAt": "2026-08-14"
  },
- "https://github.com/creght-dev/skills": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/crTnT/dsh-plugin-suite/tree/main/dsh-plugin-center": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/crTnT/dsh-plugin-suite/tree/main/dsh-plugin-updater": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/czm15053/dsh-peer-link": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/CZX2244/dsh-bilibili": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/dhicoc/dsh-reverse-skill": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
  "https://github.com/DietCokewithSugar/dsh-user-experience": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/dingyi222666/dsh-focus-chat": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/dingyi222666/dsh-session-notification": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/disyli/dsh-tool-call-stats": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/doncelee229-cmyk/dsh-plugin-approval-alert": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/dongsheng123132/task-passport": {
-  "npm": "task-passport",
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/dsh-market/dsh-market": {
-  "npm": "dshmarket",
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/dylan121322/llm-adaptive": {
   "npm": null,
   "checkedAt": "2026-08-14"
  },
@@ -287,31 +127,7 @@
   "npm": null,
   "checkedAt": "2026-08-14"
  },
- "https://github.com/fakechris/dsh-track": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/feibi-mochi/deepseek-harness-wallet": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
  "https://github.com/Fishsb/dsh-prompt-enhancer": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/fishxcode/dsh-plugin-deepseek-balance": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/fly233338/dsh-overleaf": {
-  "npm": "dsh-overleaf",
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/flymysql/dsh-memory": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/flymysql/dsh-remote": {
   "npm": null,
   "checkedAt": "2026-08-14"
  },
@@ -319,32 +135,16 @@
   "npm": "dsh-vision-proxy",
   "checkedAt": "2026-08-14"
  },
- "https://github.com/forrestchang/dsh-multica-runtime": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/franksong2702/dsh-codex-connect": {
-  "npm": "dsh-codex-connect",
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/freehul/sgme": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/fuhefei/dsh-sentinel": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
  "https://github.com/FuRongJun-1999/dsh-memory": {
   "npm": "@furongjun1999/dsh-memory",
   "checkedAt": "2026-08-14"
  },
- "https://github.com/Ghost011118/dsh-balance-meter": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
  "https://github.com/GIT121995/dsh-memory-gate": {
   "npm": "dsh-memory-gate",
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/Ghost011118/dsh-balance-meter": {
+  "npm": null,
   "checkedAt": "2026-08-14"
  },
  "https://github.com/GooodWei/arcana": {
@@ -363,22 +163,6 @@
   "npm": null,
   "checkedAt": "2026-08-14"
  },
- "https://github.com/hccccc01333/dsh-excel-chat": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/heartmove/dsh-side-chat": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/hellodigua/dsh-emoji": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/hellodigua/dsh-share": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
  "https://github.com/HsiangNianian/dsh-auto-continue": {
   "npm": "dsh-client-auto-continue",
   "checkedAt": "2026-08-14"
@@ -388,18 +172,6 @@
   "checkedAt": "2026-08-14"
  },
  "https://github.com/HuanLinOTO/dsh-plugin-mineru": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/huey1in/trio": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/huiliyi37/dsh-tianshu-tui": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/hust-open-atom-club/oh-dsh": {
   "npm": null,
   "checkedAt": "2026-08-14"
  },
@@ -416,18 +188,6 @@
   "checkedAt": "2026-08-14"
  },
  "https://github.com/ICCuse/dsh-premise-guard": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/icetomoyo/dsh_workflow": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/ilharp/dsh-tool-approval": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/imetn/dsh-lark-bridge": {
   "npm": null,
   "checkedAt": "2026-08-14"
  },
@@ -479,6 +239,522 @@
   "npm": null,
   "checkedAt": "2026-08-14"
  },
+ "https://github.com/Jolly-J/dsh-deepseek-billing": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/Karbo123/DSH-EvoResearch/tree/main/packages/evoresearch-plugin": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/KinGao294/dsh-skin": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/LaoYueHanNi/dsh-token-usage": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/LeemanCheung/dsh-agent-preset-recommender": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/LeemanCheung/dsh-task-dag": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/LeemanCheung/dsh-token-usage": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/LeemanCheung/dsh-whale-animation": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/Leon0555/dsh-lan-access": {
+  "npm": "dsh-lan-access",
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/LeslieWylie/dsh-fleet-audit": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/LeslieWylie/dsh-md-preview": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/LeslieWylie/dsh-ops-kit": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/LeslieWylie/dsh-session-search-pro": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/LeslieWylie/dsh-task-relay": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/Letter2025/dsh-approval-llm": {
+  "npm": "dsh-approval-llm",
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/Letter2025/dsh-model-failover": {
+  "npm": "dsh-model-failover",
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/Letter2025/dsh-tool-search": {
+  "npm": "dsh-tool-search",
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/LoserFox/distill": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/LoserFox/dsh-git-identity": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/LoserFox/telegram": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/Luaphes/dsh-web-attention-badge": {
+  "npm": "dsh-web-attention-badge",
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/Luke-Yong/dsh-plugin-knowledge-graph": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/Lum1104/dsh-browser": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/MAXeaglet/dsh-bash-terminal": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/Make0209/dsh-usage-stats": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/Max-Samson/dsh-usage-chart": {
+  "npm": "dsh-usage-chart",
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/Meredith2328/dsh-sticky-note": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/Moeblack/deepseek-manners": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/Moeblack/dsh-message-edit": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/Moeblack/dsh-prompt-studio": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/MorGogh/widget-dock": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/Nagi-ovo/dsh-ads": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/Nagi-ovo/dsh-visualize": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/Nanki-nn/dsh-answer-pet": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/NanmiCoder/dsh-agent-teams": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/Noob-stupid/dsh-plugin-hub": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/Nwflower/dsh-chat-import": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/Nwflower/dsh-file-claim": {
+  "npm": "dsh-file-claim",
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/PAKIKNOWLEDGE/dsh-client-ui-skin-claude": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/PC2005-cloud/dsh-pet/tree/main/dsh-pet": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/PerryLink/dsh-doublecheck": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/PerryLink/dsh-mcp-panel": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/PerryLink/dsh-memento": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/Phant0Meow/dsh-memory-meow": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/PicGo/dsh-plugin": {
+  "npm": "@picgo/dsh-plugin",
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/QT-Chen/dsh-mic-input": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/RAFOLIE/dsh-desktop-windowos/tree/main/plugin": {
+  "npm": "dsh-desktop-plugin",
+  "checkedAt": "2026-08-15"
+ },
+ "https://github.com/SPYQWER1/dsh-codex-tools": {
+  "npm": "dsh-codex-tools",
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/SamXiaBing/dsh-adb": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/Sanqi-normal/dsh-webui-market-plugin": {
+  "npm": "@sanqi-normal/dsh-webui-market-plugin",
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/Sev7een/ds-api-usage": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/Sev7een/dsh-plugin-automations": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/Small-tailqwq/dsh-deep-whale": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/Small-tailqwq/dsh-tps": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/Smalldy/godot-bridge": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/SnowCrescenter-tech/dsh-milestone": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/Starfie1d1272/dsh-builtin-toggles": {
+  "npm": "dsh-builtin-toggles",
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/Sttrevens/dsh-cost-meter": {
+  "npm": "@steven-wu/dsh-cost-meter",
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/THU-MAIC/dsh-openmaic": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/TonyDua/dsh-web-search-exa": {
+  "npm": "@tonydua/dsh-web-search-exa",
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/Wine-Red/dsh-prompt-stash": {
+  "npm": "dsh-prompt-stash",
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/Xplore-LAB/dsh-plugin-asmemory": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/YTxue/dsh-skill-manager": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/YTxue/dsh-skill-manager-ytxue": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/Yuuz12/dsh-webui-auth": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/ZK-Andy/dsh-continual-evolve": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/ZRui-C/dsh-computer-use": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/ZSeven-W/dsh-openpencil": {
+  "npm": "@zseven-w/dsh-openpencil",
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/Zhenyu98/dsh-context-doctor": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/a903067276-rgb/dsh-file-mentions": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/a903067276-rgb/dsh-hud": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/alingalingling/ui-status-label": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/anweat/dsh-browser": {
+  "npm": "@anweat/dsh-browser",
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/anweat/dsh-restart": {
+  "npm": "dsh-restart",
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/anweat/dsh-voice-webspeech": {
+  "npm": "dsh-voice-webspeech",
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/anweat/dsh-web-search-pro": {
+  "npm": "dsh-web-search-pro",
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/arrow949/dsh-turn-approval": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/asukasec/dsh-message-preview": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/awesome-dsh-plugin/dsh-find-plugin": {
+  "npm": "dsh-find-plugin",
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/bill9109/dsh-101": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/bill9109/dsh-conversation-share": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/bill9109/dsh-drag-and-drop": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/bill9109/dsh-web-ui-notify": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/bill9109/dsh-webbridge": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/biociao/dsh-science": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/bobcat848/dsh-calculator": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/bobleer/dsh-acp-for-bitfun": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/bowenliang123/dsh-context": {
+  "npm": "dsh-context",
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/btspoony/dsh-advisor": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/btspoony/dsh-llm-fallbacks": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/btspoony/mstar-harness": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/bujue600-arch/dsh-testgen": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/bwndlct/dsh-session-audit": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/bwndlct/dsh-session-export": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/causebefore/dsh-pomodoro": {
+  "npm": "dsh-pomodoro",
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/ccch1mneyyy/dsh-TUI": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/ccq1/dsh-side-panel": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/crTnT/dsh-plugin-suite/tree/main/dsh-plugin-center": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/crTnT/dsh-plugin-suite/tree/main/dsh-plugin-updater": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/creght-dev/skills": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/czm15053/dsh-peer-link": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/dhicoc/dsh-reverse-skill": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/dingyi222666/dsh-focus-chat": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/dingyi222666/dsh-session-notification": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/disyli/dsh-tool-call-stats": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/doncelee229-cmyk/dsh-plugin-approval-alert": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/dongsheng123132/task-passport": {
+  "npm": "task-passport",
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/dsh-market/dsh-market": {
+  "npm": "dshmarket",
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/dylan121322/llm-adaptive": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/fakechris/dsh-track": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/feibi-mochi/deepseek-harness-wallet": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/fishxcode/dsh-plugin-deepseek-balance": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/fly233338/dsh-overleaf": {
+  "npm": "dsh-overleaf",
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/flymysql/dsh-memory": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/flymysql/dsh-remote": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/forrestchang/dsh-multica-runtime": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/franksong2702/dsh-codex-connect": {
+  "npm": "dsh-codex-connect",
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/freehul/sgme": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/fuhefei/dsh-sentinel": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/hccccc01333/dsh-excel-chat": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/heartmove/dsh-side-chat": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/hellodigua/dsh-emoji": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/hellodigua/dsh-share": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/huey1in/trio": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/huiliyi37/dsh-tianshu-tui": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/hust-open-atom-club/oh-dsh": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/icetomoyo/dsh_workflow": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/ilharp/dsh-tool-approval": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
+ "https://github.com/imetn/dsh-lark-bridge": {
+  "npm": null,
+  "checkedAt": "2026-08-14"
+ },
  "https://github.com/jiangnanquan/dsh-ux": {
   "npm": null,
   "checkedAt": "2026-08-14"
@@ -519,19 +795,7 @@
   "npm": null,
   "checkedAt": "2026-08-14"
  },
- "https://github.com/Jolly-J/dsh-deepseek-billing": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
  "https://github.com/kam74515-boop/dsh-everything-oauth": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/Karbo123/DSH-EvoResearch/tree/main/packages/evoresearch-plugin": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/KinGao294/dsh-skin": {
   "npm": null,
   "checkedAt": "2026-08-14"
  },
@@ -543,10 +807,6 @@
   "npm": null,
   "checkedAt": "2026-08-14"
  },
- "https://github.com/LaoYueHanNi/dsh-token-usage": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
  "https://github.com/ldchaowin/dsh-plugin-notify-sound": {
   "npm": "dsh-plugin-notify-sound",
   "checkedAt": "2026-08-14"
@@ -555,60 +815,8 @@
   "npm": null,
   "checkedAt": "2026-08-14"
  },
- "https://github.com/LeemanCheung/dsh-agent-preset-recommender": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/LeemanCheung/dsh-task-dag": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/LeemanCheung/dsh-token-usage": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/LeemanCheung/dsh-whale-animation": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
  "https://github.com/lehhair/dsh-diff-viewer": {
   "npm": null,
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/Leon0555/dsh-lan-access": {
-  "npm": "dsh-lan-access",
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/LeslieWylie/dsh-fleet-audit": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/LeslieWylie/dsh-md-preview": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/LeslieWylie/dsh-ops-kit": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/LeslieWylie/dsh-session-search-pro": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/LeslieWylie/dsh-task-relay": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/Letter2025/dsh-approval-llm": {
-  "npm": "dsh-approval-llm",
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/Letter2025/dsh-model-failover": {
-  "npm": "dsh-model-failover",
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/Letter2025/dsh-tool-search": {
-  "npm": "dsh-tool-search",
   "checkedAt": "2026-08-14"
  },
  "https://github.com/lhh010/dsh-minigames": {
@@ -655,18 +863,6 @@
   "npm": null,
   "checkedAt": "2026-08-14"
  },
- "https://github.com/LoserFox/distill": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/LoserFox/dsh-git-identity": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/LoserFox/telegram": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
  "https://github.com/lsz-asd/dsh-chameleon/tree/main/bundle": {
   "npm": null,
   "checkedAt": "2026-08-14"
@@ -676,18 +872,6 @@
   "checkedAt": "2026-08-14"
  },
  "https://github.com/lsz-asd/dsh-plugin-session-delete": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/Luaphes/dsh-web-attention-badge": {
-  "npm": "dsh-web-attention-badge",
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/Luke-Yong/dsh-plugin-knowledge-graph": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/Lum1104/dsh-browser": {
   "npm": null,
   "checkedAt": "2026-08-14"
  },
@@ -711,22 +895,6 @@
   "npm": null,
   "checkedAt": "2026-08-14"
  },
- "https://github.com/Make0209/dsh-usage-stats": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/Max-Samson/dsh-usage-chart": {
-  "npm": "dsh-usage-chart",
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/MAXeaglet/dsh-bash-terminal": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/Meredith2328/dsh-sticky-note": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
  "https://github.com/minybear/DeepSeek-Harness-Pet": {
   "npm": null,
   "checkedAt": "2026-08-14"
@@ -735,39 +903,7 @@
   "npm": null,
   "checkedAt": "2026-08-14"
  },
- "https://github.com/Moeblack/deepseek-manners": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/Moeblack/dsh-message-edit": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/Moeblack/dsh-prompt-studio": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/MorGogh/widget-dock": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
  "https://github.com/muretai/muretai-dsh-skill": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/Nagi-ovo/dsh-ads": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/Nagi-ovo/dsh-visualize": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/Nanki-nn/dsh-answer-pet": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/NanmiCoder/dsh-agent-teams": {
   "npm": null,
   "checkedAt": "2026-08-14"
  },
@@ -775,20 +911,16 @@
   "npm": "dsh-spend",
   "checkedAt": "2026-08-14"
  },
- "https://github.com/Noob-stupid/dsh-plugin-hub": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
  "https://github.com/nowledge-co/nowledge-mem-deepseek-harness": {
   "npm": null,
   "checkedAt": "2026-08-14"
  },
- "https://github.com/Nwflower/dsh-chat-import": {
+ "https://github.com/omdsh-dev/DSH-better-sidebar": {
   "npm": null,
   "checkedAt": "2026-08-14"
  },
- "https://github.com/Nwflower/dsh-file-claim": {
-  "npm": "dsh-file-claim",
+ "https://github.com/omdsh-dev/Qwen-MM-Plugins": {
+  "npm": null,
   "checkedAt": "2026-08-14"
  },
  "https://github.com/omdsh-dev/dsh-annotation": {
@@ -800,10 +932,6 @@
   "checkedAt": "2026-08-14"
  },
  "https://github.com/omdsh-dev/dsh-auto-chess": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/omdsh-dev/DSH-better-sidebar": {
   "npm": null,
   "checkedAt": "2026-08-14"
  },
@@ -915,10 +1043,6 @@
   "npm": null,
   "checkedAt": "2026-08-14"
  },
- "https://github.com/omdsh-dev/Qwen-MM-Plugins": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
  "https://github.com/omdsh-dev/sandbox-micro": {
   "npm": null,
   "checkedAt": "2026-08-14"
@@ -943,14 +1067,6 @@
   "npm": null,
   "checkedAt": "2026-08-14"
  },
- "https://github.com/PAKIKNOWLEDGE/dsh-client-ui-skin-claude": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/PC2005-cloud/dsh-pet/tree/main/dsh-pet": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
  "https://github.com/pc439527/dsh-notify-bark": {
   "npm": null,
   "checkedAt": "2026-08-14"
@@ -959,32 +1075,8 @@
   "npm": null,
   "checkedAt": "2026-08-14"
  },
- "https://github.com/PerryLink/dsh-doublecheck": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/PerryLink/dsh-mcp-panel": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/PerryLink/dsh-memento": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/Phant0Meow/dsh-memory-meow": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/PicGo/dsh-plugin": {
-  "npm": "@picgo/dsh-plugin",
-  "checkedAt": "2026-08-14"
- },
  "https://github.com/qjcnmd/dsh-reasoning-slider": {
   "npm": "reasoning-slider",
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/QT-Chen/dsh-mic-input": {
-  "npm": null,
   "checkedAt": "2026-08-14"
  },
  "https://github.com/qyw233/dsh-deeplink": {
@@ -1003,23 +1095,7 @@
   "npm": "@sakikotgw/pack-agent",
   "checkedAt": "2026-08-14"
  },
- "https://github.com/SamXiaBing/dsh-adb": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/Sanqi-normal/dsh-webui-market-plugin": {
-  "npm": "@sanqi-normal/dsh-webui-market-plugin",
-  "checkedAt": "2026-08-14"
- },
  "https://github.com/sereinmono/dsh-desktop-pet": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/Sev7een/ds-api-usage": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/Sev7een/dsh-plugin-automations": {
   "npm": null,
   "checkedAt": "2026-08-14"
  },
@@ -1035,36 +1111,8 @@
   "npm": null,
   "checkedAt": "2026-08-14"
  },
- "https://github.com/Small-tailqwq/dsh-deep-whale": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/Small-tailqwq/dsh-tps": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/Smalldy/godot-bridge": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/SnowCrescenter-tech/dsh-milestone": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/SPYQWER1/dsh-codex-tools": {
-  "npm": "dsh-codex-tools",
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/Starfie1d1272/dsh-builtin-toggles": {
-  "npm": "dsh-builtin-toggles",
-  "checkedAt": "2026-08-14"
- },
  "https://github.com/stevenx65/dsh-balance-plugin": {
   "npm": null,
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/Sttrevens/dsh-cost-meter": {
-  "npm": "@steven-wu/dsh-cost-meter",
   "checkedAt": "2026-08-14"
  },
  "https://github.com/suntianc/dsh-codex-auth": {
@@ -1087,20 +1135,12 @@
   "npm": null,
   "checkedAt": "2026-08-14"
  },
- "https://github.com/THU-MAIC/dsh-openmaic": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
  "https://github.com/titanwings/dsh-automation": {
   "npm": null,
   "checkedAt": "2026-08-14"
  },
  "https://github.com/titanwings/dsh-plannotator": {
   "npm": null,
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/TonyDua/dsh-web-search-exa": {
-  "npm": "@tonydua/dsh-web-search-exa",
   "checkedAt": "2026-08-14"
  },
  "https://github.com/tsonglew/dsh-media-preview": {
@@ -1179,10 +1219,6 @@
   "npm": null,
   "checkedAt": "2026-08-14"
  },
- "https://github.com/Wine-Red/dsh-prompt-stash": {
-  "npm": "dsh-prompt-stash",
-  "checkedAt": "2026-08-14"
- },
  "https://github.com/wjy9902/dsh-web-default-session": {
   "npm": null,
   "checkedAt": "2026-08-14"
@@ -1215,10 +1251,6 @@
   "npm": null,
   "checkedAt": "2026-08-14"
  },
- "https://github.com/Xplore-LAB/dsh-plugin-asmemory": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
  "https://github.com/yeruizhi/dsh-lark-meeting-notifier": {
   "npm": null,
   "checkedAt": "2026-08-14"
@@ -1235,24 +1267,12 @@
   "npm": null,
   "checkedAt": "2026-08-14"
  },
- "https://github.com/YTxue/dsh-skill-manager": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/YTxue/dsh-skill-manager-ytxue": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
  "https://github.com/yuezengwu/dsh-explain": {
   "npm": null,
   "checkedAt": "2026-08-14"
  },
  "https://github.com/yun520-1/deepseek-heartflow": {
   "npm": "@yun520-1/deepseek-heartflow",
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/Yuuz12/dsh-webui-auth": {
-  "npm": null,
   "checkedAt": "2026-08-14"
  },
  "https://github.com/yyh-001/dsh-expression": {
@@ -1264,10 +1284,6 @@
   "checkedAt": "2026-08-14"
  },
  "https://github.com/zhaoolee/notes": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/Zhenyu98/dsh-context-doctor": {
   "npm": null,
   "checkedAt": "2026-08-14"
  },
@@ -1299,20 +1315,8 @@
   "npm": null,
   "checkedAt": "2026-08-14"
  },
- "https://github.com/ZK-Andy/dsh-continual-evolve": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
  "https://github.com/zp-home/dsh-recommend": {
   "npm": "dsh-recommend",
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/ZRui-C/dsh-computer-use": {
-  "npm": null,
-  "checkedAt": "2026-08-14"
- },
- "https://github.com/ZSeven-W/dsh-openpencil": {
-  "npm": "@zseven-w/dsh-openpencil",
   "checkedAt": "2026-08-14"
  },
  "https://github.com/ztl34245881-commits/dsh-task-planner": {


### PR DESCRIPTION
Follow-up to #212: the plugin is now published to npm as [dsh-desktop-plugin@0.1.0](https://www.npmjs.com/package/dsh-desktop-plugin).

Adds one `npm-map.json` entry mapping the monorepo entry URL to the package. The rest of the file diff is only a stable re-sort (data unchanged except the 4 new lines) — CI's daily probe will rewrite timestamps as usual.

With the npm mapping set, the dsh-market install button works for this entry (it prefers registry tarballs over full-repo GitHub downloads).