### PR TITLE
Add dsh-codex-timeline to UI Enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ dsh plugin --profile web add dshmarket
 - [cirelir/dsh-change-review](https://github.com/cirelir/dsh-change-review) - Session change-review plugin for DeepSeek Harness: tracks write/edit tool calls per session and renders line-level diffs with customizable colors, with session isolation, subagent aggregation, and SSE live updates.
 - [baisama-cloud/dsh-custom-brand](https://github.com/baisama-cloud/dsh-custom-brand) - Customizable brand area for the Web UI: replace the whale logo and DeepSeek wordmark with local images, and edit the HARNESS badge text (double-click to change, right-click to reset).
 - [Fayelin12/dsh-office](https://github.com/Fayelin12/dsh-office) - Office workspace & session dashboard: a floating 6-column sprite panel visualizing workspaces, sessions, token usage and subagents.
+- [Wine-Red/dsh-codex-timeline](https://github.com/Wine-Red/dsh-codex-timeline) - Left-edge user-Turn navigation rail with reading-position highlighting, hover previews of per-turn metrics and model-answer excerpts, keyboard and click-to-jump controls, and local conversation search.
 ### Themes & Appearance
 
 - [keke050/dsh-wallpaper](https://github.com/keke050/dsh-wallpaper) - Wallpaper skin for the DSH Web UI: presets, image URL or upload, and an opacity slider that fades the interface to reveal the wallpaper.

--- a/README.zh.md
+++ b/README.zh.md
@@ -225,6 +225,7 @@ dsh plugin --profile web add dshmarket
 - [cirelir/dsh-change-review](https://github.com/cirelir/dsh-change-review) — 会话修改审查插件：追踪会话内 write/edit 工具调用并展示 diff 对比；会话隔离、子代理聚合、SSE 实时推送、角标与颜色自定义。
 - [baisama-cloud/dsh-custom-brand](https://github.com/baisama-cloud/dsh-custom-brand) — Web UI 品牌区自定义：鲸鱼 logo 与 DeepSeek 文字可换成本地图片，HARNESS 徽章文字可双击编辑（双击修改，右键恢复）。
 - [Fayelin12/dsh-office](https://github.com/Fayelin12/dsh-office) — 办公室工作区/会话仪表盘：悬浮 6 列精灵面板，可视化工作区、会话、token 用量与子代理。
+- [Wine-Red/dsh-codex-timeline](https://github.com/Wine-Red/dsh-codex-timeline) — 左侧用户轮次导航轨道：随阅读位置高亮，悬停预览单轮指标与模型回答摘要，支持键盘和点击跳转及本地会话搜索。
 ### 🎭 主题与外观
 
 - [keke050/dsh-wallpaper](https://github.com/keke050/dsh-wallpaper) — DSH Web 壁纸皮肤：预设 / 图片 URL / 本地上传，透明度滑块让整面界面透出壁纸。


### PR DESCRIPTION
## Summary

Adds [Wine-Red/dsh-codex-timeline](https://github.com/Wine-Red/dsh-codex-timeline) to the **UI Enhancements** section in both the English and Chinese lists.

The description distinguishes its left-edge user-Turn rail, reading-position highlight, per-turn metric and model-answer previews, keyboard/click navigation, and local conversation search.

## Submission checklist

- [x] The plugin declares `dsh.bundle` in its root `package.json`.
- [x] One neutral, period-terminated line was added to both `README.md` and `README.zh.md` under the matching category.
- [x] The repository contains working code and has the `dsh-plugin` topic.
- [x] The prebuilt package is published to npm as `dsh-codex-timeline`.

## Verification

- `npm ci`
- `node scripts/build-site.mjs` — 596 entries parsed across 2 locales; site, sitemap, and count badge generated successfully.
- `dsh plugin --profile web add dsh-codex-timeline` — verified against DSH `0.1.0-rc.6`.

`awesome-lint` is left to the repository's Ubuntu PR check because its local Windows runner treats an absolute drive path as a GitHub repository URL.
