### PR TITLE
Add dsh-maid-whale-webUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ dsh plugin --profile web add dshmarket
 
 - [zhijun-dai/Catppuccin-dsh-theme](https://github.com/zhijun-dai/Catppuccin-dsh-theme) - Catppuccin theme plugin: Latte, Frappé, Macchiato, and Mocha skins for the DSH Web theme runtime.
 - [zhijun-dai/Solarized-dsh-theme](https://github.com/zhijun-dai/Solarized-dsh-theme) - Solarized and Selenized theme plugin: four faithful palettes registered with the DSH Web theme runtime.
+- [yunxiiQwQ/dsh-maid-whale-webUI#maid-whale-webui](https://github.com/yunxiiQwQ/dsh-maid-whale-webUI/tree/main/maid-whale-webui) - Whale-maid paper theme for the DSH Web UI with light and dark palettes, ocean illustrations, hand-drawn frames, decorative assets, and a persistent pet.
 
 ### Sessions & Messages
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -184,6 +184,7 @@ dsh plugin --profile web add dshmarket
 
 - [zhijun-dai/Catppuccin-dsh-theme](https://github.com/zhijun-dai/Catppuccin-dsh-theme) — Catppuccin 主题插件：为 DSH Web 主题运行时提供 Latte、Frappé、Macchiato、Mocha 四套皮肤。
 - [zhijun-dai/Solarized-dsh-theme](https://github.com/zhijun-dai/Solarized-dsh-theme) — Solarized 与 Selenized 主题插件：向 DSH Web 主题运行时注册四套忠实色板。
+- [yunxiiQwQ/dsh-maid-whale-webUI#maid-whale-webui](https://github.com/yunxiiQwQ/dsh-maid-whale-webUI/tree/main/maid-whale-webui) — DSH Web UI 鲸鱼女仆纸面主题：亮暗配色、海洋插画、手绘边框、装饰素材与常驻桌宠。
 
 ### 💬 会话与消息
 


### PR DESCRIPTION
Adds `yunxiiQwQ/dsh-maid-whale-webUI` as the first entry under Themes & Appearance in both language lists.

- [x] My repo's `package.json` declares `dsh.bundle` (not just `dsh.client`)
- [x] One line added to both `README.md` (English) and `README.zh.md` (中文), under the matching category
- [x] Description states what the plugin does, with no superlatives
- [x] My repo has the `dsh-plugin` topic

Recommended:

- [ ] Published to npm
- [x] Official `@deepseek-ai/*` packages are declared as `peerDependencies`