### PR TITLE
Add jorinyang/dsh-doctor to Development & Runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -573,6 +573,7 @@ dsh plugin --profile web add dshmarket
 
 - [YZz-S/dsh-update-checker](https://github.com/YZz-S/dsh-update-checker) - Conversation header badge showing the DeepSeek Harness version, checking npm for the latest release and prompting upgrades.
 - [jorinyang/dsh-clawshell](https://github.com/jorinyang/dsh-clawshell) - Self-healing runtime layer: a resource control loop with strategy switching and repair escalation, error-storm and fiber-failure insight, cross-session knowledge carry-over, a self-healing dashboard and 7 tools.
+- [jorinyang/dsh-doctor](https://github.com/jorinyang/dsh-doctor) - DSH environment diagnosis, graded repair with one-click rollback, and a runtime self-healing service.
 ### Plugin Markets & Managers
 
 - [dsh-market/dsh-market](https://github.com/dsh-market/dsh-market) - (Recommended) The plugin market inside DSH: a Settings page to browse and search the full community catalog by category, with confirmed one-click installs and an installed-plugins view.

--- a/README.zh.md
+++ b/README.zh.md
@@ -573,6 +573,7 @@ dsh plugin --profile web add dshmarket
 
 - [YZz-S/dsh-update-checker](https://github.com/YZz-S/dsh-update-checker) — 会话顶栏徽章：显示 DeepSeek Harness 当前版本，自动检查 npm 最新版本，有新版时提示升级。
 - [jorinyang/dsh-clawshell](https://github.com/jorinyang/dsh-clawshell) — 运行时自愈层：资源控制闭环（策略切换 + 修复升级链）、错误风暴与 fiber 失败洞察、跨会话知识传承，附自愈可视化面板与 7 个工具。
+- [jorinyang/dsh-doctor](https://github.com/jorinyang/dsh-doctor) — DSH 环境诊断、分级修复与一键回滚，附带运行时自愈服务。
 ### 🛒 插件市场与管理
 
 - [dsh-market/dsh-market](https://github.com/dsh-market/dsh-market) — （推荐）装在 DSH 里的插件市场：设置页内逛/搜全部社区插件，按分类筛选，确认后一键安装，已装插件一目了然。


### PR DESCRIPTION
## Summary / 概述

Adds **[@jorinyang/dsh-doctor](https://github.com/jorinyang/dsh-doctor)** to the Development & Runtime / 开发与运行时 category.

## Plugin / 插件

DSH 环境诊断、分级修复与一键回滚，附带运行时自愈服务。

- `dsh_doctor` — read-only diagnosis (9 categories: env, home, profile, config, bundles, mount, port, health, disk)
- `dsh_doctor_fix` — graded repair (safe/deps/full), every reversible change journaled
- `dsh_doctor_rollback` — LIFO rollback of a repair
- `dsh-doctor` runtime service — Cordis ctx.provide / ctx.on / ctx.effect for live self-healing

## Requirements check / 要求核对

- [x] Declares dsh.bundle manifest in package.json + cordis.patch.yml
- [x] Real, working code (published to npm: @jorinyang/dsh-doctor)
- [x] Actively maintained
- [x] Has dsh-plugin topic
- [x] Factual description, no superlatives
