### PR TITLE
docs: add zhengjy01/dsh-notify to Notifications & Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,6 +406,7 @@ dsh plugin --profile web add dshmarket
 - [xmanrui/dsh-weixin](https://github.com/xmanrui/dsh-weixin) - Connect a Weixin bot to DeepSeek Harness by scanning a QR code.
 - [xmanrui/dsh-im](https://github.com/xmanrui/dsh-im) - Connect IM bots to DeepSeek Harness by scanning QR codes (supports Feishu, Weixin, DingTalk, and more).
 - [THEWOLFWALKER/dsh-notifier](https://github.com/THEWOLFWALKER/dsh-notifier) - Unified notification push for DSH: one minimal notify() API with 8 channel adapters (Telegram / DingTalk / Feishu / WxPusher / PushPlus / ServerChan / Bark / webhook), auto session-event push on turn-end, approval and error, plus an agent-callable notify tool; zero runtime deps.
+- [zhengjy01/dsh-notify](https://github.com/zhengjy01/dsh-notify) - System-level desktop notifications: turn-completion and workflow-end banners, plus a modal alert when an approval is needed (macOS osascript / Linux notify-send).
 
 ### Models & Providers
 - [Noob-stupid/dsh-github-login](https://github.com/Noob-stupid/dsh-github-login) - Visual GitHub login without a terminal: in-window device flow, token synced into the gh CLI, and host status/launch endpoints.

--- a/README.zh.md
+++ b/README.zh.md
@@ -404,6 +404,7 @@ dsh plugin --profile web add dshmarket
 - [xmanrui/dsh-weixin](https://github.com/xmanrui/dsh-weixin) — 通过微信扫码把微信机器人接入 DeepSeek Harness。
 - [xmanrui/dsh-im](https://github.com/xmanrui/dsh-im) — 通过扫码把IM机器人接入DeepSeek Harness（支持飞书、微信、钉钉等）。
 - [THEWOLFWALKER/dsh-notifier](https://github.com/THEWOLFWALKER/dsh-notifier) — 统一通知推送：一个 notify() API 接 8 个渠道（Telegram / 钉钉 / 飞书 / WxPusher / PushPlus / Server 酱 / Bark / webhook），回合结束、待审批、报错时自动推送，agent 也能主动调用 notify 工具；零运行时依赖。
+- [zhengjy01/dsh-notify](https://github.com/zhengjy01/dsh-notify) — 系统级桌面通知：回合完成 / 工作流完成横幅，需要审批时弹出模态提醒（macOS osascript / Linux notify-send）。
 
 ### 🔌 模型与账号接入
 - [Noob-stupid/dsh-github-login](https://github.com/Noob-stupid/dsh-github-login) — 零终端的 GitHub 可视化登录插件：窗口内完成设备码授权，令牌同步进 gh CLI，附宿主端状态与唤起接口。


### PR DESCRIPTION
Add [zhengjy01/dsh-notify](https://github.com/zhengjy01/dsh-notify) to the **Notifications & Integrations** category (both README.md and README.zh.md).

**dsh-notify** — system-level desktop notifications for DeepSeek Harness, with session names in every title:

- turn-completion / turn-error (modal) / turn-interruption banners, workflow-end banners
- **tool-call failure** banners (`tools/result` isError) with per-session cooldown and optional tool allowlist to avoid spam
- **goal completion** banner and **goal-blocked** modal (`goal/changed`)
- **modal alert when an approval is needed** (per-policy: ask → modal, never → informational banner)
- severity-graded: real failures and approvals use the strongest system attention (macOS modal via osascript, Linux notify-send -u critical)
- standard DSH bundle (dsh.bundle.patch manifest + cordis.patch.yml), repo tagged with the `dsh-plugin` topic