### PR TITLE
Add dsh-swarm-router to Models & Providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,7 @@ dsh plugin --profile web add dshmarket
 
 ### Models & Providers
 - [WNJXYK/dsh-codex-oauth](https://github.com/WNJXYK/dsh-codex-oauth) - Use a ChatGPT/Codex subscription in DeepSeek Harness with GPT models, image generation, web search, subscription quota reporting, model and feature controls, and browser or device-code OAuth sign-in.
+- [r600a-code/dsh-swarm-router](https://github.com/r600a-code/dsh-swarm-router) - Sub-agent matrix swarm that routes heterogeneous tasks to the most suitable model from an OpenRouter-like gateway plus cfgpu.com/llm/square, dispatches each via in-process subagents or direct LLM calls, and tracks per-model token consumption with a feedback-driven ranking.
 - [BruceLanLan/dsh-tier-router](https://github.com/BruceLanLan/dsh-tier-router) - Two-tier model routing: a strong tier plans, advises and reviews while a cheap tier implements, with plan-mode-aware auto routing, a high-impact escalation guard, failure auto-escalation, and subagent tiering.
 - [wss534857356/dsh-plugin-codex](https://github.com/wss534857356/dsh-plugin-codex) - Codex App Server model provider using a local Codex login, with session reuse, Harness tool bridging, native action traces, and durable generated-image projection.
 - [GodD6366/dsh-sub2api](https://github.com/GodD6366/dsh-sub2api) - Connect a sub2api gateway to DeepSeek Harness: OpenAI-compatible multi-provider routes (OpenAI / Claude / Grok / Gemini) behind one base URL, with per-key model discovery, usage lookup, and global vision/image tools.

--- a/README.zh.md
+++ b/README.zh.md
@@ -287,6 +287,7 @@ dsh plugin --profile web add dshmarket
 
 ### 🔌 模型与账号接入
 - [WNJXYK/dsh-codex-oauth](https://github.com/WNJXYK/dsh-codex-oauth) — 在 DeepSeek Harness 中使用 ChatGPT/Codex 订阅接入 GPT 模型、图像生成与 Web 搜索，并支持订阅额度显示、模型与功能控制，以及浏览器或设备码 OAuth 登录。
+- [r600a-code/dsh-swarm-router](https://github.com/r600a-code/dsh-swarm-router) — 子智能体矩阵蜂群：把异质任务路由到最合适的模型（OpenRouter 类网关 + cfgpu.com/llm/square），通过进程内子智能体或直接 LLM 调用下放，并按模型统计 token 消耗、用真实反馈驱动排名。
 - [BruceLanLan/dsh-tier-router](https://github.com/BruceLanLan/dsh-tier-router) — 双档模型路由：强档负责规划/咨询/评审、弱档负责实现；含计划模式自动路由、高危操作守卫、失败自动升级与子代理分层。
 - [wss534857356/dsh-plugin-codex](https://github.com/wss534857356/dsh-plugin-codex) — 使用本地 Codex 登录的 Codex App Server 模型提供方，支持会话复用、Harness 工具桥接、原生动作轨迹和生成图片持久化。
 - [GodD6366/dsh-sub2api](https://github.com/GodD6366/dsh-sub2api) — 将 sub2api 网关接入 DeepSeek Harness：用一个 base URL 统一管理 OpenAI / Claude / Grok / Gemini 等多供应商路由，支持按 key 发现模型、用量查询与全局视觉/图像生成工具。


### PR DESCRIPTION
## What

Adds [r600a-code/dsh-swarm-router](https://github.com/r600a-code/dsh-swarm-router) under **Models & Providers** / **模型与账号接入** in both `README.md` and `README.zh.md`.

## Why it qualifies

- ✅ Declares `dsh.bundle` manifest in `package.json` (with `cordis.patch.yml`)
- ✅ Real, working code (not placeholder/README-only) — 3 commits, end-to-end verified
- ✅ [`dsh-plugin`](https://github.com/topics/dsh-plugin) topic applied to the repo
- ✅ Official `@deepseek-ai/*` packages declared as `peerDependencies`

## What the plugin does

A sub-agent **matrix swarm** that routes heterogeneous tasks to the most suitable model from an OpenRouter-like gateway plus the cfgpu.com/llm/square catalog, dispatches each via in-process subagents or direct `ctx.llm` calls, and tracks per-model token consumption with a feedback-driven ranking. Four contributions:

1. Model multi-aggregation registry + PR flow (`models/registry.json`, validator, CONTRIBUTING.md)
2. Plugin extension point (`ctx.swarmRouter` service)
3. Real-task feedback + model ranking (persisted, influences routing)
4. Token-consumption statistics, cfgpu highlighted (exact per-call capture via `llm/stream`)

Verified end-to-end through DSH headless: 5-task subagent benchmark 27/27 green; 3-task direct benchmark 31/31 green with exact token attribution per child.