### PR TITLE
Add ovdoesw/dsh-xiangqi: Chinese chess (Xiangqi) pastime plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -781,6 +781,7 @@ dsh plugin --profile web add dshmarket
 - [nzl153/pet-whale](https://github.com/nzl153/pet-whale) - Desktop pet drawn from the official whale outline: pure-SVG animation follows agent state (thinking, working, celebrating, error), with poke and double-click flip interactions, cursor avoidance, 7 palettes, light/dark theme sync, and a playable web preview.
 
 - [skiuniverse/dsh-running-liang](https://github.com/skiuniverse/dsh-running-liang) - A Chrome-dino-style runner for the DeepSeek Harness Web UI: play while the agent replies, score from 梁子 to 梁圣 on a persistent progress strip.
+- [ovdoesw/dsh-xiangqi](https://github.com/ovdoesw/dsh-xiangqi) - A draggable mascot invites you to play Xiangqi (Chinese chess) while the AI thinks, with a built-in engine, move-record export, and optional multi-model commentary.
 ## Contributing
 
 PRs welcome — add one line under the matching category in both `README.md` and `README.zh.md`: `- [name](link) — one-line description`.

--- a/README.zh.md
+++ b/README.zh.md
@@ -781,6 +781,7 @@ dsh plugin --profile web add dshmarket
 - [nzl153/pet-whale](https://github.com/nzl153/pet-whale) — 官方鲸鱼轮廓的桌宠：纯 SVG 动画随 agent 状态切换（思考／工作／完成／报错），可戳可拖、双击翻滚，光标停留在身侧会自己避让，7 套色板并跟随亮暗主题，附网页预览可直接试玩。
 
 - [skiuniverse/dsh-running-liang](https://github.com/skiuniverse/dsh-running-liang) — 等待 Agent 回复时的恐龙快跑小游戏：常驻进度条从「梁子」冲向「梁圣」，折叠即暂停、任意键恢复。
+- [ovdoesw/dsh-xiangqi](https://github.com/ovdoesw/dsh-xiangqi) — 卡通小宠物邀请你在 AI 思考间隙下中国象棋：内置引擎、走子记谱导出、可选多模型局势点评。
 ## 贡献
 
 欢迎提 PR 收录你的插件：在 `README.md` 和 `README.zh.md` 的对应分类下各加一行，格式 `- [名称](链接) — 一句话描述`。


### PR DESCRIPTION
Adds **ovdoesw/dsh-xiangqi** to the **Just for Fun / 🎮 娱乐** category.

A draggable mascot invites you to play Xiangqi (Chinese chess) while the AI thinks.

- Unscoped npm package name \dsh-xiangqi\ (the \@deepseek-ai/*\ scope is reserved for official packages)
- Declares \dsh.bundle\ + \cordis.patch.yml\ — installable via \dsh plugin add\
- Tagged \dsh-plugin\
- Pure-TS engine (negamax + α-β + iterative deepening), easy/medium/hard tiers
- Traditional Chinese move notation with game-record export
- Optional multi-model LLM commentary; works offline otherwise