### PR TITLE
Add dsh-movein (Development & Runtime), now a dsh plugin add installable plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,6 +521,7 @@ dsh plugin --profile web add dshmarket
 - [strukto-ai/mirage#dsh](https://github.com/strukto-ai/mirage/tree/main/typescript/packages/dsh) - Swaps the filesystem and bash providers for a mirage virtual workspace: file tools and shell commands run over mounted resources (RAM, S3, Redis, Slack, Gmail, Notion, Postgres) instead of the host disk, with per-mount read/write/exec modes, per-command sandbox routing (monty, pyodide, quickjs in process; docker, e2b, daytona remote), and installed CLIs (git, gh, slack, linear, ntn, gws, or one you register) as head words in the virtual terminal.
 - [truelove-dreamer/dsh-plugin-vetting](https://github.com/truelove-dreamer/dsh-plugin-vetting) - Heuristic vetting of installed third-party plugins: static scan for exfiltration, credential access, obfuscation, and persistence patterns, plus an optional runtime subprocess tripwire.
 - [anweat/dsh-restart](https://github.com/anweat/dsh-restart) - Restart DSH: configurable restart method (Node native / legacy PowerShell), post-restart continue prompt, optional watchdog auto-relaunch.
+- [sjh9714/dsh-movein](https://github.com/sjh9714/dsh-movein) - Move a whole Claude Code setup into DSH. Skills, MCP servers, hooks, subagents and permission rules, with a dry-run moving estimate and a migration diff report; installs as a plugin exposing a movein_from_claude_code tool so the agent can do the move for you.
 
 ### Just for Fun
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -521,6 +521,7 @@ dsh plugin --profile web add dshmarket
 - [strukto-ai/mirage#dsh](https://github.com/strukto-ai/mirage/tree/main/typescript/packages/dsh) — 把文件系统与 bash 提供者换成 mirage 虚拟工作区：文件工具与 shell 命令作用于挂载的资源（RAM、S3、Redis、Slack、Gmail、Notion、Postgres）而非宿主磁盘，支持按挂载点设置读/写/执行模式、按命令选择沙箱（进程内 monty、pyodide、quickjs；远程 docker、e2b、daytona），并可在虚拟终端中安装 CLI（git、gh、slack、linear、ntn、gws，或自行注册的程序树）作为命令头词。
 - [truelove-dreamer/dsh-plugin-vetting](https://github.com/truelove-dreamer/dsh-plugin-vetting) — 第三方插件启发式体检：静态扫描网络外传、凭据访问、代码混淆、持久化等可疑模式并按权重打分（SAFE/LOW/MEDIUM/HIGH），可选运行时子进程绊线（只记不改）。
 - [anweat/dsh-restart](https://github.com/anweat/dsh-restart) — DSH 重启插件：可配置的重启方式（Node 原生/旧 PowerShell 适配）、重启后自动继续的提示词、可选看门狗自动拉起。
+- [sjh9714/dsh-movein](https://github.com/sjh9714/dsh-movein) — 把整套 Claude Code 配置搬进 DSH：技能、MCP、hooks、子代理、权限规则，默认先出搬家清单预演并输出迁移差异报告；作为插件提供 movein_from_claude_code 工具，直接让 agent 帮你搬。
 
 ### 🎮 娱乐
 


### PR DESCRIPTION
Follow-up to #326. Both requirements from the review are now shipped in v0.3.0.

1. Plugin shell. `package.json` declares `dsh.bundle`, `cordis.patch.yml` inserts the plugin row, so `dsh plugin --profile web add dsh-movein` installs it in one line (verified on a clean web profile, boots with zero module errors).
2. In-DSH trigger. The plugin registers a `movein_from_claude_code` model tool, saying "帮我把 Claude Code 的配置搬过来" runs the scan and returns the moving-estimate report, `apply=true` performs the move. Core logic in `lib/` is shared verbatim with the CLI, exactly the thin-shell shape suggested (modeled on the clippy-harness plugin layout).

Also new since the last review, from #1672 feedback. Permission migration diff report (enforced vs unmapped rules, fail-closed), hook env var scan at dry run, and a per-move manifest.

Entries added to both README.md and README.zh.md under Development & Runtime.

npm https://www.npmjs.com/package/dsh-movein · release https://github.com/sjh9714/dsh-movein/releases/tag/v0.3.0