### PR TITLE
Add dsh-dream-skin to Themes & Appearance / 主题与外观

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ dsh plugin --profile web add dshmarket
 - [ook826092-cloud/dsh-mobile-css](https://github.com/ook826092-cloud/dsh-mobile-css) - Mobile adaptation for the DSH Web UI: compact typography, full-width composer with caret fix, drawer sidebar with overlay-close, two-page settings flow, responsive tables and stats, safe touch targets.
 ### Themes & Appearance
 
+- [RevolutionLA/dsh-dream-skin](https://github.com/RevolutionLA/dsh-dream-skin) - One-command skin plugin: 8 original themes, translucent wallpaper with opacity/blur, per-user accent, and shareable theme-pack import/export, favorites and surprise-me — purely native on DSH's token system.
 - [KinGao294/dsh-skin](https://github.com/KinGao294/dsh-skin) - Codex-style skin switcher plus a custom wallpaper layer with opacity and blur controls.
 - [Small-tailqwq/dsh-deep-whale](https://github.com/Small-tailqwq/dsh-deep-whale) - Whale-girl skin series for the DSH Web UI (maid-atelier).
 - [wsxwj123/dsh-plugins#theme-gallery](https://github.com/wsxwj123/dsh-plugins/tree/main/packages/theme-gallery) - Fifteen curated theme families with complete light and dark palettes that follow the native Light, Dark, and Follow system modes.

--- a/README.zh.md
+++ b/README.zh.md
@@ -162,6 +162,7 @@ dsh plugin --profile web add dshmarket
 - [ook826092-cloud/dsh-mobile-css](https://github.com/ook826092-cloud/dsh-mobile-css) — DSH Web UI 移动端适配：紧凑排版、全宽输入卡（含光标修复）、抽屉式侧边栏（点击遮罩关闭）、两页式设置流程、响应式表格与统计、安全触控目标。
 ### 🎭 主题与外观
 
+- [RevolutionLA/dsh-dream-skin](https://github.com/RevolutionLA/dsh-dream-skin) — 一键换肤插件：8 套原创主题、背景壁纸（透明度/模糊）、强调色、主题包导入/导出+分享链接、收藏与随机，纯原生 token 系统接入。
 - [KinGao294/dsh-skin](https://github.com/KinGao294/dsh-skin) — Codex 风格皮肤切换器 + 自定义壁纸层，可调透明度与模糊。
 - [Small-tailqwq/dsh-deep-whale](https://github.com/Small-tailqwq/dsh-deep-whale) — DSH Web 鲸鱼娘皮肤系列（深海女仆工坊 maid-atelier）。
 - [wsxwj123/dsh-plugins#theme-gallery](https://github.com/wsxwj123/dsh-plugins/tree/main/packages/theme-gallery) — 15 个精选主题家族，浅深配色完整，跟随 DSH 原生浅色/深色/跟随系统模式。


### PR DESCRIPTION
Add [RevolutionLA/dsh-dream-skin](https://github.com/RevolutionLA/dsh-dream-skin) to the **Themes & Appearance /** **主题与外观** category (in both `README.md` and `README.zh.md`).

**What it is**: a DeepSeek Harness skin plugin —
- 8 original curated themes (Mirage series)
- translucent wallpaper with opacity/blur + URL/gradient presets + recent history
- per-user accent override with 12 one-click presets
- shareable theme-pack import/export (JSON, validated) + share links
- local pack library, favorites, surprise-me
- purely native on DSH's official `--dsw-*` token system (dual-face `dsh.bundle` + `dsh.client`; installs via `dsh plugin --profile web add dsh-dream-skin`; published to npm @ `dsh-dream-skin`)

I'm the maintainer (GitHub account `RevolutionLA`). Happy to adjust the wording if needed.