### PR TITLE
Add ishuowang/dsh-agent-team-room

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ dsh plugin --profile web add dshmarket
 
 ### Sessions & Messages
 
+- [ishuowang/dsh-agent-team-room](https://github.com/ishuowang/dsh-agent-team-room) - Persistent rooms for independent DSH Agent sessions, with explicit membership, direct and broadcast messages, tracked tasks, and a shared Web timeline.
 - [cindyguyuehu123/dsh-webchatlike](https://github.com/cindyguyuehu123/dsh-webchatlike) - Bring the deepseek.com web/app chat experience to DSH: edit your prompt and regenerate answers in place, with a per-message <i/N> version pager (tree model, stable across conversations).
 - [penguin-oo/dsh-bookmarks](https://github.com/penguin-oo/dsh-bookmarks) - Bookmark assistant replies with notes and tags; browse every bookmark in one cross-session center and export to Markdown.
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -151,6 +151,7 @@ dsh plugin --profile web add dshmarket
 
 ### 💬 会话与消息
 
+- [ishuowang/dsh-agent-team-room](https://github.com/ishuowang/dsh-agent-team-room) — 面向独立 DSH Agent 会话的持久化协作房间，支持显式成员管理、定向与广播消息、任务跟踪和共享 Web 时间线。
 - [cindyguyuehu123/dsh-webchatlike](https://github.com/cindyguyuehu123/dsh-webchatlike) — 更贴近 deepseek 网页版/App 的聊天体验：原位编辑提问、重新生成回复、每条消息带 <i/N> 版本翻页器（树状版本模型，跨对话保持稳定）。
 - [penguin-oo/dsh-bookmarks](https://github.com/penguin-oo/dsh-bookmarks) — 收藏 AI 回复（备注/标签），跨会话收藏中心（搜索/筛选/跳回会话），一键导出 Markdown。
 


### PR DESCRIPTION
Adds Agent Team Room to the Sessions & Messages category in both English and Chinese.

Repository checks:
- declares `dsh.bundle` with a Cordis patch
- contains a tested TypeScript implementation and committed build artifacts
- has the `dsh-plugin` topic
- provides a tagged GitHub install at `v0.1.0`
- verified with DSH `0.1.0-rc.6` via a clean GitHub install and Web boot

Only `README.md` and `README.zh.md` are changed, as requested by the contribution guide.
