### PR TITLE
Add dsh-doctor under Tools & Capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,6 +446,7 @@ dsh plugin --profile web add dshmarket
 
 ### Tools & Capabilities
 
+- [asdf17128/dsh-doctor](https://github.com/asdf17128/dsh-doctor) - Registers a `config_doctor` tool that checks the harness's own configuration for problems that boot silently: fields a patch dropped by whole-config replacement, patches targeting missing entry ids, and tool-name collisions. Read-only.
 - [TZHR-invest/dsh-plugins#dsh-web-search-metaso](https://github.com/TZHR-invest/dsh-plugins/tree/main/packages/dsh-web-search-metaso) - Metaso (秘塔AI搜索) search & reader providers for the web seam: web_search returns page summaries, web_fetch reads full-page markdown, multi-scope search (webpage/document/paper/image/video/podcast).
 - [niuniuaba/dsh-subagent-vision](https://github.com/niuniuaba/dsh-subagent-vision) - Lets a text-only DeepSeek agent read images in the same session by delegating to a vision-capable subagent, with send-time image-to-path conversion.
 - [cerebrixos-org/dsh-asimovbox](https://github.com/cerebrixos-org/dsh-asimovbox) - Connects DeepSeek Harness to AsimovBox for creating, updating, rendering, and finishing videos through API-key-authenticated tools.

--- a/README.zh.md
+++ b/README.zh.md
@@ -446,6 +446,7 @@ dsh plugin --profile web add dshmarket
 
 ### 🛠️ 工具与能力
 
+- [asdf17128/dsh-doctor](https://github.com/asdf17128/dsh-doctor) — 注册 `config_doctor` 工具，检查 harness 自身配置里那些会静默通过启动的问题：patch 整体替换 config 而丢失的字段、指向不存在 entry id 的 patch、工具重名冲突。只读。
 - [TZHR-invest/dsh-plugins#dsh-web-search-metaso](https://github.com/TZHR-invest/dsh-plugins/tree/main/packages/dsh-web-search-metaso) — 秘塔AI搜索 providers for ctx.web：web_search 返回网页摘要，web_fetch 读取网页全文 markdown，多范围搜索（网页/文库/论文/图片/视频/播客）。
 - [niuniuaba/dsh-subagent-vision](https://github.com/niuniuaba/dsh-subagent-vision) — 让纯文本 DeepSeek 代理在同一会话内读图：委派给视觉子代理，发送时自动把图片转为文件路径。
 - [cerebrixos-org/dsh-asimovbox](https://github.com/cerebrixos-org/dsh-asimovbox) — 通过 API 密钥认证的工具将 DeepSeek Harness 连接到 AsimovBox，用于创建、更新、渲染和完成视频。


### PR DESCRIPTION
One line in each README, per the contributing guide.

**dsh-doctor** registers a `config_doctor` tool so the agent can inspect the configuration it is itself running under. It exists because two dsh behaviours boot cleanly with exit code 0:

- an id-targeted patch replaces an entry's whole `config`, silently dropping every sibling field the patch does not restate
- a patch targeting an unknown entry id prints one stderr line and boots anyway — invisible in a Web UI launch

So when a user asks "why isn't my setting taking effect", the agent can now answer from the composed tree instead of guessing.

Manifest check: `package.json` declares `dsh.bundle.patch → ./cordis.patch.yml`, which inserts the plugin row. Verified installable and working:

```sh
dsh plugin --profile web add github:asdf17128/dsh-doctor
```

The tool registers, executes against the live profile and reports findings. Read-only — it shells out to `dsh --dump-config`, never writes to the Harness home, never evaluates `!!js` expressions. MIT, zero runtime dependencies, 18 tests, CI on Node 18/20/22.