### PR TITLE
add dsh-island: bridge DSH agent status to the CodeIsland macOS notch panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -717,6 +717,7 @@ dsh plugin --profile web add dshmarket
 - [hanwuji1/dsh-web-launcher](https://github.com/hanwuji1/dsh-web-launcher) - One-click launcher for the Web UI: a double-click Start-DSH-Web.cmd on the Windows desktop that boots dsh web and auto-opens the browser (polling until ready), plus a web_launcher model tool (install / open / status).
 - [loongsuite/pilot-dsh](https://github.com/loongsuite/pilot-dsh) - Standalone OpenTelemetry GenAI observability for DeepSeek Harness that exports native session, agent, LLM, and tool traces and metrics over OTLP to any compatible backend.
 - [pitetow/dsh-notify-on-complete](https://github.com/pitetow/dsh-notify-on-complete) - Desktop notifications for run completion, model questions, and approval requests with per-platform system sounds, zero runtime dependencies.
+- [cdxiaodong/dsh-island](https://github.com/cdxiaodong/dsh-island) - Bridge DSH agent sessions, tool calls, and approvals to the CodeIsland macOS notch panel over a Unix socket, with in-panel allow/deny.
 
 ### Development & Runtime
 - [zoahdev/dsh-rule-evolve](https://github.com/zoahdev/dsh-rule-evolve/tree/main/plugin) - Verification-driven self-evolution loop: failure logs become verified AGENTS.md rules; in-session plugin (evolve_learn / evolve_apply / evolve_touch / evolve_recall), tool-verify gate, rule lifecycle, local recall.

--- a/README.zh.md
+++ b/README.zh.md
@@ -717,6 +717,7 @@ dsh plugin --profile web add dshmarket
 - [hanwuji1/dsh-web-launcher](https://github.com/hanwuji1/dsh-web-launcher) — Web 界面一键启动器：在 Windows 桌面创建双击即用的 Start-DSH-Web.cmd（自动启动 dsh web，轮询就绪后自动打开浏览器），并提供 web_launcher 模型工具（install / open / status）。
 - [loongsuite/pilot-dsh](https://github.com/loongsuite/pilot-dsh) — DeepSeek Harness 独立 OpenTelemetry GenAI 可观测插件，采集原生会话、Agent、LLM 与工具调用链及指标，并通过 OTLP 上报到任意兼容后端。
 - [pitetow/dsh-notify-on-complete](https://github.com/pitetow/dsh-notify-on-complete) — 系统桌面通知：运行结束、模型提问与审批请求即时提醒，三平台提示音，零运行时依赖。
+- [cdxiaodong/dsh-island](https://github.com/cdxiaodong/dsh-island) — 通过 Unix socket 把 DSH agent 的会话、工具调用与审批实时桥接到 CodeIsland macOS 刘海面板，可直接在面板上批准/拒绝。
 
 ### 🧑‍💻 开发与运行时
 - [zoahdev/dsh-rule-evolve](https://github.com/zoahdev/dsh-rule-evolve/tree/main/plugin) — 验证驱动的自我进化循环：失败日志自动变成经过验证的 AGENTS.md 规则；会话内插件（evolve_learn/evolve_apply/evolve_touch/evolve_recall）、工具体检、规则生命周期、本地召回。


### PR DESCRIPTION
## What

Adds **dsh-island** under **Notifications & Integrations**.

`dsh-island` bridges DeepSeek Harness (DSH) agent sessions, tool calls, and approval requests to [CodeIsland](https://github.com/wxtsky/CodeIsland)'s macOS notch panel over the CodeIsland Unix socket. It listens to DSH built-in events (`session/created`, `tools/pre-execute`, `approval/request`, …) and forwards them so DSH status renders live in the Dynamic Island, with allow/deny directly on the panel.

## Qualification

- Declares a `dsh.bundle` manifest (`dsh.bundle.patch: cordis.patch.yml`) → installable via `dsh plugin add github:cdxiaodong/dsh-island`.
- Real working code: 8 passing tests + a live demo panel screenshot.
- Repo has the `dsh-plugin` / `dsh` topics.

## Links

- Repo: https://github.com/cdxiaodong/dsh-island
- Companion CodeIsland support PR: https://github.com/wxtsky/CodeIsland/pull/315