### PR TITLE
Add dsh-modal-enhancer to UI Enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ dsh plugin --profile web add dshmarket
 - [kongerly/dsline](https://github.com/kongerly/dsline) - LINE-style chat bubbles for the DSH web GUI: green outgoing bubbles, assistant bubbles with avatar and a collapsible thinking row, a typing indicator, and full markdown rendering.
 - [SongMiao-tech/dsh-prompt-optimizer](https://github.com/SongMiao-tech/dsh-prompt-optimizer) - Optimize Prompt button under the composer: one click rewrites your draft into a clearer, more executable prompt, with a before-and-after dialog and one-click replacement.
 - [wenzetan/dsh-quota-panel](https://github.com/wenzetan/dsh-quota-panel) - Bottom-right quota capsule that auto-discovers every configured provider (DeepSeek, OpenRouter, SiliconFlow, GLM, one-api/new-api, coding plans) and shows balance or rolling 5-hour and weekly usage, with per-provider visibility, alert thresholds and proxy support.
+- [lisniuse/dsh-modal-enhancer](https://github.com/lisniuse/dsh-modal-enhancer) - Window-like controls for every Web UI modal: drag by title bar, eight-way resize, pin against outside clicks, maximize to the full viewport, removable backdrop blur, and per-dialog persistent state.
 ### Themes & Appearance
 
 - [RizenHNT/dsh-skin-digital-arcade](https://github.com/RizenHNT/dsh-skin-digital-arcade) - Digital arcade HUD skin: neon cyan/violet/magenta palette, Ark Pixel fonts, animated sprites (city backdrop, data core, mascot), custom crosshair cursor; light and dark themes follow the system.

--- a/README.zh.md
+++ b/README.zh.md
@@ -191,6 +191,7 @@ dsh plugin --profile web add dshmarket
 - [kongerly/dsline](https://github.com/kongerly/dsline) — 把 DSH 网页版对话区改为 LINE 风格：用户绿色气泡、助手气泡带头像与思考折叠行、打字指示器，支持完整 markdown 渲染。
 - [SongMiao-tech/dsh-prompt-optimizer](https://github.com/SongMiao-tech/dsh-prompt-optimizer) — 输入框下方「优化提示词」按钮：一键把草稿重写为更清晰、更可执行的提示词，弹出前后对比，支持一键替换回输入框。
 - [wenzetan/dsh-quota-panel](https://github.com/wenzetan/dsh-quota-panel) — 右下角额度胶囊：自动发现所有已配置 Key 的供应商（DeepSeek、OpenRouter、SiliconFlow、GLM、one-api/new-api、各类 Coding 套餐），显示余额或 5 小时/周滚动用量，支持按供应商设置可见性、告警阈值与代理。
+- [lisniuse/dsh-modal-enhancer](https://github.com/lisniuse/dsh-modal-enhancer) — 为所有 Web UI 弹窗添加窗口化操作：标题栏拖动、八向缩放、钉住防误触关闭、全屏最大化、移除背景模糊，以及按弹窗持久化的状态。
 ### 🎭 主题与外观
 
 - [RizenHNT/dsh-skin-digital-arcade](https://github.com/RizenHNT/dsh-skin-digital-arcade) — 数码电玩风 HUD 皮肤：霓虹青/紫/品红配色、Ark Pixel 像素字体、动画精灵（背景城市/数据核心/吉祥物）、自定义十字准星光标，浅深双主题跟随系统。


### PR DESCRIPTION
## What

Adds \lisniuse/dsh-modal-enhancer\ under **UI Enhancements / 🎨 UI 增强** in both \README.md\ and \README.zh.md\.

## Plugin

**dsh-modal-enhancer** — window-like controls for every DeepSeek Harness Web UI modal:
- drag by title bar
- eight-way resize (edges + corners)
- pin against outside clicks
- maximize to the full viewport
- removable backdrop blur
- per-dialog persistent state (geometry / maximized / pinned / blurless)

## Checklist

- [x] Repo declares \dsh.bundle\ + \dsh.client\ (platform web) + \cordis.patch.yml\ — installable via \dsh plugin add github:lisniuse/dsh-modal-enhancer\
- [x] Real, working code (pure JS, no build step)
- [x] \dsh-plugin\ topic added to the repo
- [x] English + Chinese entry, functional description, period-terminated