### PR TITLE
Add FleetingEcho/dsh-handoff to the Memory category

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ dsh plugin --profile web add dshmarket
 
 - [truelove-dreamer/dsh-plugin-recall](https://github.com/truelove-dreamer/dsh-plugin-recall) - Cross-session memory for the model: full-text search all past sessions (SQLite FTS5 via ctx.sessionQuery) and bring the strongest matching excerpts back into the current context.
 - [Noelune/unified-agent-memory](https://github.com/Noelune/unified-agent-memory) - One shared Obsidian vault for every agent: dependency-free Python core (search/promote/adjudicate/forget), vault template, dsh plugin (memory_search/show/submit/status).
+- [FleetingEcho/dsh-handoff](https://github.com/FleetingEcho/dsh-handoff) - Self-maintaining handoff memory per working directory and git branch: records turns, folds them into concise Markdown, and injects the result into future sessions from ~/.agent/agent-handoff, byte-compatible with pi-handoff.
 ### Tools & Capabilities
 - [Edge-Echo/dsh-mcp-bridge](https://github.com/Edge-Echo/dsh-mcp-bridge) - Curated MCP server bundle: one install brings demo, memory, filesystem, GitHub, Playwright and remote HTTP MCP servers, plus a connectivity verifier tool and CI checks.
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -222,6 +222,7 @@ dsh plugin --profile web add dshmarket
 
 - [truelove-dreamer/dsh-plugin-recall](https://github.com/truelove-dreamer/dsh-plugin-recall) — 跨会话记忆：全文检索所有历史会话（复用 ctx.sessionQuery 的 SQLite FTS5 索引），把最强匹配片段带回当前上下文。
 - [Noelune/unified-agent-memory](https://github.com/Noelune/unified-agent-memory) — 多 Agent 共享一个 Obsidian vault：零依赖 Python core（检索/晋升/裁决/遗忘）+ vault 模板 + dsh 插件（memory_search/show/submit/status）。
+- [FleetingEcho/dsh-handoff](https://github.com/FleetingEcho/dsh-handoff) — 每个工作目录与 git 分支自动维护 handoff.md：记录回合、折叠为简洁 Markdown 并注入后续会话，存储于 ~/.agent/agent-handoff，与 pi-handoff 字节级兼容。
 ### 🛠️ 工具与能力
 - [Edge-Echo/dsh-mcp-bridge](https://github.com/Edge-Echo/dsh-mcp-bridge) — 精选 MCP 服务器全家桶：一键接入演示、记忆、文件系统、GitHub、Playwright、远程 HTTP 等服务器，自带连通性验证工具与 CI 检查。
 


### PR DESCRIPTION
Adds [FleetingEcho/dsh-handoff](https://github.com/FleetingEcho/dsh-handoff) to the **Memory** category in both `README.md` and `README.zh.md`, following [contributing.md](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/main/contributing.md).

The plugin is a [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) port of **pi-handoff**: it auto-maintains a `handoff.md` per working directory and git branch under `~/.agent/agent-handoff`, records recent turns, folds them into concise Markdown, and injects the result into future sessions via a runtime-context snapshot. The on-disk store is byte-identical to pi-handoff's, so dsh, Claude Code, and Codex agents share one store.

Requirements checklist:
- [x] `dsh.bundle` manifest declared in `package.json` (`bundle.patch: ./cordis.patch.yml`), installable via `dsh plugin add github:FleetingEcho/dsh-handoff` — verified in a live profile
- [x] Real, working code (`src/` TypeScript + prebuilt `lib/index.js`); no placeholders
- [x] Active maintenance (commits this week)
- [x] [`dsh-plugin`](https://github.com/topics/dsh-plugin) topic added to the repo
- [x] Description states what the plugin does, one line per README, English + 中文
- [x] `@deepseek-ai/*` packages declared as `peerDependencies`
