### PR TITLE
Add PAKIKNOWLEDGE/dsh-notify-skill to Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,6 +388,7 @@ dsh plugin --profile web add dshmarket
 - [jeremy9682/dsh-skill-pack](https://github.com/jeremy9682/dsh-skill-pack) - 11 shareable workflow skills (handoff, triage, to-spec, to-tickets, wayfinder, teach, wait-what, dsh-mode-routing, ask-matt, overnight-execution, full-throttle) as an installable skill pack.
 - [Cavan-Ou/hermes-dsh-collab](https://github.com/Cavan-Ou/hermes-dsh-collab) - Hook DeepSeek Harness into a Hermes pipeline: dispatch-spec template, model-tier routing, orchestrator-run quality gates, git single-writer rule, as a SKILL.md pack (bundle installable).
 - [linxichen/dsh-rigorquant](https://github.com/linxichen/dsh-rigorquant) - RigorQuant preset + skill pack: unattended walled multi-agent research for empirical and computational mathematics (economics, finance, portfolio), with a four-part pre-implementation check battery and a jacobian/Lean escalation lane.
+- [PAKIKNOWLEDGE/dsh-notify-skill](https://github.com/PAKIKNOWLEDGE/dsh-notify-skill) - Email reminders from your DSH agent when you're away: fires at goal completion, blockage, before asking the user a decision, and at long-task milestones via a bundled zero-dependency Node SMTP sender.
 ### Workflow & Automation
 
 - [ztl34245881-commits/dsh-task-planner](https://github.com/ztl34245881-commits/dsh-task-planner) - Task planning with experience muscle-memory: condition-reflex recall of past solutions, LLM capability matching, and auto-persisted lessons.

--- a/README.zh.md
+++ b/README.zh.md
@@ -389,6 +389,7 @@ dsh plugin --profile web add dshmarket
 - [jeremy9682/dsh-skill-pack](https://github.com/jeremy9682/dsh-skill-pack) — 11 个可分享的工作流 skills（handoff、triage、to-spec、to-tickets、wayfinder、teach、wait-what、dsh-mode-routing、ask-matt、overnight-execution、full-throttle），打包为可安装 bundle。
 - [Cavan-Ou/hermes-dsh-collab](https://github.com/Cavan-Ou/hermes-dsh-collab) — 把 DeepSeek Harness 接进 Hermes 管线：派单 spec 模板、模型档位路由、质量门、git 唯一写者约定，SKILL.md 技能包（bundle 可安装）。
 - [linxichen/dsh-rigorquant](https://github.com/linxichen/dsh-rigorquant) — RigorQuant 预设与技能包：面向实证与计算数学（经济学、金融、组合）的无人值守隔离多智能体研究，内置四重实现前校验与 jacobian/Lean 升级通道。
+- [PAKIKNOWLEDGE/dsh-notify-skill](https://github.com/PAKIKNOWLEDGE/dsh-notify-skill) — 你不在电脑前时由 agent 邮件提醒你：goal 完成、阻塞、向你提问决策前、长任务节点时触发，自带零依赖 Node SMTP 发送器。
 ### 🔁 工作流与自动化
 
 - [ztl34245881-commits/dsh-task-planner](https://github.com/ztl34245881-commits/dsh-task-planner) — 带经验肌肉记忆的任务规划：条件反射检索历史方案 + LLM 能力匹配 + 经验自动沉淀。


### PR DESCRIPTION
## Adding `PAKIKNOWLEDGE/dsh-notify-skill` under Skills

A single entry under the `### Skills` / `### 🧩 技能包` section (README.md + README.zh.md).

### What it is

A DSH skill plugin that sends email reminders to the user's phone when they're away from the computer — fires at goal completion, goal blockage, before asking the user a decision, and at long-task milestones.

- **Installable via `dsh plugin add`**: `package.json` declares `dsh.bundle` (`cordis.patch.yml`); published on npm as `dsh-notify-skill@0.1.0`
- **Registers on `ctx.skills`**: `index.mjs` mounts `skills/notify` via `@deepseek-ai/dsh-skill-filesystem`
- **Bundled zero-dependency Node SMTP sender** (`sender.mjs`, `node:tls`) with the SMTP protocol as fallback instructions for non-Node environments
- Config contract (`config.json`) is gitignored; the npm tarball ships only `config.example.json`

### Install

```sh
dsh plugin --profile web add dsh-notify-skill
```

- Repo: https://github.com/PAKIKNOWLEDGE/dsh-notify-skill
- npm: https://www.npmjs.com/package/dsh-notify-skill
