### PR TITLE
Add dsh-balance-plugin to UI Enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ dsh plugin --profile web add dshmarket
 - [x2802490130-prog/dsh-lan-pass](https://github.com/x2802490130-prog/dsh-lan-pass) - A LAN password gate for the Web UI: phones and tablets on the same network log in with a shared key and see the same sessions in real time, with a built-in randomUUID polyfill for plain-HTTP origins.
 - [magicOF2/dsh-turn-marks](https://github.com/magicOF2/dsh-turn-marks) - Left-edge turn-marks strip in chat: one bar per user message, click to jump to that message, hover for a preview, active bar turns white.
 - [magicOF2/dsh-chat-width-customizer](https://github.com/magicOF2/dsh-chat-width-customizer) - Session-header button that cycles the conversation width (748-1600px), widening the chat column, composer, and user bubbles together.
+- [luokai-demo/dsh-plugins#plugins/dsh-balance-plugin](https://github.com/luokai-demo/dsh-plugins/tree/main/plugins/dsh-balance-plugin) - DeepSeek wallet balance at the sidebar foot: a credit-card icon with the amount tinted by remaining balance (green over ¥2, amber ¥0–2, red below), refreshed on mount, per turn-end, and on click.
 ### Themes & Appearance
 
 - [KinGao294/dsh-skin](https://github.com/KinGao294/dsh-skin) - Codex-style skin switcher plus a custom wallpaper layer with opacity and blur controls.

--- a/README.zh.md
+++ b/README.zh.md
@@ -150,6 +150,7 @@ dsh plugin --profile web add dshmarket
 - [x2802490130-prog/dsh-lan-pass](https://github.com/x2802490130-prog/dsh-lan-pass) — Web UI 局域网密码门禁：同网手机/平板输共享密钥登录，会话与电脑实时同步，内置 randomUUID polyfill。
 - [magicOF2/dsh-turn-marks](https://github.com/magicOF2/dsh-turn-marks) — 会话左侧消息标记条：每发一条消息多一根条条，点击跳转到该消息、悬停预览内容，当前消息对应的条条变白。
 - [magicOF2/dsh-chat-width-customizer](https://github.com/magicOF2/dsh-chat-width-customizer) — 会话标题栏按钮循环切换对话宽度（748–1600px），消息区、输入框、用户气泡同步加宽。
+- [luokai-demo/dsh-plugins#plugins/dsh-balance-plugin](https://github.com/luokai-demo/dsh-plugins/tree/main/plugins/dsh-balance-plugin) — 侧边栏底部的 DeepSeek 钱包余额：信用卡图标配余额数字，按剩余额度着色（≥ ¥2 绿色、¥0–2 黄色、≤ ¥0 红色），挂载时、每轮对话结束和点击时刷新。
 ### 🎭 主题与外观
 
 - [KinGao294/dsh-skin](https://github.com/KinGao294/dsh-skin) — Codex 风格皮肤切换器 + 自定义壁纸层，可调透明度与模糊。


### PR DESCRIPTION
## What

Adds [luokai-demo/dsh-plugins](https://github.com/luokai-demo/dsh-plugins) — the `dsh-balance-plugin` — to the **UI Enhancements** section (bilingual: README.md + README.zh.md).

## The plugin

- Shows the DeepSeek wallet balance at the sidebar foot: a credit-card icon with the amount tinted by remaining balance (green ≥ ¥2, amber ¥0–2, red ≤ ¥0).
- Refreshes on mount, after every turn ends (turn/end event → SSE push), and on click — no polling, deduped in-flight requests.
- Reads the API key through the harness credentials seam (`~/.dsh/.credentials.yaml`) or the `DEEPSEEK_API_KEY` env var; stays silent when unconfigured.
- Distributed via npm (`dsh-balance-plugin`) and GitHub Release tarballs, with a `cordis.patch.yml` bundle layer for `dsh plugin add`.

Install:

```sh
dsh plugin add dsh-balance-plugin
```