### PR TITLE
Add dsh-cursor-codex (Cursor/Codex ↔ DeepSeek Harness integration kit)

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,6 +352,7 @@ dsh plugin --profile web add dshmarket
 - [omdsh-dev/dsh-notification](https://github.com/omdsh-dev/dsh-notification) - Desktop notifications for turn completions, with per-outcome controls and keyword rules.
 - [bobleer/dsh-acp-for-bitfun](https://github.com/bobleer/dsh-acp-for-bitfun) - ACP bridge between BitFun and DSH.
 - [openma-ai/deepseek-harness-acp](https://github.com/openma-ai/deepseek-harness-acp) - ACP profile plugin and standalone stdio server for using the full DSH agent from Zed and other ACP clients while sharing DSH credentials and sessions.
+- [jeremy9682/dsh-cursor-codex](https://github.com/jeremy9682/dsh-cursor-codex) - Connect DeepSeek Harness to the Cursor editor and Codex CLI: ACP profile bundle, zero-dependency MCP server, delegation skills, and config templates.
 - [LoserFox/telegram](https://github.com/LoserFox/telegram) - Bridge to the Telegram Bot API: long polling, per-chat sessions, HTML formatting.
 - [Jesse-njx/dsh-chatnode-wechat](https://github.com/Jesse-njx/dsh-chatnode-wechat) - Chat with, monitor, and approve your DSH agents from WeChat via the iLink gateway: text both ways, session targeting, digest heartbeats, and numbered approval prompts.
 - [dingyi222666/dsh-session-notification](https://github.com/dingyi222666/dsh-session-notification) - Notifications for four session states, with browser alerts and prompts.

--- a/README.zh.md
+++ b/README.zh.md
@@ -350,6 +350,7 @@ dsh plugin --profile web add dshmarket
 - [omdsh-dev/dsh-notification](https://github.com/omdsh-dev/dsh-notification) — 回合完成桌面通知，按结果分控 + 关键词过滤。
 - [bobleer/dsh-acp-for-bitfun](https://github.com/bobleer/dsh-acp-for-bitfun) — BitFun 与 DSH 的 ACP 交互对接。
 - [openma-ai/deepseek-harness-acp](https://github.com/openma-ai/deepseek-harness-acp) — ACP profile 插件与独立 stdio server，可从 Zed 等 ACP 客户端使用完整 DSH agent，并共享 DSH 凭据与会话。
+- [jeremy9682/dsh-cursor-codex](https://github.com/jeremy9682/dsh-cursor-codex) — 把 DeepSeek Harness 接入 Cursor 编辑器与 Codex CLI：ACP profile bundle、零依赖 MCP 服务、委派 skills 与配置模板。
 - [LoserFox/telegram](https://github.com/LoserFox/telegram) — Telegram Bot API 桥接：长轮询、per-chat 会话、HTML 格式化。
 - [Jesse-njx/dsh-chatnode-wechat](https://github.com/Jesse-njx/dsh-chatnode-wechat) — 通过 iLink 网关在微信里与 DSH agent 聊天、监控与审批：双向文本、会话切换、进度摘要与编号审批提示。
 - [dingyi222666/dsh-session-notification](https://github.com/dingyi222666/dsh-session-notification) — 会话完成等四种状态的通知响应，支持浏览器提示。


### PR DESCRIPTION
Adds [jeremy9682/dsh-cursor-codex](https://github.com/jeremy9682/dsh-cursor-codex) to **通知与集成 / Notifications & Integrations** (one line in each README).

- Repo declares `dsh.bundle` in the `acp/` subpackage (`@jeremy9682/dsh-acp`), installable via `dsh plugin --profile acp add ...`.
- Real, tested code: ACP bundle (verified end-to-end: initialize → session/new → session/prompt → end_turn on dsh 0.1.0-rc.6) plus a zero-dependency MCP server and dual-end delegation skills.
- Topic `dsh-plugin` added.