### PR TITLE
Add dsh-subscribe ? Steam-style plugin marketplace (in-DSH storefront, CLI, agent tools)

### DIFF
--- a/README.md
+++ b/README.md
@@ -629,6 +629,7 @@ dsh plugin --profile web add dshmarket
 ### Plugin Markets & Managers
 
 - [dsh-market/dsh-market](https://github.com/dsh-market/dsh-market) - (Recommended) The plugin market inside DSH: a Settings page to browse and search the full community catalog by category, with confirmed one-click installs and an installed-plugins view.
+- [zoahdev/dsh-subscribe](https://github.com/zoahdev/dsh-subscribe/tree/main/plugin) - Steam-style plugin marketplace: 536-plugin registry, in-DSH one-click install/uninstall/update, zero-dependency CLI, and agent market tools.
 - [Sanqi-normal/dsh-webui-market-plugin](https://github.com/Sanqi-normal/dsh-webui-market-plugin) - In-harness plugin market for the dsh web GUI: browse the awesome-dsh-plugin.com catalog and install/uninstall plugins into a profile from Settings → Plugins → Plugin Market.
 - [whyihaveyou/dsh-suite#plugin-manager](https://github.com/whyihaveyou/dsh-suite/tree/main/packages/plugins/plugin-manager) - In-app plugin store for the DSH Web UI: browse, search, one-click install, compat badges.
 - [loguhan/dsh-workshop](https://github.com/loguhan/dsh-workshop) - Steam Workshop-style plugin store for the DSH Web UI: browse, search, and one-click install community plugins with mirror acceleration, progress UI, security checks, and Chinese descriptions.

--- a/README.zh.md
+++ b/README.zh.md
@@ -629,6 +629,7 @@ dsh plugin --profile web add dshmarket
 ### 🛒 插件市场与管理
 
 - [dsh-market/dsh-market](https://github.com/dsh-market/dsh-market) — （推荐）装在 DSH 里的插件市场：设置页内逛/搜全部社区插件，按分类筛选，确认后一键安装，已装插件一目了然。
+- [zoahdev/dsh-subscribe](https://github.com/zoahdev/dsh-subscribe/tree/main/plugin) ? Steam ??????536 ??????DSH ?????/??/?????? CLI ?????????
 - [Sanqi-normal/dsh-webui-market-plugin](https://github.com/Sanqi-normal/dsh-webui-market-plugin) — dsh Web GUI 内的社区插件市场：浏览 awesome-dsh-plugin.com 目录，从 设置 → 插件 → 插件市场 安装/卸载插件到 profile。
 - [whyihaveyou/dsh-suite#plugin-manager](https://github.com/whyihaveyou/dsh-suite/tree/main/packages/plugins/plugin-manager) — DSH Web UI 内置插件商店：浏览、搜索、一键安装、兼容性徽章。
 - [loguhan/dsh-workshop](https://github.com/loguhan/dsh-workshop) — DSH Web UI 的 Steam 创意工坊式插件商店：浏览、搜索并一键安装社区插件，支持镜像加速、进度 UI、安全检测与中文描述。


### PR DESCRIPTION
Adds [dsh-subscribe](https://github.com/zoahdev/dsh-subscribe/tree/main/plugin) under **Plugin Markets & Managers**:

- 536-plugin registry (awesome-dsh-plugin mirror + 20 verified entries)
- in-DSH storefront at `/dsh-subscribe/`: one-click install/uninstall/update, build-script approval, live progress
- zero-dependency CLI (`sync`, `--dry-run`, `--json`)
- agent tools: `market_search` / `market_stats` / `market_install_command`

Subpackage `plugin/` declares `dsh.bundle` (cordis.patch.yml) and is installable via `dsh plugin add github:zoahdev/dsh-subscribe#path:/plugin`. CI-green: registry contract ? CLI e2e ? packed runtime tool invocation ? fresh DSH profile boot + real one-click install via HTTP.