### PR TITLE
Add bpc-oss/chrome-faithful to Tools & Capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,7 @@ dsh plugin --profile web add dshmarket
 
 - [Aik358/dsh-auto-memory](https://github.com/Aik358/dsh-auto-memory) - Auto-memory for DSH: three-layer memory (user / project notes / daily logs) with automatic injection, per-turn auto-consolidation, AI greetings, smart search, a calendar view and a settings page, plus inheritance of other AI tools' memories.
 ### Tools & Capabilities
+- [bpc-oss/chrome-faithful](https://github.com/bpc-oss/chrome-faithful) - Exact-profile control of your real logged-in Chrome browser: an MCP server plus MV3 extension and authenticated localhost bridge for tabs, locators, file injection, media export, and durable scroll capture, with no debug profile or remote-debugging port.
 - [Johnny-xuan/dsh-paste-to-path](https://github.com/Johnny-xuan/dsh-paste-to-path) - Adds a path-backed attachment dock for images, documents, archives, code, and other files, leaving file reading to the Agent's available tools.
 - [moononnn/DeepSeek-Harness-biaoqingbao](https://github.com/moononnn/DeepSeek-Harness-biaoqingbao) - Sticker/emoji expression for assistants: emotion-driven auto-matching, library management, AI image tagging, dialects, style mimicry, and chat-based tag refinement.
 - [wloops/dsh-git-worktree](https://github.com/wloops/dsh-git-worktree) - Domi-grade git worktree isolation and delivery: permanent worktrees under .dsh-worktrees, ready-for-review / apply / finish / discard lifecycle with conflict handling and safe cleanup (ported from Domi's production system).

--- a/README.zh.md
+++ b/README.zh.md
@@ -320,6 +320,7 @@ dsh plugin --profile web add dshmarket
 
 - [Aik358/dsh-auto-memory](https://github.com/Aik358/dsh-auto-memory) — DSH 自动记忆插件：三层记忆自动注入与检索、每轮对话自动沉淀、AI 时段问候与三级抽屉、智能检索、日历视图与设置页，支持继承其他 AI 工具的记忆。
 ### 🛠️ 工具与能力
+- [bpc-oss/chrome-faithful](https://github.com/bpc-oss/chrome-faithful) — 按精确 Profile 名控制你真实已登录的 Chrome 浏览器：MCP 服务器 + MV3 扩展 + 认证本地桥接，提供标签页、定位器、文件注入、媒体导出与持久滚动采集，不使用调试 Profile 或远程调试端口。
 - [Johnny-xuan/dsh-paste-to-path](https://github.com/Johnny-xuan/dsh-paste-to-path) — 为图片、文档、压缩包、代码及其他文件提供路径附件 Dock，文件读取交由 Agent 的当前可用工具完成。
 - [moononnn/DeepSeek-Harness-biaoqingbao](https://github.com/moononnn/DeepSeek-Harness-biaoqingbao) — 表情包表达插件：让助手用表情包表达情绪，按情绪自动配图，含图库管理、AI 识图打标、方言口音、学我说话，还能点「和助手聊聊」直接调教标签。
 - [wloops/dsh-git-worktree](https://github.com/wloops/dsh-git-worktree) — Domi 级 git worktree 隔离与交付：.dsh-worktrees 永久 worktree，ready-for-review / apply / finish / discard 完整生命周期，冲突处理与安全清理（移植自 Domi 生产系统）。


### PR DESCRIPTION
<!-- Thanks for contributing! Quick checklist / 提交前快速自查 -->

- [x] My repo's `package.json` declares **`dsh.bundle`** (not just `dsh.client`) — declared in the monorepo subpackage `packages/dsh-plugin-chrome-faithful` (`dsh.bundle.patch: ./cordis.patch.yml`), which is what makes it installable via `dsh plugin add`. / 仓库 `package.json` 已声明 `dsh.bundle`（monorepo 子包 `packages/dsh-plugin-chrome-faithful` 声明，可 `dsh plugin add` 安装）。
- [x] One line added to **both** `README.md` (English) and `README.zh.md` (中文), under the matching category (`Tools & Capabilities` / `工具与能力`). / 两个语言文件各加一行，放在对应分类。
- [x] Description states what the plugin does, no superlatives / 描述只说功能，不带营销词。
- [x] My repo has the `dsh-plugin` topic / 仓库已打 `dsh-plugin` topic。

**Recommended (not required) / 推荐但不强制：**

- npm publication is planned but not yet done — the plugin currently installs from the GitHub repo (the market supports GitHub-only installs). `@bpc-oss/dsh-plugin-chrome-faithful@0.4.0` will be published to npm before or alongside the next release. / npm 包尚未发布（计划中），当前可经 GitHub 仓库安装。

Chrome Faithful = exact-profile control of real logged-in Chrome: MCP server + MV3 extension + authenticated localhost bridge (38 tools), with a first-party DSH bundle in `packages/dsh-plugin-chrome-faithful`.
