### PR TITLE
Add DeepSeek-Skin-Studio to Themes & Appearance

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ dsh plugin --profile web add dshmarket
 - [wsxwj123/dsh-plugins#theme-gallery](https://github.com/wsxwj123/dsh-plugins/tree/main/packages/theme-gallery) - Fifteen curated theme families with complete light and dark palettes that follow the native Light, Dark, and Follow system modes.
 - [PAKIKNOWLEDGE/dsh-client-ui-skin-claude](https://github.com/PAKIKNOWLEDGE/dsh-client-ui-skin-claude) - Claude-style skin with a warm-black canvas, clay accent, and serif UI that follows the native light and dark themes.
 - [tianyhjg-lab/dsh-font](https://github.com/tianyhjg-lab/dsh-font) - Font switcher for the DSH Web GUI: 99 UI fonts and 31 code fonts with CJK-Latin pairing stacks, instant apply and localStorage persistence.
+- [JueMing2049/deepseek-skin-studio](https://github.com/JueMing2049/deepseek-skin-studio) - DeepSeek Harness skin studio: one image = one skin; three injection channels (bookmarklet / CDP / native plugin), visual studio, 13 built-in themes, DSH-SKIN-SPEC v0.1 export.
 
 
 ### Sessions & Messages

--- a/README.zh.md
+++ b/README.zh.md
@@ -143,6 +143,7 @@ dsh plugin --profile web add dshmarket
 - [Small-tailqwq/dsh-deep-whale](https://github.com/Small-tailqwq/dsh-deep-whale) — DSH Web 鲸鱼娘皮肤系列（深海女仆工坊 maid-atelier）。
 - [wsxwj123/dsh-plugins#theme-gallery](https://github.com/wsxwj123/dsh-plugins/tree/main/packages/theme-gallery) — 15 个精选主题家族，浅深配色完整，跟随 DSH 原生浅色/深色/跟随系统模式。
 - [PAKIKNOWLEDGE/dsh-client-ui-skin-claude](https://github.com/PAKIKNOWLEDGE/dsh-client-ui-skin-claude) — Claude 风格皮肤：暖黑画布、陶橙点缀、衬线 UI，跟随原生亮/暗主题。
+- [JueMing2049/deepseek-skin-studio](https://github.com/JueMing2049/deepseek-skin-studio) - DeepSeek Harness 换肤工作室：一张图一套皮肤；书签 / CDP / 原生插件三通道注入，可视化工坊，13 套内置主题，支持导出 DSH-SKIN-SPEC v0.1 皮肤包。
 - [tianyhjg-lab/dsh-font](https://github.com/tianyhjg-lab/dsh-font) — DSH Web GUI 字体切换器：99 个界面字体与 31 个代码字体，中西文自动搭配，即选即生效，localStorage 持久化。
 
 


### PR DESCRIPTION
Add [deepseek-skin-studio](https://github.com/JueMing2049/deepseek-skin-studio) to the Themes & Appearance section.

- One image = one skin (auto color extraction)
- Three injection channels: bookmarklet / CDP / native DSH-SKIN-SPEC plugin
- Visual studio + 13 built-in themes
- DSH-SKIN-SPEC v0.1 export (standard skin package)
- topics: dsh-plugin · dsh · cordis