### PR TITLE
docs: add Vladimir-Human/humanizer-ru#dsh

### DIFF
--- a/README.md
+++ b/README.md
@@ -613,6 +613,7 @@ dsh plugin --profile web add dshmarket
 
 - [Starfie1d1272/dsh-github-skills](https://github.com/Starfie1d1272/dsh-github-skills) - Four GitHub workflow skills for PR triage, review feedback, GitHub Actions diagnosis, and safe draft-PR publishing, reusing existing DSH capabilities with gh/git fallbacks.
 - [xiongjiamu/dsh-atomgit](https://github.com/xiongjiamu/dsh-atomgit) - AtomGit plugin bundle for DeepSeek Harness: six built-in AtomGit skills (plan issues, implement issues, review PRs, merge PRs, publish CLI releases, mirror to GitHub) plus ag CLI integration and platform-hosted MCP tools for repos, branches, issues, PRs, and search.
+- [Vladimir-Human/humanizer-ru#dsh](https://github.com/Vladimir-Human/humanizer-ru/tree/main/dsh) - Cleans AI traces from Russian text: finds chatbot copy-paste artefacts (ChatGPT, Gemini, Grok, Perplexity, DeepSeek) and rewrites the text into natural prose on request; 39 regex markers with an evidence registry, offline, text-only bundle.
 ### Workflow & Automation
 - [ZhenHuangLab/dsh-sync](https://github.com/ZhenHuangLab/dsh-sync) - Policy-driven Git sync for DSH settings and profile configuration, with secret-aware projections, conflict review, and per-line apply controls.
 - [QlzqQlzq/dsh-dual-agent-presets](https://github.com/QlzqQlzq/dsh-dual-agent-presets) - Installs two selectable Agent Presets: a shell-restricted general-purpose agent and a repository-focused coding agent.

--- a/README.zh.md
+++ b/README.zh.md
@@ -614,6 +614,7 @@ dsh plugin --profile web add dshmarket
 
 - [Starfie1d1272/dsh-github-skills](https://github.com/Starfie1d1272/dsh-github-skills) — 四个面向 GitHub 工程工作流的 DSH Skill：PR 分诊、review 反馈、GitHub Actions 诊断和安全的 draft PR 发布；优先复用现有 DSH 能力，必要时回退到 gh/git。
 - [xiongjiamu/dsh-atomgit](https://github.com/xiongjiamu/dsh-atomgit) — AtomGit 插件包：内置六个 AtomGit 技能（Issue 规划、Issue 实现、PR 审查、PR 合并、CLI 版本发布、GitHub 镜像），并集成 ag CLI 与平台托管的 MCP 工具（仓库/分支/Issue/PR/搜索）。
+- [Vladimir-Human/humanizer-ru#dsh](https://github.com/Vladimir-Human/humanizer-ru/tree/main/dsh) — 清理俄语文本中的 AI 痕迹：识别聊天机器人复制粘贴残留（ChatGPT、Gemini、Grok、Perplexity、DeepSeek），并按需改写为自然行文；39 个正则标记配证据登记表，离线运行，纯文本 bundle。
 ### 🔁 工作流与自动化
 - [ZhenHuangLab/dsh-sync](https://github.com/ZhenHuangLab/dsh-sync) — 面向 DSH 设置与 Profile 配置的策略化 Git 同步，支持敏感信息隔离、冲突审阅与按行选择应用。
 - [QlzqQlzq/dsh-dual-agent-presets](https://github.com/QlzqQlzq/dsh-dual-agent-presets) — 安装两个可选 Agent Preset：默认不暴露 Shell 的通用 Agent，以及面向真实代码仓库的 Coding Pro。


### PR DESCRIPTION
I packaged humanizer-ru as a dsh bundle and I'd like to add it to Skills.

**What it does.** It cleans AI traces from Russian text. First it finds the copy-paste artefacts that ChatGPT, Gemini, Grok, Perplexity and DeepSeek leave behind; then, if the user asks, it rewrites the text into natural prose. There are 39 regex markers, and each one is backed by an immutable source in an evidence registry. It works offline and never opens a link from the text it is checking.

**Install.**

```
dsh plugin --profile web add github:Vladimir-Human/humanizer-ru#path:/dsh
```

**Requirements checklist.**

- `dsh.bundle` manifest: declared in the `dsh/` subpackage — `"dsh": { "bundle": { "patch": "./cordis.patch.yml" } }` — with `cordis.patch.yml` next to it. Per contributing.md, a subpackage qualifies.
- `dsh-plugin` topic: added to the repository.
- Real working code: the bundle mounts the stock `@deepseek-ai/dsh-skill-filesystem` onto the packaged skill files. I verified installation on dsh 0.1.0-rc.6 with the exact command above, on a clean profile: the package resolves as `humanizer-ru-dsh`, joins `dsh.profile.bundles`, the layer mounts, the skill is served from inside the package, and `remove` leaves the profile clean.
- Actively maintained: released as v3.13.0 today; 36 CI gates on every change.
- Description states what it does, no superlatives.

**No build step.** The bundle ships only `cordis.patch.yml` and the skill's Markdown — nothing executable, so there is nothing for pnpm's `allowBuilds` to approve. I have not published to npm because the git install needs no prebuild.

**A note on automated scanners, in case one flags this.** The marker reference deliberately contains the string `ppl-ai-file-upload` — that is Perplexity's S3 bucket id and it is precisely one of the artefacts the skill detects. A scanner reading it as a download link is matching our test data, not our behaviour: the skill is text-only and its safety section forbids opening any link from the text under review.

As far as I can tell this would be the first Russian-language skill in the list.
