### PR TITLE
Add dsh-observability (subagent-run observability + cursor_delegate tool)

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,6 +437,7 @@ dsh plugin --profile web add dshmarket
 - [huguangyu666/dsh-store](https://github.com/huguangyu666/dsh-store) - Plugin store: npm authoritative catalog + awesome curated list (550+ plugins, 11 categories), dsh-field quality verification, official `dsh plugin add/remove` one-click install, sidebar + settings entry.
 - [liqichen/dsh-plugin-manager](https://github.com/liqichen/dsh-plugin-manager) - GUI in the DSH settings panel: toggle/delete MCP servers, browse and trash skills, and list built-in plugin packages — hot-applied without restart.
 
+- [jeremy9682/dsh-observability](https://github.com/jeremy9682/dsh-observability) - Subagent-run observability: session-root fingerprinting with attribution envelopes, and a cursor_delegate tool for the official cursor-agent CLI.
 
 ### Just for Fun
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -435,6 +435,7 @@ dsh plugin --profile web add dshmarket
 - [huguangyu666/dsh-store](https://github.com/huguangyu666/dsh-store) — dsh 插件商店：npm 权威目录 + awesome 精选（550+ 插件、11 分类）、dsh 字段质量验证、官方 `dsh plugin add/remove` 一键安装，侧边栏与设置页入口。
 - [liqichen/dsh-plugin-manager](https://github.com/liqichen/dsh-plugin-manager) — 在 DSH 设置面板内嵌的图形化管理器：开关/删除 MCP 服务、浏览并回收 Skills、查看内置插件包，改动热生效无需重启。
 
+- [jeremy9682/dsh-observability](https://github.com/jeremy9682/dsh-observability) — subagent 运行可观测性：会话根指纹 + 归因信封，以及委派官方 cursor-agent CLI 的 cursor_delegate 工具。
 
 ### 🎮 娱乐
 


### PR DESCRIPTION
Adds [jeremy9682/dsh-observability](https://github.com/jeremy9682/dsh-observability) to **Development & Runtime / 🧑‍💻 开发与运行时** (one line in each README).

- Declares `dsh.bundle` at the repo root; installable via `dsh plugin --profile web add github:jeremy9682/dsh-observability`.
- Two boot-tested packages: `dsh-codex-observability` (session-root fingerprinting + attribution envelope) and `dsh-tool-cursor` (`cursor_delegate` tool for the official cursor-agent CLI).
- Topic `dsh-plugin` present; upstream proposal tracked in deepseek-ai/deepseek-harness#1493.