### PR TITLE
Add dsh-plugin-market to Plugin Markets & Managers

### DIFF
--- a/README.md
+++ b/README.md
@@ -663,6 +663,7 @@ dsh plugin --profile web add dshmarket
 - [cynch18/plugin-switch](https://github.com/cynch18/plugin-switch) - Toggle switches for the plugin inventory: enable/disable any plugin live from Settings → Plugins → Plugin list without restarting, with groups/filters, bulk toggle, undo, and backup.
 - [LKMeng2001/dsh-mcp-market](https://github.com/LKMeng2001/dsh-mcp-market) - MCP server marketplace for DSH: browse a curated, npm-verified catalog and install MCP servers into the current profile with one click, live without restart.
 - [klarkxy/dsh-plugin-autoevo](https://github.com/klarkxy/dsh-plugin-autoevo) - Resolves local tools and skills first, then searches, reviews and installs a community plugin after a one-time approval.
+- [kimiya1010/dsh-plugin-market](https://github.com/kimiya1010/dsh-plugin-market) - A plugin market for DeepSeek Harness: search and one-click install GitHub dsh-plugin plugins straight from the web GUI.
 
 ### Just for Fun
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -663,6 +663,7 @@ dsh plugin --profile web add dshmarket
 - [cynch18/plugin-switch](https://github.com/cynch18/plugin-switch) — 插件清单页滑块开关：在设置 → 插件 → 插件清单实时启用/停用任意插件，无需重启；支持分组/筛选、批量开关、撤销与自动备份。
 - [LKMeng2001/dsh-mcp-market](https://github.com/LKMeng2001/dsh-mcp-market) — DSH 的 MCP 服务器商场：浏览经过 npm 校验的精选目录，一键安装 MCP 服务器到当前 profile，免重启立即生效。
 - [klarkxy/dsh-plugin-autoevo](https://github.com/klarkxy/dsh-plugin-autoevo) — 先检查本地工具与技能，不够用再搜索、审查社区插件，并在一次性批准后自动安装。
+- [kimiya1010/dsh-plugin-market](https://github.com/kimiya1010/dsh-plugin-market) — DeepSeek Harness 插件市场：在 Web 界面里搜索并一键安装 GitHub 上的 dsh-plugin 插件。
 
 ### 🎮 娱乐
 


### PR DESCRIPTION
Adds [kimiya1010/dsh-plugin-market](https://github.com/kimiya1010/dsh-plugin-market) — a DeepSeek Harness plugin market that lets users search and one-click install GitHub \dsh-plugin\ plugins straight from the web GUI.

- Declares \dsh.bundle\ + \dsh.client\ in package.json ✅
- Has a \cordis.patch.yml\ at the repo root ✅
- Real, working code (host + client halves) ✅
- Tagged with \dsh-plugin\ ✅
- Official \@deepseek-ai/*\ packages declared as \peerDependencies\ ✅