### PR TITLE
add dsh-island: bridge DSH agent status to the CodeIsland macOS notch panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -751,6 +751,7 @@ dsh plugin --profile web add dshmarket
 - [pitetow/dsh-notify-on-complete](https://github.com/pitetow/dsh-notify-on-complete) - Desktop notifications for run completion, model questions, and approval requests with per-platform system sounds, zero runtime dependencies.
 - [Alan2Z/dsh-speak](https://github.com/Alan2Z/dsh-speak) - Voice-announce the final reply on Windows (SAPI5 natural voices) and macOS (system voice); skips reasoning and tool calls, one-line npm install.
 - [mingzeng21/dsh-notion](https://github.com/mingzeng21/dsh-notion) - Connect dsh to Notion via the official Notion MCP (OAuth + PKCE): search, read, and write pages, databases, and comments through `mcp__notion__*` tools.
+- [cdxiaodong/dsh-island](https://github.com/cdxiaodong/dsh-island) - Bridge DSH agent sessions, tool calls, and approvals to the CodeIsland macOS notch panel over a Unix socket, with in-panel allow/deny.
 
 ### Development & Runtime
 - [litestartup-com/dsh-api-gateway](https://github.com/litestartup-com/dsh-api-gateway) - REST + SSE gateway exposing running Harness sessions to third-party clients: API-key auth, token streaming, workspace grouping, and adopting GUI sessions to keep chatting.

--- a/README.zh.md
+++ b/README.zh.md
@@ -750,6 +750,7 @@ dsh plugin --profile web add dshmarket
 - [pitetow/dsh-notify-on-complete](https://github.com/pitetow/dsh-notify-on-complete) — 系统桌面通知：运行结束、模型提问与审批请求即时提醒，三平台提示音，零运行时依赖。
 - [Alan2Z/dsh-speak](https://github.com/Alan2Z/dsh-speak) — 语音播报 agent 最终回复：Windows SAPI5 自然语音 / macOS 系统语音，自动跳过思考与工具调用，npm 一行安装。
 - [mingzeng21/dsh-notion](https://github.com/mingzeng21/dsh-notion) — 通过官方 Notion MCP（OAuth + PKCE）把 dsh 连接到 Notion：通过 `mcp__notion__*` 工具搜索、读写页面、数据库与评论。
+- [cdxiaodong/dsh-island](https://github.com/cdxiaodong/dsh-island) — 通过 Unix socket 把 DSH agent 的会话、工具调用与审批实时桥接到 CodeIsland macOS 刘海面板，可直接在面板上批准/拒绝。
 
 ### 🧑‍💻 开发与运行时
 - [litestartup-com/dsh-api-gateway](https://github.com/litestartup-com/dsh-api-gateway) — 为第三方客户端提供 REST + SSE 网关：API 密钥鉴权、token 流式回包、会话工作区分组，并可接管 GUI 会话继续对话。


### PR DESCRIPTION
## What

Adds **dsh-island** under **Notifications & Integrations**.

`dsh-island` bridges DeepSeek Harness (DSH) agent sessions, tool calls, and approval requests to [CodeIsland](https://github.com/wxtsky/CodeIsland)'s macOS notch panel over the CodeIsland Unix socket. It listens to DSH built-in events (`session/created`, `tools/pre-execute`, `approval/request`, …) and forwards them so DSH status renders live in the Dynamic Island, with allow/deny directly on the panel.

## Qualification

- Declares a `dsh.bundle` manifest (`dsh.bundle.patch: cordis.patch.yml`) → installable via `dsh plugin add github:cdxiaodong/dsh-island`.
- Real working code: 8 passing tests + a live demo panel screenshot.
- Repo has the `dsh-plugin` / `dsh` topics.

## Links

- Repo: https://github.com/cdxiaodong/dsh-island
- Companion CodeIsland support PR: https://github.com/wxtsky/CodeIsland/pull/315