### PR TITLE
Add dsh-update-copilot / 收录 dsh-update-copilot

### DIFF
--- a/README.md
+++ b/README.md
@@ -646,6 +646,8 @@ dsh plugin --profile web add dshmarket
 - [PAKIKNOWLEDGE/dsh-auto-classifier](https://github.com/PAKIKNOWLEDGE/dsh-auto-classifier) - Autonomous permission classifier for the auto preset: tool-scoped allow/deny rules, an LLM semantic judge, and git checkpointing for unattended sessions.
 - [fuyue521/dsh-desktop-shortcut](https://github.com/fuyue521/dsh-desktop-shortcut) - Windows desktop shortcut for dsh web: launches the server, auto-opens the browser when ready, and stops the service when the Harness window closes.
 - [sjh9714/dsh-win32](https://github.com/sjh9714/dsh-win32) - Makes Minimal mode work on Windows: supplies the missing win32 process inspector so the persistent Git Bash shell runs, plus a faithful minimal-windows preset and an install-trap doctor (koffi crashes, PS 5.1 fallback, localhost 403).
+- [hezhongtang/dsh-update-copilot](https://github.com/hezhongtang/dsh-update-copilot) - Update copilot for DeepSeek Harness: one scan covers the dsh core, official bundles, and every profile plugin; explains what changed and how risky each update is, then updates only what you confirm.
+
 ### Plugin Markets & Managers
 
 - [dsh-market/dsh-market](https://github.com/dsh-market/dsh-market) - (Recommended) The plugin market inside DSH: a Settings page to browse and search the full community catalog by category, with confirmed one-click installs and an installed-plugins view.

--- a/README.zh.md
+++ b/README.zh.md
@@ -646,6 +646,8 @@ dsh plugin --profile web add dshmarket
 - [PAKIKNOWLEDGE/dsh-auto-classifier](https://github.com/PAKIKNOWLEDGE/dsh-auto-classifier) — auto（自主模式）权限分类器：工具作用域的放行/拒绝规则、LLM 语义裁判与 git 快照，面向无人值守会话。
 - [fuyue521/dsh-desktop-shortcut](https://github.com/fuyue521/dsh-desktop-shortcut) — Windows 桌面快捷方式：一键启动 dsh web，就绪后自动打开浏览器，关闭 Harness 窗口即停服务。
 - [sjh9714/dsh-win32](https://github.com/sjh9714/dsh-win32) — 让 Minimal 模式在 Windows 上真正可用：补上缺失的 win32 进程探测，常驻 Git Bash shell 才能正常工作；附还原度高的 minimal-windows 预设与安装排障工具（koffi 崩溃、PS 5.1 回退、localhost 403）。
+- [hezhongtang/dsh-update-copilot](https://github.com/hezhongtang/dsh-update-copilot) — DeepSeek Harness 的更新助手：一次扫描覆盖 dsh 本体、官方 bundle 和每个 profile 的插件，说清改了什么、风险多大，只更新你确认过的那些。
+
 ### 🛒 插件市场与管理
 
 - [dsh-market/dsh-market](https://github.com/dsh-market/dsh-market) — （推荐）装在 DSH 里的插件市场：设置页内逛/搜全部社区插件，按分类筛选，确认后一键安装，已装插件一目了然。


### PR DESCRIPTION
## What this adds / 这个 PR 做了什么

Adds [hezhongtang/dsh-update-copilot](https://github.com/hezhongtang/dsh-update-copilot) to the **Development & Runtime / 开发与运行时** section in both `README.md` and `README.zh.md`.

It is an update copilot for DeepSeek Harness: one scan covers the dsh core, official bundles, and every profile plugin. Each item comes with a plain-language brief on what changed and the risk level, and updates run only after explicit confirmation.

把 [hezhongtang/dsh-update-copilot](https://github.com/hezhongtang/dsh-update-copilot) 加进两个 README 的「开发与运行时」分类。

它是 DeepSeek Harness 的更新助手：一次扫描覆盖 dsh 本体、官方 bundle 和每个 profile 的插件；每一项都附上通俗易懂的变更说明和风险等级，并且只有明确确认后才会执行更新。

## Checklist / 收录自查

- [x] Repo is public and has the `dsh-plugin` topic / 仓库公开且带 `dsh-plugin` topic
- [x] `package.json` declares a `dsh.bundle.patch` manifest with a real `cordis.patch.yml` / 已声明 `dsh.bundle.patch` 并提供真实的 `cordis.patch.yml`
- [x] Working code, bilingual README / 代码可用，README 中英双语
- [x] One line added per language, no superlatives / 每种语言各加一行，无营销词