### PR TITLE
Add stakeswky/awesome-dsh to Plugin Markets & Managers

### DIFF
--- a/README.md
+++ b/README.md
@@ -726,6 +726,7 @@ dsh plugin --profile web add dshmarket
 - [cynch18/plugin-switch](https://github.com/cynch18/plugin-switch) - Toggle switches for the plugin inventory: enable/disable any plugin live from Settings → Plugins → Plugin list without restarting, with groups/filters, bulk toggle, undo, and backup.
 - [LKMeng2001/dsh-mcp-market](https://github.com/LKMeng2001/dsh-mcp-market) - MCP server marketplace for DSH: browse a curated, npm-verified catalog and install MCP servers into the current profile with one click, live without restart.
 - [klarkxy/dsh-plugin-autoevo](https://github.com/klarkxy/dsh-plugin-autoevo) - Resolves local tools and skills first, then searches, reviews and installs a community plugin after a one-time approval.
+- [stakeswky/awesome-dsh](https://github.com/stakeswky/awesome-dsh) - Turns a stated need into a plugin choice: an agent skill that queries a catalog of the whole `dsh-plugin` topic (2600+ repos, recrawled every 6 hours, Chinese descriptions from Workers AI) through a ranked search API, then hands back the matching `dsh plugin add` command.
 
 ### Just for Fun
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -726,6 +726,7 @@ dsh plugin --profile web add dshmarket
 - [cynch18/plugin-switch](https://github.com/cynch18/plugin-switch) — 插件清单页滑块开关：在设置 → 插件 → 插件清单实时启用/停用任意插件，无需重启；支持分组/筛选、批量开关、撤销与自动备份。
 - [LKMeng2001/dsh-mcp-market](https://github.com/LKMeng2001/dsh-mcp-market) — DSH 的 MCP 服务器商场：浏览经过 npm 校验的精选目录，一键安装 MCP 服务器到当前 profile，免重启立即生效。
 - [klarkxy/dsh-plugin-autoevo](https://github.com/klarkxy/dsh-plugin-autoevo) — 先检查本地工具与技能，不够用再搜索、审查社区插件，并在一次性批准后自动安装。
+- [stakeswky/awesome-dsh](https://github.com/stakeswky/awesome-dsh) — 把「我想让 DSH 做什么」直接变成选好的插件：技能查询覆盖整个 `dsh-plugin` topic 的目录（2600+ 仓库，每 6 小时重抓，简介由 Workers AI 译成中文）的相关度检索接口，再给出对应的 `dsh plugin add` 命令。
 
 ### 🎮 娱乐
 


### PR DESCRIPTION
Adds [stakeswky/awesome-dsh](https://github.com/stakeswky/awesome-dsh) — a plugin that turns "I want DSH to do X" into a concrete plugin choice plus its install command.

The bundle registers one on-demand skill (`dsh-plugin-finder`) on `ctx.skills`. The skill queries a catalog that covers the **whole** `dsh-plugin` topic — 2652 of 2683 repos at the time of writing — through a ranked search API, so the agent picks from the full ecosystem without pulling the 1.1 MB catalog into context. Descriptions are translated to Chinese by Workers AI. The catalog recrawls every 6 hours; star-range partitioning keeps it from being capped by the Search API's 1000-results-per-query limit.

Category: filed under **Plugin Markets & Managers** next to `dsh-plugin-scout` and `dsh-plugin-autoevo`, since the function is discovery and installation. Happy to move it to **Skills** if you prefer classifying by delivery form — it is shipped as a skill bundle.

### Checklist against contributing.md

- `package.json` declares `dsh.bundle` → [`"dsh": { "bundle": { "patch": "./cordis.patch.yml" } }`](https://github.com/stakeswky/awesome-dsh/blob/main/package.json), with `cordis.patch.yml` next to it.
- Real working code, verified installed rather than assumed:
  - `dsh plugin --profile ghtest add github:stakeswky/awesome-dsh` completes in 6.1s, and the profile manifest gains `awesome-dsh` in `dsh.profile.bundles`.
  - `dsh --profile ghtest --dump-config` composes the row `id: dsh-plugin-finder` under the `# == awesome-dsh` layer.
  - Mounting the bundle registers exactly one skill (`source: bundled`, directory `resourceBase`, frontmatter stripped); the effect disposer removes it again.
  - `dsh plugin remove awesome-dsh` restores `bundles` to `@deepseek-ai/dsh-base` alone.
- No `prepare` script, so the first `add` from git needs no `allowBuilds` approval.
- `@deepseek-ai/dsh` is an optional `peerDependency`, not a dependency.
- Repo carries the `dsh-plugin` topic. MIT licensed.

Both `README.md` and `README.zh.md` are updated in this PR.