### PR TITLE
Add dshp under Tools & Capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,6 +459,7 @@ dsh plugin --profile web add dshmarket
 ### Tools & Capabilities
 
 - [asdf17128/dsh-doctor](https://github.com/asdf17128/dsh-doctor) - Registers a `config_doctor` tool that checks the harness's own configuration for problems that boot silently: fields a patch dropped by whole-config replacement, patches targeting missing entry ids, and tool-name collisions. Read-only.
+- [asdf17128/dshp](https://github.com/asdf17128/dshp) - Registers `list_profiles` and `export_profile`, so the agent can show what setups exist and hand back a whole profile — bundle order, plugin versions and patch — as one portable file to share. Read-only.
 - [TZHR-invest/dsh-plugins#dsh-web-search-metaso](https://github.com/TZHR-invest/dsh-plugins/tree/main/packages/dsh-web-search-metaso) - Metaso (秘塔AI搜索) search & reader providers for the web seam: web_search returns page summaries, web_fetch reads full-page markdown, multi-scope search (webpage/document/paper/image/video/podcast).
 - [rogerdigital/dsh-searxng](https://github.com/rogerdigital/dsh-searxng) - SearXNG-backed web_search provider for the web seam: free, self-hosted, key-less metasearch through your own instance's JSON API, with a bundled loopback-only docker-compose example.
 - [niuniuaba/dsh-subagent-vision](https://github.com/niuniuaba/dsh-subagent-vision) - Lets a text-only DeepSeek agent read images in the same session by delegating to a vision-capable subagent, with send-time image-to-path conversion.

--- a/README.zh.md
+++ b/README.zh.md
@@ -459,6 +459,7 @@ dsh plugin --profile web add dshmarket
 ### 🛠️ 工具与能力
 
 - [asdf17128/dsh-doctor](https://github.com/asdf17128/dsh-doctor) — 注册 `config_doctor` 工具，检查 harness 自身配置里那些会静默通过启动的问题：patch 整体替换 config 而丢失的字段、指向不存在 entry id 的 patch、工具重名冲突。只读。
+- [asdf17128/dshp](https://github.com/asdf17128/dshp) — 注册 `list_profiles` 与 `export_profile`：让 agent 列出本机有哪些配置，并把整套 profile（bundle 顺序、插件版本、patch）导出成一个可直接分享的文件。只读。
 - [TZHR-invest/dsh-plugins#dsh-web-search-metaso](https://github.com/TZHR-invest/dsh-plugins/tree/main/packages/dsh-web-search-metaso) — 秘塔AI搜索 providers for ctx.web：web_search 返回网页摘要，web_fetch 读取网页全文 markdown，多范围搜索（网页/文库/论文/图片/视频/播客）。
 - [rogerdigital/dsh-searxng](https://github.com/rogerdigital/dsh-searxng) — 基于 SearXNG 的 web_search provider：通过自建实例的 JSON API 实现免费、免密钥的元搜索，附仅绑定回环地址的 docker-compose 示例。
 - [niuniuaba/dsh-subagent-vision](https://github.com/niuniuaba/dsh-subagent-vision) — 让纯文本 DeepSeek 代理在同一会话内读图：委派给视觉子代理，发送时自动把图片转为文件路径。


### PR DESCRIPTION
One line in each README, per the contributing guide.

**dshp** registers `list_profiles` and `export_profile`. The second is the point: the portable format is short enough to paste, so when a user says "export my setup so I can send it to a colleague", the agent hands back the file content directly instead of pointing at a CLI.

It also fills gaps dsh leaves — dsh can boot a profile and forward installs to pnpm, but cannot create an empty one, list what exists, or copy a working setup before you experiment on it.

Manifest check: `package.json` declares `dsh.bundle.patch → ./cordis.patch.yml`. Verified installable and working:

```sh
dsh plugin --profile web add github:asdf17128/dshp
```

Both tools are read-only; `new`/`clone`/`rm` stay CLI-only because they write to the Harness home. Export/import is verified end-to-end: a 132-entry profile reproduced into a fresh $DSH_HOME composes an identical tree, patch included. MIT, zero runtime dependencies, 17 tests, CI on Node 18/20/22.