### PR TITLE
Add Bing-Bryan/dsh-unread-dot to Notifications & Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -604,6 +604,7 @@ dsh plugin --profile web add dshmarket
 
 - [YZz-S/dsh-notifier](https://github.com/YZz-S/dsh-notifier) - System-native notifications when a task finishes or needs your confirmation: Windows toast, macOS osascript, and Linux notify-send.
 - [PeterBon/dsh-hooks](https://github.com/PeterBon/dsh-hooks) - Config-driven lifecycle hooks: event→command declarations in cordis.patch.yml, with Feishu card notifications and a QR scan-to-create bot setup.
+- [Bing-Bryan/dsh-unread-dot](https://github.com/Bing-Bryan/dsh-unread-dot) - macOS Dock badge and bubble chime: shows an unread badge on the Dock (dot while running, count when done) and plays a chime while the app is hidden; clears on return, built on the Badging API.
 ### Development & Runtime
 - [zoahdev/dsh-rule-evolve](https://github.com/zoahdev/dsh-rule-evolve/tree/main/plugin) - Verification-driven self-evolution loop: failure logs become verified AGENTS.md rules; in-session plugin (evolve_learn / evolve_apply / evolve_touch / evolve_recall), tool-verify gate, rule lifecycle, local recall.
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -604,6 +604,7 @@ dsh plugin --profile web add dshmarket
 
 - [YZz-S/dsh-notifier](https://github.com/YZz-S/dsh-notifier) — 任务完成或需要确认/输入时发送操作系统原生通知：Windows toast、macOS osascript、Linux notify-send。
 - [PeterBon/dsh-hooks](https://github.com/PeterBon/dsh-hooks) — 配置驱动生命周期 hooks：在 cordis.patch.yml 声明事件→命令，附飞书卡片通知与扫码一键创建机器人。
+- [Bing-Bryan/dsh-unread-dot](https://github.com/Bing-Bryan/dsh-unread-dot) — macOS Dock 角标与提示音：最小化/切走时 Dock 显示未读角标（运行中=红点、跑完=数字）并播放水泡提示音，回到应用自动清除，基于 Badging API。
 ### 🧑‍💻 开发与运行时
 - [zoahdev/dsh-rule-evolve](https://github.com/zoahdev/dsh-rule-evolve/tree/main/plugin) — 验证驱动的自我进化循环：失败日志自动变成经过验证的 AGENTS.md 规则；会话内插件（evolve_learn/evolve_apply/evolve_touch/evolve_recall）、工具体检、规则生命周期、本地召回。
 


### PR DESCRIPTION
Add [dsh-unread-dot](https://github.com/Bing-Bryan/dsh-unread-dot) to the 🔔 Notifications & Integrations category in both README.md and README.zh.md.

- macOS Dock unread red dot + bubble chime plugin for DeepSeek Harness
- Declares `dsh.bundle` manifest (`dsh.bundle.patch` → `cordis.patch.yml`) — installable via `dsh plugin add`
- Built on the Badging API (`navigator.setAppBadge`), dot = running, number = results, clears on return
- Repo has the `dsh-plugin` topic