### PR TITLE
Add dsh-commandcode-provider to Models & Providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ dsh plugin --profile web add dshmarket
 - [AKS1st/dsh-cyber-particle](https://github.com/AKS1st/dsh-cyber-particle) - Particle-network background overlay for the DSH Web shell: full-screen, click-through, zero runtime dependencies.
 
 ### Models & Providers
+- [Mars-Sea/dsh-commandcode-provider](https://github.com/Mars-Sea/dsh-commandcode-provider) - Unofficial Command Code LLM provider: registers a `commandcode` route with a live model catalog and reasoning-effort support.
 - [Noob-stupid/dsh-github-login](https://github.com/Noob-stupid/dsh-github-login) - Visual GitHub login without a terminal: in-window device flow, token synced into the gh CLI, and host status/launch endpoints.
 
 - [dylan121322/llm-adaptive](https://github.com/dylan121322/llm-adaptive) - Adaptive model routing: per-request complexity classification with automatic provider routing.

--- a/README.zh.md
+++ b/README.zh.md
@@ -198,6 +198,7 @@ dsh plugin --profile web add dshmarket
 - [AKS1st/dsh-cyber-particle](https://github.com/AKS1st/dsh-cyber-particle) — 为 DSH Web 界面提供粒子网络动态背景：全屏覆盖、点击穿透、零运行时依赖。
 
 ### 🔌 模型与账号接入
+- [Mars-Sea/dsh-commandcode-provider](https://github.com/Mars-Sea/dsh-commandcode-provider) — 非官方 Command Code 模型接入插件：注册 `commandcode` 路由，带实时模型目录与推理强度支持。
 - [Noob-stupid/dsh-github-login](https://github.com/Noob-stupid/dsh-github-login) — 零终端的 GitHub 可视化登录插件：窗口内完成设备码授权，令牌同步进 gh CLI，附宿主端状态与唤起接口。
 
 - [dylan121322/llm-adaptive](https://github.com/dylan121322/llm-adaptive) — 自适应模型路由：请求级复杂度分类，按配置链自动选择后端 provider。


### PR DESCRIPTION
## What

Adds [Mars-Sea/dsh-commandcode-provider](https://github.com/Mars-Sea/dsh-commandcode-provider) to the **Models & Providers** category in both `README.md` and `README.zh.md`.

## About the plugin

Unofficial DeepSeek Harness LLM provider plugin for **Command Code** (ported from [pi-commandcode-provider](https://github.com/patlux/pi-commandcode-provider), MIT). Registers a `commandcode` provider route on the `llm` service with a live model catalog and reasoning-effort support.

- Declares a `dsh.bundle` manifest (`dsh.bundle.patch` → `cordis.patch.yml`) — installable via `dsh plugin add`
- Published on npm: [`@mars-sea/dsh-commandcode-provider`](https://www.npmjs.com/package/@mars-sea/dsh-commandcode-provider)
- Official `@deepseek-ai/*` packages declared as `peerDependencies`
- `dsh-plugin` topic already added to the repo

## Checklist

- [x] `dsh.bundle` manifest declared in `package.json`
- [x] Real, working code (tests + CI)
- [x] `dsh-plugin` topic on the repo
- [x] One line in each of `README.md` and `README.zh.md`, pure factual description