### PR TITLE
Add dsh-client-ui-theme-xp — Windows XP Luna desktop theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ dsh plugin --profile web add dshmarket
 - [tianyhjg-lab/dsh-font](https://github.com/tianyhjg-lab/dsh-font) - Font switcher for the DSH Web GUI: 99 UI fonts and 31 code fonts with CJK-Latin pairing stacks, instant apply and localStorage persistence.
 - [starslittle/dsh-blue-whale](https://github.com/starslittle/dsh-blue-whale) - DeepSeek-Chat-style blue-whale skin: brand #4D6BFE on light and dark, following the built-in appearance.
 - [chinaRXQ/dsh-wallpaper](https://github.com/chinaRXQ/dsh-wallpaper) - Wallpaper skin for the DSH Web UI: image background with opacity, mask and blur controls.
+- [SamizuHM/dsh-client-ui-theme-xp](https://github.com/SamizuHM/dsh-client-ui-theme-xp) - Windows XP Luna desktop for the DSH Web UI: a floating window manager with taskbar and desktop icons, plus the era-accurate Luna skin.
 
 
 ### Sessions & Messages

--- a/README.zh.md
+++ b/README.zh.md
@@ -151,6 +151,7 @@ dsh plugin --profile web add dshmarket
 - [tianyhjg-lab/dsh-font](https://github.com/tianyhjg-lab/dsh-font) — DSH Web GUI 字体切换器：99 个界面字体与 31 个代码字体，中西文自动搭配，即选即生效，localStorage 持久化。
 - [starslittle/dsh-blue-whale](https://github.com/starslittle/dsh-blue-whale) — 复刻 DeepSeek Chat 蓝鲸配色的皮肤：主色 #4D6BFE，亮色/深色跟随系统外观。
 - [chinaRXQ/dsh-wallpaper](https://github.com/chinaRXQ/dsh-wallpaper) — DSH Web 壁纸皮肤：图片背景，可调透明度、压暗遮罩与模糊。
+- [SamizuHM/dsh-client-ui-theme-xp](https://github.com/SamizuHM/dsh-client-ui-theme-xp) — Windows XP Luna 桌面化主题：浮动窗口管理器（任务栏、桌面图标）加上还原度很高的 Luna 皮肤。
 
 
 ### 💬 会话与消息


### PR DESCRIPTION
## What

Adds **[SamizuHM/dsh-client-ui-theme-xp](https://github.com/SamizuHM/dsh-client-ui-theme-xp)** to the **Themes & Appearance** section (both `README.md` and `README.zh.md`).

## Why

`dsh-client-ui-theme-xp` turns the DSH Web GUI into a Windows XP Luna desktop:

- **Floating window manager** — sessions open as real XP windows (draggable, resizable, minimize/maximize/close), with a taskbar, start button and desktop icons (我的工作区 / 搜索 / 添加工作区 / 设置).
- **Workspace/session browser** — Explorer-style folders: workspaces are folders, sessions are icons inside; each folder has a 新建会话 action that creates a genuinely new session in that workspace; adding a workspace uses the host's native directory picker.
- **Settings & search** — the app's own settings modal opens directly on the desktop; content search opens a window over `sessions.search()`.
- **Luna token palette** — Tahoma, classic blue selection, XP scrollbars, Bliss wallpaper; blank sessions are hidden exactly like the official sidebar.

Installable via `dsh plugin --profile web add dsh-client-ui-theme-xp` (declares `dsh.bundle` / `dsh.client`).

## Checklist

- [x] Entry added in the correct section of `README.md` and `README.zh.md`
- [x] Follows the existing list format (owner/repo link + one-line description)