### PR TITLE
Add KanoNoUta/dsh-captain

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,7 @@ dsh plugin --profile web add dshmarket
 
 - [ztl34245881-commits/dsh-task-planner](https://github.com/ztl34245881-commits/dsh-task-planner) - Task planning with experience muscle-memory: condition-reflex recall of past solutions, LLM capability matching, and auto-persisted lessons.
 - [icetomoyo/dsh_workflow](https://github.com/icetomoyo/dsh_workflow) - UltraCode-style multi-agent orchestration: a generatable, savable, governable, observable, resumable workflow layer.
+- [KanoNoUta/dsh-captain](https://github.com/KanoNoUta/dsh-captain) - GPT plans dependency DAGs, DeepSeek workers execute tasks with adaptive parallelism, and an optional GPT reviewer audits incremental Git diffs and drives repair rounds.
 - [NanmiCoder/dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) - AgentTeams multi-agent teams.
 - [titanwings/dsh-automation](https://github.com/titanwings/dsh-automation) - Scheduled coding runs in fresh agent sessions with auditable history.
 - [Sev7een/dsh-plugin-automations](https://github.com/Sev7een/dsh-plugin-automations) - Settings-based scheduled tasks that run on time or during DeepSeek off-peak hours, with one-time and daily schedules backed by durable task state.

--- a/README.zh.md
+++ b/README.zh.md
@@ -316,6 +316,7 @@ dsh plugin --profile web add dshmarket
 
 - [ztl34245881-commits/dsh-task-planner](https://github.com/ztl34245881-commits/dsh-task-planner) — 带经验肌肉记忆的任务规划：条件反射检索历史方案 + LLM 能力匹配 + 经验自动沉淀。
 - [icetomoyo/dsh_workflow](https://github.com/icetomoyo/dsh_workflow) — 把 UltraCode 式多 Agent 调度带给 DSH：可生成、可保存、可治理、可观察、可恢复的 Workflow 层。
+- [KanoNoUta/dsh-captain](https://github.com/KanoNoUta/dsh-captain) — GPT 规划依赖 DAG，DeepSeek Worker 自适应并行执行任务，可选 GPT Reviewer 审核增量 Git Diff 并驱动返工轮次。
 - [NanmiCoder/dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) — AgentTeams 多智能体团队。
 - [titanwings/dsh-automation](https://github.com/titanwings/dsh-automation) — 定时任务：让 Coding 任务按计划在全新 Agent Session 中运行，保留可审计历史。
 - [Sev7een/dsh-plugin-automations](https://github.com/Sev7een/dsh-plugin-automations) — 设置页定时任务：支持准点或 DeepSeek 谷时段执行、单次/每日重复，并持久化任务状态。


### PR DESCRIPTION
## Summary

- add `KanoNoUta/dsh-captain` under Workflow & Automation
- describe its GPT planner, adaptive DeepSeek workers, incremental diff review, and repair loop
- add matching English and Chinese entries

## Submission checklist

- [x] The plugin declares `dsh.bundle` and ships `cordis.patch.yml`.
- [x] One line is added to both `README.md` and `README.zh.md` under the matching category.
- [x] Descriptions are factual and contain no superlatives.
- [x] The plugin repository has the `dsh-plugin` topic.
- [x] Official `@deepseek-ai/*` packages are declared as peer dependencies.
- [x] Built Host and Client artifacts are included for GitHub installation.

## Verification

- `git diff --check`
- Captain CI: https://github.com/KanoNoUta/dsh-captain/actions/runs/31826894584