### PR TITLE
Add nzl153/pet-whale to Just for Fun / 娱乐

### DIFF
--- a/README.md
+++ b/README.md
@@ -690,6 +690,7 @@ dsh plugin --profile web add dshmarket
 - [skr311/dsh-codex-pet#dsh-codex-pet](https://github.com/skr311/dsh-codex-pet/tree/main/packages/dsh-codex-pet) - Import Codex-style sprite-sheet pets and render them as a floating shell.overlay with a pet library, interactions, and agent-state linkage.
 - [swaylq/dsh-digipet](https://github.com/swaylq/dsh-digipet) - Digimon-style raising game: hatch an egg that feeds on real work (turns, tool calls, errors) and evolves along four branching lines shaped by how you work; zero tokens, invisible to the model.
 - [marvin9551/dynamic-schulte-dsh](https://github.com/marvin9551/dynamic-schulte-dsh) - Dynamic Schulte grid waiting-time mini-game: click 1..N in order on a static grid or a spinning roulette wheel while the model thinks.
+- [nzl153/pet-whale](https://github.com/nzl153/pet-whale) - Desktop pet drawn from the official whale outline: pure-SVG animation follows agent state (thinking, working, celebrating, error), with poke and double-click flip interactions, cursor avoidance, 7 palettes, light/dark theme sync, and a playable web preview.
 
 ## Contributing
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -690,6 +690,7 @@ dsh plugin --profile web add dshmarket
 - [skr311/dsh-codex-pet#dsh-codex-pet](https://github.com/skr311/dsh-codex-pet/tree/main/packages/dsh-codex-pet) — 导入/上传 Codex 风格精灵图序列帧宠物，在 DSH Web GUI 以悬浮浮层渲染，含图库管理、交互与 Agent 状态联动。
 - [swaylq/dsh-digipet](https://github.com/swaylq/dsh-digipet) — 数码宝贝式养成：孵一颗吃真实工作长大的蛋（回合、工具调用、报错都是营养），按你的工作方式走四条进化分支；零 token，模型完全看不见。
 - [marvin9551/dynamic-schulte-dsh](https://github.com/marvin9551/dynamic-schulte-dsh) — 动态舒尔特方格等待小游戏：模型思考时，在静态网格或旋转轮盘上按顺序点击 1..N，边玩边等。
+- [nzl153/pet-whale](https://github.com/nzl153/pet-whale) — 官方鲸鱼轮廓的桌宠：纯 SVG 动画随 agent 状态切换（思考／工作／完成／报错），可戳可拖、双击翻滚，光标停留在身侧会自己避让，7 套色板并跟随亮暗主题，附网页预览可直接试玩。
 
 ## 贡献
 


### PR DESCRIPTION
Adds [pet-whale](https://github.com/nzl153/pet-whale) — a desktop pet for the DSH web UI, drawn from the official whale outline.

One line added to each of `README.md` and `README.zh.md` under **Just for Fun / 🎮 娱乐**. No other files touched.

Checklist against `contributing.md`:

- [x] `package.json` declares `dsh.bundle` (`{ "patch": "./cordis.patch.yml" }`), not only `dsh.client`
- [x] `cordis.patch.yml` present at the repo root
- [x] Real working code — pure-SVG/DOM implementation, zero runtime dependencies, jsdom smoke tests
- [x] `dsh-plugin` topic added to the repo
- [x] Description states what it does, no superlatives
- [x] Official `@deepseek-ai/*` packages are declared in `devDependencies`, not `dependencies`
- [x] Build output (`lib/`) is committed, so a git install needs no build approval

Playable preview, no install required: <https://nzl153.github.io/pet-whale/preview.html>