### PR TITLE
Add fieldnote-ops/keyringseam to Models & Providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,6 +459,7 @@ dsh plugin --profile web add dshmarket
 - [feibi-mochi/deepseek-harness-wallet](https://github.com/feibi-mochi/deepseek-harness-wallet) - Multi-provider wallet chip: official DeepSeek balance, per-session cost & tokens, third-party token totals, recharge shortcut, low-balance alerts.
 - [superboy911/dsh-model-router](https://github.com/superboy911/dsh-model-router) - Deterministic keyword routing, allowlisted model switching, and an isolated image_gen channel for DeepSeek Harness.
 - [kaixinbaba/dsh-vision-recognizer](https://github.com/kaixinbaba/dsh-vision-recognizer) - Vision provider route that transcribes attached images to text through a configurable model (15+ OpenAI-compatible and Anthropic vendors) while DeepSeek keeps answering.
+- [fieldnote-ops/keyringseam](https://github.com/fieldnote-ops/keyringseam) - macOS Keychain credential provider that replaces the local-file provider and uses a signed, notarized universal helper.
 
 ### Development & Runtime
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -459,6 +459,7 @@ dsh plugin --profile web add dshmarket
 - [feibi-mochi/deepseek-harness-wallet](https://github.com/feibi-mochi/deepseek-harness-wallet) — 多供应商钱包标签：官方 DeepSeek 余额、本会话花费与 token、第三方合计 token、一键充值、低余额提醒。
 - [superboy911/dsh-model-router](https://github.com/superboy911/dsh-model-router) — DSH 关键词路由与隔离生图插件：确定性关键词路由、白名单模型切换与隔离的 image_gen 生图通道。
 - [kaixinbaba/dsh-vision-recognizer](https://github.com/kaixinbaba/dsh-vision-recognizer) — 视觉模型路由：把附加图片经可配置模型（15+ OpenAI 兼容与 Anthropic 供应商）转译为文字，对话仍由 DeepSeek 作答。
+- [fieldnote-ops/keyringseam](https://github.com/fieldnote-ops/keyringseam) — macOS Keychain 凭据提供器：替换本地文件提供器，并使用已签名、公证的通用二进制辅助程序。
 
 ### 🧑‍💻 开发与运行时
 


### PR DESCRIPTION
Adds [fieldnote-ops/keyringseam](https://github.com/fieldnote-ops/keyringseam) to **Models & Providers / 模型与账号接入** in both README files.

KeyringSeam replaces the local-file credential provider on macOS and delegates Keychain access to a signed, notarized `arm64` + `x86_64` helper. A disposable Keychain lifecycle and clean-profile replacement boot have passed.

Requirements checklist:
- [x] Root `package.json` declares `dsh.bundle`; `cordis.patch.yml` inserts the replacement provider
- [x] Real source, tests, signed helper, and immutable CI evidence
- [x] Active maintenance
- [x] `dsh-plugin` topic present
- [x] Factual one-line descriptions in English and Chinese
- [x] Official `@deepseek-ai/*` packages are `peerDependencies`

The project is independently maintained and does not claim affiliation with DeepSeek or Apple.