### PR TITLE
feat: add pr-genius to Skills section

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,6 +475,7 @@ dsh plugin --profile web add dshmarket
 - [PerryLink/dsh-plugin-guide](https://github.com/PerryLink/dsh-plugin-guide) - The DSH plugin-development knowledge base as an on-demand agent skill: official constraints, task workflows, API reference and community gotchas, installed with the bundle so the agent can look things up while building a plugin.
 - [Chu-Xin-r/wanjiqi-meme](https://github.com/Chu-Xin-r/wanjiqi-meme) - Barrage-meme skill distilled from 22,771 real messages in the 6657 live room: wanjiqi-style banter, CS and DOTA cross-memes, player roasting and casting commentary.
 - [zsxh1990/pr-genius](https://github.com/zsxh1990/pr-genius) - Pre-submission PR advisor: AI-powered review with 346+ anti-pattern rules across 61 repos, coach mode for iterative improvement, harvest mode for lesson extraction, MCP server support for DSH skill integration.
+- [Ikalus1988/MisakaNet](https://github.com/Ikalus1988/MisakaNet) - Git-backed failure-memory for AI coding agents: zero-dependency lesson library with MCP server, 289+ verified debugging patterns, search-by-error in 0.02s.
 ### Workflow & Automation
 
 - [ztl34245881-commits/dsh-task-planner](https://github.com/ztl34245881-commits/dsh-task-planner) - Task planning with experience muscle-memory: condition-reflex recall of past solutions, LLM capability matching, and auto-persisted lessons.

--- a/README.md
+++ b/README.md
@@ -474,6 +474,7 @@ dsh plugin --profile web add dshmarket
 - [xsoc1/math-research-dsh](https://github.com/xsoc1/math-research-dsh) - Rigorous open mathematics research suite: four agent skills (rigorous-open-math-research, manage-math-research-program, math-research-workflow, lean-verify) for theorem solving with adversarial audit, research program management, pipeline orchestration, and Lean 4 formalization audit; CI-verified tests and mechanical upstream sync.
 - [PerryLink/dsh-plugin-guide](https://github.com/PerryLink/dsh-plugin-guide) - The DSH plugin-development knowledge base as an on-demand agent skill: official constraints, task workflows, API reference and community gotchas, installed with the bundle so the agent can look things up while building a plugin.
 - [Chu-Xin-r/wanjiqi-meme](https://github.com/Chu-Xin-r/wanjiqi-meme) - Barrage-meme skill distilled from 22,771 real messages in the 6657 live room: wanjiqi-style banter, CS and DOTA cross-memes, player roasting and casting commentary.
+- [zsxh1990/pr-genius](https://github.com/zsxh1990/pr-genius) - Pre-submission PR advisor: AI-powered review with 346+ anti-pattern rules across 61 repos, coach mode for iterative improvement, harvest mode for lesson extraction, MCP server support for DSH skill integration.
 ### Workflow & Automation
 
 - [ztl34245881-commits/dsh-task-planner](https://github.com/ztl34245881-commits/dsh-task-planner) - Task planning with experience muscle-memory: condition-reflex recall of past solutions, LLM capability matching, and auto-persisted lessons.

--- a/README.md
+++ b/README.md
@@ -475,7 +475,6 @@ dsh plugin --profile web add dshmarket
 - [PerryLink/dsh-plugin-guide](https://github.com/PerryLink/dsh-plugin-guide) - The DSH plugin-development knowledge base as an on-demand agent skill: official constraints, task workflows, API reference and community gotchas, installed with the bundle so the agent can look things up while building a plugin.
 - [Chu-Xin-r/wanjiqi-meme](https://github.com/Chu-Xin-r/wanjiqi-meme) - Barrage-meme skill distilled from 22,771 real messages in the 6657 live room: wanjiqi-style banter, CS and DOTA cross-memes, player roasting and casting commentary.
 - [zsxh1990/pr-genius](https://github.com/zsxh1990/pr-genius) - Pre-submission PR advisor: AI-powered review with 346+ anti-pattern rules across 61 repos, coach mode for iterative improvement, harvest mode for lesson extraction, MCP server support for DSH skill integration.
-- [Ikalus1988/MisakaNet](https://github.com/Ikalus1988/MisakaNet) - Git-backed failure-memory for AI coding agents: zero-dependency lesson library with MCP server, 289+ verified debugging patterns, search-by-error in 0.02s.
 ### Workflow & Automation
 
 - [ztl34245881-commits/dsh-task-planner](https://github.com/ztl34245881-commits/dsh-task-planner) - Task planning with experience muscle-memory: condition-reflex recall of past solutions, LLM capability matching, and auto-persisted lessons.

--- a/README.zh.md
+++ b/README.zh.md
@@ -476,7 +476,6 @@ dsh plugin --profile web add dshmarket
 - [PerryLink/dsh-plugin-guide](https://github.com/PerryLink/dsh-plugin-guide) — DSH 插件开发知识库，作为按需加载的 agent 技能随 bundle 安装：官方约束、任务工作流、API 参考与社区踩坑，写插件时让 DSH 自己查。
 - [Chu-Xin-r/wanjiqi-meme](https://github.com/Chu-Xin-r/wanjiqi-meme) — 玩机器（6657 直播间）烂梗技能包：22771 条真实弹幕蒸馏而成，涵盖玩机器式弹幕烂梗、CS×DOTA 双料梗、选手锐评与解说吐槽。
 - [zsxh1990/pr-genius](https://github.com/zsxh1990/pr-genius) — 提交前 PR 顾问：346+ 反模式规则覆盖 61 个仓库，Coach 模式迭代改进，Harvest 模式提取可复用经验，MCP 服务器支持 DSH 技能集成。
-- [Ikalus1988/MisakaNet](https://github.com/Ikalus1988/MisakaNet) — AI 编程 Agent 的 Git 失败记忆库：零依赖，289+ 验证过的调试经验，0.02 秒按错误信息搜索，MCP 服务器支持。
 ### 🔁 工作流与自动化
 
 - [ztl34245881-commits/dsh-task-planner](https://github.com/ztl34245881-commits/dsh-task-planner) — 带经验肌肉记忆的任务规划：条件反射检索历史方案 + LLM 能力匹配 + 经验自动沉淀。

--- a/README.zh.md
+++ b/README.zh.md
@@ -475,6 +475,8 @@ dsh plugin --profile web add dshmarket
 - [xsoc1/math-research-dsh](https://github.com/xsoc1/math-research-dsh) — 严谨开放数学研究套件：4 个 agent skill（rigorous-open-math-research、manage-math-research-program、math-research-workflow、lean-verify），覆盖对抗性审计的定理求解、研究项目管理、流水线编排与 Lean 4 形式化审计；CI 测试与机械式上游同步。
 - [PerryLink/dsh-plugin-guide](https://github.com/PerryLink/dsh-plugin-guide) — DSH 插件开发知识库，作为按需加载的 agent 技能随 bundle 安装：官方约束、任务工作流、API 参考与社区踩坑，写插件时让 DSH 自己查。
 - [Chu-Xin-r/wanjiqi-meme](https://github.com/Chu-Xin-r/wanjiqi-meme) — 玩机器（6657 直播间）烂梗技能包：22771 条真实弹幕蒸馏而成，涵盖玩机器式弹幕烂梗、CS×DOTA 双料梗、选手锐评与解说吐槽。
+- [zsxh1990/pr-genius](https://github.com/zsxh1990/pr-genius) — 提交前 PR 顾问：346+ 反模式规则覆盖 61 个仓库，Coach 模式迭代改进，Harvest 模式提取可复用经验，MCP 服务器支持 DSH 技能集成。
+- [Ikalus1988/MisakaNet](https://github.com/Ikalus1988/MisakaNet) — AI 编程 Agent 的 Git 失败记忆库：零依赖，289+ 验证过的调试经验，0.02 秒按错误信息搜索，MCP 服务器支持。
 ### 🔁 工作流与自动化
 
 - [ztl34245881-commits/dsh-task-planner](https://github.com/ztl34245881-commits/dsh-task-planner) — 带经验肌肉记忆的任务规划：条件反射检索历史方案 + LLM 能力匹配 + 经验自动沉淀。


### PR DESCRIPTION
## What

Add [pr-genius](https://github.com/zsxh1990/pr-genius) to the Skills section.

## Why

PR Genius is a pre-submission PR advisor that helps contributors improve their PRs before submitting to open-source projects. It features:

- **346+ anti-pattern rules** across 61 repos — catches issues before maintainers do
- **Coach mode** — iterative guidance to polish PRs
- **Harvest mode** — extract reusable lessons from git history
- **Profile-driven context** — project-specific rules for targeted advice
- **MCP server support** — integrates with DSH via skill mode

## Integration

DSH users can add pr-genius as an MCP skill server:

```json
{
  "mcpServers": {
    "pr-genius": {
      "command": "uvx",
      "args": ["--from", "git+https://github.com/zsxh1990/pr-genius@main", "pr-genius", "--stdio"],
      "env": { "GITHUB_TOKEN": "<your-token>" }
    }
  }
}
```

See [dsh-integration.md](https://github.com/zsxh1990/pr-genius/blob/main/docs/dsh-integration.md) for full setup guide.