### PR TITLE
Add zijun1991/dsh-vim-keymap

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ dsh plugin --profile web add dshmarket
 
 > 💡 Prefer chat? [dsh-find-plugin](https://github.com/awesome-dsh-plugin/dsh-find-plugin#readme) lets your agent find plugins for you (`dsh plugin --profile web add dsh-find-plugin`).
 
-**365** plugins · [PRs welcome](#contributing)
+**366** plugins · [PRs welcome](#contributing)
 
 ## Contents
 
@@ -138,6 +138,8 @@ dsh plugin --profile web add dshmarket
 - [ZichengGurrr/dsh-window#plugin](https://github.com/ZichengGurrr/dsh-window/tree/main/plugin) - Native Windows desktop window (WebView2) for DSH: one-command install, auto-fetches the app zip from GitHub Releases, creates a desktop shortcut, and adds a desktop_launch tool to start it from chat.
 - [yyyyukari/dsh-plugin-workshop](https://github.com/yyyyukari/dsh-plugin-workshop) - Steam Workshop-style in-app plugin browser: search, hot/newest/trending (7/30/90-day) sorting, Chinese keyword mapping, bilingual descriptions and README translation, plugin-signature filtering, and one-click install/update.
 - [zoumutou/dsh-web-preview](https://github.com/zoumutou/dsh-web-preview) - Side web-preview panel: local static hosting, Markdown/code/image preview, one-click run of non-static projects (Cargo/npm/Go/Python) with live logs, web element mark & annotate, and link-click takeover into the side panel.
+- [zijun1991/dsh-vim-keymap](https://github.com/zijun1991/dsh-vim-keymap) - Vim keybindings for the Web GUI: real per-line j/k motion in the composer, a Session mode for keyboard-driven workspace/session-tree navigation, and a floating Command palette — an out-of-tree Cordis plugin, no deepseek-harness changes required.
+
 ### Themes & Appearance
 
 - [KinGao294/dsh-skin](https://github.com/KinGao294/dsh-skin) - Codex-style skin switcher plus a custom wallpaper layer with opacity and blur controls.

--- a/README.zh.md
+++ b/README.zh.md
@@ -18,7 +18,7 @@ dsh plugin --profile web add dshmarket
 
 > 💡 更喜欢对话式？装 [dsh-find-plugin](https://github.com/awesome-dsh-plugin/dsh-find-plugin#readme)，想要什么插件直接问 agent（`dsh plugin --profile web add dsh-find-plugin`）。
 
-**365** 个插件 · 欢迎 [PR](#贡献)
+**366** 个插件 · 欢迎 [PR](#贡献)
 
 ## 目录
 
@@ -139,6 +139,8 @@ dsh plugin --profile web add dshmarket
 - [ZichengGurrr/dsh-window#plugin](https://github.com/ZichengGurrr/dsh-window/tree/main/plugin) — DSH 的 Windows 原生窗口（WebView2）：一键安装，自动从 GitHub Releases 下载应用 zip、创建桌面快捷方式，并提供 desktop_launch 工具在对话中一键启动。
 - [yyyyukari/dsh-plugin-workshop](https://github.com/yyyyukari/dsh-plugin-workshop) — 创意工坊式插件浏览器：侧栏常驻入口，搜索/最热/最新/近 7-90 天飙升榜、中文关键词映射、描述与 README 机翻、插件特征验证过滤、一键安装/更新。
 - [zoumutou/dsh-web-preview](https://github.com/zoumutou/dsh-web-preview) — 侧边网页预览面板：本地静态托管、Markdown/代码/图片预览、非静态项目一键运行（Cargo/npm/Go/Python）实时日志、网页元素标记批注、链接点击接管到侧边预览。
+- [zijun1991/dsh-vim-keymap](https://github.com/zijun1991/dsh-vim-keymap) — 为 Web GUI 提供 vim 键位：composer 内真实的逐行 j/k 移动、工作区/会话树的键盘化 Session 模式、悬浮 Command 面板——完全独立于 deepseek-harness 的 Cordis 插件，无需改动宿主代码。
+
 ### 🎭 主题与外观
 
 - [KinGao294/dsh-skin](https://github.com/KinGao294/dsh-skin) — Codex 风格皮肤切换器 + 自定义壁纸层，可调透明度与模糊。


### PR DESCRIPTION
## Summary

Adds [dsh-vim-keymap](https://github.com/zijun1991/dsh-vim-keymap) under **UI Enhancements** in both `README.md` and `README.zh.md`, and bumps the plugin count (365 → 366).

- Vim keybindings for the deepseek-harness Web GUI: real per-line j/k motion in the composer, a Session mode for keyboard-driven workspace/session-tree navigation, and a floating Command palette.
- Ships as an out-of-tree Cordis plugin — depends only on published `@deepseek-ai/dsh-client-*` packages, never modifies deepseek-harness itself.
- Published on npm as `dsh-vim-keymap`; repo already carries the `dsh-plugin` topic.

## Test plan

- [x] Entry added to `README.md` and `README.zh.md` under the same category, matching the existing `- [owner/repo](link) - description` format
- [x] Plugin count updated in both files