### PR TITLE
docs: add Vncntvx/dsh-zotero to Tools & Capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,6 +392,7 @@ dsh plugin --profile web add dshmarket
 - [kw78/dsh-office-tools](https://github.com/kw78/dsh-office-tools) - Workspace-safe Office tools for agents: create/read Word, create/read/update Excel, and create/read PowerPoint decks with PNG/JPG/GIF image placement.
 
 - [YZz-S/dsh-bili-summary](https://github.com/YZz-S/dsh-bili-summary) - Provides the bili_summary tool: Bilibili video metadata, subtitle timeline, and sharp-based frame capture with built-in error handling and graceful degradation.
+- [Vncntvx/dsh-zotero](https://github.com/Vncntvx/dsh-zotero) - Let agents search, read, and cite your local Zotero library: find papers, view notes and annotations, pull evidence by question, open the source document, and generate citations.
 ### Skills
 - [dhicoc/dsh-reverse-skill](https://github.com/dhicoc/dsh-reverse-skill) - Complete reverse-skill pack (85 SKILL.md) as a DeepSeek Harness Cordis plugin: reverse engineering, authorized pentesting and security-research skill router.
 - [dhicoc/dsh-wuyun-liuqi](https://github.com/dhicoc/dsh-wuyun-liuqi) - Complete wuyun-liuqi (five-evolutions-six-qi / 五运六气) Traditional Chinese Medicine skill pack as a DeepSeek Harness Cordis plugin: annual and guest-qi calculation, clinical pattern differentiation, and pathogenesis reasoning.

--- a/README.zh.md
+++ b/README.zh.md
@@ -393,6 +393,7 @@ dsh plugin --profile web add dshmarket
 - [kw78/dsh-office-tools](https://github.com/kw78/dsh-office-tools) — 面向 agent 的工作区安全 Office 工具集：创建/读取 Word、创建/读取/更新 Excel、创建/读取 PowerPoint，并支持 PNG/JPG/GIF 图片排版。
 
 - [YZz-S/dsh-bili-summary](https://github.com/YZz-S/dsh-bili-summary) — 提供 bili_summary 工具：B 站视频元数据、字幕时间轴与 sharp 切帧配图，内置错误处理与优雅降级。
+- [Vncntvx/dsh-zotero](https://github.com/Vncntvx/dsh-zotero) — 让 Agent 搜索、阅读并引用本地 Zotero 文献库：找文献、查看笔记与批注、按问题取证、打开原文、生成引用。
 ### 🧩 技能包
 - [dhicoc/dsh-reverse-skill](https://github.com/dhicoc/dsh-reverse-skill) — 完整 reverse-skill（85 个 SKILL.md）的 DeepSeek Harness 插件：逆向工程、授权渗透测试与安全研究的技能路由包。
 - [dhicoc/dsh-wuyun-liuqi](https://github.com/dhicoc/dsh-wuyun-liuqi) — 完整 wuyun-liuqi（五运六气）中医运气学技能包，封装为 DeepSeek Harness 插件：年度与客气推算、临床辨证、病机推演。


### PR DESCRIPTION
## What changed

Adds [Vncntvx/dsh-zotero](https://github.com/Vncntvx/dsh-zotero) to the **Tools & Capabilities** category in both English and Chinese lists.

The plugin lets agents search, read, and cite a local Zotero library: find papers, view notes and annotations, pull evidence by question, open the source document, and generate citations. It is read-only against the library, talks to Zotero's local API over loopback only, and includes no cloud dependency.

## Submission checklist

- [x] Repository declares `dsh.bundle.patch`
- [x] One matching line added to both `README.md` and `README.zh.md`
- [x] Descriptions are factual and non-marketing
- [x] Repository has the `dsh-plugin` topic
- [x] Published to npm as `dsh-zotero@0.1.0`
- [x] Official `@deepseek-ai/*` runtime packages are peer dependencies

## Verification

Local unit tests pass (vitest, mocked Zotero server); smoke run against the installed tarball reports `SMOKE PASS`. Locale parity maintained — site build parses 503 entries across both locales.