### PR TITLE
Add dsh-paperclip-upload to UI Enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ dsh plugin --profile web add dshmarket
 ## Plugins
 
 ### UI Enhancements
+- [paul-xing/dsh-paperclip-upload](https://github.com/paul-xing/dsh-paperclip-upload) - Paperclip upload button: pick a desktop file, upload it into the session workspace uploads/ directory, and insert a 📄 filename into the composer.
 - [littleboylittlegirl/dsh-community-hot](https://github.com/littleboylittlegirl/dsh-community-hot) - Floating community panel for the Web UI: 24h hot topics and hot plugins TOP10 with a draggable, always-on-top button.
 - [1624318455/dsh-plugin-tts](https://github.com/1624318455/dsh-plugin-tts) - Reads assistant replies aloud via free Edge TTS: per-message read-aloud buttons, an auto-read toggle, and a voice settings panel.
 - [x2802490130-prog/dsh-client-ui-writing](https://github.com/x2802490130-prog/dsh-client-ui-writing) - Client-side writing panel for the Web UI: project volumes and stats, corpus library, full-text search, evolution version-chain diffs, and an SVG thread graph, shown only in writing-preset sessions.

--- a/README.zh.md
+++ b/README.zh.md
@@ -41,6 +41,7 @@ dsh plugin --profile web add dshmarket
 ## 插件
 
 ### 🎨 UI 增强
+- [paul-xing/dsh-paperclip-upload](https://github.com/paul-xing/dsh-paperclip-upload) - 回形针上传按钮：从桌面选择文件上传到会话工作区 uploads/ 目录，并在输入框插入 📄 文件名。
 - [littleboylittlegirl/dsh-community-hot](https://github.com/littleboylittlegirl/dsh-community-hot) — Web UI 的社区热门悬浮面板：24 小时热门话题与热门插件 TOP10，悬浮按钮可拖动置顶、点击居中展开。
 - [1624318455/dsh-plugin-tts](https://github.com/1624318455/dsh-plugin-tts) — 用免费 Edge TTS 朗读 AI 回复：消息朗读按钮、自动朗读开关与语音设置面板。
 - [x2802490130-prog/dsh-client-ui-writing](https://github.com/x2802490130-prog/dsh-client-ui-writing) — Web 客户端「写作」面板：项目分卷与统计、书库与全文检索、设定演化版本链 diff、线索 SVG 图谱，仅在写作预设会话显示。


### PR DESCRIPTION
Add [dsh-paperclip-upload](https://github.com/paul-xing/dsh-paperclip-upload) to the UI Enhancements category (README.md + README.zh.md).

A paperclip upload button for the DSH Web UI: pick a desktop file, upload it into the current session workspace uploads/ directory, and insert a 📄 filename into the composer so the agent can read it. Repo is tagged with the dsh-plugin topic.