### PR TITLE
Add dsh-movein (Development & Runtime)

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,6 +494,7 @@ dsh plugin --profile web add dshmarket
 - [x2802490130-prog/dsh-guard](https://github.com/x2802490130-prog/dsh-guard) - A development safety kit: rolling config snapshots, automatic rollback on plugin failures, boot-failure rescue, and an in-settings management panel.
 - [x2802490130-prog/dsh-shield](https://github.com/x2802490130-prog/dsh-shield) - A hands-off safety net: directories the agent deletes go to a trash folder first and symlinks are never followed, with zero approvals.
 - [strukto-ai/mirage#dsh](https://github.com/strukto-ai/mirage/tree/main/typescript/packages/dsh) - Swaps the filesystem and bash providers for a mirage virtual workspace: file tools and shell commands run over mounted resources (RAM, S3, Redis, Slack, Gmail, Notion, Postgres) instead of the host disk, with per-mount read/write/exec modes, per-command sandbox routing (monty, pyodide, quickjs in process; docker, e2b, daytona remote), and installed CLIs (git, gh, slack, linear, ntn, gws, or one you register) as head words in the virtual terminal.
+- [sjh9714/dsh-movein](https://github.com/sjh9714/dsh-movein) - Move a whole Claude Code setup into DSH with one command. Skills, MCP servers, hooks and global instructions arrive together, dry-run moving estimate first.
 
 ### Just for Fun
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -492,6 +492,7 @@ dsh plugin --profile web add dshmarket
 - [x2802490130-prog/dsh-guard](https://github.com/x2802490130-prog/dsh-guard) — 开发配套守护：滚动快照、插件失败自动回退、启动失败救援、设置页管理面板。
 - [x2802490130-prog/dsh-shield](https://github.com/x2802490130-prog/dsh-shield) — 脱手模式安全网：agent 删除的目录先进回收站、链接绝不跟随，零审批。
 - [strukto-ai/mirage#dsh](https://github.com/strukto-ai/mirage/tree/main/typescript/packages/dsh) — 把文件系统与 bash 提供者换成 mirage 虚拟工作区：文件工具与 shell 命令作用于挂载的资源（RAM、S3、Redis、Slack、Gmail、Notion、Postgres）而非宿主磁盘，支持按挂载点设置读/写/执行模式、按命令选择沙箱（进程内 monty、pyodide、quickjs；远程 docker、e2b、daytona），并可在虚拟终端中安装 CLI（git、gh、slack、linear、ntn、gws，或自行注册的程序树）作为命令头词。
+- [sjh9714/dsh-movein](https://github.com/sjh9714/dsh-movein) — 一条命令把整套 Claude Code 配置搬进 DSH：技能、MCP、hooks、全局指令一起到位，默认先出搬家清单预演。
 
 ### 🎮 娱乐
 


### PR DESCRIPTION
Adds dsh-movein to Development & Runtime in both README.md and README.zh.md.

dsh-movein moves a whole Claude Code setup into DSH with one command. Skills (SKILL.md loads as is), MCP servers (.mcp.json converted to dsh-mcp-client rows), hooks (wired through the first party dsh-hooks-claude-code bridge) and global instructions. Dry run by default, idempotent re-runs, needed packages installed pinned to the host dsh version.

npm. https://www.npmjs.com/package/dsh-movein (dsh-plugin topic added)

一条命令把整套 Claude Code 配置搬进 DSH，技能、MCP、hooks、全局指令一起到位，默认先预演。