### PR TITLE
Add dsh-md2pdf: Markdown to print-friendly PDF plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,7 @@ dsh plugin --profile web add dshmarket
 
 - [Aik358/dsh-auto-memory](https://github.com/Aik358/dsh-auto-memory) - Auto-memory for DSH: three-layer memory (user / project notes / daily logs) with automatic injection, per-turn auto-consolidation, AI greetings, smart search, a calendar view and a settings page, plus inheritance of other AI tools' memories.
 ### Tools & Capabilities
+- [Raymond-Leung7/dsh-md2pdf](https://github.com/Raymond-Leung7/dsh-md2pdf) - Markdown → print-friendly PDF (A4/CJK fonts/tables with repeated headers) via the md_to_pdf model tool
 - [moononnn/DeepSeek-Harness-biaoqingbao](https://github.com/moononnn/DeepSeek-Harness-biaoqingbao) - Sticker/emoji expression for assistants: emotion-driven auto-matching, library management, AI image tagging, dialects, style mimicry, and chat-based tag refinement.
 - [x2802490130-prog/dsh-tool-writing](https://github.com/x2802490130-prog/dsh-tool-writing) - A web-novel writing engine for DeepSeek Harness: parallel drafting, outlining and brainstorming with a separate DeepSeek key, lore and foreshadowing management, semantic vector retrieval, a corpus library, usage ledger, mechanical proofreading, and a local serialization plan.
 - [x2802490130-prog/dsh-writing-remote](https://github.com/x2802490130-prog/dsh-writing-remote) - Host-side Typert remote for dsh-tool-writing: serves project volumes, chapter status, corpus library, full-text search, evolution entries, and thread-graph data to the client writing panel.


### PR DESCRIPTION
## 新增插件：Raymond-Leung7/dsh-md2pdf

DSH 插件：把 Markdown 文件转换为**打印友好的 PDF**，提供 `md_to_pdf` 模型工具。

- 仓库：https://github.com/Raymond-Leung7/dsh-md2pdf
- 话题：`dsh-plugin`
- 安装：`dsh plugin --profile web add "github:Raymond-Leung7/dsh-md2pdf"`

### 功能

- 默认 A4，自动中文字体（SimHei / SimSun / 微软雅黑），符号回退 Segoe UI Symbol
- 表格跨页自动重复表头、按内容分配列宽
- 支持标题/段落/列表/引用/代码块/表格/图片及粗体斜体行内样式
- 每页底部页码，页眉显示文档标题，纯本地转换

### 已验证

- 渲染器 6/6 用例：空文件、纯文本、复杂文档、长表格跨页、超长单元格、大量段落
- 参数组合 5/5：A5 横版、Letter、字号/边距、中文标题、紧凑组合
- 工具端 5/5：全参数转换、缺省参数推导、错误路径、render 输出、schema 完整性

归类于 **Tools & Capabilities**。
