### PR TITLE
Restore market site build

### DIFF
--- a/README.md
+++ b/README.md
@@ -636,7 +636,6 @@ dsh plugin --profile web add dshmarket
 ### Plugin Markets & Managers
 
 - [dsh-market/dsh-market](https://github.com/dsh-market/dsh-market) - (Recommended) The plugin market inside DSH: a Settings page to browse and search the full community catalog by category, with confirmed one-click installs and an installed-plugins view.
-- [zoahdev/dsh-subscribe](https://github.com/zoahdev/dsh-subscribe/tree/main/plugin) - Steam-style plugin marketplace: 536-plugin registry, in-DSH one-click install/uninstall/update, zero-dependency CLI, and agent market tools.
 - [Sanqi-normal/dsh-webui-market-plugin](https://github.com/Sanqi-normal/dsh-webui-market-plugin) - In-harness plugin market for the dsh web GUI: browse the awesome-dsh-plugin.com catalog and install/uninstall plugins into a profile from Settings → Plugins → Plugin Market.
 - [whyihaveyou/dsh-suite#plugin-manager](https://github.com/whyihaveyou/dsh-suite/tree/main/packages/plugins/plugin-manager) - In-app plugin store for the DSH Web UI: browse, search, one-click install, compat badges.
 - [loguhan/dsh-workshop](https://github.com/loguhan/dsh-workshop) - Steam Workshop-style plugin store for the DSH Web UI: browse, search, and one-click install community plugins with mirror acceleration, progress UI, security checks, and Chinese descriptions.

--- a/README.zh.md
+++ b/README.zh.md
@@ -636,7 +636,6 @@ dsh plugin --profile web add dshmarket
 ### 🛒 插件市场与管理
 
 - [dsh-market/dsh-market](https://github.com/dsh-market/dsh-market) — （推荐）装在 DSH 里的插件市场：设置页内逛/搜全部社区插件，按分类筛选，确认后一键安装，已装插件一目了然。
-- [zoahdev/dsh-subscribe](https://github.com/zoahdev/dsh-subscribe/tree/main/plugin) ? Steam ??????536 ??????DSH ?????/??/?????? CLI ?????????
 - [Sanqi-normal/dsh-webui-market-plugin](https://github.com/Sanqi-normal/dsh-webui-market-plugin) — dsh Web GUI 内的社区插件市场：浏览 awesome-dsh-plugin.com 目录，从 设置 → 插件 → 插件市场 安装/卸载插件到 profile。
 - [whyihaveyou/dsh-suite#plugin-manager](https://github.com/whyihaveyou/dsh-suite/tree/main/packages/plugins/plugin-manager) — DSH Web UI 内置插件商店：浏览、搜索、一键安装、兼容性徽章。
 - [loguhan/dsh-workshop](https://github.com/loguhan/dsh-workshop) — DSH Web UI 的 Steam 创意工坊式插件商店：浏览、搜索并一键安装社区插件，支持镜像加速、进度 UI、安全检测与中文描述。


### PR DESCRIPTION
## What

Temporarily removes the `zoahdev/dsh-subscribe` entry from both locale lists.

## Root cause

PR #492 links to `zoahdev/dsh-subscribe/tree/main/plugin`, which contains `README.md` but no `README.zh.md`. The post-merge site build therefore stops with the locale-parity error:

```text
README.zh.md missing: https://github.com/zoahdev/dsh-subscribe/tree/main/plugin
README locale parity broken — fix the language files; refusing to build
```

This blocked the site snapshot after several otherwise valid entries had already merged, including PR #501.

## Impact

The site can build and deploy again. `dsh-subscribe` can be re-added once its linked plugin directory provides both README locales.

## Validation

- `git diff --check`
- `npx awesome-lint`
- `node scripts/build-site.mjs` (`578 entries parsed across 2 locales`; site built successfully)
