### PR TITLE
Add dsh-voice: full-duplex voice mode with true barge-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ dsh plugin --profile web add dshmarket
 - [Physicolor/harness-widgets](https://github.com/Physicolor/harness-widgets) - Right-hand widget rail for the DSH Web UI: live session stats (turns, LLM/tool time, TTFT, speed, cache, tokens) and OpenCode Go quota via a same-origin host proxy; extensible widget registry for more platform usage widgets, visuals, utility actions and external integrations.
 - [Elohia/dsh-plugin-image-input](https://github.com/Elohia/dsh-plugin-image-input) - Image-to-text input for the Web UI: paste or drag an image and it is transcribed into structured text and sent, giving text-only LLMs image-input takeover (OpenAI-compatible vision API).
 - [zer0zio-stack/dsh-opencode-go-quota](https://github.com/zer0zio-stack/dsh-opencode-go-quota) - Bottom-right 余额 badge for the DSH Web UI: on expand it fetches the currently-selected provider's OpenCode Go plan limits or DeepSeek prepaid balance, plus local token usage and pricing-based spend estimates.
+- [haoku123/dsh-voice](https://github.com/haoku123/dsh-voice) - Full-duplex voice mode for the Web UI: a composer mic (RMS endpoint detection) transcribes speech with whisper running locally in the browser, assistant replies stream back as spoken audio sentence-by-sentence, and speaking interrupts playback and the running turn (true barge-in). No API key.
 ### Themes & Appearance
 
 - [keke050/dsh-wallpaper](https://github.com/keke050/dsh-wallpaper) - Wallpaper skin for the DSH Web UI: presets, image URL or upload, and an opacity slider that fades the interface to reveal the wallpaper.

--- a/README.zh.md
+++ b/README.zh.md
@@ -211,6 +211,7 @@ dsh plugin --profile web add dshmarket
 - [Physicolor/harness-widgets](https://github.com/Physicolor/harness-widgets) — DSH Web UI 右侧部件栏：实时会话统计（轮次/LLM 与工具耗时/首 token 延迟/速率/缓存/tokens）与 OpenCode Go 套餐用量（同源代理）；可扩展部件注册表，为更多平台用量部件、视觉表现、实用工具与外部接口集成打基础。
 - [Elohia/dsh-plugin-image-input](https://github.com/Elohia/dsh-plugin-image-input) — 图片转文字输入插件：粘贴/拖拽图片自动转为结构化文字描述发送，给纯文本 LLM 提供图片输入接管（OpenAI 兼容视觉 API）。
 - [zer0zio-stack/dsh-opencode-go-quota](https://github.com/zer0zio-stack/dsh-opencode-go-quota) — DSH Web 右下角「余额」徽标：展开时读取当前所选提供方，显示 OpenCode Go 计划限额或 DeepSeek 预充值余额，并附本机 token 用量与按定价表估算的消费金额。
+- [haoku123/dsh-voice](https://github.com/haoku123/dsh-voice) — Web UI 全双工语音对话：输入框麦克风（RMS 端点检测）配合浏览器本地 whisper 转写，回复按句流式朗读，开口说话即打断播放与正在运行的回合（真 barge-in），无需 API key。
 ### 🎭 主题与外观
 
 - [keke050/dsh-wallpaper](https://github.com/keke050/dsh-wallpaper) — DSH Web 壁纸皮肤：预设 / 图片 URL / 本地上传，透明度滑块让整面界面透出壁纸。


### PR DESCRIPTION
## What

Add [haoku123/dsh-voice](https://github.com/haoku123/dsh-voice) under **UI Enhancements** (both README.md and README.zh.md).

## The plugin

Full-duplex voice mode for the DSH web UI — the loop the existing voice entries don't close:

- **Voice in**: composer mic button with zero-dependency RMS endpoint detection; transcription runs whisper fully **in the browser** (transformers.js, q8 onnx, browser-cached, hf-mirror compatible). No API key, no server-side speech processing.
- **Voice out**: assistant replies stream back as spoken audio sentence-by-sentence over SSE (Edge TTS, free), with live captions.
- **True barge-in**: speaking interrupts playback, drops the host synthesis queue (epoch-based cancel covers in-flight synthesis), and cancels the running turn through the stop-button route. Aborted turns never flush their trailing half-sentence.

The repo carries the `dsh-plugin` topic per the contributing guide, and installs with `dsh plugin --profile web add github:haoku123/dsh-voice`.