### PR TITLE
docs: add dynamic-schulte-dsh (Just for Fun)

### DIFF
--- a/README.md
+++ b/README.md
@@ -686,6 +686,7 @@ dsh plugin --profile web add dshmarket
 - [lucky8197/dsh-devquest](https://github.com/lucky8197/dsh-devquest) - Turns coding into an RPG: finished turns, tool calls and completed todos earn XP, with 27+ achievement badges, levels, titles and seasons. Event-driven scoring with a pure-function engine — the work itself is the game.
 - [skr311/dsh-codex-pet#dsh-codex-pet](https://github.com/skr311/dsh-codex-pet/tree/main/packages/dsh-codex-pet) - Import Codex-style sprite-sheet pets and render them as a floating shell.overlay with a pet library, interactions, and agent-state linkage.
 - [swaylq/dsh-digipet](https://github.com/swaylq/dsh-digipet) - Digimon-style raising game: hatch an egg that feeds on real work (turns, tool calls, errors) and evolves along four branching lines shaped by how you work; zero tokens, invisible to the model.
+- [marvin9551/dynamic-schulte-dsh](https://github.com/marvin9551/dynamic-schulte-dsh) - Dynamic Schulte grid waiting-time mini-game: click 1..N in order on a static grid or a spinning roulette wheel while the model thinks.
 
 ## Contributing
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -686,6 +686,7 @@ dsh plugin --profile web add dshmarket
 - [lucky8197/dsh-devquest](https://github.com/lucky8197/dsh-devquest) — 把开发变成 RPG：回合/工具/todo 积累 XP、27+ 成就徽章、等级与赛季。事件流驱动、纯函数计分——你的工作就是游戏。
 - [skr311/dsh-codex-pet#dsh-codex-pet](https://github.com/skr311/dsh-codex-pet/tree/main/packages/dsh-codex-pet) — 导入/上传 Codex 风格精灵图序列帧宠物，在 DSH Web GUI 以悬浮浮层渲染，含图库管理、交互与 Agent 状态联动。
 - [swaylq/dsh-digipet](https://github.com/swaylq/dsh-digipet) — 数码宝贝式养成：孵一颗吃真实工作长大的蛋（回合、工具调用、报错都是营养），按你的工作方式走四条进化分支；零 token，模型完全看不见。
+- [marvin9551/dynamic-schulte-dsh](https://github.com/marvin9551/dynamic-schulte-dsh) — 动态舒尔特方格等待小游戏：模型思考时，在静态网格或旋转轮盘上按顺序点击 1..N，边玩边等。
 
 ## 贡献
 


### PR DESCRIPTION
Adds **dynamic-schulte-dsh** to Just for Fun (both README.md and README.zh.md).

**What it is**: a dynamic Schulte-grid waiting-time mini-game for the DSH Web UI. It opens in the sidebar while the model is thinking — click 1..N in order on a static n×n grid (3×3–7×7) or on a spinning concentric roulette wheel with adjustable speed. History and settings persist in browser localStorage; no backend and no model involvement.

**Checklist**:

- `package.json` declares `dsh.bundle` (`{"bundle": {"patch": "./cordis.patch.yml"}}`) — installable via `dsh plugin --profile <name> add -w /path/to/dynamic-schulte-dsh`
- `dsh-plugin` topic added
- One line in each of README.md / README.zh.md, matching separators (`-` / `—`)

---

**Also fixes** the corrupted Chinese entry for `zoahdev/dsh-subscribe` in README.zh.md (its description and separator were garbled into `?`, which broke the site build's README locale parity check for every PR). Restored a translation of the English description and the em-dash separator.
