### PR TITLE
Add dsh-recall-plugin to Sessions & Messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,7 @@ dsh plugin --profile web add dshmarket
 - [wsxwj123/dsh-plugins#dsh-session-manager](https://github.com/wsxwj123/dsh-plugins/tree/main/packages/dsh-session-manager) - Delete sessions with a 5-second undo and a recycle bin, plus an archive view to browse and unarchive, for the DSH Web GUI.
 - [reinocheong/dsh-session-move](https://github.com/reinocheong/dsh-session-move) - Move a session to another folder from the Web UI via drag & drop or a menu picker, permanently delete a session with a risk-consent dialog, and AI-rename a session by summarizing the whole conversation (typo-aware). Each action also ships as an agent tool.
 - [dylan121322/dsh-session-unarchive](https://github.com/dylan121322/dsh-session-unarchive) - Restore archived sessions to their original workspace from the Web GUI sidebar.
+- [limbo947/dsh-recall-plugin](https://github.com/limbo947/dsh-recall-plugin) - Recall any user message: rolls the conversation (official session fork) and workspace files (per-message shadow git snapshots) back to before it, with a diff-preview confirmation panel.
 
 ### Memory
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -287,6 +287,7 @@ dsh plugin --profile web add dshmarket
 - [wsxwj123/dsh-plugins#dsh-session-manager](https://github.com/wsxwj123/dsh-plugins/tree/main/packages/dsh-session-manager) — 会话删除（5 秒可撤销 + 回收站）与归档视图（查看、取消归档）。
 - [reinocheong/dsh-session-move](https://github.com/reinocheong/dsh-session-move) — 在 Web 侧边栏把会话移动到别的文件夹（拖拽或菜单选择），带风险确认地永久删除会话，以及 AI 重命名会话（总结整个对话并自动纠正错别字）；每个操作都提供 agent 工具。
 - [dylan121322/dsh-session-unarchive](https://github.com/dylan121322/dsh-session-unarchive) — 从 Web GUI 侧栏查看已归档会话，并一键恢复到原工作区。
+- [limbo947/dsh-recall-plugin](https://github.com/limbo947/dsh-recall-plugin) — 消息撤回：在用户消息旁加「撤回」按钮，把对话历史（官方会话 fork）与项目文件（逐消息影子 git 快照）一并回退到该消息发送之前，带差异预览确认面板。
 
 ### 🧠 记忆
 


### PR DESCRIPTION
Adds [dsh-recall-plugin](https://github.com/limbo947/dsh-recall-plugin) to the **Sessions & Messages** section (both `README.md` and `README.zh.md`).

- Recall button on user messages that rolls back both tracks at once: the conversation (official `sessions.fork`) and workspace files (per-message snapshots in a shadow git repository under `~/.dsh`), with a diff-preview confirmation panel before execution.
- Published on npm (`dsh-recall-plugin@1.2.2`): `dsh plugin --profile web add dsh-recall-plugin`
- Compliance: `dsh.bundle` manifest + `cordis.patch.yml` ✓ / official `@deepseek-ai/*` packages as `peerDependencies` ✓ / [`dsh-plugin`](https://github.com/topics/dsh-plugin) topic ✓ / MIT / cross-platform (Windows / Linux / macOS)
