### PR TITLE
Add 2nd1st/dsh-plugin-open-app (UI Enhancements)

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ dsh plugin --profile web add dshmarket
 - [Fayelin12/dsh-office](https://github.com/Fayelin12/dsh-office) - Office workspace & session dashboard: a floating 6-column sprite panel visualizing workspaces, sessions, token usage and subagents.
 - [Wine-Red/dsh-codex-timeline](https://github.com/Wine-Red/dsh-codex-timeline) - Left-edge user-Turn navigation rail with reading-position highlighting, hover previews of per-turn metrics and model-answer excerpts, keyboard and click-to-jump controls, and local conversation search.
 - [guo-ziao/dsh-interrupt-button](https://github.com/guo-ziao/dsh-interrupt-button) - A green interrupt button beside the send box: silently stops a running agent, which then summarizes its progress and asks for your new requirements, with a customizable interrupt prompt.
+- [2nd1st/dsh-plugin-open-app](https://github.com/2nd1st/dsh-plugin-open-app) - Runs open-mcp-apps inside DSH: every MCP app gets its own sidebar container with a separate workspace, session, and App mode, an agent status strip under the app, and inline app rendering in ordinary chats.
 ### Themes & Appearance
 
 - [keke050/dsh-wallpaper](https://github.com/keke050/dsh-wallpaper) - Wallpaper skin for the DSH Web UI: presets, image URL or upload, and an opacity slider that fades the interface to reveal the wallpaper.

--- a/README.zh.md
+++ b/README.zh.md
@@ -227,6 +227,7 @@ dsh plugin --profile web add dshmarket
 - [Fayelin12/dsh-office](https://github.com/Fayelin12/dsh-office) — 办公室工作区/会话仪表盘：悬浮 6 列精灵面板，可视化工作区、会话、token 用量与子代理。
 - [Wine-Red/dsh-codex-timeline](https://github.com/Wine-Red/dsh-codex-timeline) — 左侧用户轮次导航轨道：随阅读位置高亮，悬停预览单轮指标与模型回答摘要，支持键盘和点击跳转及本地会话搜索。
 - [guo-ziao/dsh-interrupt-button](https://github.com/guo-ziao/dsh-interrupt-button) — 发送按钮旁的绿色打断按钮：运行时一键静默中断 AI，AI 停止后总结进展并向你征求新要求，支持自定义打断提示词。
+- [2nd1st/dsh-plugin-open-app](https://github.com/2nd1st/dsh-plugin-open-app) — 把 open-mcp-apps 接进 DSH：每个 MCP app 都是侧边栏里自己的容器，带独立 workspace、会话与 App mode，应用下方是 agent 状态条，普通聊天里也能行内渲染 app。
 ### 🎭 主题与外观
 
 - [keke050/dsh-wallpaper](https://github.com/keke050/dsh-wallpaper) — DSH Web 壁纸皮肤：预设 / 图片 URL / 本地上传，透明度滑块让整面界面透出壁纸。


### PR DESCRIPTION
Adds [`2nd1st/dsh-plugin-open-app`](https://github.com/2nd1st/dsh-plugin-open-app) under **UI Enhancements / 🎨 UI 增强** — one line in `README.md` and one in `README.zh.md`.

It brings [open-mcp-apps](https://github.com/2nd1st/open-mcp-apps) into DSH: each MCP app becomes its own sidebar container with a separate workspace, session and App mode, an agent status strip under the app, and inline app rendering in ordinary chats.

Checklist:

- [x] `package.json` declares **`dsh.bundle`** (`{ "bundle": { "patch": "./cordis.patch.yml" }, "client": { "platform": "web", ... } }`), not just `dsh.client` — since 0.1.1 `dsh plugin --profile <profile> add @2nd1st/dsh-plugin-open-app` is the whole install; the bundle patch inserts the plugin row itself, so nothing has to be pasted into `cordis.patch.yml` by hand.
- [x] One line added to **both** `README.md` and `README.zh.md`, same category.
- [x] Description states what it does, no superlatives.
- [x] Repo carries the `dsh-plugin` topic (also `dsh`, `cordis`, `mcp`, `mcp-apps`).

Recommended items:

- 📦 Published on npm as [`@2nd1st/dsh-plugin-open-app`](https://www.npmjs.com/package/@2nd1st/dsh-plugin-open-app) `0.1.1` (prebuilt, so no `allowBuilds` step). MIT.
- 🔗 No runtime `dependencies` at all — the official `@deepseek-ai/*` client modules are pulled in through `dsh.client.inject`, so no duplicate runtime lands in the profile.

Gates run locally on this branch: `node scripts/build-site.mjs` → `596 entries parsed across 2 locales`, site built, exit 0; `npx awesome-lint` → exit 0 (the 13 spell-check warnings it prints are pre-existing lines, none on the added entry).

Note for anyone cross-checking an earlier listing elsewhere: the package was renamed from the unscoped `dsh-plugin-open-app` to `@2nd1st/dsh-plugin-open-app` with 0.1.1; the old name is deprecated on npm and points at the new one. The GitHub repo path is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
