### PR TITLE
Add JAdpp/dsh-whale-galgame

### DIFF
--- a/README.md
+++ b/README.md
@@ -930,6 +930,7 @@ dsh plugin --profile web add dshmarket
 - [chen731215-dev/-](https://github.com/chen731215-dev/-) - Native tavern management panel for DeepSeek Harness: multiple character cards, multiple worldbooks, switchable presets.
 - [hellodigua/dsh-emoji](https://github.com/hellodigua/dsh-emoji) - Automatically add emojis to AI replies.
 - [HuanLinOTO/dsh-plugin-d399](https://github.com/HuanLinOTO/dsh-plugin-d399) - Pops up a mini-game menu (wordle, match-3, extensible) while the model generates.
+- [JAdpp/dsh-whale-galgame](https://github.com/JAdpp/dsh-whale-galgame) - Multi-character Galgame conversation view with separate character and reply-model selection, per-character affection, memory, dialogue history, and CG galleries, plus responses informed by task events across Harness sessions.
 - [jitengfei/dsh-whale-arcade](https://github.com/jitengfei/dsh-whale-arcade) - Floating, browser-local whale arcade with three score games and ocean-themed Gomoku for breaks while waiting on the agent.
 - [KongChengZhi/dsh-pixel-studio#dsh-cli-anything-aseprite](https://github.com/KongChengZhi/dsh-pixel-studio/tree/main/dsh-cli-anything-aseprite) - Aseprite-style pixel art studio: the AI draws sprites stroke by stroke with selections, layers, animation frames, gradients, symmetry and reference layers, each step rendered live as ANSI terminal frames.
 - [lhh010/dsh-minigames](https://github.com/lhh010/dsh-minigames) - Side-panel arcade: 18 offline mini-games to play while the model thinks.

--- a/README.zh.md
+++ b/README.zh.md
@@ -930,6 +930,7 @@ dsh plugin --profile web add dshmarket
 - [chen731215-dev/-](https://github.com/chen731215-dev/-) — 酒馆管理原生面板：多角色卡、多世界书、可切换预设，深浅色跟随，点侧边栏自动关闭。
 - [hellodigua/dsh-emoji](https://github.com/hellodigua/dsh-emoji) — 为 AI 回复自动添加表情。
 - [HuanLinOTO/dsh-plugin-d399](https://github.com/HuanLinOTO/dsh-plugin-d399) — 模型生成时弹出小游戏菜单（wordle/消消乐，可扩展）。
+- [JAdpp/dsh-whale-galgame](https://github.com/JAdpp/dsh-whale-galgame) — 多角色 Galgame 对话界面：角色与回复模型可独立切换，分角色保存好感度、记忆、对话历史与 CG 图鉴，并根据 Harness 跨会话任务事件做出角色回应。
 - [jitengfei/dsh-whale-arcade](https://github.com/jitengfei/dsh-whale-arcade) — 浏览器本地运行的悬浮鲸鱼游戏中心，包含三款积分游戏和海洋主题五子棋，适合等待 Agent 时随手游玩。
 - [KongChengZhi/dsh-pixel-studio#dsh-cli-anything-aseprite](https://github.com/KongChengZhi/dsh-pixel-studio/tree/main/dsh-cli-anything-aseprite) — Aseprite 风格像素画工作室：AI 像人类一样分步绘制精灵，支持选区、图层、动画帧、渐变、对称、参考层与 rgb16 4096 色，每一步实时渲染为 ANSI 终端帧。
 - [lhh010/dsh-minigames](https://github.com/lhh010/dsh-minigames) — 右侧小游戏面板：18 款离线小游戏，等模型回复时的摸鱼神器。

--- a/data/plugins/JAdpp__dsh-whale-galgame.yml
+++ b/data/plugins/JAdpp__dsh-whale-galgame.yml
@@ -1,0 +1,6 @@
+url: https://github.com/JAdpp/dsh-whale-galgame
+name: JAdpp/dsh-whale-galgame
+category: fun
+description:
+  en: Multi-character Galgame conversation view with separate character and reply-model selection, per-character affection, memory, dialogue history, and CG galleries, plus responses informed by task events across Harness sessions.
+  zh: 多角色 Galgame 对话界面：角色与回复模型可独立切换，分角色保存好感度、记忆、对话历史与 CG 图鉴，并根据 Harness 跨会话任务事件做出角色回应。


### PR DESCRIPTION
## Summary

- Add `JAdpp/dsh-whale-galgame` to the **Just for Fun / 娱乐** category.
- Keep the English and Chinese entries synchronized with a factual description of the plugin.

## Checklist

- [x] The plugin's `package.json` declares `dsh.bundle`.
- [x] One line was added to both `README.md` and `README.zh.md` under the matching category.
- [x] The description states functionality without superlatives or marketing language.
- [x] The plugin repository has the `dsh-plugin` topic.

## Validation

- `node scripts/probe-npm.mjs`
- `node scripts/build-site.mjs` — parsed 821 entries across both locales.
- `git diff --check`
