### PR TITLE
Add dsh-premise-guard-cn

### DIFF
--- a/README.md
+++ b/README.md
@@ -612,6 +612,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 
 ### Memory
 
+- [111111AAA111111/dsh-premise-guard-cn](https://github.com/111111AAA111111/dsh-premise-guard-cn) - Chinese-aware premise-drift guard for novel/long-form writing: alarms when a compaction summary drops key premise anchors (Chinese quotes, title marks, term chains, codes, paths), with a manual anchor list, `premise_anchor` tool and `/anchor` command. Fork of ICCuse/dsh-premise-guard (MIT).
 - [863683348/dsh-plugin-focus](https://github.com/863683348/dsh-plugin-focus) - Focus board for DeepSeek Harness agents: durable, model-maintained notes in the session workspace that pin the objective, constraints, and decisions across compaction and sessions, with automatic context injection, archive on clear, and an optional web panel.
 - [aerince/dsh-active-context-pruning](https://github.com/aerince/dsh-active-context-pruning) - Model-authored context pruning for DeepSeek Harness through the official compaction API.
 - [Aik358/dsh-auto-memory](https://github.com/Aik358/dsh-auto-memory) - Cache-friendly three-layer memory for DSH: lean auto injection, per-turn AI consolidation, proactive calendar reminders and warm greetings, plus memory inheritance from other AI tools.

--- a/README.zh.md
+++ b/README.zh.md
@@ -612,6 +612,7 @@ dsh plugin --profile web add dshmarket
 
 ### 🧠 记忆
 
+- [111111AAA111111/dsh-premise-guard-cn](https://github.com/111111AAA111111/dsh-premise-guard-cn) — 中文前提锚点守卫（前提守卫）：面向中文小说/长文创作，压缩摘要丢失关键前提（中文引号/书名号/术语链/编号/路径锚点）时报警，支持手动锚点清单、premise_anchor 工具与 /anchor 命令。fork of ICCuse/dsh-premise-guard (MIT)。
 - [863683348/dsh-plugin-focus](https://github.com/863683348/dsh-plugin-focus) — 为 DeepSeek Harness agent 提供持久化专注板：在会话工作区维护目标、约束与决策笔记，跨压缩与会话存活，支持自动注入上下文、清空归档与可选 Web 面板。
 - [aerince/dsh-active-context-pruning](https://github.com/aerince/dsh-active-context-pruning) — 面向 DeepSeek Harness 的模型驱动上下文裁剪插件，通过官方 compaction API 释放上下文空间。
 - [Aik358/dsh-auto-memory](https://github.com/Aik358/dsh-auto-memory) — DSH 三层自动记忆引擎：缓存友好的精简注入与每轮 AI 自动沉淀，主动日历提醒与暖心问候，可继承其他 AI 工具的记忆。

--- a/data/plugins/111111AAA111111__dsh-premise-guard-cn.yml
+++ b/data/plugins/111111AAA111111__dsh-premise-guard-cn.yml
@@ -1,0 +1,6 @@
+url: https://github.com/111111AAA111111/dsh-premise-guard-cn
+name: 111111AAA111111/dsh-premise-guard-cn
+category: memory
+description:
+  en: 'Chinese-aware premise-drift guard for novel/long-form writing: alarms when a compaction summary drops key premise anchors (Chinese quotes, title marks, term chains, codes, paths), with a manual anchor list, `premise_anchor` tool and `/anchor` command. Fork of ICCuse/dsh-premise-guard (MIT).'
+  zh: 中文前提锚点守卫（前提守卫）：面向中文小说/长文创作，压缩摘要丢失关键前提（中文引号/书名号/术语链/编号/路径锚点）时报警，支持手动锚点清单、premise_anchor 工具与 /anchor 命令。fork of ICCuse/dsh-premise-guard (MIT)。


### PR DESCRIPTION
Adds the Chinese-aware premise-drift guard to the Memory section in both README.md and README.zh.md.`n`nThe plugin targets novel and long-form writing, with Chinese premise-anchor detection and an opt-in manual anchor registry.