### PR TITLE
Add dsh-hot-plugin-host (Development & Runtime)

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,6 +437,7 @@ dsh plugin --profile web add dshmarket
 - [huguangyu666/dsh-store](https://github.com/huguangyu666/dsh-store) - Plugin store: npm authoritative catalog + awesome curated list (550+ plugins, 11 categories), dsh-field quality verification, official `dsh plugin add/remove` one-click install, sidebar + settings entry.
 - [liqichen/dsh-plugin-manager](https://github.com/liqichen/dsh-plugin-manager) - GUI in the DSH settings panel: toggle/delete MCP servers, browse and trash skills, and list built-in plugin packages — hot-applied without restart.
 
+- [tianyaZTY/dsh-hot-plugin-host](https://github.com/tianyaZTY/dsh-hot-plugin-host) - Runtime plugin loading for the Web UI: a watched hot directory installs/updates client-plugin bundles live on every open page, no restart. Includes a right-column subagent dashboard example.
 
 ### Just for Fun
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -435,6 +435,7 @@ dsh plugin --profile web add dshmarket
 - [huguangyu666/dsh-store](https://github.com/huguangyu666/dsh-store) — dsh 插件商店：npm 权威目录 + awesome 精选（550+ 插件、11 分类）、dsh 字段质量验证、官方 `dsh plugin add/remove` 一键安装，侧边栏与设置页入口。
 - [liqichen/dsh-plugin-manager](https://github.com/liqichen/dsh-plugin-manager) — 在 DSH 设置面板内嵌的图形化管理器：开关/删除 MCP 服务、浏览并回收 Skills、查看内置插件包，改动热生效无需重启。
 
+- [tianyaZTY/dsh-hot-plugin-host](https://github.com/tianyaZTY/dsh-hot-plugin-host) — Web UI 运行时插件加载：监视热目录，运行中安装/更新客户端插件 bundle，所有页面即时生效，免重启。附子智能体看板示例。
 
 ### 🎮 娱乐
 


### PR DESCRIPTION
Adds tianyaZTY/dsh-hot-plugin-host: runtime install/update of static client plugins via a watched hot directory (~/.dsh/hot-plugins) + SSE broadcast + loader.create mounting — the same mechanism the official cordis client runner uses, giving hot plugins the full fiber lifecycle. No restarts for future plugin work.

Verified on dsh rc.6: host routes (/hot-plugins/list|events|client.js), hot-install of a demo widget and the subagent dashboard example.