### PR TITLE
docs: add jyh20030112/dsh-visual-plugin to Models & Providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ dsh plugin --profile web add dshmarket
 - [fieldnote-ops/keyringseam](https://github.com/fieldnote-ops/keyringseam) - macOS Keychain credential provider that replaces the local-file provider and uses a signed, notarized universal helper.
 
 - [YZz-S/dsh-billing-balance](https://github.com/YZz-S/dsh-billing-balance) - Shows DeepSeek API account balance and Volcengine Ark Coding/Agent Plan quota windows (5h/weekly/monthly with reset countdowns) in the settings panel, composer dock, and a draggable floating refresh button.
+- [jyh20030112/dsh-visual-plugin](https://github.com/jyh20030112/dsh-visual-plugin) - Gives text-only models vision: forwards user images to an OpenAI-compatible vision model and shows the descriptions in a Web UI right panel.
 ### Sessions & Messages
 
 - [HuiHuitie-zhu/dsh-incognito](https://github.com/HuiHuitie-zhu/dsh-incognito) - Incognito sessions: a standalone ephemeral sub-agent with its own preset (no parent context) and full toolset, draggable floating window, burned to zero traces on close.

--- a/README.zh.md
+++ b/README.zh.md
@@ -208,6 +208,7 @@ dsh plugin --profile web add dshmarket
 - [fieldnote-ops/keyringseam](https://github.com/fieldnote-ops/keyringseam) — macOS Keychain 凭据提供器：替换本地文件提供器，并使用已签名、公证的通用二进制辅助程序。
 
 - [YZz-S/dsh-billing-balance](https://github.com/YZz-S/dsh-billing-balance) — 在设置页、输入框下方读数条与可拖动悬浮按钮三处显示 DeepSeek 官方 API 余额与火山方舟 Coding/Agent Plan 套餐额度（5小时/周/月窗口及重置倒计时）。
+- [jyh20030112/dsh-visual-plugin](https://github.com/jyh20030112/dsh-visual-plugin) — 给纯文本模型装上眼睛：把用户图片转发给任意 OpenAI 兼容的视觉模型生成描述，并在 Web UI 右侧面板展示结果。
 ### 💬 会话与消息
 
 - [HuiHuitie-zhu/dsh-incognito](https://github.com/HuiHuitie-zhu/dsh-incognito) — 无痕会话：独立临时子 Agent（独立 preset 不继承父会话、全量工具集），浮窗可拖动，关闭即焚毁、磁盘零痕迹。


### PR DESCRIPTION
Register [jyh20030112/dsh-visual-plugin](https://github.com/jyh20030112/dsh-visual-plugin) under **Models & Providers / 模型与账号接入**.

One line added to both `README.md` (English) and `README.zh.md` (中文), grouped next to the other vision-bridge entry (`dsh-vision-recognizer`).

**Checklist / 自查清单**

- [x] Repo's `package.json` declares **`dsh.bundle`** (`"dsh": { "bundle": { "patch": "./cordis.patch.yml" }, "client": { "platform": "web" } }`) — installable via `dsh plugin add`. / 仓库已声明 `dsh.bundle`，可安装。
- [x] One line added to both `README.md` and `README.zh.md`, under the matching category / 两个语言文件各加一行，分类一致。
- [x] Description states what the plugin does, no superlatives / 描述只说功能。
- [x] Repo has the `dsh-plugin` topic / 仓库已打 `dsh-plugin` topic。

**Recommended / 推荐项**

- 📦 Published to npm — `dsh-visual-plugin@0.2.3` is the current `latest`; prebuilt installs skip the `allowBuilds` step / 已发布 npm（0.2.3，`latest`）。
- 🔗 Official `@deepseek-ai/*` packages declared as `peerDependencies` (all optional) / 官方包均以 `peerDependencies`（全部 optional）声明。
