### PR TITLE
Add dsh-web-mobile to UI Enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ dsh plugin --profile web add dshmarket
 ### UI Enhancements
 
 - [AcidGr/dsh-web-mobile-fix](https://github.com/AcidGr/dsh-web-mobile-fix) - Mobile layout fixes for the Web UI on narrow screens: full-screen settings panel, one-row plugin nav, full-screen sidebar, centered popups, icon-only session-log button.
+- [mexiaosqwq/dsh-web-mobile](https://github.com/mexiaosqwq/dsh-web-mobile) - Mobile-adaptive layout for the DSH Web UI: the sidebar becomes a content-hugging overlay drawer, the conversation gets the full width, and the settings panel becomes a near-full-width sheet.
 
 - [AcidGr/dsh-web-lan-access](https://github.com/AcidGr/dsh-web-lan-access) - LAN/remote access for the Web UI: injects a crypto.randomUUID polyfill on plain-HTTP origins so the frontend survives LAN or Tailscale IP direct links.
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -42,6 +42,7 @@ dsh plugin --profile web add dshmarket
 ### 🎨 UI 增强
 
 - [AcidGr/dsh-web-mobile-fix](https://github.com/AcidGr/dsh-web-mobile-fix) — Web UI 移动端布局修复：窄屏下设置面板全屏化、插件导航单行排满、侧边栏全屏、弹层居中、会话日志按钮图标化。
+- [mexiaosqwq/dsh-web-mobile](https://github.com/mexiaosqwq/dsh-web-mobile) — DSH Web UI 移动端适配：窄屏下侧边栏变为贴合内容的 overlay 抽屉、会话独占全宽，设置面板改为近全宽 sheet。
 
 - [AcidGr/dsh-web-lan-access](https://github.com/AcidGr/dsh-web-lan-access) — Web UI 局域网/远程访问：为纯 HTTP 非安全上下文注入 crypto.randomUUID polyfill，局域网/Tailscale IP 直连时前端不再崩溃。
 


### PR DESCRIPTION
Adds [mexiaosqwq/dsh-web-mobile](https://github.com/mexiaosqwq/dsh-web-mobile) under **UI Enhancements** in both README.md and README.zh.md.

- declares `dsh.bundle` (patch: ./cordis.patch.yml) — installable via `dsh plugin --profile web add github:mexiaosqwq/dsh-web-mobile`
- ships real client code + prebuilt lib (no allowBuilds step needed)
- has the `dsh-plugin` topic