### PR TITLE
Fix npm repository probing and remove duplicate LoongSuite entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -715,7 +715,6 @@ dsh plugin --profile web add dshmarket
 - [shaobeichen/dsh-pocket](https://github.com/shaobeichen/dsh-pocket) - Remote phone access to the DSH Web UI: scan a QR code for LAN or public (cloudflared tunnel) access with real-time sync, a mobile-adaptive layout, and a settings tab.
 - [jiezeng2004-design/dsh-chatgpt-bridge](https://github.com/jiezeng2004-design/dsh-chatgpt-bridge) - MCP bridge that lets ChatGPT Web create, view, continue, and supervise DeepSeek Harness agent sessions and goals while preserving DSH's native approval, sandbox, and workspace security model.
 - [hanwuji1/dsh-web-launcher](https://github.com/hanwuji1/dsh-web-launcher) - One-click launcher for the Web UI: a double-click Start-DSH-Web.cmd on the Windows desktop that boots dsh web and auto-opens the browser (polling until ready), plus a web_launcher model tool (install / open / status).
-- [loongsuite/pilot-dsh](https://github.com/loongsuite/pilot-dsh) - Standalone OpenTelemetry GenAI observability for DeepSeek Harness that exports native session, agent, LLM, and tool traces and metrics over OTLP to any compatible backend.
 - [pitetow/dsh-notify-on-complete](https://github.com/pitetow/dsh-notify-on-complete) - Desktop notifications for run completion, model questions, and approval requests with per-platform system sounds, zero runtime dependencies.
 
 ### Development & Runtime

--- a/README.zh.md
+++ b/README.zh.md
@@ -715,7 +715,6 @@ dsh plugin --profile web add dshmarket
 - [shaobeichen/dsh-pocket](https://github.com/shaobeichen/dsh-pocket) — 手机远程访问 DSH Web 界面：扫码即用局域网或公网（cloudflared 隧道）访问，实时同屏、移动端适配布局，带设置页管理。
 - [jiezeng2004-design/dsh-chatgpt-bridge](https://github.com/jiezeng2004-design/dsh-chatgpt-bridge) — 通过 MCP 让 ChatGPT Web 创建、查看、继续和监督 DeepSeek Harness Agent 会话与 Goal，同时保留 DSH 原生的审批、沙箱与工作区安全模型。
 - [hanwuji1/dsh-web-launcher](https://github.com/hanwuji1/dsh-web-launcher) — Web 界面一键启动器：在 Windows 桌面创建双击即用的 Start-DSH-Web.cmd（自动启动 dsh web，轮询就绪后自动打开浏览器），并提供 web_launcher 模型工具（install / open / status）。
-- [loongsuite/pilot-dsh](https://github.com/loongsuite/pilot-dsh) — DeepSeek Harness 独立 OpenTelemetry GenAI 可观测插件，采集原生会话、Agent、LLM 与工具调用链及指标，并通过 OTLP 上报到任意兼容后端。
 - [pitetow/dsh-notify-on-complete](https://github.com/pitetow/dsh-notify-on-complete) — 系统桌面通知：运行结束、模型提问与审批请求即时提醒，三平台提示音，零运行时依赖。
 
 ### 🧑‍💻 开发与运行时

--- a/scripts/probe-npm.mjs
+++ b/scripts/probe-npm.mjs
@@ -63,7 +63,12 @@ async function probe(url) {
     const name = typeof pkg.name === 'string' ? pkg.name : null
     if (name === null) return { npm: null, checkedAt: today }
     const meta = await fetchJson(`https://registry.npmjs.org/${encodeURIComponent(name)}`)
-    const repoField = typeof meta.repository === 'string' ? meta.repository : meta.repository?.url ?? ''
+    // Registry documents can retain repository metadata from the first
+    // publication at the top level. Resolve the current `latest` manifest
+    // first so repository renames in later releases are recognized.
+    const latest = typeof meta['dist-tags']?.latest === 'string' ? meta['dist-tags'].latest : null
+    const repository = (latest === null ? null : meta.versions?.[latest]?.repository) ?? meta.repository
+    const repoField = typeof repository === 'string' ? repository : repository?.url ?? ''
     const linked = repoField.toLowerCase().includes(repo.toLowerCase())
     return { npm: linked ? name : null, checkedAt: today }
   } catch {


### PR DESCRIPTION
## Summary

- resolve npm repository metadata from the manifest selected by dist-tags.latest, with the registry top-level field as a compatibility fallback
- remove the duplicate LoongSuite entry that still uses the retired loongsuite/pilot-dsh path
- retain the canonical loongsuite/dsh-plugin entry added by #698 under Development & Runtime
- keep the English and Chinese catalogs aligned

## Context

PR #590 and PR #698 were merged close together during the repository rename, leaving two entries for the same plugin. @loongsuite/dsh-plugin@0.1.0-beta.2 now publishes the canonical repository URL in its version manifest, but the npm registry document retains the beta.1 repository at the top level. Reading the latest version manifest handles repository renames correctly for this and other packages.

## Validation

- node --check scripts/probe-npm.mjs
- live registry check: latest=0.1.0-beta.2, latest repository=loongsuite/dsh-plugin, linked=true
- git diff --check
- node scripts/build-site.mjs (765 entries parsed across 2 locales)
- exactly one loongsuite/dsh-plugin entry remains in each locale

After merge, a probe_all site build (or the nightly scheduled build) will refresh cached npm mappings.