### PR TITLE
Add dsh-solo-thinking

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ dsh plugin --profile web add dshmarket
 
 ### Sessions & Messages
 
+- [fredalxin/dsh-solo-thinking](https://github.com/fredalxin/dsh-solo-thinking) - Visual branch brainstorming that creates an isolated Session for each direction, automates parent, sibling, checkpoint, and return Handoffs, and provides a full tree tab with an optional Better Sidebar view.
 - [ishuowang/dsh-agent-team-room](https://github.com/ishuowang/dsh-agent-team-room) - Persistent rooms for independent DSH Agent sessions, with explicit membership, direct and broadcast messages, tracked tasks, and a shared Web timeline.
 - [cindyguyuehu123/dsh-webchatlike](https://github.com/cindyguyuehu123/dsh-webchatlike) - Bring the deepseek.com web/app chat experience to DSH: edit your prompt and regenerate answers in place, with a per-message <i/N> version pager (tree model, stable across conversations).
 - [penguin-oo/dsh-bookmarks](https://github.com/penguin-oo/dsh-bookmarks) - Bookmark assistant replies with notes and tags; browse every bookmark in one cross-session center and export to Markdown.

--- a/README.zh.md
+++ b/README.zh.md
@@ -171,6 +171,7 @@ dsh plugin --profile web add dshmarket
 
 ### 💬 会话与消息
 
+- [fredalxin/dsh-solo-thinking](https://github.com/fredalxin/dsh-solo-thinking) — 可视化分支头脑风暴：为每个方向创建独立 Session，自动处理父子继承、兄弟感知、进展与回传 Handoff，并提供完整树形 Tab 与可选 Better Sidebar 右栏。
 - [ishuowang/dsh-agent-team-room](https://github.com/ishuowang/dsh-agent-team-room) — 面向独立 DSH Agent 会话的持久化协作房间，支持显式成员管理、定向与广播消息、任务跟踪和共享 Web 时间线。
 - [cindyguyuehu123/dsh-webchatlike](https://github.com/cindyguyuehu123/dsh-webchatlike) — 更贴近 deepseek 网页版/App 的聊天体验：原位编辑提问、重新生成回复、每条消息带 <i/N> 版本翻页器（树状版本模型，跨对话保持稳定）。
 - [penguin-oo/dsh-bookmarks](https://github.com/penguin-oo/dsh-bookmarks) — 收藏 AI 回复（备注/标签），跨会话收藏中心（搜索/筛选/跳回会话），一键导出 Markdown。


### PR DESCRIPTION
## Summary

- Add [`fredalxin/dsh-solo-thinking`](https://github.com/fredalxin/dsh-solo-thinking) to **Sessions & Messages**.
- Provide matching English and Chinese descriptions.

## Plugin qualification

- Declares `dsh.bundle` in `package.json` and ships `cordis.patch.yml`.
- Contains working host/client code, tests, documentation, and a public v0.1.18 GitHub Release.
- Uses the `dsh-plugin` repository topic.
- Provides a complete thinking-tree tab and an optional Better Sidebar integration.

## Checks

- Both entries follow the repository's one-line description format.
- The repository and release links are public.