### PR TITLE
Add ibka512/dsh-ibka-balance (余额监测卡片) to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ dsh plugin --profile web add dshmarket
 
 - [Make0209/dsh-usage-stats](https://github.com/Make0209/dsh-usage-stats) - GitHub-style usage heatmap dashboard: per-workspace turn counts and token spend (with cache-hit rate), DeepSeek account balance, and workspace aliases.
 - [zoumutou/dsh-cost-balance](https://github.com/zoumutou/dsh-cost-balance) - Collapsible iOS-style stats pill under the composer: session cost, DeepSeek account balance, cache-hit rate, and token usage in a frosted panel.
+- [ibka512/dsh-ibka-balance](https://github.com/ibka512/dsh-ibka-balance) - Permanent composer-dock balance card: real-time DeepSeek API account balance with 5-minute auto-refresh, a manual refresh button, and low-balance color warnings.
 
 - [bowenliang123/dsh-context](https://github.com/bowenliang123/dsh-context) - Context insight panel: see what the model's context window is made of and how it evolves — composition vs. window size, per-request history, compression/injection events, and per-message token stats.
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -51,6 +51,7 @@ dsh plugin --profile web add dshmarket
 
 - [Make0209/dsh-usage-stats](https://github.com/Make0209/dsh-usage-stats) — GitHub 风格用量热力图看板：按工作区统计使用次数与 Token 花费（含缓存命中率）、DeepSeek 账户余额查询、工作区别名管理。
 - [zoumutou/dsh-cost-balance](https://github.com/zoumutou/dsh-cost-balance) — 输入框下方的 iOS 风格统计条：一键展开查看会话花费、DeepSeek 账户余额、缓存命中率与 Token 用量。
+- [ibka512/dsh-ibka-balance](https://github.com/ibka512/dsh-ibka-balance) — 输入框下方常驻余额卡片：实时显示 DeepSeek API 账户余额，每 5 分钟自动刷新，支持手动刷新，余额过低自动变色提醒。
 
 - [bowenliang123/dsh-context](https://github.com/bowenliang123/dsh-context) — 上下文洞察面板：一眼看清模型上下文窗口的组成与变化——构成对照窗口大小、按请求历史趋势、压缩/注入事件、消息级 token 统计。
 


### PR DESCRIPTION
## 加了什么 / What's added

把 `ibka512/dsh-ibka-balance` 收录进精选列表（英文 + 中文条目各一行）。

## 为什么做这个插件 / Why this plugin exists

因为 **DeepSeek 要涨价了**！！💸

价格一涨，token 就变成了硬通货。这个插件是为了让大家（和大家的钱包）心里有数：聊天输入框下方常驻一张余额卡片，每 5 分钟自动看一眼 DeepSeek 账户余额，低于 ¥10 变橙、低于 ¥5 变红，带手动刷新按钮，悬停还能看充值/赠金明细。

**大家记得省着点用 token 啊！！** 别问我是怎么知道的。🫠

（技术层面它很朴素：Host 端经凭据服务取 Key + curl 查余额并注册 HTTP 路由，客户端用浏览器原生 fetch 轮询渲染，API Key 绝不出进程。）

## 检查项 / Checks

- [x] 英文 README 一行
- [x] 中文 README 一行
- [x] 链接指向公开仓库：https://github.com/ibka512/dsh-ibka-balance