### PR TITLE
Add kinmat-A/dsh-theme-switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -842,6 +842,8 @@ dsh plugin --profile web add dshmarket
 - [kimiya1010/dsh-plugin-market](https://github.com/kimiya1010/dsh-plugin-market) - A plugin market for DeepSeek Harness: search and one-click install GitHub dsh-plugin plugins straight from the web GUI.
 
 
+- [kinmat-A/dsh-theme-switch](https://github.com/kinmat-A/dsh-theme-switch) - One-click skin switching for DSH Web settings: auto-detects installed themes, keeps exactly one active at a time, and falls back to the official look when all are off. Changes apply instantly and survive restarts.
+
 ### Just for Fun
 
 - [xczhanjun/lazeword](https://github.com/xczhanjun/lazeword) - A cozy offline vocabulary trainer for the whole family: 1094 curated words, spaced repetition, 6 quiz types, spelling games and a lazy large-screen mode; opens as a sidebar panel and also runs standalone as one HTML file.

--- a/README.zh.md
+++ b/README.zh.md
@@ -842,6 +842,8 @@ dsh plugin --profile web add dshmarket
 - [kimiya1010/dsh-plugin-market](https://github.com/kimiya1010/dsh-plugin-market) — DeepSeek Harness 插件市场：在 Web 界面里搜索并一键安装 GitHub 上的 dsh-plugin 插件。
 
 
+- [kinmat-A/dsh-theme-switch](https://github.com/kinmat-A/dsh-theme-switch) — DSH 主题切换：自动检测已安装的皮肤/主题，在设置页一键互斥切换，全部停用时回退官方默认外观，切换即时生效并跨重启保留。
+
 ### 🎮 娱乐
 
 - [xczhanjun/lazeword](https://github.com/xczhanjun/lazeword) — 舒服的离线背单词全家桶：1094 个精选单词、间隔重复、6 种题型、拼写游戏和躺着背大字模式；侧边栏面板打开，也可作为单个 HTML 文件独立运行。


### PR DESCRIPTION
Add the dsh-theme-switch plugin under Plugin Markets & Managers / ???????.

- Repo: https://github.com/kinmat-A/dsh-theme-switch
- Declares dsh.bundle in package.json with cordis.patch.yml (installable via `dsh plugin add github:kinmat-A/dsh-theme-switch`)
- Auto-detects installed skins, one-click mutually exclusive switching in an official-style settings tab; falls back to the official look when all skins are off. State lives in the home-layer patch, so changes apply instantly and survive restarts.