### PR TITLE
Add ChuanTianML/dsh-local-share

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ dsh plugin --profile web add dshmarket
 - [dongsheng123132/task-passport](https://github.com/dongsheng123132/task-passport) - Carry durable task state across DeepSeek Harness, WorkBuddy, Claude Code and Codex with machine-readable checkpoints and optimistic locking.
 - [LeslieWylie/dsh-task-relay](https://github.com/LeslieWylie/dsh-task-relay) - Cross-session task queue with handoff notes: sessions and subagents push, claim, complete and cancel tasks on a shared file-backed queue, and leave a handoff summary for whoever picks up next.
 - [hellodigua/dsh-share](https://github.com/hellodigua/dsh-share) - Share your conversations with one click.
+- [ChuanTianML/dsh-local-share](https://github.com/ChuanTianML/dsh-local-share) - Export a complete Web Session to local Markdown or a self-contained HTML file, with preview-first redaction and opt-in bounded tool-call details.
 - [Moeblack/dsh-message-edit](https://github.com/Moeblack/dsh-message-edit) - Branch-based message editing, reroll, retry, and a version timeline.
 - [Buyi-wsgzg/dsh-sidechain](https://github.com/Buyi-wsgzg/dsh-sidechain) - `/side` persistent side sessions and `/btw` one-shot side questions, run in a temporary fork without touching main history.
 - [bill9109/dsh-conversation-share](https://github.com/bill9109/dsh-conversation-share) - Share any excerpt of a conversation.

--- a/README.zh.md
+++ b/README.zh.md
@@ -224,6 +224,7 @@ dsh plugin --profile web add dshmarket
 - [dongsheng123132/task-passport](https://github.com/dongsheng123132/task-passport) — 通过机器可读检查点与乐观锁，在 DeepSeek Harness、WorkBuddy、Claude Code 和 Codex 之间交接持久任务状态。
 - [LeslieWylie/dsh-task-relay](https://github.com/LeslieWylie/dsh-task-relay) — 跨会话任务队列与交接摘要：会话与子 agent 在共享的文件队列上投递、认领、完成、取消任务，并留下交接摘要供后续会话查看。
 - [hellodigua/dsh-share](https://github.com/hellodigua/dsh-share) — 一键分享你的对话。
+- [ChuanTianML/dsh-local-share](https://github.com/ChuanTianML/dsh-local-share) — 把完整 Web Session 导出为本地 Markdown 或自包含 HTML 文件，提供导出前预览、默认脱敏和可选的有界工具调用详情。
 - [Moeblack/dsh-message-edit](https://github.com/Moeblack/dsh-message-edit) — 基于分支的消息编辑、reroll、重试与版本时间线。
 - [Buyi-wsgzg/dsh-sidechain](https://github.com/Buyi-wsgzg/dsh-sidechain) — `/side` 持续性侧会话与 `/btw` 一次性侧问，在临时 fork 中运行、不写入主会话历史。
 - [bill9109/dsh-conversation-share](https://github.com/bill9109/dsh-conversation-share) — 分享任意段落的对话。


### PR DESCRIPTION
## What changed

Adds `ChuanTianML/dsh-local-share` to the Sessions & Messages category in both language indexes.

The description focuses on the installable behavior: complete Web Session export to local Markdown or self-contained HTML, preview-first redaction, and opt-in bounded tool-call details.

## Why

The project previously used the colliding `dsh-share` name. It has been renamed to the unique `dsh-local-share` identity so users and plugin-finding agents can distinguish it from the existing `hellodigua/dsh-share` entry and the several `dsh-session-export` projects.

The rename is merged in [ChuanTianML/dsh-local-share#1](https://github.com/ChuanTianML/dsh-local-share/pull/1), and the documented install target is published as [v0.2.0](https://github.com/ChuanTianML/dsh-local-share/releases/tag/v0.2.0).

## Validation

- `npm ci`
- `npx awesome-lint` (passes; the reported spelling warnings predate this entry)
- `node scripts/build-site.mjs` (`520 entries parsed across 2 locales`)

## Checklist

- [x] The plugin package declares `dsh.bundle` and includes working Host and Web code.
- [x] One line was added to both `README.md` and `README.zh.md` under Sessions & Messages.
- [x] The descriptions state behavior without superlatives.
- [x] The repository has the `dsh-plugin` topic.
- [x] Official `@deepseek-ai/*` packages are peer dependencies.
