### PR TITLE
Add dsh-file-upload: Claude-style file upload + MarkItDown document conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ dsh plugin --profile web add dshmarket
 - [GLFzr/dsh-drop-file-to-path](https://github.com/GLFzr/dsh-drop-file-to-path) - Codex-style drag-drop: drag any file into the DSH web GUI, it lands in ~/.dsh-dropbox, and the path is inserted into the composer as a whole blue chip.
 - [taxueseek/dsh-files](https://github.com/taxueseek/dsh-files) - File upload with color-coded attachment cards (session-isolated storage, sha256 dedup, TTL sweep) plus a content-sniffing read_document tool for PDF/DOCX/XLSX/TXT.
 - [l541402398/dsh-file-uploads](https://github.com/l541402398/dsh-file-uploads) - Upload arbitrary local files from the Web composer, show pending cards, and manage stored files in Settings.
+- [HongMing-Huang/dsh-file-upload](https://github.com/HongMing-Huang/dsh-file-upload) - Claude-style drag-and-drop/paperclip file upload with content sniffing, document-to-Markdown via Microsoft MarkItDown (built-in JS fallback), text inlining, and a read_document tool for agents.
 - [qyw233/dsh-deeplink](https://github.com/qyw233/dsh-deeplink) - Deep links: open a specific session or workspace via `?session=` / `?workspace=`.
 - [lehhair/dsh-diff-viewer](https://github.com/lehhair/dsh-diff-viewer) - PiUI-style diff viewer replacing the stock DiffBlock for write/edit tool calls.
 - [omdsh-dev/ex-setting](https://github.com/omdsh-dev/ex-setting) - Settings extensions for DSH.

--- a/README.zh.md
+++ b/README.zh.md
@@ -102,6 +102,7 @@ dsh plugin --profile web add dshmarket
 - [GLFzr/dsh-drop-file-to-path](https://github.com/GLFzr/dsh-drop-file-to-path) — Codex 式拖拽：把任意文件拖入 DSH Web 界面，文件存入 ~/.dsh-dropbox，路径以整块蓝色 chip 插入输入框。
 - [taxueseek/dsh-files](https://github.com/taxueseek/dsh-files) — 文件上传（彩色附件卡片、会话隔离存储、sha256 去重、TTL 清扫）+ 内容嗅探的 read_document 文档读取（PDF/DOCX/XLSX/TXT）。
 - [l541402398/dsh-file-uploads](https://github.com/l541402398/dsh-file-uploads) — 从 Web 输入框上传任意本地文件，以待发送卡片展示，并在设置中管理已存文件。
+- [HongMing-Huang/dsh-file-upload](https://github.com/HongMing-Huang/dsh-file-upload) — Claude 风格拖拽/回形针文件上传：内容嗅探、文档转 Markdown（微软 MarkItDown，内置 JS 兜底）、文本直插输入框、read_document 工具。
 - [qyw233/dsh-deeplink](https://github.com/qyw233/dsh-deeplink) — `?session=` / `?workspace=` 深链直达指定项目对话。
 - [lehhair/dsh-diff-viewer](https://github.com/lehhair/dsh-diff-viewer) — PiUI 风格 diff 查看器，替换 write/edit 工具调用的默认 DiffBlock。
 - [omdsh-dev/ex-setting](https://github.com/omdsh-dev/ex-setting) — DSH 的设置扩展。


### PR DESCRIPTION
## What

Adds [HongMing-Huang/dsh-file-upload](https://github.com/HongMing-Huang/dsh-file-upload) to the **UI Enhancements** category (both README.md and README.zh.md).

## Plugin summary

A dual-face DeepSeek Harness bundle:

- **Claude-style upload**: composer paperclip button + global drag-and-drop overlay (release-to-attach), multi-file support
- **Content sniffing** that never trusts extensions: text / PDF / DOCX / XLSX / image / archive / binary
- **Text inlining**: small text files (code/JSON/CSV/logs) land straight in the composer via the official `slash/input-insert-text` event
- **Document → Markdown, out of the box**: bundled [markitdown-node](https://www.npmjs.com/package/markitdown-node) engine (Microsoft MarkItDown TypeScript port, 20+ formats incl. PDF/DOCX/PPTX/XLSX/HTML/CSV/JSON/ZIP/Jupyter, image OCR via Tesseract) — zero external tooling; the official MarkItDown CLI is auto-detected when present for extra formats (audio transcription, EPUB)
- **read_document tool** for agents: paged reads via `ctx.fs`, byte-budgeted LRU cache, size pre-checks
- **Security**: loopback-only uploads, sanitized names, session-isolated storage, sha256 dedup, TTL sweep

Verified against dsh 0.1.0-rc.6: installs via `dsh plugin add`, zero official patches (all official seams: `ctx.webServer` / `ctx.tools` / `ctx.systemPrompt` / `slash/input-insert-text`), 28 tests green.

## Checklist

- [x] Added one line in README.md (English)
- [x] Added one line in README.zh.md (中文)
- [x] Repo has the `dsh-plugin` topic