### PR TITLE
Add moonquake2004/dsh-doctor (offline diagnostic) to Development & Runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -457,6 +457,7 @@ dsh plugin --profile web add dshmarket
 - [buhuikongpan/dsh-pluginmanager](https://github.com/buhuikongpan/dsh-pluginmanager) - Layered plugin manager for DSH web: native plugins grouped read-only by system/WebUI/tools, user extensions with enable/disable, register, uninstall and editable descriptions.
 
 - [tianyaZTY/dsh-hot-plugin-host](https://github.com/tianyaZTY/dsh-hot-plugin-host) - Runtime plugin loading for the Web UI: a watched hot directory installs/updates client-plugin bundles live on every open page, no restart. Includes a right-column subagent dashboard example.
+- [moonquake2004/dsh-doctor#plugin](https://github.com/moonquake2004/dsh-doctor/tree/main/plugin) - Offline diagnostic for DSH: 19 checks across env, profile, and session state, with a settings "Doctor" panel and a read-only JSON API.
 
 ### Just for Fun
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -455,6 +455,7 @@ dsh plugin --profile web add dshmarket
 - [buhuikongpan/dsh-pluginmanager](https://github.com/buhuikongpan/dsh-pluginmanager) — DSH 分层插件管理器：原生插件按系统/WebUI/工具三层只读展示，用户扩展支持停用/启用、补登记、卸载与可编辑描述。
 
 - [tianyaZTY/dsh-hot-plugin-host](https://github.com/tianyaZTY/dsh-hot-plugin-host) — Web UI 运行时插件加载：监视热目录，运行中安装/更新客户端插件 bundle，所有页面即时生效，免重启。附子智能体看板示例。
+- [moonquake2004/dsh-doctor#plugin](https://github.com/moonquake2004/dsh-doctor/tree/main/plugin) — 离线诊断工具：环境/Profile/会话共 19 项检查，带设置「诊断」面板与只读 JSON API。
 
 ### 🎮 娱乐
 


### PR DESCRIPTION
Adds [moonquake2004/dsh-doctor](https://github.com/moonquake2004/dsh-doctor) to the Development & Runtime category (both READMEs).

- Offline diagnostic: 19 checks across env / profile / session state (each mapped to a deepseek-harness discussion: #1404/#1197/#1486/#1363/#466/#1550/...).
- Ships as a dsh bundle (`plugin/` subpackage declares `dsh.bundle` + `dsh.client`) with a settings **Doctor** panel and a read-only `GET /dsh-doctor/run` JSON API.
- Repo has the `dsh-plugin` topic; `@deepseek-ai/*` are peerDependencies.