### PR TITLE
Add dsh-achievements

### DIFF
--- a/README.md
+++ b/README.md
@@ -932,7 +932,7 @@ dsh plugin --profile web add dshmarket
 - [ovdoesw/dsh-xiangqi](https://github.com/ovdoesw/dsh-xiangqi) - A draggable mascot invites you to play Xiangqi (Chinese chess) while the AI thinks, with a built-in engine, move-record export, and optional multi-model commentary.
 - [KongChengZhi/dsh-pixel-studio#dsh-cli-anything-aseprite](https://github.com/KongChengZhi/dsh-pixel-studio/tree/main/dsh-cli-anything-aseprite) - Aseprite-style pixel art studio: the AI draws sprites stroke by stroke with selections, layers, animation frames, gradients, symmetry and reference layers, each step rendered live as ANSI terminal frames.
 - [yushi-xxh/dsh-homepage-skin](https://github.com/yushi-xxh/dsh-homepage-skin) - Adds the DeepSeek Harness homepage background to dsh web: WebGL fluid light, dot-line grid and a digital point-cloud whale, with dark and light palettes.
-- [Blaczz/dsh-achievements](https://github.com/Blaczz/dsh-achievements) - Achievement and gamification plugin: unlock badges for turns, tool calls, sessions, daily streaks and coding behavior (edits/reads/tests), with a badge wall, unlock toasts and a ctx.achievements SDK.
+- [luumod/dsh-achievements](https://github.com/luumod/dsh-achievements) - Achievement and gamification plugin: unlock badges for turns, tool calls, sessions, daily streaks and coding behavior (edits/reads/tests), with a badge wall, unlock toasts and a ctx.achievements SDK.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -932,6 +932,7 @@ dsh plugin --profile web add dshmarket
 - [ovdoesw/dsh-xiangqi](https://github.com/ovdoesw/dsh-xiangqi) - A draggable mascot invites you to play Xiangqi (Chinese chess) while the AI thinks, with a built-in engine, move-record export, and optional multi-model commentary.
 - [KongChengZhi/dsh-pixel-studio#dsh-cli-anything-aseprite](https://github.com/KongChengZhi/dsh-pixel-studio/tree/main/dsh-cli-anything-aseprite) - Aseprite-style pixel art studio: the AI draws sprites stroke by stroke with selections, layers, animation frames, gradients, symmetry and reference layers, each step rendered live as ANSI terminal frames.
 - [yushi-xxh/dsh-homepage-skin](https://github.com/yushi-xxh/dsh-homepage-skin) - Adds the DeepSeek Harness homepage background to dsh web: WebGL fluid light, dot-line grid and a digital point-cloud whale, with dark and light palettes.
+- [Blaczz/dsh-achievements](https://github.com/Blaczz/dsh-achievements) - Achievement and gamification plugin: unlock badges for turns, tool calls, sessions, daily streaks and coding behavior (edits/reads/tests), with a badge wall, unlock toasts and a ctx.achievements SDK.
 
 ## Contributing
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -931,6 +931,7 @@ dsh plugin --profile web add dshmarket
 - [ovdoesw/dsh-xiangqi](https://github.com/ovdoesw/dsh-xiangqi) — 卡通小宠物邀请你在 AI 思考间隙下中国象棋：内置引擎、走子记谱导出、可选多模型局势点评。
 - [KongChengZhi/dsh-pixel-studio#dsh-cli-anything-aseprite](https://github.com/KongChengZhi/dsh-pixel-studio/tree/main/dsh-cli-anything-aseprite) — Aseprite 风格像素画工作室：AI 像人类一样分步绘制精灵，支持选区、图层、动画帧、渐变、对称、参考层与 rgb16 4096 色，每一步实时渲染为 ANSI 终端帧。
 - [yushi-xxh/dsh-homepage-skin](https://github.com/yushi-xxh/dsh-homepage-skin) — 给 dsh web 铺上 DeepSeek Harness 首页同款背景：WebGL 流体光效、点线网格与数字点云鲸鱼，深色/亮色两套配色。
+- [luumod/dsh-achievements](https://github.com/luumod/dsh-achievements) — 成就与游戏化插件：按回合、工具调用、会话、连续天数与编码行为（编辑/读取/测试）解锁徽章，带徽章墙、解锁 toast 与 ctx.achievements SDK。
 
 ## 贡献
 


### PR DESCRIPTION
Follow-up to #689 for the achievements entry — the `dsh-desktop-lifecycle` half already landed in `68438447`.

## What

Adds [luumod/dsh-achievements](https://github.com/luumod/dsh-achievements), the achievement / gamification plugin, under **Just for Fun** (`README.md`) and **🎮 娱乐** (`README.zh.md`) — one line each.

## Fork vs upstream

The feature work was opened upstream at [Blaczz/dsh-achievements#1](https://github.com/Blaczz/dsh-achievements/pull/1), which is still open. Rather than block on its timeline, this lists the fork. Per your #689 guidance, the fork README now:

- installs from the fork (`github:luumod/dsh-achievements#main`)
- describes itself as a fork of Blaczz/dsh-achievements
- keeps the upstream `MIT © 2026 Blaczz` attribution

If upstream merges, I'll open a one-line PR pointing the entry at `Blaczz/dsh-achievements` and archive this fork.

## Changes

- `README.md`: one entry under `### Just for Fun`
- `README.zh.md`: one entry under `### 🎮 娱乐`

## Checklist

- [x] `package.json` declares `dsh.bundle.patch` with `cordis.patch.yml` at the repo root
- [x] Real, working code (pure engine + Host/Browser halves + Vitest suite)
- [x] `@deepseek-ai/*` packages declared as `peerDependencies`
- [x] Factual, marketing-free description

cc @fkysly