### PR TITLE
Add dsh-desktop-app — DSH desktop packaging skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -537,6 +537,7 @@ dsh plugin --profile web add dshmarket
 - [moguiyu/dsh-tavily#packages/dsh-tool-tavily-search](https://github.com/moguiyu/dsh-tavily/tree/main/packages/dsh-tool-tavily-search) - Tavily search with multiple API keys, key rotation and failover, a usage gauge, and a settings card.
 - [wade20250715/dsh-pubmed](https://github.com/wade20250715/dsh-pubmed) - PubMed deep-research toolset: literature search, author investigation, same-name disambiguation, institution statistics and mentor-student matching.
 ### Skills
+- [happpsee/dsh-desktop-app](https://github.com/happpsee/dsh-desktop-app) - Skill for packaging DeepSeek Harness into a Tauri 2 desktop app (macOS + Windows): dual-platform install playbook, China mirror bootstrap with a subagent timeout sentinel, admin-free Windows toolchain recipe (no VS Build Tools), and three-path acceptance checklists.
 - [STARDUSTLC666/dsh-remotion](https://github.com/STARDUSTLC666/dsh-remotion) - Official Remotion skill ported to DSH: programmatic video with React (animation/audio/captions/3D/charts/fonts, 38 rule files).
 - [STARDUSTLC666/dsh-hyperframes](https://github.com/STARDUSTLC666/dsh-hyperframes) - Five official HyperFrames by HeyGen skills: HTML video / CLI / registry / website-to-video / GSAP reference.
 - [YuanyuanMa03/cot-lint](https://github.com/YuanyuanMa03/cot-lint) - Chain-of-thought leakage linter: zero-dependency CLI that finds AI-session residue in docs and comments (dead design citations, PR vantage, change narration, review choreography), shipping the cot-trim fixing skill as the installable bundle.

--- a/README.zh.md
+++ b/README.zh.md
@@ -538,6 +538,7 @@ dsh plugin --profile web add dshmarket
 - [moguiyu/dsh-tavily#packages/dsh-tool-tavily-search](https://github.com/moguiyu/dsh-tavily/tree/main/packages/dsh-tool-tavily-search) — Tavily 多密钥搜索：支持密钥轮换/故障转移、用量仪表盘与设置卡片。
 - [wade20250715/dsh-pubmed](https://github.com/wade20250715/dsh-pubmed) — PubMed 深度科研工具集：文献检索、作者调查、同名消歧、机构统计与师承匹配。
 ### 🧩 技能包
+- [happpsee/dsh-desktop-app](https://github.com/happpsee/dsh-desktop-app) — 把 DeepSeek Harness 封装成 Tauri 2 桌面应用（macOS + Windows）的技能包：双平台安装、国内镜像加速（含 subagent 超时哨兵）、无管理员 Windows 工具链方案、三路径验收清单。
 - [STARDUSTLC666/dsh-remotion](https://github.com/STARDUSTLC666/dsh-remotion) — Remotion 官方移植技能：React 编程式视频（动画/音频/字幕/3D/图表/字体，38 规则文件），安装即用。
 - [STARDUSTLC666/dsh-hyperframes](https://github.com/STARDUSTLC666/dsh-hyperframes) — HyperFrames by HeyGen 官方移植技能五件套：HTML 写视频 / CLI / 注册表 / 网址转视频 / GSAP 参考。
 - [YuanyuanMa03/cot-lint](https://github.com/YuanyuanMa03/cot-lint) — 思维链泄漏检测：零依赖 CLI 扫描 AI 留在文档与注释里的会话残留（死设计引用、PR 视角、变更叙述、评审编排），内置 cot-trim 语义修复技能包。


### PR DESCRIPTION
Adds [dsh-desktop-app](https://github.com/happpsee/dsh-desktop-app) under Skills (README.md + README.zh.md).

A -installable bundle that registers a skill for packaging DeepSeek Harness into a Tauri 2 desktop app (macOS + Windows). Distinguishing content vs. the many desktop shells on GitHub:

- Dual-platform DSH install playbook (macOS / Windows)
- China mirror bootstrap (rustup/cargo/npm/GitHub/NSIS) with a subagent timeout sentinel
- Admin-free Windows toolchain recipe (xwin + rust-lld + clang-cl + real rc.exe, no VS Build Tools)
- Three-path acceptance checklists, backed by a real-machine Win11 audit report (docs/)

Declares dsh.bundle in package.json; MIT licensed.