### PR TITLE
docs: add dsh-digipet (Just for Fun)

### DIFF
--- a/README.md
+++ b/README.md
@@ -674,6 +674,7 @@ dsh plugin --profile web add dshmarket
 - [sjh9714/clippy-harness#plugin](https://github.com/sjh9714/clippy-harness/tree/master/plugin) - Clippy is back and this time he can actually help. An office assistant pet that reacts to real agent state, jumps when the turn completes, and opens a classic "illegal operation" dialog when a turn fails.
 - [lucky8197/dsh-devquest](https://github.com/lucky8197/dsh-devquest) - Turns coding into an RPG: finished turns, tool calls and completed todos earn XP, with 27+ achievement badges, levels, titles and seasons. Event-driven scoring with a pure-function engine — the work itself is the game.
 - [skr311/dsh-codex-pet#dsh-codex-pet](https://github.com/skr311/dsh-codex-pet/tree/main/packages/dsh-codex-pet) - Import Codex-style sprite-sheet pets and render them as a floating shell.overlay with a pet library, interactions, and agent-state linkage.
+- [swaylq/dsh-digipet](https://github.com/swaylq/dsh-digipet) - Digimon-style raising game: hatch an egg that feeds on real work (turns, tool calls, errors) and evolves along four branching lines shaped by how you work; zero tokens, invisible to the model.
 
 ## Contributing
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -674,6 +674,7 @@ dsh plugin --profile web add dshmarket
 - [sjh9714/clippy-harness#plugin](https://github.com/sjh9714/clippy-harness/tree/master/plugin) — 回形针助手回来了，这次它真的会干活：会对真实 agent 状态做出反应的办公助手宠物，任务完成时跳起来庆祝，回合失败时弹出经典的 "illegal operation" 对话框。
 - [lucky8197/dsh-devquest](https://github.com/lucky8197/dsh-devquest) — 把开发变成 RPG：回合/工具/todo 积累 XP、27+ 成就徽章、等级与赛季。事件流驱动、纯函数计分——你的工作就是游戏。
 - [skr311/dsh-codex-pet#dsh-codex-pet](https://github.com/skr311/dsh-codex-pet/tree/main/packages/dsh-codex-pet) — 导入/上传 Codex 风格精灵图序列帧宠物，在 DSH Web GUI 以悬浮浮层渲染，含图库管理、交互与 Agent 状态联动。
+- [swaylq/dsh-digipet](https://github.com/swaylq/dsh-digipet) — 数码宝贝式养成：孵一颗吃真实工作长大的蛋（回合、工具调用、报错都是营养），按你的工作方式走四条进化分支；零 token，模型完全看不见。
 
 ## 贡献
 


### PR DESCRIPTION
Adds **dsh-digipet** to Just for Fun (both README.md and README.zh.md).

**What it is**: a Digimon-style raising game — `/pet hatch` lays an egg that feeds on the agent's real work (completed turns, tool calls, user messages, even errors) and evolves through the full classic stage chain (Egg → Baby Ⅰ → Baby Ⅱ → Child → Adult → Perfect → Ultimate) across a 22-slot dex, along four lineages (dragon / sage / angel / virus) chosen by which stat dominated the stage — plus a hidden care-mistake line for those who evolve on a stuffed belly. One pet per DSH home, persisted across sessions; old saves migrate automatically.

**Why it's distinct from existing pets**: the 20+ desktop pets on the list are state mirrors or skins (whale-girl being the deepest with XP titles). dsh-digipet is the first *raising game*: hatching, stage evolution, and work-profile-driven branching. It is also deliberately zero-cost: no model-facing tool, no context injection, no client half — four event taps and one slash command.

**Checklist**:
- [x] `package.json` declares `dsh.bundle` (`{"bundle": {"patch": "./cordis.patch.yml"}}`) — installable via `dsh plugin --profile web add github:swaylq/dsh-digipet`
- [x] `dsh-plugin` topic added
- [x] One line in each of README.md / README.zh.md, matching separators (` - ` / ` — `)
- [x] Verified on dsh `0.1.0-rc.6` (macOS, web profile): install → boot → command dispatch → real-event feeding → hatch ceremony → cross-restart save migration; 42 unit/integration tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
