### PR TITLE
Add dsh-plugin-sentinel, dsh-windtunnel, dsh-remote-link (Development & Runtime)

### DIFF
--- a/README.md
+++ b/README.md
@@ -520,6 +520,9 @@ dsh plugin --profile web add dshmarket
 - [YZz-S/dsh-notifier](https://github.com/YZz-S/dsh-notifier) - System-native notifications when a task finishes or needs your confirmation: Windows toast, macOS osascript, and Linux notify-send.
 ### Development & Runtime
 
+- [BotonJ/dsh-plugin-sentinel](https://github.com/BotonJ/dsh-plugin-sentinel) - Static pre-install security auditor for plugin bundles: lifecycle scripts, dynamic execution, credential-exfiltration combos, and patch-layer hazards, with zero dependencies and in-memory tar parsing.
+- [BotonJ/dsh-windtunnel](https://github.com/BotonJ/dsh-windtunnel) - Contract regression harness for plugin authors: a scripted LLM adapter drives the real pipeline in isolated child processes with session-event assertions (load/contract/behavior/fault layers); zero API key, CI-ready.
+- [BotonJ/dsh-remote-link](https://github.com/BotonJ/dsh-remote-link) - Secure remote access for the official Web UI: authenticated LAN/tunnel gateway with QR + HMAC one-time pairing, per-device sessions and revocation, mDNS discovery, and a fork_session tool.
 - [Starfie1d1272/dsh-builtin-toggles](https://github.com/Starfie1d1272/dsh-builtin-toggles) - Evidence-backed inspector for DSH Web built-in capabilities: runtime/config provenance, compatibility and drift diagnostics, plus fail-closed controls for nine reviewed UI leaves.
 - [SaiSenBox/dsh-boot-guard](https://github.com/SaiSenBox/dsh-boot-guard) - Loader-independent startup recovery for DSH Web that detects likely broken plugins, temporarily skips them, and restores only Boot Guard-managed changes.
 - [leechen298/Code2Skill](https://github.com/leechen298/Code2Skill) - Generate Functions, MCP tools, workflow Skills, and offline test packages from user-authorized source code.

--- a/README.zh.md
+++ b/README.zh.md
@@ -520,6 +520,9 @@ dsh plugin --profile web add dshmarket
 - [YZz-S/dsh-notifier](https://github.com/YZz-S/dsh-notifier) — 任务完成或需要确认/输入时发送操作系统原生通知：Windows toast、macOS osascript、Linux notify-send。
 ### 🧑‍💻 开发与运行时
 
+- [BotonJ/dsh-plugin-sentinel](https://github.com/BotonJ/dsh-plugin-sentinel) — 插件安装前静态安全审计：生命周期脚本、动态执行、凭据外传组合特征与 patch 层风险；零依赖，tar 包全程内存解析不落盘。
+- [BotonJ/dsh-windtunnel](https://github.com/BotonJ/dsh-windtunnel) — 插件作者的契约回归风洞：剧本适配器在隔离子进程中驱动真实管线，会话事件断言覆盖加载/契约/行为/故障四层；零 API key，可进 CI。
+- [BotonJ/dsh-remote-link](https://github.com/BotonJ/dsh-remote-link) — 官方 Web UI 的安全远程接入：带认证的局域网/隧道网关，QR + HMAC 一次性配对、按设备吊销，mDNS 发现，附 fork_session 会话分叉工具。
 - [Starfie1d1272/dsh-builtin-toggles](https://github.com/Starfie1d1272/dsh-builtin-toggles) — DSH Web 内置 capability 的 evidence-backed 检查器：展示运行/配置溯源、兼容性与漂移诊断，并仅为 9 个经过审阅的 UI leaf 提供 fail-closed 控制。
 - [SaiSenBox/dsh-boot-guard](https://github.com/SaiSenBox/dsh-boot-guard) — 独立于常规客户端插件加载链的 DSH Web 启动救援工具，可定位疑似故障插件、临时跳过，并且只恢复 Boot Guard 写入的配置。
 - [leechen298/Code2Skill](https://github.com/leechen298/Code2Skill) — 从用户授权的源码生成 Function、MCP 工具、工作流 Skill 与离线测试包。


### PR DESCRIPTION
## Added plugins

All three declare a `dsh.bundle` manifest (`dsh: { bundle: { patch: "./cordis.patch.yml" } }`) with a root `cordis.patch.yml`, per the contribution requirements.

| Plugin | What it does | Verification |
|---|---|---|
| [dsh-plugin-sentinel](https://github.com/BotonJ/dsh-plugin-sentinel) | Static pre-install security audit for plugin bundles (lifecycle scripts, dynamic execution, exfiltration combos, patch-layer hazards). Zero deps, in-memory tar parsing. | 27/27 unit tests; real-model double-blind test (malicious fixture → block verdict); installed and loaded in dsh 0.1.0-rc.6 |
| [dsh-windtunnel](https://github.com/BotonJ/dsh-windtunnel) | Contract regression harness for plugin authors: scripted LLM adapter drives the real pipeline in isolated child processes; session-event assertions (load/contract/behavior/fault + concurrency). | 10/10 dogfood suite against sentinel (first run caught 2 real contract violations); engine self-tests 9/9 |
| [dsh-remote-link](https://github.com/BotonJ/dsh-remote-link) | Authenticated remote gateway for the official Web UI: QR + HMAC one-time pairing, per-device sessions/revocation, mDNS, plus a fork_session tool. | 87/87 tests; end-to-end verified over LAN and a public tunnel (phone pairing → official UI) |

Lines added to both `README.md` and `README.zh.md` under **Development & Runtime** / **开发与运行时**.

Happy to adjust descriptions or categories if maintainers see a better fit.