### PR TITLE
Add dsh-qq2007-skin

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ dsh plugin --profile web add dshmarket
 - [xingyingyuzhui/dsh-liquid-glass](https://github.com/xingyingyuzhui/dsh-liquid-glass) - Wallpaper plus optional Liquid Glass islands for the DSH Web UI: Ice/Deepwater presets, import, wallpaper opacity, and per-island blur on official light/dark/system.
 - [caoyiwei850/dsh-client-ui-skins](https://github.com/caoyiwei850/dsh-client-ui-skins) - Skin plugin for the DSH Web UI: 4 built-in skins plus custom image skins with the photo as a full-interface background and the palette following its dominant hue.
 - [AKS1st/dsh-cyber-particle](https://github.com/AKS1st/dsh-cyber-particle) - Particle-network background overlay for the DSH Web shell: full-screen, click-through, zero runtime dependencies.
+- [LeemanCheung/dsh-qq2007-skin](https://github.com/LeemanCheung/dsh-qq2007-skin) - QQ 2007-inspired retro skin for the DSH Web GUI, with native theme tokens, scoped three-pane chrome, an original pixel buddy, and a reversible Settings switch.
 
 ### Models & Providers
 - [Noob-stupid/dsh-github-login](https://github.com/Noob-stupid/dsh-github-login) - Visual GitHub login without a terminal: in-window device flow, token synced into the gh CLI, and host status/launch endpoints.

--- a/README.zh.md
+++ b/README.zh.md
@@ -196,6 +196,7 @@ dsh plugin --profile web add dshmarket
 - [xingyingyuzhui/dsh-liquid-glass](https://github.com/xingyingyuzhui/dsh-liquid-glass) — DSH Web 液态玻璃皮肤：冰原/深水壁纸、可导入、壁纸透明度，以及叠在官方浅色/深色/跟随系统上的分岛模糊。
 - [caoyiwei850/dsh-client-ui-skins](https://github.com/caoyiwei850/dsh-client-ui-skins) — DSH Web 换肤插件：4 套内置皮肤 + 自定义图片皮肤，图片作为全界面背景，配色自动跟随图片主色调。
 - [AKS1st/dsh-cyber-particle](https://github.com/AKS1st/dsh-cyber-particle) — 为 DSH Web 界面提供粒子网络动态背景：全屏覆盖、点击穿透、零运行时依赖。
+- [LeemanCheung/dsh-qq2007-skin](https://github.com/LeemanCheung/dsh-qq2007-skin) — DSH Web GUI 的 QQ 2007 风格复古皮肤：原生主题 token、三栏窗框、原创像素伙伴及可在设置中恢复的开关。
 
 ### 🔌 模型与账号接入
 - [Noob-stupid/dsh-github-login](https://github.com/Noob-stupid/dsh-github-login) — 零终端的 GitHub 可视化登录插件：窗口内完成设备码授权，令牌同步进 gh CLI，附宿主端状态与唤起接口。


### PR DESCRIPTION
## Summary

Add `LeemanCheung/dsh-qq2007-skin` under **Themes & Appearance** in both language lists.

The plugin is a QQ 2007-inspired retro visual layer for the DSH Web GUI. It uses the native ThemeRuntime and Settings Slot APIs, keeps DSH controls intact, and ships only original artwork.

## Verification

- [x] Public repository with a root `dsh.bundle` manifest and `cordis.patch.yml`
- [x] `dsh-plugin` repository topic
- [x] Official `@deepseek-ai/*` packages declared as peer dependencies
- [x] `npm test` — deterministic build plus module/theme/startup/settings/lifecycle regression gate
- [x] `npm pack --dry-run`
- [x] Installed from `github:LeemanCheung/dsh-qq2007-skin#v0.1.0` into an isolated DSH `0.1.0-rc.6` Web profile; bundle appeared in `--dump-config`
- [x] Chromium integration: active token palette, scoped style/status DOM, General-settings row, and disable/re-enable cycle verified

The project is unofficial and unaffiliated with Tencent/QQ/DeepSeek. It includes no QQ logos, mascot art, historical icons, sounds, or theme files.