### PR TITLE
Add dsh-deepseek-quota-left: left-edge DeepSeek quota panel for Web UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ dsh plugin --profile web add dshmarket
 
 ### UI Enhancements
 
+- [dk33333333/dsh-deepseek-quota-left](https://github.com/dk33333333/dsh-deepseek-quota-left) - DeepSeek API quota panel collapsed into a left-edge handle for the Web UI: click to expand balance, official today's consumption (with platform token) and live conversation cost; fork of dsh-deepseek-quota.
 - [Limitinfinitude/DSH-Right-Sidebar](https://github.com/Limitinfinitude/DSH-Right-Sidebar) - DSH Web right-side output dock that collects session artifacts, previews user-facing files, and preserves tab state per session.
 - [No-PRM/dsh-explorer](https://github.com/No-PRM/dsh-explorer) - Git-first file-tree sidebar for the DSH web GUI: VS Code-style indent guides, M/A/U/D/R git decorations, HEAD-vs-worktree diff preview, media preview, and drag-to-reference (files/folders/selected code with line numbers) — pure plugin.
 - [xiaweiliang060035/dsh-opencode-go-usage](https://github.com/xiaweiliang060035/dsh-opencode-go-usage) - Floating widget showing real-time OpenCode Go subscription usage (rolling/weekly/monthly) for every API key, with rate-limit alerts and automatic key-pool discovery.

--- a/README.zh.md
+++ b/README.zh.md
@@ -43,6 +43,7 @@ dsh plugin --profile web add dshmarket
 
 ### 🎨 UI 增强
 
+- [dk33333333/dsh-deepseek-quota-left](https://github.com/dk33333333/dsh-deepseek-quota-left) — DeepSeek API 额度面板折叠为左侧边框把手：点击展开查看余额、官方精确今日已消费（配置平台 token 后）与实时对话费用；dsh-deepseek-quota 的修改版。
 - [Limitinfinitude/DSH-Right-Sidebar](https://github.com/Limitinfinitude/DSH-Right-Sidebar) — DSH Web 原生右侧产物栏，按会话收集用户产物，预览用户可读文件并保存标签状态。
 - [No-PRM/dsh-explorer](https://github.com/No-PRM/dsh-explorer) — Git 优先的文件树侧栏：VS Code 风格层级线、M/A/U/D/R git 状态装饰、HEAD 与工作区对照预览、媒体预览、拖拽引用（文件/文件夹/选中代码带行号）—— 纯插件。
 - [xiaweiliang060035/dsh-opencode-go-usage](https://github.com/xiaweiliang060035/dsh-opencode-go-usage) — 悬浮组件实时显示 OpenCode Go 各 key 用量（滚动/每周/每月），限流预警，自动发现 key 池。

--- a/data/added-dates.json
+++ b/data/added-dates.json
@@ -198,6 +198,7 @@
  "https://github.com/dingyi222666/dsh-focus-chat": "2026-08-13",
  "https://github.com/dingyi222666/dsh-session-notification": "2026-08-13",
  "https://github.com/disyli/dsh-tool-call-stats": "2026-08-14",
+ "https://github.com/dk33333333/dsh-deepseek-quota-left": "2026-08-16",
  "https://github.com/doncelee229-cmyk/dsh-plugin-approval-alert": "2026-08-14",
  "https://github.com/dongsheng123132/task-passport": "2026-08-14",
  "https://github.com/dsh-market/dsh-market": "2026-08-14",


### PR DESCRIPTION
Adds [dsh-deepseek-quota-left](https://github.com/dk33333333/dsh-deepseek-quota-left) to the UI Enhancements category.

- Left-edge collapsed handle: click to expand DeepSeek API balance panel.
- Official today's consumption (with `DEEPSEEK_PLATFORM_TOKEN`) and live conversation cost.
- Fork of dsh-deepseek-quota with the `todayConsumedSource` front-end propagation fixed.

Both README.md and README.zh.md updated; added to data/added-dates.json.