### PR TITLE
docs: add dsh-genie (Development & Runtime)

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,6 +549,7 @@ dsh plugin --profile web add dshmarket
 - [truelove-dreamer/dsh-plugin-vetting](https://github.com/truelove-dreamer/dsh-plugin-vetting) - Heuristic vetting of installed third-party plugins: static scan for exfiltration, credential access, obfuscation, and persistence patterns, plus an optional runtime subprocess tripwire.
 - [anweat/dsh-restart](https://github.com/anweat/dsh-restart) - Restart DSH: configurable restart method (Node native / legacy PowerShell), post-restart continue prompt, optional watchdog auto-relaunch.
 - [sjh9714/dsh-movein](https://github.com/sjh9714/dsh-movein) - Move a whole Claude Code setup into DSH. Skills, MCP servers, hooks, subagents and permission rules, with a dry-run moving estimate and a migration diff report; installs as a plugin exposing a movein_from_claude_code tool so the agent can do the move for you.
+- [swaylq/dsh-genie](https://github.com/swaylq/dsh-genie) - Keeps what the agent builds at runtime: turns a `cordis_define` dynamic package into a real installed plugin that survives restart, writing the bundle and registering the profile layer with no pnpm, no network, and no build authorization.
 
 ### Just for Fun
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -549,6 +549,7 @@ dsh plugin --profile web add dshmarket
 - [truelove-dreamer/dsh-plugin-vetting](https://github.com/truelove-dreamer/dsh-plugin-vetting) — 第三方插件启发式体检：静态扫描网络外传、凭据访问、代码混淆、持久化等可疑模式并按权重打分（SAFE/LOW/MEDIUM/HIGH），可选运行时子进程绊线（只记不改）。
 - [anweat/dsh-restart](https://github.com/anweat/dsh-restart) — DSH 重启插件：可配置的重启方式（Node 原生/旧 PowerShell 适配）、重启后自动继续的提示词、可选看门狗自动拉起。
 - [sjh9714/dsh-movein](https://github.com/sjh9714/dsh-movein) — 把整套 Claude Code 配置搬进 DSH：技能、MCP、hooks、子代理、权限规则，默认先出搬家清单预演并输出迁移差异报告；作为插件提供 movein_from_claude_code 工具，直接让 agent 帮你搬。
+- [swaylq/dsh-genie](https://github.com/swaylq/dsh-genie) — 把 agent 现场造出来的插件留下来：将 `cordis_define` 的动态包固化成能跨重启存活的正式插件，写包并注册 profile 层的全过程不用 pnpm、不联网、不需要构建授权。
 
 ### 🎮 娱乐
 


### PR DESCRIPTION
Adds one entry to **Development & Runtime** in both `README.md` and `README.zh.md`, per the contributing note.

**[swaylq/dsh-genie](https://github.com/swaylq/dsh-genie)** — DSH ships `cordis_define` / `cordis_run` so an agent can write a plugin and hot-load it, but the upstream README is explicit that a dynamic package "cannot be promoted automatically" and does not survive a restart. dsh-genie adds the missing half: `genie_keep` reads a dynamic package back out of the live runtime and writes it as a real installable bundle; `genie_wish` does the same for code written directly.

Install path deliberately avoids the usual friction — it writes the package into `$DSH_HOME/genie/`, links it where the launcher already resolves modules, and appends one name to `dsh.profile.bundles`. No pnpm, no network, and no `allowBuilds` grant.

Notes for review:
- Repo carries the `dsh-plugin` topic.
- MIT, plain JavaScript, no build step — so `dsh plugin add github:swaylq/dsh-genie` needs no build authorization. Verified end to end against `@deepseek-ai/dsh@0.1.0-rc.6`: install from GitHub, boot, grant a wish, restart, wish still loads, revoke, restart, gone.
- 19 unit tests (`npm test`), no network.
- The README has an explicit trust-stance section: a granted wish is ordinary code that runs at every boot, nothing executes in the session that writes it, and generated modules are parse-checked with `node --check` rather than evaluated.