### PR TITLE
Add PerryLink/dsh-plugin-guide under Skills / 技能包

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,6 +437,7 @@ dsh plugin --profile web add dshmarket
 - [GanyuanRan/Aegis](https://github.com/GanyuanRan/Aegis) - Software-engineering method pack for coding agents, with skills for baseline-first planning, systematic debugging, prompt hygiene, verification before completion, and repair/retirement tracking.
 - [superdesigndev/superdesign-skill](https://github.com/superdesigndev/superdesign-skill) - Design skill for UI and marketing graphics on the Superdesign canvas: reads the repo for context, extracts its design system, then generates and iterates branchable design drafts, flow pages, and reusable components through the Superdesign CLI.
 - [xsoc1/math-research-dsh](https://github.com/xsoc1/math-research-dsh) - Rigorous open mathematics research suite: four agent skills (rigorous-open-math-research, manage-math-research-program, math-research-workflow, lean-verify) for theorem solving with adversarial audit, research program management, pipeline orchestration, and Lean 4 formalization audit; CI-verified tests and mechanical upstream sync.
+- [PerryLink/dsh-plugin-guide](https://github.com/PerryLink/dsh-plugin-guide) - DeepSeek Harness plugin-development knowledge base: official constraints, task workflows, API references, and community pitfalls as an on-demand agent skill.
 ### Workflow & Automation
 
 - [ztl34245881-commits/dsh-task-planner](https://github.com/ztl34245881-commits/dsh-task-planner) - Task planning with experience muscle-memory: condition-reflex recall of past solutions, LLM capability matching, and auto-persisted lessons.

--- a/README.zh.md
+++ b/README.zh.md
@@ -437,6 +437,7 @@ dsh plugin --profile web add dshmarket
 - [PAKIKNOWLEDGE/dsh-notify-skill](https://github.com/PAKIKNOWLEDGE/dsh-notify-skill) — 你不在电脑前时由 agent 邮件提醒你：goal 完成、阻塞、向你提问决策前、长任务节点时触发，自带零依赖 Node SMTP 发送器。
 - [GanyuanRan/Aegis](https://github.com/GanyuanRan/Aegis) — 面向编码 Agent 的软件工程方法包，提供基线优先规划、系统化调试、提示词卫生、完成前验证，以及修复/退役双轨跟踪技能。
 - [superdesigndev/superdesign-skill](https://github.com/superdesigndev/superdesign-skill) — 在 Superdesign 画布上做 UI 与营销图的设计技能：先读代码库拿上下文、抽取现有设计系统，再通过 Superdesign CLI 生成并迭代可分支的设计稿、流程页与可复用组件。
+- [PerryLink/dsh-plugin-guide](https://github.com/PerryLink/dsh-plugin-guide) — DeepSeek Harness 插件开发知识库：官方约束、任务工作流、API 参考与社区踩坑，作为按需加载的智能体技能。
 - [xsoc1/math-research-dsh](https://github.com/xsoc1/math-research-dsh) — 严谨开放数学研究套件：4 个 agent skill（rigorous-open-math-research、manage-math-research-program、math-research-workflow、lean-verify），覆盖对抗性审计的定理求解、研究项目管理、流水线编排与 Lean 4 形式化审计；CI 测试与机械式上游同步。
 ### 🔁 工作流与自动化
 


### PR DESCRIPTION
Supersedes the auto-closed #461 (its head branch on the shared fork was clobbered by an unrelated submission and GitHub closed it).

Installs the dsh-plugin-guide plugin-development knowledge base as an on-demand agent skill (official docs, Cordis primer, community deep-dives, battle-tested pitfalls).

- Repo: https://github.com/PerryLink/dsh-plugin-guide
- Declares a full `dsh.bundle` manifest (`bundle.patch` -> root `cordis.patch.yml`) - installable via `dsh plugin add`; no browser UI, so no `dsh.client`.
- Topic `dsh-plugin` added; `@deepseek-ai/dsh` pinned as an optional peerDependency.
- Added one line to README.md (Skills) and README.zh.md (???) per contributing.md.