### PR TITLE
Add dsh-plugin-scout — scout the DSH ecosystem and judge what to try

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,7 @@ dsh plugin --profile web add dshmarket
 
 ### Development & Runtime
 
+- [icefall7/dsh-plugin-scout](https://github.com/icefall7/dsh-plugin-scout) - Scouts the deepseek-harness repo and every dsh-plugin-tagged repository to discover harnesses related to your goal, then judges each as worth trying, watching, or skipping.
 - [SaiSenBox/dsh-boot-guard](https://github.com/SaiSenBox/dsh-boot-guard) - Loader-independent startup recovery for DSH Web that detects likely broken plugins, temporarily skips them, and restores only Boot Guard-managed changes.
 - [leechen298/Code2Skill](https://github.com/leechen298/Code2Skill) - Generate Functions, MCP tools, workflow Skills, and offline test packages from user-authorized source code.
 - [bujue600-arch/dsh-testgen](https://github.com/bujue600-arch/dsh-testgen) - Automated unit-test generation: a /testgen command and generate_tests tool that scaffold, run, and fix tests until they pass (LLM + offline template generators; vitest/jest/mocha/node:test).

--- a/README.zh.md
+++ b/README.zh.md
@@ -384,6 +384,7 @@ dsh plugin --profile web add dshmarket
 
 ### 🧑‍💻 开发与运行时
 
+- [icefall7/dsh-plugin-scout](https://github.com/icefall7/dsh-plugin-scout) — 侦察 deepseek-harness 官方仓库与所有 dsh-plugin topic 仓库，发现与目标相关的 harness，并判断每个值得试用、观望还是跳过。
 - [SaiSenBox/dsh-boot-guard](https://github.com/SaiSenBox/dsh-boot-guard) — 独立于常规客户端插件加载链的 DSH Web 启动救援工具，可定位疑似故障插件、临时跳过，并且只恢复 Boot Guard 写入的配置。
 - [leechen298/Code2Skill](https://github.com/leechen298/Code2Skill) — 从用户授权的源码生成 Function、MCP 工具、工作流 Skill 与离线测试包。
 - [bujue600-arch/dsh-testgen](https://github.com/bujue600-arch/dsh-testgen) — 自动化单元测试生成：/testgen 命令与 generate_tests 工具，生成、运行并修复测试直至通过（LLM 与离线模板双生成器；支持 vitest/jest/mocha/node:test）。


### PR DESCRIPTION
## Summary

Add icefall7/dsh-plugin-scout to Development & Runtime / 开发与运行时.

dsh-plugin-scout is a DeepSeek Harness plugin + skill that scouts the ecosystem: it surveys the core deepseek-harness repo and every repository tagged dsh-plugin, discovers harnesses related to your goal, and judges whether each is worth trying (TRY / WATCH / SKIP, with evidence).

## Checklist

- Repo declares a dsh.bundle manifest in package.json (installable via dsh plugin add).
- Contains real, working code: a Cordis plugin that registers the plugin-scout skill, plus two deterministic Node scripts (survey-harness.mjs, search-topic.mjs).
- dsh-plugin topic added to the repo.
- Added one line to both README.md and README.zh.md.
- Description states what it does, no marketing.

This is distinct from existing entries: dsh-find-plugins finds + installs, make-dsh-plugin builds new plugins, market UIs browse + install. This one only scouts and judges before you build or adopt.
