### PR TITLE
docs: add skr311/dsh-codex-pet to Just for Fun

### DIFF
--- a/README.md
+++ b/README.md
@@ -623,6 +623,7 @@ dsh plugin --profile web add dshmarket
 - [Awu12277/dsh-stock-watch](https://github.com/Awu12277/dsh-stock-watch) - A-share watchlist real-time market monitoring plugin: a collapsible popup in the top-right corner of the DeepSeek Harness (DSH) web interface for real-time quote monitoring, group switching, intraday and candlestick (K-line) charts, and buy/sell target price settings.
 - [sjh9714/clippy-harness#plugin](https://github.com/sjh9714/clippy-harness/tree/master/plugin) - Clippy is back and this time he can actually help. An office assistant pet that reacts to real agent state, jumps when the turn completes, and opens a classic "illegal operation" dialog when a turn fails.
 - [lucky8197/dsh-devquest](https://github.com/lucky8197/dsh-devquest) - Turns coding into an RPG: finished turns, tool calls and completed todos earn XP, with 27+ achievement badges, levels, titles and seasons. Event-driven scoring with a pure-function engine — the work itself is the game.
+- [skr311/dsh-codex-pet#dsh-codex-pet](https://github.com/skr311/dsh-codex-pet/tree/main/packages/dsh-codex-pet) - Import Codex-style sprite-sheet pets and render them as a floating shell.overlay with a pet library, interactions, and agent-state linkage.
 
 ## Contributing
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -623,6 +623,7 @@ dsh plugin --profile web add dshmarket
 - [Awu12277/dsh-stock-watch](https://github.com/Awu12277/dsh-stock-watch) — A 股自选股实时行情盯盘插件：在 DeepSeek Harness（DSH）Web 界面的右上角显示一个可折叠弹窗，实时监控自选股行情、切换分组、查看分时与 K 线、设置买卖目标价。
 - [sjh9714/clippy-harness#plugin](https://github.com/sjh9714/clippy-harness/tree/master/plugin) — 回形针助手回来了，这次它真的会干活：会对真实 agent 状态做出反应的办公助手宠物，任务完成时跳起来庆祝，回合失败时弹出经典的 "illegal operation" 对话框。
 - [lucky8197/dsh-devquest](https://github.com/lucky8197/dsh-devquest) — 把开发变成 RPG：回合/工具/todo 积累 XP、27+ 成就徽章、等级与赛季。事件流驱动、纯函数计分——你的工作就是游戏。
+- [skr311/dsh-codex-pet#dsh-codex-pet](https://github.com/skr311/dsh-codex-pet/tree/main/packages/dsh-codex-pet) — 导入/上传 Codex 风格精灵图序列帧宠物，在 DSH Web GUI 以悬浮浮层渲染，含图库管理、交互与 Agent 状态联动。
 
 ## 贡献
 


### PR DESCRIPTION
Add [skr311/dsh-codex-pet](https://github.com/skr311/dsh-codex-pet) (DSH desktop pet plugin) under **Just for Fun / 🎮 娱乐**, one line each in `README.md` and `README.zh.md`.

The plugin is a monorepo subpackage, so the entry links `packages/dsh-codex-pet` via `/tree/` (matching the existing `#subdir` convention), which also keeps the GitHub install command valid (`github:skr311/dsh-codex-pet#path:/packages/dsh-codex-pet`).

<!-- Quick checklist / 提交前快速自查 -->
- [x] My repo's `package.json` declares **`dsh.bundle`** (not just `dsh.client`) — 已声明 `bundle.patch` + `client.platform: web`
- [x] One line added to **both** `README.md` (English) and `README.zh.md` (中文), under the matching category — 两个语言文件各加一行，放在 Just for Fun / 🎮 娱乐
- [x] Description states what the plugin does, no superlatives — 描述只说功能
- [x] My repo has the `dsh-plugin` topic — 已打该 topic

**Recommended / 推荐（已满足）：**
- [x] Published to npm: `dsh-codex-pet@0.2.2` — 预构建产物免 `allowBuilds` 授权，用户一条命令 `dsh plugin --profile web add dsh-codex-pet`
- [x] 官方 `@deepseek-ai/*` 包用 `peerDependencies` 声明（本插件未依赖官方运行时包）
