### PR TITLE
Refresh dsh-local-share description for v0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ dsh plugin --profile web add dshmarket
 - [dongsheng123132/task-passport](https://github.com/dongsheng123132/task-passport) - Carry durable task state across DeepSeek Harness, WorkBuddy, Claude Code and Codex with machine-readable checkpoints and optimistic locking.
 - [LeslieWylie/dsh-task-relay](https://github.com/LeslieWylie/dsh-task-relay) - Cross-session task queue with handoff notes: sessions and subagents push, claim, complete and cancel tasks on a shared file-backed queue, and leave a handoff summary for whoever picks up next.
 - [hellodigua/dsh-share](https://github.com/hellodigua/dsh-share) - Share your conversations with one click.
-- [ChuanTianML/dsh-local-share](https://github.com/ChuanTianML/dsh-local-share) - Export a complete Web Session to local Markdown or a self-contained HTML file, with preview-first redaction and opt-in bounded tool-call details.
+- [ChuanTianML/dsh-local-share](https://github.com/ChuanTianML/dsh-local-share) - Export complete Web Sessions to local Markdown or self-contained HTML, with stable rendered previews, default redaction, and opt-in bounded tool-call details.
 - [Moeblack/dsh-message-edit](https://github.com/Moeblack/dsh-message-edit) - Branch-based message editing, reroll, retry, and a version timeline.
 - [Buyi-wsgzg/dsh-sidechain](https://github.com/Buyi-wsgzg/dsh-sidechain) - `/side` persistent side sessions and `/btw` one-shot side questions, run in a temporary fork without touching main history.
 - [bill9109/dsh-conversation-share](https://github.com/bill9109/dsh-conversation-share) - Share any excerpt of a conversation.

--- a/README.zh.md
+++ b/README.zh.md
@@ -252,7 +252,7 @@ dsh plugin --profile web add dshmarket
 - [dongsheng123132/task-passport](https://github.com/dongsheng123132/task-passport) — 通过机器可读检查点与乐观锁，在 DeepSeek Harness、WorkBuddy、Claude Code 和 Codex 之间交接持久任务状态。
 - [LeslieWylie/dsh-task-relay](https://github.com/LeslieWylie/dsh-task-relay) — 跨会话任务队列与交接摘要：会话与子 agent 在共享的文件队列上投递、认领、完成、取消任务，并留下交接摘要供后续会话查看。
 - [hellodigua/dsh-share](https://github.com/hellodigua/dsh-share) — 一键分享你的对话。
-- [ChuanTianML/dsh-local-share](https://github.com/ChuanTianML/dsh-local-share) — 把完整 Web Session 导出为本地 Markdown 或自包含 HTML 文件，提供导出前预览、默认脱敏和可选的有界工具调用详情。
+- [ChuanTianML/dsh-local-share](https://github.com/ChuanTianML/dsh-local-share) — 把完整 Web Session 导出为本地 Markdown 或自包含 HTML，提供稳定的 Markdown 渲染预览、默认脱敏和可选的有界工具调用详情。
 - [Moeblack/dsh-message-edit](https://github.com/Moeblack/dsh-message-edit) — 基于分支的消息编辑、reroll、重试与版本时间线。
 - [Buyi-wsgzg/dsh-sidechain](https://github.com/Buyi-wsgzg/dsh-sidechain) — `/side` 持续性侧会话与 `/btw` 一次性侧问，在临时 fork 中运行、不写入主会话历史。
 - [bill9109/dsh-conversation-share](https://github.com/bill9109/dsh-conversation-share) — 分享任意段落的对话。


### PR DESCRIPTION
## Summary

- refresh the English and Chinese `dsh-local-share` descriptions for v0.3.0 so the listing mentions stable rendered Markdown previews and default redaction
- repair the newly merged mojibake in the Chinese `zoahdev/dsh-subscribe` row, which currently breaks locale parity for every PR based on `main`

The plugin detail page already reads the project README, which now includes v0.3.0 install instructions and a privacy-safe synthetic product preview.

## Checks

- `node scripts/build-site.mjs` — 579 entries parsed across 2 locales; site build passed
- `npx awesome-lint` — passed (13 pre-existing spelling warnings)
- `git diff --check`

Plugin release: https://github.com/ChuanTianML/dsh-local-share/releases/tag/v0.3.0
