### PR TITLE
add: dsh-session-flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,6 +363,7 @@ dsh plugin --profile web add dshmarket
 
 - [tuogusa/dsh-session-nav](https://github.com/tuogusa/dsh-session-nav) - A floating button beside the chat that opens a searchable list of all questions in the session for quick jumps.
 - [Leeminjing/dsh-messages-sanitizer](https://github.com/Leeminjing/dsh-messages-sanitizer) - Auto-repairs the messages array after a tool-dispatch crash (orphaned tool_calls / tool messages), preventing 400 INVALID_REQUEST session lock-ups.
+- [YeqingTang/dsh-session-flow](https://github.com/YeqingTang/dsh-session-flow) - Cross-session archive: overview workbench, folded timeline, subagent lineage, content search, rule+LLM summaries, ZIP export, live tracking.
 
 
 ### Memory

--- a/README.zh.md
+++ b/README.zh.md
@@ -364,6 +364,7 @@ dsh plugin --profile web add dshmarket
 
 - [tuogusa/dsh-session-nav](https://github.com/tuogusa/dsh-session-nav) — 对话旁的悬浮按钮，打开当前会话全部提问的可搜索列表并快速跳转。
 - [Leeminjing/dsh-messages-sanitizer](https://github.com/Leeminjing/dsh-messages-sanitizer) — 工具调度崩溃后自动修复 messages 数组（孤儿 tool_calls / tool 消息），防止 400 INVALID_REQUEST 会话卡死。
+- [YeqingTang/dsh-session-flow](https://github.com/YeqingTang/dsh-session-flow) — 跨会话档案柜：总览工作台、折叠时间线、子代理血缘、内容检索、规则+LLM 双模式摘要、ZIP 导出、实时跟踪。
 
 
 ### 🧠 记忆


### PR DESCRIPTION
Add [YeqingTang/dsh-session-flow](https://github.com/YeqingTang/dsh-session-flow) to Sessions & Messages.

DSH 会话信息流重设计插件：跨会话档案柜（总览工作台、折叠时间线、子代理血缘、内容检索、规则+LLM 双模式摘要、ZIP 分卷导出、实时跟踪）。已发布至 npm（dsh-session-flow@0.1.0），package.json 含 dsh.bundle manifest（cordis.patch.yml）。