### PR TITLE
Add bainianlaoyao/windows-bash: Git Bash as the only terminal tool for dsh on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -784,6 +784,8 @@ dsh plugin --profile web add dshmarket
 
 ### Development & Runtime
 
+- [bainianlaoyao/windows-bash](https://github.com/bainianlaoyao/windows-bash) - Makes Git Bash the only terminal tool for DeepSeek Harness on Windows: enables the bash executor and tool, disables PowerShell everywhere, and ships standard/code/cordis bash-only agent presets with the full-access sandbox defaults Git Bash's cygwin runtime needs.
+
 - [litestartup-com/dsh-api-gateway](https://github.com/litestartup-com/dsh-api-gateway) - REST + SSE gateway exposing running Harness sessions to third-party clients: API-key auth, token streaming, workspace grouping, and adopting GUI sessions to keep chatting.
 - [534119219/chicheng-gate](https://github.com/534119219/chicheng-gate) - LAN / remote-access control, frpc NAT tunneling, a panel password gate, and mobile UI adaptation for the DSH Web GUI.
 - [zoahdev/dsh-rule-evolve](https://github.com/zoahdev/dsh-rule-evolve/tree/main/plugin) - Verification-driven self-evolution loop: failure logs become verified AGENTS.md rules; in-session plugin (evolve_learn / evolve_apply / evolve_touch / evolve_recall), tool-verify gate, rule lifecycle, local recall.

--- a/README.zh.md
+++ b/README.zh.md
@@ -784,6 +784,8 @@ dsh plugin --profile web add dshmarket
 
 ### 🧑‍💻 开发与运行时
 
+- [bainianlaoyao/windows-bash](https://github.com/bainianlaoyao/windows-bash) — 让 Windows 上 DeepSeek Harness 的终端工具只剩 Git Bash：启用 bash 执行器与工具、全局禁用 PowerShell，并附 standard/code/cordis 三个 bash-only agent 预设及配套的 full-access 沙箱默认值。
+
 - [litestartup-com/dsh-api-gateway](https://github.com/litestartup-com/dsh-api-gateway) — 为第三方客户端提供 REST + SSE 网关：API 密钥鉴权、token 流式回包、会话工作区分组，并可接管 GUI 会话继续对话。
 - [534119219/chicheng-gate](https://github.com/534119219/chicheng-gate) — DSH Web 插件：局域网/远程访问控制、frpc 内网穿透、面板密码门禁与手机端 UI 适配。
 - [zoahdev/dsh-rule-evolve](https://github.com/zoahdev/dsh-rule-evolve/tree/main/plugin) — 验证驱动的自我进化循环：失败日志自动变成经过验证的 AGENTS.md 规则；会话内插件（evolve_learn/evolve_apply/evolve_touch/evolve_recall）、工具体检、规则生命周期、本地召回。


### PR DESCRIPTION
Adds [bainianlaoyao/windows-bash](https://github.com/bainianlaoyao/windows-bash) under **Development & Runtime** in both README.md and README.zh.md.

### What it does
Makes **Git Bash the only terminal tool** for DeepSeek Harness on Windows: a bundle patch (`dsh.bundle` manifest → `cordis.patch.yml`) that enables the bash executor/tool and disables PowerShell on win32, plus three bash-only agent preset variants (`standard-bash` / `code-bash` / `cordis-bash`) since a bundle patch cannot modify dsh's shipped preset files. On macOS/Linux it is a no-op (stock default is already bash-only). On win32 the sandbox default is set to `danger-full-access` because Git Bash's cygwin runtime fails under confined sandbox modes (`DSH_PERMISSION_MODE` env remains the escape hatch, documented in SECURITY.md).

### Checklist
- [x] `dsh.bundle` manifest declared in [package.json](https://github.com/bainianlaoyao/windows-bash/blob/main/package.json) (patch: `cordis.patch.yml`, present at repo root) — installable via `dsh plugin add`
- [x] `dsh-plugin` topic added to the repo
- [x] One line added to each of `README.md` / `README.zh.md`, no removals (+2/-0)
- [x] Real working code: bundle patch + generated presets verified by `scripts/check-rows.mjs` (contract test)