### PR TITLE
docs: add dsh-obsidian (Tools & Capabilities)

### DIFF
--- a/README.md
+++ b/README.md
@@ -635,6 +635,7 @@ dsh plugin --profile web add dshmarket
 - [wqty123/dsh-browser](https://github.com/wqty123/dsh-browser) - Shared real browser for DSH: a native Electron window the human can watch and take over, driven by the agent over CDP with 20 browser_* tools (open/snapshot/execute/fill/screenshot/download/auth), per-task session isolation, cookie persistence, CAPTCHA detection; self-hosts on plain dsh web without a desktop shell.
 
 - [zhangzhenwen1/qmd-autosearch](https://github.com/zhangzhenwen1/qmd-autosearch) - Auto-supplement QMD semantic search when the model greps/globs a knowledge-base directory: zero-dependency DSH plugin, async injection via next-step, no manual invocation.
+- [mingzeng21/dsh-obsidian](https://github.com/mingzeng21/dsh-obsidian) - Connect dsh to a local Obsidian vault: search, read, write, move, and trash notes through `obsidian_*` tools.
 ### Skills
 
 - [mudden2380078550-creator/write-chinese-long-screenplay](https://github.com/mudden2380078550-creator/write-chinese-long-screenplay) - Chinese long-form screenwriting skill: two input blocks (background + character bible) feeding a causal-value engine, anti-AI-flavor review, and a continuity ledger; works on Codex / Claude Code / dsh / zcode.

--- a/README.zh.md
+++ b/README.zh.md
@@ -634,6 +634,7 @@ dsh plugin --profile web add dshmarket
 - [kexuejin/dsh-zhihu-dashboard](https://github.com/kexuejin/dsh-zhihu-dashboard) — 知乎面板：热榜（带趋势标记）、关注动态（收藏/创作/关注的人）、帖子追踪（问题/关键词/关注的人，支持自动创意简报），并提供 5 个对话工具（zhihu_search / hot / answer / global_search / followees）。
 
 - [wqty123/dsh-browser](https://github.com/wqty123/dsh-browser) — 共享真实浏览器：用户可观看并随时接管的原生 Electron 窗口，agent 通过 CDP 驱动，内置 20 个 browser_* 工具（打开/快照/执行/填表/截图/下载/登录态）；任务级会话隔离、登录态持久化、人机验证识别，纯 `dsh web` 无需桌面外壳即可自托管。
+- [mingzeng21/dsh-obsidian](https://github.com/mingzeng21/dsh-obsidian) — 把 dsh 连接到本地 Obsidian vault：通过 `obsidian_*` 工具搜索、读取、写入、移动与回收笔记。
 
 ### 🧩 技能包
 


### PR DESCRIPTION
Adds `dsh-obsidian` to the Tools & Capabilities category.

Connects DeepSeek Harness (`dsh`) to a local Obsidian vault via 12 `obsidian_*` tools — list, search, read, frontmatter, backlinks, write, append, move, delete, set_property, delete_property, tags — with path-containment safety and a reversible trash-based delete.

- Repo: https://github.com/mingzeng21/dsh-obsidian
- npm: https://www.npmjs.com/package/dsh-obsidian
- Declares a `dsh.bundle` manifest (installable via `dsh plugin add dsh-obsidian`)
- `dsh-plugin` topic added