### PR TITLE
Add dsh-token-billing to Notifications & Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -909,6 +909,7 @@ dsh plugin --profile web add dshmarket
 ### Notifications & Integrations
 
 - [117BS/dsh-perlica-ding](https://github.com/117BS/dsh-perlica-ding) - Perlica (Arknights: Endfield) themed tiered sound notifications: plan-ready, task-done, needs-your-input, and error tones; silent for plain chat, system-level playback (works in background), cross-platform (Windows/macOS/Linux), custom TTS sounds.
+- [2006spy/dsh-token-billing](https://github.com/2006spy/dsh-token-billing) - Real-time token billing for DSH web: official DeepSeek CNY pricing with automatic peak/off-peak switching, hourly price sync from the official site, visual custom model prices, and multi-currency fallback.
 - [AbcdefgXW/dsh-msg-hub](https://github.com/AbcdefgXW/dsh-msg-hub) - IM channel bridge: WeChat (ilinkai) / QQ / Feishu with proactive push — wake the channel bot from scheduled tasks and deliver AI replies to your phone.
 - [AI-Galaxy-GPU/dsh-sound](https://github.com/AI-Galaxy-GPU/dsh-sound) - Per-event sound notifications: turn completion, approval, question, plan-review, goal-blocked, and task-failure each get their own sound and volume, configurable in the Web UI (built-in synth, mute, or local audio file).
 - [Alan2Z/dsh-speak](https://github.com/Alan2Z/dsh-speak) - Voice-announce the final reply on Windows (SAPI5 natural voices) and macOS (system voice); skips reasoning and tool calls, one-line npm install.

--- a/README.zh.md
+++ b/README.zh.md
@@ -909,6 +909,7 @@ dsh plugin --profile web add dshmarket
 ### 🔔 通知与集成
 
 - [117BS/dsh-perlica-ding](https://github.com/117BS/dsh-perlica-ding) — 明日方舟终末地佩丽卡主题分级提示音：计划出方案 / 任务完成 / 需要你回应 / 出错四档独立音效，普通问答保持安静；系统级播放（窗口在后台也响），跨平台（Windows/macOS/Linux），支持自定义 TTS 语音。
+- [2006spy/dsh-token-billing](https://github.com/2006spy/dsh-token-billing) — DSH Web 实时 token 计费插件：官网人民币价直接计费、高峰/错峰自动切换、价格实时跟随官网、可视化自定义模型价格、多币种兜底。
 - [AbcdefgXW/dsh-msg-hub](https://github.com/AbcdefgXW/dsh-msg-hub) — IM 渠道桥：微信（ilinkai）/ QQ / 飞书接入，支持主动推送——定时任务可唤醒渠道 bot 并把 AI 回复推送到手机。
 - [AI-Galaxy-GPU/dsh-sound](https://github.com/AI-Galaxy-GPU/dsh-sound) — 六类事件独立提示音：回合完成、审批、提问、计划评审、目标受阻、任务失败各有独立声音与音量，可在 Web 设置面板配置（内置合成音 / 静音 / 本地音频文件）。
 - [Alan2Z/dsh-speak](https://github.com/Alan2Z/dsh-speak) — 语音播报 agent 最终回复：Windows SAPI5 自然语音 / macOS 系统语音，自动跳过思考与工具调用，npm 一行安装。

--- a/data/plugins/2006spy__dsh-token-billing.yml
+++ b/data/plugins/2006spy__dsh-token-billing.yml
@@ -1,0 +1,6 @@
+url: https://github.com/2006spy/dsh-token-billing
+name: 2006spy/dsh-token-billing
+category: notify
+description:
+  en: 'Real-time token billing for DSH web: official DeepSeek CNY pricing with automatic peak/off-peak switching, hourly price sync from the official site, visual custom model prices, and multi-currency fallback.'
+  zh: DSH Web 实时 token 计费插件：官网人民币价直接计费、高峰/错峰自动切换、价格实时跟随官网、可视化自定义模型价格、多币种兜底。


### PR DESCRIPTION
## 新增：dsh-token-billing

在 **Notifications & Integrations** 分类下新增 [dsh-token-billing](https://github.com/2006spy/dsh-token-billing) 插件条目（README.md + README.zh.md 双语同步）。

**插件简介**：DSH Web 实时 token 计费插件——
- 官网人民币价直接计费，无需汇率换算
- DeepSeek 高峰/错峰（北京时间窗口）自动切换，实时显示「高峰/空闲」徽标
- 价格默认每小时自动跟随官网更新，生效时刻 1 分钟内切换
- 可视化自定义模型价格、多币种兜底

仓库已添加 `dsh-plugin` topic，符合收录要求。