### PR TITLE
Add dsh-clawshell: cybernetic self-healing exoskeleton for DeepSeek Harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -572,6 +572,7 @@ dsh plugin --profile web add dshmarket
 - [swaylq/dsh-genie](https://github.com/swaylq/dsh-genie) - Keeps what the agent builds at runtime: turns a `cordis_define` dynamic package into a real installed plugin that survives restart, writing the bundle and registering the profile layer with no pnpm, no network, and no build authorization.
 
 - [YZz-S/dsh-update-checker](https://github.com/YZz-S/dsh-update-checker) - Conversation header badge showing the DeepSeek Harness version, checking npm for the latest release and prompting upgrades.
+- [jorinyang/dsh-clawshell](https://github.com/jorinyang/dsh-clawshell) - Self-healing runtime layer: a resource control loop with strategy switching and repair escalation, error-storm and fiber-failure insight, cross-session knowledge carry-over, a self-healing dashboard and 7 tools.
 ### Plugin Markets & Managers
 
 - [dsh-market/dsh-market](https://github.com/dsh-market/dsh-market) - (Recommended) The plugin market inside DSH: a Settings page to browse and search the full community catalog by category, with confirmed one-click installs and an installed-plugins view.

--- a/README.zh.md
+++ b/README.zh.md
@@ -572,6 +572,7 @@ dsh plugin --profile web add dshmarket
 - [swaylq/dsh-genie](https://github.com/swaylq/dsh-genie) — 把 agent 现场造出来的插件留下来：将 `cordis_define` 的动态包固化成能跨重启存活的正式插件，写包并注册 profile 层的全过程不用 pnpm、不联网、不需要构建授权。
 
 - [YZz-S/dsh-update-checker](https://github.com/YZz-S/dsh-update-checker) — 会话顶栏徽章：显示 DeepSeek Harness 当前版本，自动检查 npm 最新版本，有新版时提示升级。
+- [jorinyang/dsh-clawshell](https://github.com/jorinyang/dsh-clawshell) — 运行时自愈层：资源控制闭环（策略切换 + 修复升级链）、错误风暴与 fiber 失败洞察、跨会话知识传承，附自愈可视化面板与 7 个工具。
 ### 🛒 插件市场与管理
 
 - [dsh-market/dsh-market](https://github.com/dsh-market/dsh-market) — （推荐）装在 DSH 里的插件市场：设置页内逛/搜全部社区插件，按分类筛选，确认后一键安装，已装插件一目了然。


### PR DESCRIPTION
收录插件 dsh-clawshell。

## 插件简介
dsh-clawshell（https://github.com/jorinyang/dsh-clawshell，npm: dsh-clawshell）——把 ClawShell 愿景（自感知/自适应/自组织/多 Agent 集群）实现为 DeepSeek Harness 插件全家桶：

- **sense**：自感知 metrics 服务 + 事件驱动的时空拓扑感知
- **adapt**：控制论资源自愈闭环（鲁棒控制器 + 策略切换 + 修复升级链，可逆 effect）
- **swarm**：加权信任模型（威胁窗口 + 衰减 + 持久化）+ 生态位匹配
- **insight**：错误风暴 + fiber 失败监控 + 周期摘要 + 离线检测
- **genome**：跨会话版本化知识传承 + 进化里程碑 + LRU 缓存
- 7 个工具 + 自愈可视化面板（client slot）

## 变更
- README.md / README.zh.md 的「开发与运行时 / Development & Runtime」分类各加一行。