### PR TITLE
Add dsh-lazeword — 躺着背单词 (cozy offline vocabulary trainer)

### DIFF
--- a/README.md
+++ b/README.md
@@ -666,6 +666,7 @@ dsh plugin --profile web add dshmarket
 
 ### Just for Fun
 
+- [xczhanjun/lazeword](https://github.com/xczhanjun/lazeword) - A cozy offline vocabulary trainer for the whole family: 1094 curated words, spaced repetition, 6 quiz types, spelling games and a lazy large-screen mode; opens as a sidebar panel and also runs standalone as one HTML file.
 - [Nagi-ovo/dsh-ads](https://github.com/Nagi-ovo/dsh-ads) - Parody ads in 2005-Chinese-web style: sidebar banners, in-chat feeds, corner popups, and a close button whose hit area is smaller than it looks. All fictional.
 - [omdsh-dev/dsh-gomoku](https://github.com/omdsh-dev/dsh-gomoku) - Play Gomoku against the AI, or let two AIs battle it out.
 - [AnacondaKC/dsh-stock-market](https://github.com/AnacondaKC/dsh-stock-market) - Fixes the bug where your account can't lose money while you code.

--- a/README.zh.md
+++ b/README.zh.md
@@ -666,6 +666,7 @@ dsh plugin --profile web add dshmarket
 
 ### 🎮 娱乐
 
+- [xczhanjun/lazeword](https://github.com/xczhanjun/lazeword) — 舒服的离线背单词全家桶：1094 个精选单词、间隔重复、6 种题型、拼写游戏和躺着背大字模式；侧边栏面板打开，也可作为单个 HTML 文件独立运行。
 - [Nagi-ovo/dsh-ads](https://github.com/Nagi-ovo/dsh-ads) — 2005 年中文站点风格的整活广告插件：侧栏广告/信息流/角落弹窗 + 假关闭叉，素材全虚构。
 - [omdsh-dev/dsh-gomoku](https://github.com/omdsh-dev/dsh-gomoku) — 与 AI 下五子棋，也可让 AI 对局比棋力。
 - [AnacondaKC/dsh-stock-market](https://github.com/AnacondaKC/dsh-stock-market) — 有效解决了写代码的时候账户不能同时亏钱的 BUG。


### PR DESCRIPTION
## dsh-lazeword — 🛋️ 躺着背单词 (lazeword)

A cozy, offline vocabulary trainer for the whole family.

**Repo:** https://github.com/xczhanjun/lazeword (topics: `dsh-plugin`)

### Screenshots (real installation test, `dsh plugin add dsh-lazeword` + `dsh web`)

![sidebar button](https://raw.githubusercontent.com/xczhanjun/lazeword/main/docs/screenshots/dsh-sidebar.png)

![panel with the app](https://raw.githubusercontent.com/xczhanjun/lazeword/main/docs/screenshots/dsh-panel.png)

### What it is
- **1094 curated words** (947 everyday + 147 Hong Kong junior-secondary math/science terms, 中文/繁體)
- Spaced repetition (Ebbinghaus 1→3→7→15→30 days) + mistake notebook + study heatmap + event-sourced learning trajectory
- 6 quiz types (meaning / word / IPA / listening / spelling grid / cloze); correct answers auto-pronounce
- Pronunciation: TTS + IPA syllable & stress highlighting that follows the speech + repeat-after-me scoring
- Reference: irregular verbs, grammar points, phrasal verbs, conversational sentences; 繁/簡 toggle
- Space word-matching game; lazy fullscreen mode (auto page-turn, voice 会/不会, Space to pause)
- Up to 4 family profiles, parent/teacher report, daily 10 words, JSON backup
- **Fully offline, zero dependencies** — also runs standalone as one HTML file (`app/lazeword.html`)

### Plugin shape
- Standard bundle (`dsh.bundle` manifest + `cordis.patch.yml`), host entry `lib/index.js`
- Web client bundle `lib/client.js` (`window.__ModuleLoader__` format) — `sidebar.footer.action` toggle + `shell.overlay` panel opening the app via blob-URL iframe (no server, deterministic)
- Deterministic core in `src/core.mjs` with 26 `node:test` unit tests + CI (tests + reproducible-build check)

### Notes
- Install: `dsh plugin --profile web add dsh-lazeword`
- License MIT · community-maintained, not affiliated with DeepSeek