### PR TITLE
feat: optional per-entry screenshots (data/screenshots.json)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,3 +9,4 @@
 
 - 📦 Publish to npm — npm installs are prebuilt and skip the `allowBuilds` approval, so users get a one-command install / 发布 npm 包：预构建产物免 `allowBuilds` 授权，用户一条命令装好
 - 🔗 Declare official `@deepseek-ai/*` packages as `peerDependencies` (not `dependencies`) — avoids duplicate runtimes inside the profile / 官方 `@deepseek-ai/*` 包用 `peerDependencies` 声明（而非 `dependencies`），避免 profile 里出现重复运行时
+- 🖼️ Add screenshots to [`data/screenshots.json`](../blob/main/data/screenshots.json) — they show AppStore-style in plugin markets ([how](../blob/main/contributing.md#screenshots--截图optional-recommended--可选推荐)) / 在 [`data/screenshots.json`](../blob/main/data/screenshots.json) 里附上截图——插件市场会像 App Store 一样展示（[说明](../blob/main/contributing.md#screenshots--截图optional-recommended--可选推荐)）

--- a/contributing.md
+++ b/contributing.md
@@ -52,6 +52,25 @@ Recommended for a better install experience / 推荐（更好的安装体验）�
 
 The website rebuilds automatically after merge — no need to touch anything else. / 合并后网站自动重建，无需改动其他文件。
 
+### Screenshots / 截图（optional, recommended / 可选，推荐）
+
+Storefronts (e.g. [dsh-market](https://github.com/dsh-market/dsh-market)'s detail view) show AppStore-style screenshots for your plugin. Add yours to [`data/screenshots.json`](data/screenshots.json), keyed by your entry's GitHub URL — the same URL as your README line — mapping to 1-8 image URLs:
+
+在插件市场（如 [dsh-market](https://github.com/dsh-market/dsh-market) 的详情页）中，你的插件可以像 App Store 一样展示截图。在 [`data/screenshots.json`](data/screenshots.json) 里以你条目的 GitHub URL（与 README 行完全一致）为 key，加入 1-8 张图片 URL：
+
+```jsonc
+{
+ "https://github.com/owner/repo": [
+  "https://raw.githubusercontent.com/owner/repo/main/assets/screenshot-1.png",
+  "https://raw.githubusercontent.com/owner/repo/main/assets/screenshot-2.png"
+ ]
+}
+```
+
+- Images must be **https URLs on GitHub hosting** (`raw.githubusercontent.com`, `user-images.githubusercontent.com`, `camo.githubusercontent.com`, `github.com` attachments) — third-party image hosts are rejected by the build for user-privacy reasons. / 图片必须是 **GitHub 托管的 https URL**（`raw.githubusercontent.com` 等）——出于用户隐私考虑，第三方图床会被构建校验拒绝。
+- Keep the images in your own repo (an `assets/` folder works well) so they update with your releases. / 建议把图片放在你自己的仓库里（如 `assets/` 目录），随版本一起维护。
+- No screenshots? Storefronts fall back to extracting images from your README — a maintained entry here just gives you control over order and selection. / 不提交也没关系：市场会从你的 README 自动抽取——这里的条目只是让你能控制展示的顺序与内容。
+
 ### Themes & skins / 主题与皮肤
 
 Entries under the **Themes & Appearance / 主题与外观** category automatically appear in the [dsh-market](https://github.com/dsh-market/dsh-market) plugin's dedicated **Themes tab**, where users install, switch, and uninstall them with one click — so put your theme/skin there, not under UI Enhancements. Monorepo subpackages are supported: link the subdirectory directly, e.g. `https://github.com/owner/repo/tree/main/packages/my-theme`.

--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -1,0 +1,6 @@
+{
+ "https://github.com/dsh-market/dsh-market": [
+  "https://raw.githubusercontent.com/dsh-market/dsh-market/main/assets/demo-en.png",
+  "https://raw.githubusercontent.com/dsh-market/dsh-market/main/assets/themes-en.png"
+ ]
+}

--- a/scripts/build-site.mjs
+++ b/scripts/build-site.mjs
@@ -17,6 +17,7 @@ import LOCALES from '../site/locales.mjs'
 
 const ORIGIN = 'https://awesome-dsh-plugin.com'
 const DATES_FILE = 'data/added-dates.json'
+const SCREENSHOTS_FILE = 'data/screenshots.json'
 
 // docs/ is fully generated: static assets live in site/assets/ and are copied
 // in here, so a from-scratch build (empty docs/) produces the complete site
@@ -125,6 +126,41 @@ if (ordered.some((e) => !dates[e.url])) {
 }
 const isoTs = (s) => (s.includes('T') ? s : s + 'T00:00:00Z')
 for (const e of ordered) { e.addedAt = dates[e.url]; e.added = e.addedAt.slice(0, 10) }
+
+// Optional per-entry screenshots (data/screenshots.json): keyed by the entry
+// URL like added-dates.json; values are image URLs surfaced by storefronts
+// (dsh-market #61: AppStore-style screenshots on the detail view). Validated
+// here so a bad submission fails the PR check: keys must match a listed
+// entry, and images must live on GitHub's own hosting — a third-party image
+// host would let a list PR plant a tracking pixel in every storefront
+// user's browser.
+const SCREENSHOT_HOSTS = new Set([
+  'raw.githubusercontent.com',
+  'user-images.githubusercontent.com',
+  'camo.githubusercontent.com',
+  'github.com',
+])
+const shotsMap = fs.existsSync(SCREENSHOTS_FILE) ? JSON.parse(fs.readFileSync(SCREENSHOTS_FILE, 'utf8')) : {}
+{
+  const listed = new Set(ordered.map((e) => e.url))
+  let shotsBroken = false
+  const complain = (msg) => { console.error(`${SCREENSHOTS_FILE}: ${msg}`); shotsBroken = true }
+  for (const [key, value] of Object.entries(shotsMap)) {
+    if (!listed.has(key)) complain(`"${key}" is not a listed entry URL (keys must match the README entry link exactly)`)
+    if (!Array.isArray(value) || value.length === 0 || value.length > 8 || value.some((s) => typeof s !== 'string')) {
+      complain(`"${key}" must map to an array of 1-8 image URL strings`)
+      continue
+    }
+    for (const shot of value) {
+      let parsed = null
+      try { parsed = new URL(shot) } catch { /* complain below */ }
+      if (parsed === null || parsed.protocol !== 'https:' || !SCREENSHOT_HOSTS.has(parsed.hostname)) {
+        complain(`"${key}": images must be https URLs on GitHub hosting (${[...SCREENSHOT_HOSTS].join(' / ')}), got: ${shot}`)
+      }
+    }
+  }
+  if (shotsBroken) process.exit(1)
+}
 
 // derive repo/subdir install specs and the detail-page slug once
 for (const e of ordered) {
@@ -482,6 +518,10 @@ const registry = {
       stars: e.stars,
       install: e.npm ? `dsh plugin --profile web add ${e.npm}` : e.cmdGit,
       added: e.added,
+      // Optional, author-maintained (data/screenshots.json); omitted when
+      // absent so the payload stays lean. Storefronts fall back to their own
+      // README extraction (dsh-market #61).
+      screenshots: shotsMap[e.url],
     }
   }),
 }


### PR DESCRIPTION
Implements the data-side convention for dsh-market/dsh-market#61 (AppStore-style plugin screenshots).

- **`data/screenshots.json`** — entry GitHub URL (same key style as `added-dates.json`) → 1-8 image URLs; surfaced verbatim in `/plugins.json` as an optional `screenshots` field, omitted when absent.
- **Build-time validation** (runs in the PR check): keys must match a listed entry; images must be https on GitHub hosting (`raw.githubusercontent.com` / `user-images.githubusercontent.com` / `camo.githubusercontent.com` / `github.com` attachments). Third-party image hosts are rejected — a list PR must not be able to plant a tracking pixel in every storefront user's browser.
- **Docs**: contributing.md section (bilingual) + PR-template recommended bullet. Optional by design — storefronts fall back to README extraction.
- Seeded with dsh-market's own entry as the working example.

Verified: full build passes (839 entries, field present only on the seeded entry); negative test confirms unlisted keys / http / non-GitHub hosts each fail the build.