### PR TITLE
Add zoahdev/dsh-plugin-doctor — plugin health checks (RFC #1629 dsh plugin check)

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,6 +456,7 @@ dsh plugin --profile web add dshmarket
 - [kaixinbaba/dsh-vision-recognizer](https://github.com/kaixinbaba/dsh-vision-recognizer) - Vision provider route that transcribes attached images to text through a configurable model (15+ OpenAI-compatible and Anthropic vendors) while DeepSeek keeps answering.
 
 ### Development & Runtime
+- [zoahdev/dsh-plugin-doctor](https://github.com/zoahdev/dsh-plugin-doctor) - Health checks for dsh plugins: manifest, patch validity, entry points, build, pack, and fresh-profile install verification (the `dsh plugin check` from RFC #1629).
 
 - [icefall7/dsh-plugin-scout](https://github.com/icefall7/dsh-plugin-scout) - Scouts the deepseek-harness repo and every dsh-plugin-tagged repository to discover harnesses related to your goal, then judges each as worth trying, watching, or skipping.
 - [SaiSenBox/dsh-boot-guard](https://github.com/SaiSenBox/dsh-boot-guard) - Loader-independent startup recovery for DSH Web that detects likely broken plugins, temporarily skips them, and restores only Boot Guard-managed changes.

--- a/README.zh.md
+++ b/README.zh.md
@@ -456,6 +456,7 @@ dsh plugin --profile web add dshmarket
 - [kaixinbaba/dsh-vision-recognizer](https://github.com/kaixinbaba/dsh-vision-recognizer) — 视觉模型路由：把附加图片经可配置模型（15+ OpenAI 兼容与 Anthropic 供应商）转译为文字，对话仍由 DeepSeek 作答。
 
 ### 🧑‍💻 开发与运行时
+- [zoahdev/dsh-plugin-doctor](https://github.com/zoahdev/dsh-plugin-doctor) — dsh 插件健康检查：manifest、patch 合法性、入口、build、pack，以及全新 profile 安装验证（RFC #1629 的 `dsh plugin check` 落地）。
 
 - [icefall7/dsh-plugin-scout](https://github.com/icefall7/dsh-plugin-scout) — 侦察 deepseek-harness 官方仓库与所有 dsh-plugin topic 仓库，发现与目标相关的 harness，并判断每个值得试用、观望还是跳过。
 - [SaiSenBox/dsh-boot-guard](https://github.com/SaiSenBox/dsh-boot-guard) — 独立于常规客户端插件加载链的 DSH Web 启动救援工具，可定位疑似故障插件、临时跳过，并且只恢复 Boot Guard 写入的配置。


### PR DESCRIPTION
Add [dsh-plugin-doctor](https://github.com/zoahdev/dsh-plugin-doctor) under **Development & Runtime**: repeatable health checks for dsh plugin bundles (manifest, patch validity, entry, files, optional build, and full pack + fresh-profile install verification), with `--json` output for CI.