### PR TITLE
add: shaobeichen/dsh-im-bridge (IM bridge, Feishu/WeCom/Telegram)

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,6 +433,7 @@ dsh plugin --profile web add dshmarket
 - [toolclub/dsh-agent-team-gui](https://github.com/toolclub/dsh-agent-team-gui) - Global persistent agent squads with per-agent model/tool policies: manage them in Settings, select and toggle one per conversation, then collaborate on normal sends in a fixed or model-planned order.
 
 ### Notifications & Integrations
+- [shaobeichen/dsh-im-bridge](https://github.com/shaobeichen/dsh-im-bridge) - IM bridge for DeepSeek Harness: dispatch tasks, receive result notifications, and approve risky operations from Feishu, WeCom, and Telegram.
 
 - [radres/dsh-plugin-call-me](https://github.com/radres/dsh-plugin-call-me) - Rings your phone over CallKit: `call_me` and `text_me` tools, plus optional turn-end and approval calls whose spoken answer is transcribed back into the session.
 - [omdsh-dev/dsh-open-in-vscode](https://github.com/omdsh-dev/dsh-open-in-vscode) - Open DSH workspace directories in VS Code directly from the web GUI.

--- a/README.zh.md
+++ b/README.zh.md
@@ -434,6 +434,7 @@ dsh plugin --profile web add dshmarket
 - [toolclub/dsh-agent-team-gui](https://github.com/toolclub/dsh-agent-team-gui) — 全局持久 Agent 小队：每个成员独立配置模型与工具策略；在 Settings 中管理、按对话选择并开关协作，普通发送按固定顺序或由模型规划执行。
 
 ### 🔔 通知与集成
+- [shaobeichen/dsh-im-bridge](https://github.com/shaobeichen/dsh-im-bridge) — 让 DeepSeek Harness 通过飞书、企业微信、Telegram 远程派活、接收结果通知、审批危险操作。
 - [radres/dsh-plugin-call-me](https://github.com/radres/dsh-plugin-call-me) — 通过 CallKit 打电话到你的手机：`call_me` 与 `text_me` 工具，并可在回合结束或等待审批时来电，语音回答转写后送回会话。
 - [omdsh-dev/dsh-open-in-vscode](https://github.com/omdsh-dev/dsh-open-in-vscode) — 从 Web GUI 一键在 VS Code 中打开工作区目录。
 - [omdsh-dev/dsh-notification](https://github.com/omdsh-dev/dsh-notification) — 回合完成桌面通知，按结果分控 + 关键词过滤。


### PR DESCRIPTION
DeepSeek Harness即时通讯桥接工具：可通过飞书、企业微信和Telegram派发任务、接收结果通知以及审批高风险操作。
IM bridge for DeepSeek Harness: dispatch tasks, receive result notifications, and approve risky operations from Feishu, WeCom, and Telegram.