### PR TITLE
Add dsh-web-launcher (one-click desktop launcher for the DSH Web UI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -628,6 +628,7 @@ dsh plugin --profile web add dshmarket
 - [Bing-Bryan/dsh-unread-dot](https://github.com/Bing-Bryan/dsh-unread-dot) - macOS Dock badge and bubble chime: shows an unread badge on the Dock (dot while running, count when done) and plays a chime while the app is hidden; clears on return, built on the Badging API.
 - [shaobeichen/dsh-pocket](https://github.com/shaobeichen/dsh-pocket) - Remote phone access to the DSH Web UI: scan a QR code for LAN or public (cloudflared tunnel) access with real-time sync, a mobile-adaptive layout, and a settings tab.
 - [jiezeng2004-design/dsh-chatgpt-bridge](https://github.com/jiezeng2004-design/dsh-chatgpt-bridge) - MCP bridge that lets ChatGPT Web create, view, continue, and supervise DeepSeek Harness agent sessions and goals while preserving DSH's native approval, sandbox, and workspace security model.
+- [hanwuji1/dsh-web-launcher](https://github.com/hanwuji1/dsh-web-launcher) - One-click launcher for the Web UI: a double-click Start-DSH-Web.cmd on the Windows desktop that boots dsh web and auto-opens the browser (polling until ready), plus a web_launcher model tool (install / open / status).
 ### Development & Runtime
 - [zoahdev/dsh-rule-evolve](https://github.com/zoahdev/dsh-rule-evolve/tree/main/plugin) - Verification-driven self-evolution loop: failure logs become verified AGENTS.md rules; in-session plugin (evolve_learn / evolve_apply / evolve_touch / evolve_recall), tool-verify gate, rule lifecycle, local recall.
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -628,6 +628,7 @@ dsh plugin --profile web add dshmarket
 - [Bing-Bryan/dsh-unread-dot](https://github.com/Bing-Bryan/dsh-unread-dot) — macOS Dock 角标与提示音：最小化/切走时 Dock 显示未读角标（运行中=红点、跑完=数字）并播放水泡提示音，回到应用自动清除，基于 Badging API。
 - [shaobeichen/dsh-pocket](https://github.com/shaobeichen/dsh-pocket) — 手机远程访问 DSH Web 界面：扫码即用局域网或公网（cloudflared 隧道）访问，实时同屏、移动端适配布局，带设置页管理。
 - [jiezeng2004-design/dsh-chatgpt-bridge](https://github.com/jiezeng2004-design/dsh-chatgpt-bridge) — 通过 MCP 让 ChatGPT Web 创建、查看、继续和监督 DeepSeek Harness Agent 会话与 Goal，同时保留 DSH 原生的审批、沙箱与工作区安全模型。
+- [hanwuji1/dsh-web-launcher](https://github.com/hanwuji1/dsh-web-launcher) — Web 界面一键启动器：在 Windows 桌面创建双击即用的 Start-DSH-Web.cmd（自动启动 dsh web，轮询就绪后自动打开浏览器），并提供 web_launcher 模型工具（install / open / status）。
 ### 🧑‍💻 开发与运行时
 - [zoahdev/dsh-rule-evolve](https://github.com/zoahdev/dsh-rule-evolve/tree/main/plugin) — 验证驱动的自我进化循环：失败日志自动变成经过验证的 AGENTS.md 规则；会话内插件（evolve_learn/evolve_apply/evolve_touch/evolve_recall）、工具体检、规则生命周期、本地召回。
 


### PR DESCRIPTION
Adds [dsh-web-launcher](https://github.com/hanwuji1/dsh-web-launcher) to the **Development & Runtime** section (both `README.md` and `README.zh.md`).

- App-style launcher for the DSH Web UI on Windows: installs a **DeepSeek Harness Web** desktop app (black-whale icon, derived from the official Harness favicon silhouette) that boots `dsh web` and auto-opens the browser (polls until the port is ready; skips straight to the browser when the server is already running).
- Registers a `web_launcher` model tool (`install` / `open` / `status`).
- Installable via `dsh plugin --profile web add dsh-web-launcher` (npm) or `github:hanwuji1/dsh-web-launcher`; declares a `dsh.bundle` manifest.
- Repo has the `dsh-plugin` topic; unit-tested, pure-ASCII launcher works under any Windows codepage.