### PR TITLE
Add dsh-github-login — 零终端 GitHub 可视化登录插件

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,6 +374,7 @@ dsh plugin --profile web add dshmarket
 - [huguangyu666/dsh-plugin-notify](https://github.com/huguangyu666/dsh-plugin-notify) - Notification outbox: agent proactively notifies via toast / Chinese TTS voice / sound effects (explosion, victory, alarm), 60s confirmation window voice-calls you back, volume boost, settings panel.
 
 ### Models & Providers
+- [Noob-stupid/dsh-github-login](https://github.com/Noob-stupid/dsh-github-login) - Visual GitHub login without a terminal: in-window device flow, token synced into the gh CLI, and host status/launch endpoints.
 
 - [dylan121322/llm-adaptive](https://github.com/dylan121322/llm-adaptive) - Adaptive model routing: per-request complexity classification with automatic provider routing.
 - [btspoony/dsh-llm-fallbacks](https://github.com/btspoony/dsh-llm-fallbacks) - Role-based LLM retry & fallback strategies.

--- a/README.zh.md
+++ b/README.zh.md
@@ -372,6 +372,7 @@ dsh plugin --profile web add dshmarket
 - [huguangyu666/dsh-plugin-notify](https://github.com/huguangyu666/dsh-plugin-notify) — 通知出口：agent 主动通过桌面通知 / 中文语音 / 音效（炸裂、胜利、警报）联系你，60 秒确认窗口后语音呼叫，音量增强，设置面板。
 
 ### 🔌 模型与账号接入
+- [Noob-stupid/dsh-github-login](https://github.com/Noob-stupid/dsh-github-login) — 零终端的 GitHub 可视化登录插件：窗口内完成设备码授权，令牌同步进 gh CLI，附宿主端状态与唤起接口。
 
 - [dylan121322/llm-adaptive](https://github.com/dylan121322/llm-adaptive) — 自适应模型路由：请求级复杂度分类，按配置链自动选择后端 provider。
 - [btspoony/dsh-llm-fallbacks](https://github.com/btspoony/dsh-llm-fallbacks) — 基于角色的模型重试与备用策略。


### PR DESCRIPTION
收录 [Noob-stupid/dsh-github-login](https://github.com/Noob-stupid/dsh-github-login) 到 **Models & Providers / 模型与账号接入** 分类（中英两版 README 各加一行）。

- 零终端的 GitHub 可视化登录：窗口内完成 Device Flow，令牌写入 `~/.dsh/github-auth.json` 并同步进 gh CLI 的 `hosts.yml`
- 仓库 `package.json` 声明 `dsh.bundle` manifest（附 `cordis.patch.yml`），支持 `dsh plugin --profile web add github:Noob-stupid/dsh-github-login` 一键安装
- 宿主端提供 `GET /github-auth/status` 与 `POST /github-auth/open` 环回接口（只读账号名，不下发令牌）
- 仓库已添加 `dsh-plugin` topic，README 含使用截图与安装说明
