### PR TITLE
Add strukto-ai/mirage#dsh

### DIFF
--- a/README.md
+++ b/README.md
@@ -477,6 +477,7 @@ dsh plugin --profile web add dshmarket
 
 - [x2802490130-prog/dsh-guard](https://github.com/x2802490130-prog/dsh-guard) - A development safety kit: rolling config snapshots, automatic rollback on plugin failures, boot-failure rescue, and an in-settings management panel.
 - [x2802490130-prog/dsh-shield](https://github.com/x2802490130-prog/dsh-shield) - A hands-off safety net: directories the agent deletes go to a trash folder first and symlinks are never followed, with zero approvals.
+- [strukto-ai/mirage#dsh](https://github.com/strukto-ai/mirage/tree/main/typescript/packages/dsh) - Swaps the filesystem and bash providers for a mirage virtual workspace: file tools and shell commands run over mounted resources (RAM, S3, Redis, Slack, Gmail, Notion, Postgres) instead of the host disk, with per-mount read/write/exec modes, per-command sandbox routing (monty, pyodide, quickjs in process; docker, e2b, daytona remote), and installed CLIs (git, gh, slack, linear, ntn, gws, or one you register) as head words in the virtual terminal.
 
 ### Just for Fun
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -475,6 +475,7 @@ dsh plugin --profile web add dshmarket
 
 - [x2802490130-prog/dsh-guard](https://github.com/x2802490130-prog/dsh-guard) — 开发配套守护：滚动快照、插件失败自动回退、启动失败救援、设置页管理面板。
 - [x2802490130-prog/dsh-shield](https://github.com/x2802490130-prog/dsh-shield) — 脱手模式安全网：agent 删除的目录先进回收站、链接绝不跟随，零审批。
+- [strukto-ai/mirage#dsh](https://github.com/strukto-ai/mirage/tree/main/typescript/packages/dsh) — 把文件系统与 bash 提供者换成 mirage 虚拟工作区：文件工具与 shell 命令作用于挂载的资源（RAM、S3、Redis、Slack、Gmail、Notion、Postgres）而非宿主磁盘，支持按挂载点设置读/写/执行模式、按命令选择沙箱（进程内 monty、pyodide、quickjs；远程 docker、e2b、daytona），并可在虚拟终端中安装 CLI（git、gh、slack、linear、ntn、gws，或自行注册的程序树）作为命令头词。
 
 ### 🎮 娱乐
 


### PR DESCRIPTION
Adds `@struktoai/mirage-dsh` under **Development & Runtime** (one line in each README).

The plugin is a monorepo subpackage: [strukto-ai/mirage/tree/main/typescript/packages/dsh](https://github.com/strukto-ai/mirage/tree/main/typescript/packages/dsh), published on npm as [`@struktoai/mirage-dsh`](https://www.npmjs.com/package/@struktoai/mirage-dsh).

It swaps dsh's `ctx.fs` and `ctx.shell` providers for a mirage virtual workspace, so the file tools and the bash tool operate on mounted resources rather than the host disk. The bundle patch disables the host-subprocess surfaces the workspace does not contain (`fs-sandbox`, `bash-sandbox`, `pwsh-sandbox`, `tool-pwsh`, `tool-fs-search`) and inserts the three mirage rows.

```bash
dsh plugin --profile web add @struktoai/mirage-dsh
dsh --profile web
```

The world is declarative, so a profile's own `cordis.patch.yml` configures it without any host code:

```yaml
- id: mirage
  config:
    mounts:
      /tmp: { resource: ram, mode: exec }
      /slack:
        resource: slack
        mode: read
        config: { token: !!js process.env.SLACK_BOT_TOKEN }
    runtimes:
      - { name: monty, captures: [python, python3] }
```

- **Mounts** carry a per-mount mode (`read` < `write` < `exec`), so the bash tool's reach is set per resource.
- **Runtimes** are chosen per command word: `monty`, `pyodide` and `quickjs` run in process, `docker`, `e2b` and `daytona` run in a remote sandbox, and the built-in `vfs` engine serves everything unclaimed. The shell reports a `workspace-write` sandbox to dsh only when every runtime in the world stays inside the VFS; adding a host-reaching one (`local` python) drops the claim rather than reporting a false sandbox.
- **CLIs** install as head words in the virtual terminal (`git`, `gh`, `slack`, `linear`, `ntn`, `gws`, or a program tree the deployment registers), dispatched by name rather than by operand path.

Docs: https://docs.mirage.strukto.ai/typescript/agents/dsh

- [x] My repo's `package.json` declares **`dsh.bundle`** (not just `dsh.client`) — [`typescript/packages/dsh/package.json`](https://github.com/strukto-ai/mirage/blob/main/typescript/packages/dsh/package.json) with [`cordis.patch.yml`](https://github.com/strukto-ai/mirage/blob/main/typescript/packages/dsh/cordis.patch.yml) beside it (both ship in the npm tarball)
- [x] One line added to **both** `README.md` (English) and `README.zh.md` (中文), under the matching category
- [x] Description states what the plugin does, no superlatives
- [x] My repo has the `dsh-plugin` topic

**Recommended (not required):**

- [x] Published to npm — `@struktoai/mirage-dsh` (prebuilt `dist`, no `allowBuilds` step)
- [x] Official `@deepseek-ai/*` packages (`cordis`, `dsh-fs`, `dsh-shell`) declared as `peerDependencies`
