### PR TITLE
Add dsh-plugin-aflare (Workflow & Automation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -605,6 +605,7 @@ dsh plugin --profile web add dshmarket
 - [Jungod1121/dsh-anchored-standard](https://github.com/Jungod1121/dsh-anchored-standard) - Two-phase agent preset for DeepSeek V4 Pro: the first request sees only bash+read (Minimal-aligned bootstrap), then the full Standard tool catalog after the first tool call or reply; ships as an installer bundle plus a manual preset directory.
 - [cloader/dsh-taskboard](https://github.com/cloader/dsh-taskboard) - Task board for DSH: create tasks with project and model assignment, run them manually or on cron schedules; new sessions in a project automatically pick up its todo tasks and move them to in-review when done.
 - [PerryLink/dsh-auto-review](https://github.com/PerryLink/dsh-auto-review) - Second-model auto-review on the approval answerer chain: a read-only reviewer subagent returns structured allow/deny verdicts with reasons, fail-closed by default.
+- [alib8b8/dsh-plugin-aflare](https://github.com/alib8b8/dsh-plugin-aflare) - aflare workflow tools: generate, validate and run local-first deterministic YAML workflow DAGs (WAL crash recovery, Saga compensation) through the local aflare binary, with 300+ templates built in.
 
 ### Notifications & Integrations
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -606,6 +606,7 @@ dsh plugin --profile web add dshmarket
 - [Jungod1121/dsh-anchored-standard](https://github.com/Jungod1121/dsh-anchored-standard) — V4 Pro 两阶段 agent 预设：首轮仅 bash+read 完成极简开局，首个工具调用或回复后恢复 Standard 完整工具目录；以安装器 bundle 与手动预设目录双形态发布。
 - [cloader/dsh-taskboard](https://github.com/cloader/dsh-taskboard) — dsh 的任务看板：创建任务时可指定项目与模型，支持手动执行及定时执行；项目内新建会话会自动拉取该项目的待办任务，完成后移至待验收。
 - [PerryLink/dsh-auto-review](https://github.com/PerryLink/dsh-auto-review) — 审批链上的第二模型自动审查：只读审查子代理返回带理由的 allow/deny 结构化裁决，默认 fail-closed。
+- [alib8b8/dsh-plugin-aflare](https://github.com/alib8b8/dsh-plugin-aflare) — aflare 工作流工具：通过本地 aflare 二进制生成、校验并执行本地优先的确定性 YAML 工作流 DAG（WAL 崩溃恢复、Saga 补偿），内置 300+ 模板。
 
 ### 🔔 通知与集成
 - [STARDUSTLC666/dsh-slack](https://github.com/STARDUSTLC666/dsh-slack) — Slack 双向通信（notify/channels/inbox/reply，Socket Mode 免公网回调）。


### PR DESCRIPTION
Adds [alib8b8/dsh-plugin-aflare](https://github.com/alib8b8/dsh-plugin-aflare) under **Workflow & Automation** in both READMEs.

Checklist from contributing.md:

- [x] `dsh.bundle` manifest declared in `package.json` (`dsh.bundle.patch` → `cordis.patch.yml` at repo root)
- [x] Real working code — 6 registered tools (`aflare_version` / `generate` / `validate` / `run` / `template_list` / `template_run`), integration tests run against the real `aflare` binary
- [x] Actively maintained
- [x] [`dsh-plugin`](https://github.com/topics/dsh-plugin) topic added
- [x] Descriptions state what the plugin does, no marketing
- [x] Published to npm ([@alib8b8/dsh-plugin-aflare](https://www.npmjs.com/package/@alib8b8/dsh-plugin-aflare)) — prebuilt installs skip `allowBuilds`
- [x] Official `@deepseek-ai/*` packages declared as `peerDependencies`

Install:

```
dsh plugin --profile web add @alib8b8/dsh-plugin-aflare
```

(Also submitted to dsh-index: Sunrisepeak/dsh-index#35)