### PR TITLE
Add dsh-messages-sanitizer (Sessions & Messages)

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,7 @@ dsh plugin --profile web add dshmarket
 - [tuogusa/dsh-session-tags](https://github.com/tuogusa/dsh-session-tags) - Attach tags to sessions and search sessions by tag in the Web settings panel.
 
 - [tuogusa/dsh-session-nav](https://github.com/tuogusa/dsh-session-nav) - A floating button beside the chat that opens a searchable list of all questions in the session for quick jumps.
+- [Leeminjing/dsh-messages-sanitizer](https://github.com/Leeminjing/dsh-messages-sanitizer) - Auto-repairs the messages array after a tool-dispatch crash (orphaned tool_calls / tool messages), preventing 400 INVALID_REQUEST session lock-ups.
 
 
 ### Memory

--- a/README.zh.md
+++ b/README.zh.md
@@ -357,6 +357,7 @@ dsh plugin --profile web add dshmarket
 - [tuogusa/dsh-session-tags](https://github.com/tuogusa/dsh-session-tags) — 为会话添加标签，并在 Web 设置面板中按标签搜索会话。
 
 - [tuogusa/dsh-session-nav](https://github.com/tuogusa/dsh-session-nav) — 对话旁的悬浮按钮，打开当前会话全部提问的可搜索列表并快速跳转。
+- [Leeminjing/dsh-messages-sanitizer](https://github.com/Leeminjing/dsh-messages-sanitizer) — 工具调度崩溃后自动修复 messages 数组（孤儿 tool_calls / tool 消息），防止 400 INVALID_REQUEST 会话卡死。
 
 
 ### 🧠 记忆


### PR DESCRIPTION
Adds [dsh-messages-sanitizer](https://github.com/Leeminjing/dsh-messages-sanitizer) — auto-repairs the messages array after a tool-dispatch crash (orphaned `tool_calls`), preventing `400 INVALID_REQUEST` session lock-ups.

- installable via `dsh plugin --profile web add github:Leeminjing/dsh-messages-sanitizer`
- declares `dsh.bundle`
- 40 tests + real Session integration tests
