### PR TITLE
Add dsh-friendly-errors to the plugin list

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ dsh plugin --profile web add dshmarket
 - [LeemanCheung/dsh-task-dag](https://github.com/LeemanCheung/dsh-task-dag) - Displays a Session's subagents and durable workflow runs as a live DAG with status, navigation, and restart-safe history.
 - [MorGogh/widget-dock](https://github.com/MorGogh/widget-dock) - Draggable workbench of mini-cards (API balance, token usage, session stats, goal, cost) on the blank areas beside the conversation, with size tiers and official DeepSeek pricing.
 - [qjcnmd/dsh-reasoning-slider](https://github.com/qjcnmd/dsh-reasoning-slider) - Codex-style reasoning-effort slider embedded in the model selector.
+- [Semidia/dsh-friendly-errors](https://github.com/Semidia/dsh-friendly-errors) - Chinese-friendly model error messages in the Web UI: balance, rate limit, auth, timeout, network, context, and server errors get clear copy with a suggestion.
 - [causebefore/dsh-pomodoro](https://github.com/causebefore/dsh-pomodoro) - Pomodoro focus-and-break timer for DSH Web with configurable cycles, a draggable mini panel, and in-app, sound, and browser notifications.
 
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -136,6 +136,7 @@ dsh plugin --profile web add dshmarket
 - [LeemanCheung/dsh-task-dag](https://github.com/LeemanCheung/dsh-task-dag) — 将会话子代理与持久工作流运行展示为实时 DAG，支持状态展示、节点导航与重启后历史恢复。
 - [MorGogh/widget-dock](https://github.com/MorGogh/widget-dock) — 对话两侧空白区的可拖动卡片工作台：余额、Token 用量、会话统计、目标、成本估算等小组件，支持 S/M/L/XL 尺寸档位与官方定价成本估算。
 - [qjcnmd/dsh-reasoning-slider](https://github.com/qjcnmd/dsh-reasoning-slider) — Codex 风格推理等级滑块，内嵌于模型选择器，拖动切换推理档位。
+- [Semidia/dsh-friendly-errors](https://github.com/Semidia/dsh-friendly-errors) — Web 界面中文友好的模型报错提示：余额不足、限流、密钥无效、超时、断网、上下文超长、服务端错误等直接显示中文原因与处理建议。
 - [causebefore/dsh-pomodoro](https://github.com/causebefore/dsh-pomodoro) — DSH Web 番茄钟：提供可配置专注/休息循环、可拖动迷你面板，以及站内提醒、提示音和浏览器通知。
 
 


### PR DESCRIPTION
Adds [dsh-friendly-errors](https://github.com/Semidia/dsh-friendly-errors) under **UI Enhancements / UI 增强**.

Chinese-friendly model error messages in the Web UI: balance, rate limit, auth, timeout, network, context, and server errors get clear copy with a suggestion. Patches the official `displayFailureMessage` at page load — no official package files changed.

Checklist per contributing.md:
- `dsh.bundle` manifest (`cordis.patch.yml` insert) declared in `package.json` — installable via `dsh plugin add`. ✓
- Real, working code (`lib/` host + client). ✓
- `dsh-plugin` topic added to the repo. ✓
- Description states function only. ✓
