### PR TITLE
Add dsh-testkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -561,6 +561,7 @@ dsh plugin --profile web add dshmarket
 ### Development & Runtime
 
 - [BotonJ/dsh-plugin-sentinel](https://github.com/BotonJ/dsh-plugin-sentinel) - Static pre-install security auditor for plugin bundles: lifecycle scripts, dynamic execution, credential-exfiltration combos, and patch-layer hazards, with zero dependencies and in-memory tar parsing.
+- [iiwish/dsh-testkit](https://github.com/iiwish/dsh-testkit) - Docker-isolated real-host lifecycle tests for DSH plugins across install, boot, tool registration, update, uninstall, reinstall, and recovery, with structured evidence.
 - [BotonJ/dsh-windtunnel](https://github.com/BotonJ/dsh-windtunnel) - Contract regression harness for plugin authors: a scripted LLM adapter drives the real pipeline in isolated child processes with session-event assertions (load/contract/behavior/fault layers); zero API key, CI-ready.
 - [BotonJ/dsh-remote-link](https://github.com/BotonJ/dsh-remote-link) - Secure remote access for the official Web UI: authenticated LAN/tunnel gateway with QR + HMAC one-time pairing, per-device sessions and revocation, mDNS discovery, and a fork_session tool.
 - [Starfie1d1272/dsh-builtin-toggles](https://github.com/Starfie1d1272/dsh-builtin-toggles) - Evidence-backed inspector for DSH Web built-in capabilities: runtime/config provenance, compatibility and drift diagnostics, plus fail-closed controls for nine reviewed UI leaves.

--- a/README.zh.md
+++ b/README.zh.md
@@ -561,6 +561,7 @@ dsh plugin --profile web add dshmarket
 ### 🧑‍💻 开发与运行时
 
 - [BotonJ/dsh-plugin-sentinel](https://github.com/BotonJ/dsh-plugin-sentinel) — 插件安装前静态安全审计：生命周期脚本、动态执行、凭据外传组合特征与 patch 层风险；零依赖，tar 包全程内存解析不落盘。
+- [iiwish/dsh-testkit](https://github.com/iiwish/dsh-testkit) — 在 Docker 隔离的真实宿主中测试 DSH 插件的安装、启动、工具注册、更新、卸载、重装与恢复生命周期，并输出结构化证据。
 - [BotonJ/dsh-windtunnel](https://github.com/BotonJ/dsh-windtunnel) — 插件作者的契约回归风洞：剧本适配器在隔离子进程中驱动真实管线，会话事件断言覆盖加载/契约/行为/故障四层；零 API key，可进 CI。
 - [BotonJ/dsh-remote-link](https://github.com/BotonJ/dsh-remote-link) — 官方 Web UI 的安全远程接入：带认证的局域网/隧道网关，QR + HMAC 一次性配对、按设备吊销，mDNS 发现，附 fork_session 会话分叉工具。
 - [Starfie1d1272/dsh-builtin-toggles](https://github.com/Starfie1d1272/dsh-builtin-toggles) — DSH Web 内置 capability 的 evidence-backed 检查器：展示运行/配置溯源、兼容性与漂移诊断，并仅为 9 个经过审阅的 UI leaf 提供 fail-closed 控制。


### PR DESCRIPTION
## Summary

- add dsh-testkit to Development & Runtime in both locale lists
- describe its Docker-isolated real DSH lifecycle coverage and structured evidence

## Eligibility

- declares `dsh.bundle` and ships an installable patch manifest
- published as `dsh-testkit@0.2.1` on npm with provenance
- declares official DSH packages as optional peer dependencies
- repository has the `dsh-plugin` topic and real-host bundle E2E coverage
- ships equivalent English and Simplified Chinese documentation

## Evidence

- official community Show & Tell: https://github.com/deepseek-ai/deepseek-harness/discussions/2038
- v0.2.1 release: https://github.com/iiwish/dsh-testkit/releases/tag/v0.2.1
- aggregate exact-version community cohort: https://github.com/iiwish/dsh-testkit/blob/main/docs/community-validation.md

## Validation

- `npx --yes awesome-lint`
- `node scripts/build-site.mjs`