### PR TITLE
add: shaobeichen/dsh-pocket (phone access to DSH Web UI via QR, LAN + public tunnel)

### DIFF
--- a/README.md
+++ b/README.md
@@ -613,6 +613,7 @@ dsh plugin --profile web add dshmarket
 - [YZz-S/dsh-notifier](https://github.com/YZz-S/dsh-notifier) - System-native notifications when a task finishes or needs your confirmation: Windows toast, macOS osascript, and Linux notify-send.
 - [PeterBon/dsh-hooks](https://github.com/PeterBon/dsh-hooks) - Config-driven lifecycle hooks: event→command declarations in cordis.patch.yml, with Feishu card notifications and a QR scan-to-create bot setup.
 - [Bing-Bryan/dsh-unread-dot](https://github.com/Bing-Bryan/dsh-unread-dot) - macOS Dock badge and bubble chime: shows an unread badge on the Dock (dot while running, count when done) and plays a chime while the app is hidden; clears on return, built on the Badging API.
+- [shaobeichen/dsh-pocket](https://github.com/shaobeichen/dsh-pocket) - Remote phone access to the DSH Web UI: scan a QR code for LAN or public (cloudflared tunnel) access with real-time sync, a mobile-adaptive layout, and a settings tab.
 ### Development & Runtime
 - [zoahdev/dsh-rule-evolve](https://github.com/zoahdev/dsh-rule-evolve/tree/main/plugin) - Verification-driven self-evolution loop: failure logs become verified AGENTS.md rules; in-session plugin (evolve_learn / evolve_apply / evolve_touch / evolve_recall), tool-verify gate, rule lifecycle, local recall.
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -613,6 +613,7 @@ dsh plugin --profile web add dshmarket
 - [YZz-S/dsh-notifier](https://github.com/YZz-S/dsh-notifier) — 任务完成或需要确认/输入时发送操作系统原生通知：Windows toast、macOS osascript、Linux notify-send。
 - [PeterBon/dsh-hooks](https://github.com/PeterBon/dsh-hooks) — 配置驱动生命周期 hooks：在 cordis.patch.yml 声明事件→命令，附飞书卡片通知与扫码一键创建机器人。
 - [Bing-Bryan/dsh-unread-dot](https://github.com/Bing-Bryan/dsh-unread-dot) — macOS Dock 角标与提示音：最小化/切走时 Dock 显示未读角标（运行中=红点、跑完=数字）并播放水泡提示音，回到应用自动清除，基于 Badging API。
+- [shaobeichen/dsh-pocket](https://github.com/shaobeichen/dsh-pocket) — 手机远程访问 DSH Web 界面：扫码即用局域网或公网（cloudflared 隧道）访问，实时同屏、移动端适配布局，带设置页管理。
 ### 🧑‍💻 开发与运行时
 - [zoahdev/dsh-rule-evolve](https://github.com/zoahdev/dsh-rule-evolve/tree/main/plugin) — 验证驱动的自我进化循环：失败日志自动变成经过验证的 AGENTS.md 规则；会话内插件（evolve_learn/evolve_apply/evolve_touch/evolve_recall）、工具体检、规则生命周期、本地召回。
 


### PR DESCRIPTION
## 收录 shaobeichen/dsh-pocket

手机远程访问 DSH Web 界面：扫码即用局域网或公网（cloudflared 隧道）访问，实时同屏、移动端适配布局，带设置页管理。

### 满足收录要求
- ✅ `dsh.bundle` manifest（package.json 声明 `dsh.bundle.patch: ./cordis.patch.yml`，仓库根有 `cordis.patch.yml`）
- ✅ 真实可用代码：改头反向代理（Host/Origin → loopback 通过 DSH 信任栅栏）、cloudflared 隧道、移动端适配（移植 dsh-web-mobile，MIT 署名）、设置页 client 插件；7 测试全绿
- ✅ 已发布 npm（`dsh-pocket` 1.0.1，预构建免 allowBuilds）
- ✅ `dsh-plugin` topic 已加
- ✅ 描述只说功能，无营销词
- 📄 许可：**GPL-2.0**（移动端适配部分保留 dsh-web-mobile 的 MIT 署名）

### 安装
```sh
dsh plugin --profile web add dsh-pocket -w
```
设置 → 插件 → 手机访问：局域网二维码开箱即用，点「开启公网访问」出公网二维码。