### PR TITLE
Add dsh-session-move to Sessions & Messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ dsh plugin --profile web add dshmarket
 - [yangyongzhen/dsh-session-report](https://github.com/yangyongzhen/dsh-session-report) - Per-session cost & usage report cards: tokens, cache hits, duration.
 - [Boliban/dsh-enter-customizer](https://github.com/Boliban/dsh-enter-customizer) - Take over the system input shortcuts for the chat input box and configure behavior independently for each shortcut.
 - [wsxwj123/dsh-plugins#dsh-session-manager](https://github.com/wsxwj123/dsh-plugins/tree/main/packages/dsh-session-manager) - Delete sessions with a 5-second undo and a recycle bin, plus an archive view to browse and unarchive, for the DSH Web GUI.
+- [reinocheong/dsh-session-move](https://github.com/reinocheong/dsh-session-move) - Move a session to another folder from the Web UI via drag & drop or a menu picker, permanently delete a session with a risk-consent dialog, and AI-rename a session by summarizing the whole conversation (typo-aware). Each action also ships as an agent tool.
 
 ### Memory
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -227,6 +227,7 @@ dsh plugin --profile web add dshmarket
 - [yangyongzhen/dsh-session-report](https://github.com/yangyongzhen/dsh-session-report) — 会话成本与耗时报表：tokens / 缓存命中 / 耗时。
 - [Boliban/dsh-enter-customizer](https://github.com/Boliban/dsh-enter-customizer) — 接管聊天输入框的回车等快捷键，每个快捷键的行为都能单独配置。
 - [wsxwj123/dsh-plugins#dsh-session-manager](https://github.com/wsxwj123/dsh-plugins/tree/main/packages/dsh-session-manager) — 会话删除（5 秒可撤销 + 回收站）与归档视图（查看、取消归档）。
+- [reinocheong/dsh-session-move](https://github.com/reinocheong/dsh-session-move) — 在 Web 侧边栏把会话移动到别的文件夹（拖拽或菜单选择），带风险确认地永久删除会话，以及 AI 重命名会话（总结整个对话并自动纠正错别字）；每个操作都提供 agent 工具。
 
 ### 🧠 记忆
 


### PR DESCRIPTION
## What

Add **[dsh-session-move](https://github.com/reinocheong/dsh-session-move)** to the **Sessions & Messages** category (en + zh).

A session-management plugin for the DSH Web UI:

- **Move a session to another folder (workspace)** — via drag & drop onto a folder row, or the `...` menu → picker dialog. Officially sessions are locked to the folder they were created in; this is the only plugin that relocates them (rewrites the session header `cwd`, moves the persisted log slug, re-accounts through the workspace registry — history travels with the session).
- **Permanently delete a session** — risk-consent dialog; removes the log directory, projection-cache row, and workspace accounting (no "Ungrouped" residue).
- **AI rename** — one click; LLM samples the whole conversation (evenly across the timeline), fixes typos in source messages, and writes a concise title.

Each operation also ships as an agent tool (`workbench_session_move` / `_delete` / `_rename_ai`).

Lightweight: zero runtime dependencies (reuses dsh's own packages), no background tasks, ~1 ms stateless endpoints.

## Checklist

- [x] Added one line in both `README.md` and `README.zh.md` under the matching category
- [x] Repo carries the `dsh-plugin` topic