### PR TITLE
Add amlyczz/dsh-lark-link to Notifications & Integrations / 通知与集成

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,6 +446,7 @@ dsh plugin --profile web add dshmarket
 - [zhengjy01/dsh-notify](https://github.com/zhengjy01/dsh-notify) - System-level desktop notifications: turn-completion and workflow-end banners, plus a modal alert when an approval is needed (macOS osascript / Linux notify-send).
 - [ThreeBody6666/dsh-im-hub](https://github.com/ThreeBody6666/dsh-im-hub) - Multi-platform IM gateway for DSH: Feishu (Lark) WebSocket long connection (no public URL), WeCom AES-encrypted callbacks, and Telegram long polling — per-chat agent sessions, whitelist access, and a visual settings card in the web GUI.
 - [yangyongzhen/dsh-notify](https://github.com/yangyongzhen/dsh-notify) - Task-completion notifications via ServerChan / DingTalk / Feishu / generic webhooks.
+- [amlyczz/dsh-lark-link](https://github.com/amlyczz/dsh-lark-link) - High-reliability Feishu/Lark bridge for DeepSeek Harness: QR one-click auth, card-based commands and intent-confirmation cards, at-least-once zero-loss outbox, media in/out, /doctor session-log ZIP, and a reusable DSH Web GUI that lands sessions in the right workspace.
 
 ### Models & Providers
 - [Noob-stupid/dsh-github-login](https://github.com/Noob-stupid/dsh-github-login) - Visual GitHub login without a terminal: in-window device flow, token synced into the gh CLI, and host status/launch endpoints.

--- a/README.zh.md
+++ b/README.zh.md
@@ -446,6 +446,7 @@ dsh plugin --profile web add dshmarket
 - [zhengjy01/dsh-notify](https://github.com/zhengjy01/dsh-notify) — 系统级桌面通知：回合完成 / 工作流完成横幅，需要审批时弹出模态提醒（macOS osascript / Linux notify-send）。
 - [ThreeBody6666/dsh-im-hub](https://github.com/ThreeBody6666/dsh-im-hub) — 多平台 IM 网关：飞书（Lark）WebSocket 长连接（无需公网）、企业微信 AES 加密回调、Telegram 长轮询；每会话独立 agent、白名单访问、Web GUI 可视化设置卡片。
 - [yangyongzhen/dsh-notify](https://github.com/yangyongzhen/dsh-notify) — 任务完成通知：ServerChan / 钉钉 / 飞书 / 通用 Webhook。
+- [amlyczz/dsh-lark-link](https://github.com/amlyczz/dsh-lark-link) — DeepSeek Harness 的高可靠飞书/Lark 桥接：扫码一键认证、卡片化命令与意图确认、at-least-once 零丢失出站队列、多媒体出入站、/doctor 会话日志 ZIP，并复用 DSH Web GUI 把会话归入正确工作区。
 
 ### 🔌 模型与账号接入
 - [Noob-stupid/dsh-github-login](https://github.com/Noob-stupid/dsh-github-login) — 零终端的 GitHub 可视化登录插件：窗口内完成设备码授权，令牌同步进 gh CLI，附宿主端状态与唤起接口。


### PR DESCRIPTION
## Summary / 概述
Adds [amlyczz/dsh-lark-link](https://github.com/amlyczz/dsh-lark-link) to the **Notifications & Integrations / 🔔 通知与集成** category in both `README.md` and `README.zh.md`.

## Why it qualifies / 符合收录要求
- ✅ Declares a `dsh.bundle` manifest (`package.json` → `dsh.bundle.patch: ./cordis.patch.yml`) — installable via `dsh plugin add`, with a `cordis.patch.yml` in the repo root.
- ✅ Official `@deepseek-ai/*` packages declared as `peerDependencies` (not `dependencies`).
- ✅ Published to npm: `dsh-lark-link@0.2.1` (prebuilt installs skip the `allowBuilds` step).
- ✅ Has the `dsh-plugin` topic set on the repo.
- ✅ Real, actively maintained, working code (not a placeholder/README-only repo).

## What it does / 功能
High-reliability Feishu/Lark bridge for DeepSeek Harness: QR one-click app auth, card-based commands and intent-confirmation cards, at-least-once zero-loss outbox, media in/out, `/doctor` session-log ZIP, and reuses the DSH Web GUI to land sessions in the right workspace.

## Checks / 校验
- `node scripts/build-site.mjs` passes locally: `458 entries parsed across 2 locales`.
- One line added per contributing.md (`README.md` + `README.zh.md`), placed in the matching category.