### PR TITLE
Add fengMax1997/dsh-line-select (line-range selection)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ dsh plugin --profile web add dshmarket
 - [openma-ai/deepseek-harness-tui](https://github.com/openma-ai/deepseek-harness-tui) - A Rust/ratatui terminal client that speaks the DSH SDK JSON-RPC protocol directly and runs standalone or as a profile bundle.
 - [WhitePlusMS/dsh-input-plus](https://github.com/WhitePlusMS/dsh-input-plus) - Search and insert workspace file and directory paths with `@`, plus a `/h` menu for reusing prompts from the current session.
 - [omdsh-dev/dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) - Codex-style `@file` mentions: search workspace files in the composer and attach their contents to prompts.
+- [fengMax1997/dsh-line-select](https://github.com/fengMax1997/dsh-line-select) - Line-range selection: browse workspace files, preview code with line numbers, visually select a line range, and write a `@path:start-end` reference into the composer; the agent receives the exact selected lines on send.
 - [alingalingling/ui-status-label](https://github.com/alingalingling/ui-status-label) - Customize the "deep diving" thinking status label to anything you like.
 - [LeemanCheung/dsh-whale-animation](https://github.com/LeemanCheung/dsh-whale-animation) - Persistent black whale-dive animation beside the DSH Web turn status, with a reduced-motion fallback and a seamless closed loop.
 - [01Virex/dsh-status-rotator](https://github.com/01Virex/dsh-status-rotator) - Replaces the "Deep diving..." turn-status label with rotating meme-worthy phrases, with typewriter and gradient effects.

--- a/README.zh.md
+++ b/README.zh.md
@@ -76,6 +76,7 @@ dsh plugin --profile web add dshmarket
 
 - [WhitePlusMS/dsh-input-plus](https://github.com/WhitePlusMS/dsh-input-plus) — 在组合框中使用 `@` 搜索并插入工作区文件和目录路径，并通过 `/h` 菜单复用当前会话的问题。
 - [omdsh-dev/dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) — Codex 风格的 `@file` 文件引用，输入框里直接搜索并引用工作区文件。
+- [fengMax1997/dsh-line-select](https://github.com/fengMax1997/dsh-line-select) — 行选区：浏览工作区文件、带行号预览代码、可视化选中行范围，一键把 `@path:start-end` 引用写入输入框，agent 发送时自动收到所选行原文，精准修改指定行。
 - [alingalingling/ui-status-label](https://github.com/alingalingling/ui-status-label) — 把鲸鱼娘思考时的 "deep diving" 状态文案自定义成任意你想要的样子。
 - [LeemanCheung/dsh-whale-animation](https://github.com/LeemanCheung/dsh-whale-animation) — DSH Web 状态文字旁的持久化黑色鲸鱼深潜动画，提供减少动态效果回退与无缝闭环。
 - [01Virex/dsh-status-rotator](https://github.com/01Virex/dsh-status-rotator) — 把回合状态那句 "Deep diving..." 替换成更有梗的自定义文案，按阶段轮换，支持打字机与流动渐变。


### PR DESCRIPTION
## dsh-line-select — line-range selection plugin

Adds [fengMax1997/dsh-line-select](https://github.com/fengMax1997/dsh-line-select) to the **UI 增强 / UI enhancements** category.

A DeepSeek Harness Web GUI plugin: browse workspace files, preview code with line numbers, visually select a line range, and write a ` @path:start-end ` reference into the composer. At `agent/pre-step` the Host expands the reference into an injected `<workspace-selection>` containing the exact selected lines, so the agent can edit precisely that range.

- Installable via `dsh plugin add` (declares `dsh.bundle` manifest)
- `dsh-plugin` topic added
- Read-only; paths confined to the session cwd; MIT licensed
- Both `README.md` and `README.zh.md` updated