### PR TITLE
Add dsh-llm-newapi

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ dsh plugin --profile web add dshmarket
 - [YZz-S/dsh-billing-balance](https://github.com/YZz-S/dsh-billing-balance) - Shows DeepSeek API account balance and Volcengine Ark Coding/Agent Plan quota windows (5h/weekly/monthly with reset countdowns) in the settings panel, composer dock, and a draggable floating refresh button.
 - [jyh20030112/dsh-visual-plugin](https://github.com/jyh20030112/dsh-visual-plugin) - Gives text-only models vision: forwards user images to an OpenAI-compatible vision model and shows the descriptions in a Web UI right panel.
 - [jiay98528-dev/dsh-model-sync](https://github.com/jiay98528-dev/dsh-model-sync) - Syncs live provider model lists into DSH settings and shows 5h/7d quota rings for the current session model.
+- [wenzetan/dsh-llm-newapi](https://github.com/wenzetan/dsh-llm-newapi) - NewAPI (OpenAI-compatible gateway) LLM provider: registers a `newapi` route with chat-only model discovery, auto-fills model parameters (context window, reasoning effort) from models.dev, and adds a Web settings section for the base URL and API key.
 ### Sessions & Messages
 
 - [HuiHuitie-zhu/dsh-incognito](https://github.com/HuiHuitie-zhu/dsh-incognito) - Incognito sessions: a standalone ephemeral sub-agent with its own preset (no parent context) and full toolset, draggable floating window, burned to zero traces on close.

--- a/README.zh.md
+++ b/README.zh.md
@@ -229,6 +229,7 @@ dsh plugin --profile web add dshmarket
 - [YZz-S/dsh-billing-balance](https://github.com/YZz-S/dsh-billing-balance) — 在设置页、输入框下方读数条与可拖动悬浮按钮三处显示 DeepSeek 官方 API 余额与火山方舟 Coding/Agent Plan 套餐额度（5小时/周/月窗口及重置倒计时）。
 - [jyh20030112/dsh-visual-plugin](https://github.com/jyh20030112/dsh-visual-plugin) — 给纯文本模型装上眼睛：把用户图片转发给任意 OpenAI 兼容的视觉模型生成描述，并在 Web UI 右侧面板展示结果。
 - [jiay98528-dev/dsh-model-sync](https://github.com/jiay98528-dev/dsh-model-sync) — 把各提供方线上模型列表同步进 DSH 设置，并在输入框旁显示当前会话模型的 5 小时/7 天额度圆环。
+- [wenzetan/dsh-llm-newapi](https://github.com/wenzetan/dsh-llm-newapi) — NewAPI（OpenAI 兼容网关）模型接入：注册 `newapi` 路由，仅发现聊天类模型，自动从 models.dev 获取模型参数（上下文窗口、思考强度等）并填充，并在 Web 设置页配置 base URL 与 API Key。
 ### 💬 会话与消息
 
 - [HuiHuitie-zhu/dsh-incognito](https://github.com/HuiHuitie-zhu/dsh-incognito) — 无痕会话：独立临时子 Agent（独立 preset 不继承父会话、全量工具集），浮窗可拖动，关闭即焚毁、磁盘零痕迹。


### PR DESCRIPTION
Adds [wenzetan/dsh-llm-newapi](https://github.com/wenzetan/dsh-llm-newapi) under **Models & Providers** (both language files).

An LLM provider plugin that connects a NewAPI (OpenAI-compatible gateway) instance to DeepSeek Harness, with zero modifications to dsh itself.

Highlights:
- Registers a `newapi` LLM route implementing the `LlmAdapter` seam (`/chat/completions` + `/models`)
- Chat-only model discovery, so completion/embedding-only entries don't clutter the model picker
- Fetches model parameters from [models.dev](https://models.dev) and fills them in automatically (context window, reasoning effort, etc.)
- A "NewAPI" section in the Web settings panel where the API key and base URL are configured — never read from environment variables
- Declares `dsh.bundle` — installable via `dsh plugin --profile web add dsh-llm-newapi` (published on npm)

Checklist:
- [x] One line added to `README.md` (EN)
- [x] One line added to `README.zh.md` (中文)
- [x] Repo has the `dsh-plugin` GitHub topic
- [x] Declares `dsh.bundle` manifest