### PR TITLE
Add ximisi/dsh-quick-attach to UI Enhancements (EN + zh)

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ dsh plugin --profile web add dshmarket
 - [johnnycls/dsh-no-setup-mode](https://github.com/johnnycls/dsh-no-setup-mode) - No-setup mode for the DSH web UI: hides advanced surfaces, auto-applies best defaults (chat mode, full access, account balance), and one-click role-play personas (maid/butler).
 
 - [mtty-ai/mmx-quota-tool](https://github.com/mtty-ai/mmx-quota-tool) - MiniMax token-plan quota dock for the Web UI: a drop-shape 5h-usage % chip in the conversation input area, click for a detail panel listing every model's 5h & weekly usage and reset countdown, auto-hidden when the active default model is not a MiniMax model.
+- [ximisi/dsh-quick-attach](https://github.com/ximisi/dsh-quick-attach) - Paste an image into the DSH composer: auto-save it to a configured directory and send the absolute file path to the AI for recognition.
 ### Themes & Appearance
 
 - [Ultronen/dsh-liquid-glass](https://github.com/Ultronen/dsh-liquid-glass) - One toggle makes the whole DeepSeek Harness shell translucent, with an opacity slider and a custom full-page background.

--- a/README.zh.md
+++ b/README.zh.md
@@ -251,6 +251,7 @@ dsh plugin --profile web add dshmarket
 - [johnnycls/dsh-no-setup-mode](https://github.com/johnnycls/dsh-no-setup-mode) — DSH 网页免设置模式：隐藏复杂界面、自动套用最佳设置（聊天模式、Full Access、账户余额），并提供一键人设角色扮演（女僕/管家）。
 
 - [mtty-ai/mmx-quota-tool](https://github.com/mtty-ai/mmx-quota-tool) — DSH 网页 MiniMax 配额悬浮卡：会话输入区显示水滴形 5h 已用百分比，点击展开详情面板，列出每个模型的 5h/周用量与重置倒计时，当前默认模型非 MiniMax 时自动隐藏。
+- [ximisi/dsh-quick-attach](https://github.com/ximisi/dsh-quick-attach) — 在会话输入框粘贴图片时自动保存到设置中配置的目录，发送消息时把图片的绝对路径随消息发送给 AI 识别。
 ### 🎭 主题与外观
 
 - [Ultronen/dsh-liquid-glass](https://github.com/Ultronen/dsh-liquid-glass) — 一键让整个 DeepSeek Harness 界面通透起来：透明度滑块随心调，背景图自由换。


### PR DESCRIPTION
Add [ximisi/dsh-quick-attach](https://github.com/ximisi/dsh-quick-attach) to the **UI Enhancements** section (EN + zh).

- [x] Declares \dsh.bundle.patch\ + \cordis.patch.yml\ (installable via \dsh plugin add\)
- [x] Real working code, v0.1.1 released (Release tarball: https://github.com/ximisi/dsh-quick-attach/releases/tag/v0.1.1)
- [x] \dsh-plugin\ topic added
- [x] One line in README.md and README.zh.md (zh uses the file's \—\ separator convention)

**dsh-quick-attach（快捷附图）**: paste an image into the DSH web composer — the plugin auto-saves it to a user-configured directory (configurable under Settings → 快捷附图) and appends the absolute file path to the message draft, so the AI receives the path and can read the image with its file/vision tooling.