### PR TITLE
Add dsh-forge — cross-session mailbox, agent teams, subagent spawn policy, plugin market & skill panels

### DIFF
--- a/README.md
+++ b/README.md
@@ -899,6 +899,7 @@ dsh plugin --profile web add dshmarket
 
 ### Plugin Markets & Managers
 
+- [alex04130/dsh-forge](https://github.com/alex04130/dsh-forge) - Runtime extension suite for DeepSeek Harness: cross-session mailbox with wake cold-start, agent teams (captain + members + dependency task board + team_wait), subagent spawn policy with escalation approval, task-aware routing preset, plugin market, skill manager and runtime injector.
 - [buhuikongpan/dsh-pluginmanager](https://github.com/buhuikongpan/dsh-pluginmanager) - Layered plugin manager for DSH web: native plugins grouped read-only by system/WebUI/tools, user extensions with enable/disable, register, uninstall and editable descriptions.
 - [cynch18/plugin-switch](https://github.com/cynch18/plugin-switch) - Toggle switches for the plugin inventory: enable/disable any plugin live from Settings → Plugins → Plugin list without restarting, with groups/filters, bulk toggle, undo, and backup.
 - [dsh-market/dsh-market](https://github.com/dsh-market/dsh-market) - (Recommended) The plugin market inside DSH: a Settings page to browse and search the full community catalog by category, with confirmed one-click installs and an installed-plugins view.

--- a/README.zh.md
+++ b/README.zh.md
@@ -899,6 +899,7 @@ dsh plugin --profile web add dshmarket
 
 ### 🛒 插件市场与管理
 
+- [alex04130/dsh-forge](https://github.com/alex04130/dsh-forge) — DeepSeek Harness 扩展套件：跨会话邮箱与 wake 冷启动、代理团队（队长 + 成员 + 依赖任务板 + team_wait）、子代理派发策略（提权自动审批）、任务感知路由 preset、插件市场、技能管理器与运行时注入器。
 - [buhuikongpan/dsh-pluginmanager](https://github.com/buhuikongpan/dsh-pluginmanager) — DSH 分层插件管理器：原生插件按系统/WebUI/工具三层只读展示，用户扩展支持停用/启用、补登记、卸载与可编辑描述。
 - [cynch18/plugin-switch](https://github.com/cynch18/plugin-switch) — 插件清单页滑块开关：在设置 → 插件 → 插件清单实时启用/停用任意插件，无需重启；支持分组/筛选、批量开关、撤销与自动备份。
 - [dsh-market/dsh-market](https://github.com/dsh-market/dsh-market) — （推荐）装在 DSH 里的插件市场：设置页内逛/搜全部社区插件，按分类筛选，确认后一键安装，已装插件一目了然。

--- a/data/plugins/alex04130__dsh-forge.yml
+++ b/data/plugins/alex04130__dsh-forge.yml
@@ -1,0 +1,6 @@
+url: https://github.com/alex04130/dsh-forge
+name: alex04130/dsh-forge
+category: market
+description:
+  en: 'Runtime extension suite for DeepSeek Harness: cross-session mailbox with wake cold-start, agent teams (captain + members + dependency task board + team_wait), subagent spawn policy with escalation approval, task-aware routing preset, plugin market, skill manager and runtime injector.'
+  zh: DeepSeek Harness 扩展套件：跨会话邮箱与 wake 冷启动、代理团队（队长 + 成员 + 依赖任务板 + team_wait）、子代理派发策略（提权自动审批）、任务感知路由 preset、插件市场、技能管理器与运行时注入器。


### PR DESCRIPTION
Adds [dsh-forge](https://github.com/alex04130/dsh-forge) (`@dsh-forge/bundle`).

A runtime extension suite for DeepSeek Harness:
- cross-session mailbox (session_send / session_read / mailbox_check, offline queue + wake cold-start)
- Claude-Code-style agent teams (captain + role members + dependency task board + team_wait)
- subagent spawn policy (provider/model/reasoning-effort/preset/sandbox overrides, escalation approval)
- task-aware routing preset (router-standard, installed manually — see repo README)
- plugin market / skill manager / runtime injector panels
- model delegation & routing policy, subagent Ctrl+Enter steering

Install: `dsh plugin --profile web add @dsh-forge/bundle`

The repo carries the `dsh-plugin` topic.