### PR TITLE
Add 1624318455/dsh-plugin-tts

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ dsh plugin --profile web add dshmarket
 
 ### UI Enhancements
 
+- [1624318455/dsh-plugin-tts](https://github.com/1624318455/dsh-plugin-tts) - Reads assistant replies aloud via free Edge TTS: per-message read-aloud buttons, an auto-read toggle, and a voice settings panel.
 - [x2802490130-prog/dsh-client-ui-writing](https://github.com/x2802490130-prog/dsh-client-ui-writing) - Client-side writing panel for the Web UI: project volumes and stats, corpus library, full-text search, evolution version-chain diffs, and an SVG thread graph, shown only in writing-preset sessions.
 - [badai147/dsh-global-rules](https://github.com/badai147/dsh-global-rules) - Edit the global ~/.dsh/AGENTS.md rules from the web settings panel, live on save.
 - [AcidGr/dsh-web-mobile-fix](https://github.com/AcidGr/dsh-web-mobile-fix) - Mobile layout fixes for the Web UI on narrow screens: full-screen settings panel, one-row plugin nav, full-screen sidebar, centered popups, icon-only session-log button.

--- a/README.zh.md
+++ b/README.zh.md
@@ -42,6 +42,7 @@ dsh plugin --profile web add dshmarket
 
 ### 🎨 UI 增强
 
+- [1624318455/dsh-plugin-tts](https://github.com/1624318455/dsh-plugin-tts) — 用免费 Edge TTS 朗读 AI 回复：消息朗读按钮、自动朗读开关与语音设置面板。
 - [x2802490130-prog/dsh-client-ui-writing](https://github.com/x2802490130-prog/dsh-client-ui-writing) — Web 客户端「写作」面板：项目分卷与统计、书库与全文检索、设定演化版本链 diff、线索 SVG 图谱，仅在写作预设会话显示。
 - [badai147/dsh-global-rules](https://github.com/badai147/dsh-global-rules) — 在设置面板中编辑 ~/.dsh/AGENTS.md 全局规则，保存后实时生效。
 - [AcidGr/dsh-web-mobile-fix](https://github.com/AcidGr/dsh-web-mobile-fix) — Web UI 移动端布局修复：窄屏下设置面板全屏化、插件导航单行排满、侧边栏全屏、弹层居中、会话日志按钮图标化。


### PR DESCRIPTION
Edge TTS 语音大集成插件：给 AI 回复加朗读——逐条朗读按钮、自动朗读开关、语音设置面板（免费，无需 API Key）。

Checklist against contributing.md:

- `dsh.bundle` declared in `package.json`, with `cordis.patch.yml` at the repo root
- `@deepseek-ai/*` declared as `peerDependencies`
- `dsh-plugin` topic added
- Working code — end to end inside a DSH web profile: fake-ctx smoke test (route registration + real Edge TTS synthesis + audio serve) passes 4/4, and the three UI entries (read-aloud button, auto-read toggle, voice settings panel) verified in the GUI
- Not published to npm; installable via `dsh plugin --profile web add "github:1624318455/dsh-plugin-tts#main"` (prebuilt lib/, no build script)

Placed at the top of UI Enhancements / UI 增强 (the plugin adds message-action, composer, and settings-panel UI rather than a tool capability).

Both language versions updated (one line each, plain functional descriptions).