### PR TITLE
Add Ychris12138/dsh-usage-stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ dsh plugin --profile web add dshmarket
 - [Noob-stupid/dsh-plugin-hub](https://github.com/Noob-stupid/dsh-plugin-hub) - A plugin management panel: one-click enable/disable for installed plugins plus a GitHub dsh-plugin marketplace with details and one-click installs.
 
 - [Make0209/dsh-usage-stats](https://github.com/Make0209/dsh-usage-stats) - GitHub-style usage heatmap dashboard: per-workspace turn counts and token spend (with cache-hit rate), DeepSeek account balance, and workspace aliases.
+- [Ychris12138/dsh-usage-stats](https://github.com/Ychris12138/dsh-usage-stats) - Multi-provider usage dashboard with provider/model token breakdowns, calendar drill-downs, account balances, and OpenCode Go / Z.ai subscription quota tracking.
 - [V-dev-388/dsh-usage-meter](https://github.com/V-dev-388/dsh-usage-meter) - Settings-page usage dashboard: per-provider/model token summary across all sessions, with today/7-day/30-day CSS-bar trends and a cache-hit rate.
 - [zoumutou/dsh-cost-balance](https://github.com/zoumutou/dsh-cost-balance) - Collapsible iOS-style stats pill under the composer: session cost, DeepSeek account balance, cache-hit rate, and token usage in a frosted panel.
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -54,6 +54,7 @@ dsh plugin --profile web add dshmarket
 - [Noob-stupid/dsh-plugin-hub](https://github.com/Noob-stupid/dsh-plugin-hub) — 插件管理面板：已安装插件一键启用/停用，内置 GitHub dsh-plugin 插件市场，支持详情查看与一键安装。
 
 - [Make0209/dsh-usage-stats](https://github.com/Make0209/dsh-usage-stats) — GitHub 风格用量热力图看板：按工作区统计使用次数与 Token 花费（含缓存命中率）、DeepSeek 账户余额查询、工作区别名管理。
+- [Ychris12138/dsh-usage-stats](https://github.com/Ychris12138/dsh-usage-stats) — 多供应商用量看板：按供应商/模型统计 Token 与日期下钻，统一展示账户余额，并追踪 OpenCode Go / Z.ai 订阅额度。
 - [V-dev-388/dsh-usage-meter](https://github.com/V-dev-388/dsh-usage-meter) — 设置页用量仪表盘：按服务商/模型汇总全部会话 token 用量，含今日/近 7 天/近 30 天趋势柱状图与缓存命中率。
 - [zoumutou/dsh-cost-balance](https://github.com/zoumutou/dsh-cost-balance) — 输入框下方的 iOS 风格统计条：一键展开查看会话花费、DeepSeek 账户余额、缓存命中率与 Token 用量。
 


### PR DESCRIPTION
## Summary

Adds `Ychris12138/dsh-usage-stats` to the **UI Enhancements** section in both `README.md` and `README.zh.md`.

The plugin provides provider/model-level token aggregation, calendar drill-downs, multi-provider account balances, and subscription quota tracking for OpenCode Go and Z.ai.

## Not a duplicate of the existing `Make0209/dsh-usage-stats`

This is an **independent implementation**, not a fork or variant of the existing `Make0209/dsh-usage-stats` entry. The two repositories happen to share the same package/repository name, but their scopes and implementations are materially different.

The existing `Make0209/dsh-usage-stats` is primarily **workspace-oriented**:

* GitHub-style workspace activity heatmap
* per-workspace turn/token statistics and cache-hit rate
* DeepSeek account balance
* workspace alias management

`Ychris12138/dsh-usage-stats` is primarily **provider/account-oriented**:

* provider + model token aggregation across sessions
* calendar heatmap with per-date provider/model drill-downs
* account balance support for multiple providers
* OpenCode Go 5-hour / weekly / monthly subscription quota tracking
* Z.ai Coding Plan quota tracking
* server-side credential handling so API keys are not exposed to the browser

So while both plugins overlap at the broad “usage statistics” level, they expose materially different data models and account/quota features.

**This PR does not replace or modify the existing entry. It adds this separate implementation alongside it.**

## Checklist

* `package.json` declares a `dsh.bundle` manifest
* repository contains working plugin code
* repository has the `dsh-plugin` topic
* English and Chinese entries are both included
* descriptions are functional and non-marketing
