### PR TITLE
Add lucas-ward/dsh-ci-context to Workflow & Automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,6 +406,7 @@ dsh plugin --profile web add dshmarket
 - [yangyongzhen/dsh-scheduler](https://github.com/yangyongzhen/dsh-scheduler) - Cron/one-shot scheduled tasks: run shell commands or fire webhooks on a schedule, with optional ServerChan/DingTalk/Feishu/webhook delivery of results.
 - [yangyongzhen/dsh-git-workflow](https://github.com/yangyongzhen/dsh-git-workflow) - Conventional-commit enforcement, changelog generation, PR summaries and branch pushes through the plain git CLI.
 - [yangyongzhen/dsh-article-publish](https://github.com/yangyongzhen/dsh-article-publish) - Publish articles to CSDN / Juejin / CNBlog directly from the session, no external server.
+- [lucas-ward/dsh-ci-context](https://github.com/lucas-ward/dsh-ci-context) - Injects allowlisted GitHub Actions and GitLab CI run metadata into agent context without reading logs, credentials, or provider APIs.
 
 ### Notifications & Integrations
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -407,6 +407,7 @@ dsh plugin --profile web add dshmarket
 - [yangyongzhen/dsh-scheduler](https://github.com/yangyongzhen/dsh-scheduler) — cron / 一次性定时任务：按调度执行 shell 命令或投递 webhook，结果可推送到 ServerChan / 钉钉 / 飞书 / 通用 Webhook。
 - [yangyongzhen/dsh-git-workflow](https://github.com/yangyongzhen/dsh-git-workflow) — 规范提交（Conventional Commits）、自动 changelog、PR 描述生成与分支推送，纯 git CLI 实现。
 - [yangyongzhen/dsh-article-publish](https://github.com/yangyongzhen/dsh-article-publish) — 会话内直接发布文章到 CSDN / 掘金 / 博客园，无外部服务。
+- [lucas-ward/dsh-ci-context](https://github.com/lucas-ward/dsh-ci-context) — 将白名单内的 GitHub Actions 与 GitLab CI 运行元数据注入 Agent 上下文，不读取日志、凭据或服务商 API。
 
 ### 🔔 通知与集成
 - [radres/dsh-plugin-call-me](https://github.com/radres/dsh-plugin-call-me) — 通过 CallKit 打电话到你的手机：`call_me` 与 `text_me` 工具，并可在回合结束或等待审批时来电，语音回答转写后送回会话。


### PR DESCRIPTION
## Summary

- add `lucas-ward/dsh-ci-context` to Workflow & Automation
- add matching English and Chinese descriptions

## Plugin scope

`dsh-ci-context` passively injects allowlisted GitHub Actions and GitLab CI run metadata into agent context. It does not poll provider APIs, read logs or credentials, control pipelines, or write to repositories, so its scope is distinct from CI diagnosis and GitHub Action controller plugins.

## Validation

- declares `package.json#dsh.bundle.patch` and ships `cordis.patch.yml`
- Node 24.19.0: 11/11 tests passed
- `npm pack` artifact verified
- clean offline tarball install and installed-package smoke test passed
- `awesome-lint README.md` passed with only pre-existing upstream warnings
- `node scripts/build-site.mjs` passed with 452 entries across both locales
- release tag: `v0.1.1`
