### PR TITLE
Add klarkxy/dsh-plugin-autoevo to Tools & Capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -657,6 +657,7 @@ dsh plugin --profile web add dshmarket
 - [buhuikongpan/dsh-pluginmanager](https://github.com/buhuikongpan/dsh-pluginmanager) - Layered plugin manager for DSH web: native plugins grouped read-only by system/WebUI/tools, user extensions with enable/disable, register, uninstall and editable descriptions.
 - [cynch18/plugin-switch](https://github.com/cynch18/plugin-switch) - Toggle switches for the plugin inventory: enable/disable any plugin live from Settings → Plugins → Plugin list without restarting, with groups/filters, bulk toggle, undo, and backup.
 - [LKMeng2001/dsh-mcp-market](https://github.com/LKMeng2001/dsh-mcp-market) - MCP server marketplace for DSH: browse a curated, npm-verified catalog and install MCP servers into the current profile with one click, live without restart.
+- [klarkxy/dsh-plugin-autoevo](https://github.com/klarkxy/dsh-plugin-autoevo) - Resolves local tools and skills first, then searches, reviews and installs a community plugin after a one-time approval.
 
 ### Just for Fun
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -657,6 +657,7 @@ dsh plugin --profile web add dshmarket
 - [buhuikongpan/dsh-pluginmanager](https://github.com/buhuikongpan/dsh-pluginmanager) — DSH 分层插件管理器：原生插件按系统/WebUI/工具三层只读展示，用户扩展支持停用/启用、补登记、卸载与可编辑描述。
 - [cynch18/plugin-switch](https://github.com/cynch18/plugin-switch) — 插件清单页滑块开关：在设置 → 插件 → 插件清单实时启用/停用任意插件，无需重启；支持分组/筛选、批量开关、撤销与自动备份。
 - [LKMeng2001/dsh-mcp-market](https://github.com/LKMeng2001/dsh-mcp-market) — DSH 的 MCP 服务器商场：浏览经过 npm 校验的精选目录，一键安装 MCP 服务器到当前 profile，免重启立即生效。
+- [klarkxy/dsh-plugin-autoevo](https://github.com/klarkxy/dsh-plugin-autoevo) — 先检查本地工具与技能，不够用再搜索、审查社区插件，并在一次性批准后自动安装。
 
 ### 🎮 娱乐
 


### PR DESCRIPTION
## What this adds

Adds [klarkxy/dsh-plugin-autoevo](https://github.com/klarkxy/dsh-plugin-autoevo) under **Tools & Capabilities / 工具与能力**.

AutoEvo is a reuse-first capability evolution layer for DSH Agents. When the current task needs a missing capability, it follows this workflow:

`Resolve local → Discover → Review exact snapshot → Approve → Install → Verify → Adapt partial matches`

Instead of immediately rebuilding from scratch, it:

- checks already-visible tools, model-invocable Skills, and tool-search bridges first;
- discovers community DSH plugins only after a local miss;
- binds review evidence to an exact GitHub commit or local content snapshot;
- requires one-time approval before installation or removal;
- observes a real target-tool call/result round trip and task output in an isolated trial;
- minimally adapts and re-reviews partial-fit candidates before reuse.

This is why the entry belongs under **Tools & Capabilities**, rather than **Plugin Markets & Managers**: AutoEvo provides an Agent capability workflow, not a storefront or settings-page package manager.

## Verification

- `package.json` declares `dsh.bundle.patch` as `./cordis.patch.yml`.
- Official `@deepseek-ai/*` packages are peer dependencies.
- The repository has the `dsh-plugin` topic.
- Current lint, typecheck, unit/integration tests, build, and Cordis Loader smoke pass.
- Isolated local, full-fit GitHub, and partial-fit adaptation flows have been exercised through real DSH child processes, including tool call/result observation and cleanup.

## Checklist

- [x] My repo's `package.json` declares **`dsh.bundle`** (not just `dsh.client`)
- [x] One line added to **both** `README.md` and `README.zh.md` under the matching category
- [x] Description states what the plugin does, with no superlatives
- [x] My repo has the `dsh-plugin` topic
