### PR TITLE
Add dsh-mcp-market to Plugin Markets & Managers

### DIFF
--- a/README.md
+++ b/README.md
@@ -655,6 +655,7 @@ dsh plugin --profile web add dshmarket
 - [liqichen/dsh-plugin-manager](https://github.com/liqichen/dsh-plugin-manager) - GUI in the DSH settings panel: toggle/delete MCP servers, browse and trash skills, and list built-in plugin packages — hot-applied without restart.
 - [buhuikongpan/dsh-pluginmanager](https://github.com/buhuikongpan/dsh-pluginmanager) - Layered plugin manager for DSH web: native plugins grouped read-only by system/WebUI/tools, user extensions with enable/disable, register, uninstall and editable descriptions.
 - [cynch18/plugin-switch](https://github.com/cynch18/plugin-switch) - Toggle switches for the plugin inventory: enable/disable any plugin live from Settings → Plugins → Plugin list without restarting, with groups/filters, bulk toggle, undo, and backup.
+- [LKMeng2001/dsh-mcp-market](https://github.com/LKMeng2001/dsh-mcp-market) - MCP server marketplace for DSH: browse a curated, npm-verified catalog and install MCP servers into the current profile with one click, live without restart.
 
 ### Just for Fun
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -655,6 +655,7 @@ dsh plugin --profile web add dshmarket
 - [liqichen/dsh-plugin-manager](https://github.com/liqichen/dsh-plugin-manager) — 在 DSH 设置面板内嵌的图形化管理器：开关/删除 MCP 服务、浏览并回收 Skills、查看内置插件包，改动热生效无需重启。
 - [buhuikongpan/dsh-pluginmanager](https://github.com/buhuikongpan/dsh-pluginmanager) — DSH 分层插件管理器：原生插件按系统/WebUI/工具三层只读展示，用户扩展支持停用/启用、补登记、卸载与可编辑描述。
 - [cynch18/plugin-switch](https://github.com/cynch18/plugin-switch) — 插件清单页滑块开关：在设置 → 插件 → 插件清单实时启用/停用任意插件，无需重启；支持分组/筛选、批量开关、撤销与自动备份。
+- [LKMeng2001/dsh-mcp-market](https://github.com/LKMeng2001/dsh-mcp-market) — DSH 的 MCP 服务器商场：浏览经过 npm 校验的精选目录，一键安装 MCP 服务器到当前 profile，免重启立即生效。
 
 ### 🎮 娱乐
 


### PR DESCRIPTION
Adds [LKMeng2001/dsh-mcp-market](https://github.com/LKMeng2001/dsh-mcp-market) to the **Plugin Markets & Managers** category.

MCP server marketplace for DeepSeek Harness: browse a curated, npm-verified catalog and install MCP servers into the current profile with one click, live without restart.

Checklist:
- Declares `dsh.bundle` manifest + `cordis.patch.yml`
- Published to npm (`dsh-mcp-market@0.1.1`)
- `dsh-plugin` topic added
- Real, working code (host routes + client UI + tests + CI)