### PR TITLE
Add Ultronen/dsh-archived-chats under Sessions & Messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,6 +363,7 @@ dsh plugin --profile web add dshmarket
 - [xianshu-virtuous/dsh-whale-companion](https://github.com/xianshu-virtuous/dsh-whale-companion) - Automatically starts a fresh Web session near the context limit with the last complete turn, and adds an editable additive whale-maid persona with on-demand reload.
 - [mayf3/dsh-session-doctor](https://github.com/mayf3/dsh-session-doctor) - Diagnose, unstick, and read DSH sessions: list sessions with agent status, read conversations, diagnose stuck agents, recover them with cancel+keepInbox, and send messages to other sessions.
 - [MuWinds/dsh-archived-sessions](https://github.com/MuWinds/dsh-archived-sessions) - Archived-session management: browse archived sessions, unarchive them, or clear them out.
+- [Ultronen/dsh-archived-chats](https://github.com/Ultronen/dsh-archived-chats) - Archived Chats settings page for DeepSeek Harness: browse, search, unarchive, and delete archived sessions in the Web UI, grouped by workspace.
 - [anweat/dsh-assistant-message-forge](https://github.com/anweat/dsh-assistant-message-forge) - Create/modify/inject test assistant messages and import/repair session.jsonl(.zstd) session logs into new sessions.
 - [yangyongzhen/dsh-session-export](https://github.com/yangyongzhen/dsh-session-export) - Export sessions to Markdown/JSON for review, replay, and per-session cost summaries.
 - [yangyongzhen/dsh-session-report](https://github.com/yangyongzhen/dsh-session-report) - Per-session cost & usage report cards: tokens, cache hits, duration.

--- a/README.zh.md
+++ b/README.zh.md
@@ -364,6 +364,7 @@ dsh plugin --profile web add dshmarket
 - [xianshu-virtuous/dsh-whale-companion](https://github.com/xianshu-virtuous/dsh-whale-companion) — 接近上下文上限时自动创建新 Web 会话并只转移最后一个完整回合，同时提供可编辑的追加式鲸鱼娘人格与按需重读工具。
 - [mayf3/dsh-session-doctor](https://github.com/mayf3/dsh-session-doctor) — 会话医生：列出会话（含 agent 运行状态）、读取会话记录、诊断卡死的 agent、解卡（cancel + keepInbox 保留排队消息）、向其他会话发送消息。
 - [MuWinds/dsh-archived-sessions](https://github.com/MuWinds/dsh-archived-sessions) — 归档会话管理：浏览已归档会话，支持恢复（取消归档）与清空。
+- [Ultronen/dsh-archived-chats](https://github.com/Ultronen/dsh-archived-chats) — DSH 已归档聊天管理页：在设置中浏览、搜索、取消归档与删除已归档会话，按工作区分组。
 - [anweat/dsh-assistant-message-forge](https://github.com/anweat/dsh-assistant-message-forge) — 消息锻造台：创建/修改/注入测试用 assistant 消息，导入识别并安全修复 session.jsonl(.zstd) 会话日志为新会话。
 - [yangyongzhen/dsh-session-export](https://github.com/yangyongzhen/dsh-session-export) — 会话导出为 Markdown/JSON，便于复盘、重放与单会话成本汇总。
 - [yangyongzhen/dsh-session-report](https://github.com/yangyongzhen/dsh-session-report) — 会话成本与耗时报表：tokens / 缓存命中 / 耗时。


### PR DESCRIPTION
## What

Adds [dsh-archived-chats](https://github.com/Ultronen/dsh-archived-chats) to the **Sessions & Messages** category (bilingual entry in `README.md` and `README.zh.md`).

## About the plugin

An **Archived Chats** settings page for DeepSeek Harness: browse, search, unarchive, and delete archived sessions in the Web UI, grouped by workspace.

- ✅ Declares `dsh.bundle` manifest (`cordis.patch.yml` in repo root) — installable via `dsh plugin --profile web add dsh-archived-chats`
- ✅ Published on npm as `dsh-archived-chats@0.3.0` (prebuilt install, no build-approval step)
- ✅ Real, working code with smoke tests (`test/smoke.test.mjs`)
- ✅ `dsh-plugin` topic added to the repo
- ✅ Official `@deepseek-ai/*` packages declared as `peerDependencies`