### PR TITLE
Add dsh-wildmon (Pokemon-style catch-em-all, zero tokens)

### DIFF
--- a/README.md
+++ b/README.md
@@ -689,6 +689,7 @@ dsh plugin --profile web add dshmarket
 - [lucky8197/dsh-devquest](https://github.com/lucky8197/dsh-devquest) - Turns coding into an RPG: finished turns, tool calls and completed todos earn XP, with 27+ achievement badges, levels, titles and seasons. Event-driven scoring with a pure-function engine — the work itself is the game.
 - [skr311/dsh-codex-pet#dsh-codex-pet](https://github.com/skr311/dsh-codex-pet/tree/main/packages/dsh-codex-pet) - Import Codex-style sprite-sheet pets and render them as a floating shell.overlay with a pet library, interactions, and agent-state linkage.
 - [swaylq/dsh-digipet](https://github.com/swaylq/dsh-digipet) - Digimon-style raising game: hatch an egg that feeds on real work (turns, tool calls, errors) and evolves along four branching lines shaped by how you work; zero tokens, invisible to the model.
+- [swaylq/dsh-wildmon](https://github.com/swaylq/dsh-wildmon) - Pokemon-style catch-em-all: your real work is the tall grass — turns, tool calls and errors spawn wild encounters; throw balls, fill a 28-slot dex, walk a team of six. Zero tokens, invisible to the model.
 - [marvin9551/dynamic-schulte-dsh](https://github.com/marvin9551/dynamic-schulte-dsh) - Dynamic Schulte grid waiting-time mini-game: click 1..N in order on a static grid or a spinning roulette wheel while the model thinks.
 
 ## Contributing

--- a/README.zh.md
+++ b/README.zh.md
@@ -689,6 +689,7 @@ dsh plugin --profile web add dshmarket
 - [lucky8197/dsh-devquest](https://github.com/lucky8197/dsh-devquest) — 把开发变成 RPG：回合/工具/todo 积累 XP、27+ 成就徽章、等级与赛季。事件流驱动、纯函数计分——你的工作就是游戏。
 - [skr311/dsh-codex-pet#dsh-codex-pet](https://github.com/skr311/dsh-codex-pet/tree/main/packages/dsh-codex-pet) — 导入/上传 Codex 风格精灵图序列帧宠物，在 DSH Web GUI 以悬浮浮层渲染，含图库管理、交互与 Agent 状态联动。
 - [swaylq/dsh-digipet](https://github.com/swaylq/dsh-digipet) — 数码宝贝式养成：孵一颗吃真实工作长大的蛋（回合、工具调用、报错都是营养），按你的工作方式走四条进化分支；零 token，模型完全看不见。
+- [swaylq/dsh-wildmon](https://github.com/swaylq/dsh-wildmon) — 宝可梦式捕捉收集：真实工作就是草丛 —— 回合、工具调用、报错刷出野外遭遇；投球捕捉、集 28 格图鉴、带 6 只队伍。零 token，模型完全看不见。
 - [marvin9551/dynamic-schulte-dsh](https://github.com/marvin9551/dynamic-schulte-dsh) — 动态舒尔特方格等待小游戏：模型思考时，在静态网格或旋转轮盘上按顺序点击 1..N，边玩边等。
 
 ## 贡献


### PR DESCRIPTION
Adds **dsh-wildmon** to *Just for Fun*, right after its sibling dsh-digipet.

**What it is**: the collect-em-all loop (encounter → catch → dex collection → team of six) mounted on real harness work — turns, tool calls and errors roll wild encounters (errors loudest; 00:00–05:59 wakes a night pool), balls get thrown, a 28-slot dex fills up. Zero tokens, zero tools, no model-facing surface; every listener is try/catch-wrapped and it only writes its own save file.

**Why it's not a duplicate**: the pet lane has state mirrors (whale-girl, Clippy, …) and one raising game (dsh-digipet). Collecting was empty — pokemon / pokedex / catching / gacha give zero hits in the `dsh-plugin` topic (2,800+ repos) and the curated lists as of 2026-08. wildmon and digipet are complementary (breadth vs depth) and install side by side.

**Verified** on dsh `0.1.0-rc.6` (macOS, web profile): `dsh plugin --profile web add github:swaylq/dsh-wildmon` installs (pure JS, zero deps, no `prepare` script), boots clean, and the full encounter → throw → catch → dex flow was driven in a real browser, with the save file reconciling line by line against observed events. 61 unit/integration tests.

**IP note**: all 28 species names, ASCII art and copy are original; no franchise names or assets (see the README's "Homage and boundaries" section).

- [x] Repo tagged with `dsh` / `dsh-plugin` / `deepseek-harness` / `cordis` / `ai-agents` topics
- [x] Both `README.md` and `README.zh.md` updated in this PR
- [x] MIT licensed
