### PR TITLE
Add three capability-seam backends (code-runtime-container, credentials-vault, spill-s3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -905,6 +905,9 @@ dsh plugin --profile web add dshmarket
 - [hellosky983/dsh-fabric](https://github.com/hellosky983/dsh-fabric) - Unifies every DSH extensibility seam behind one declarative DSL: a runtime `fabric` service, `fabric_extend`/`fabric_inspect` tools, and a capability-graph settings page.
 - [hellosky983/dsh-foundry](https://github.com/hellosky983/dsh-foundry) - Plugin compiler with a blueprint registry (scaffold → validate → deploy) exposed as a runtime service, three model tools, and a blueprint-gallery settings page.
 - [bigclawd/dsh-security-guard](https://github.com/bigclawd/dsh-security-guard) - Static and runtime security guard for dsh: rule-based scans for malicious code, prompt injection and token waste, runtime interception of dangerous tool calls, /scan command, plugin_scan tool, web panel, and allowlist.
+- [tancheng33/dsh-code-runtime-container](https://github.com/tancheng33/dsh-code-runtime-container) - Container-isolated backend for the `ctx.codeRuntime` seam: each Code Mode program runs in a fresh container with no network, a read-only rootfs, dropped capabilities, and kernel-enforced memory, CPU and pid ceilings.
+- [tancheng33/dsh-credentials-vault](https://github.com/tancheng33/dsh-credentials-vault) - HashiCorp Vault backend for the credential seam: KV v2/v1, AppRole machine auth, per-operation reads so rotation needs no restart, and compare-and-swap writes.
+- [tancheng33/dsh-spill-s3](https://github.com/tancheng33/dsh-spill-s3) - S3-compatible backend for the spill seam: oversized tool output goes to object storage (S3, MinIO, R2) with hashed session prefixes and unguessable keys, instead of the agent's local disk.
 
 ### Plugin Markets & Managers
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -905,6 +905,9 @@ dsh plugin --profile web add dshmarket
 - [hellosky983/dsh-fabric](https://github.com/hellosky983/dsh-fabric) — 用一套声明式 DSL 统一 DSH 的所有可扩展接缝：提供 `fabric` 运行时服务、`fabric_extend`/`fabric_inspect` 工具，以及能力图谱设置页。
 - [hellosky983/dsh-foundry](https://github.com/hellosky983/dsh-foundry) — 插件编译器：以运行时服务提供蓝图注册表（脚手架 → 校验 → 部署），配三个模型工具和一个蓝图画廊设置页。
 - [bigclawd/dsh-security-guard](https://github.com/bigclawd/dsh-security-guard) — dsh 安全守卫插件：基于规则的静态扫描覆盖恶意代码、提示词注入与令牌浪费，运行时拦截危险工具调用，提供 /scan 命令、plugin_scan 工具、Web 面板与白名单。
+- [tancheng33/dsh-code-runtime-container](https://github.com/tancheng33/dsh-code-runtime-container) — `ctx.codeRuntime` seam 的容器隔离后端：每个 Code Mode 程序跑在全新容器里，无网络、根文件系统只读、丢弃全部 capability，内存/CPU/进程数上限由内核强制。
+- [tancheng33/dsh-credentials-vault](https://github.com/tancheng33/dsh-credentials-vault) — 凭证 seam 的 HashiCorp Vault 后端：支持 KV v2/v1、AppRole 机器认证、逐次操作读取（轮换无需重启）与 compare-and-swap 写入。
+- [tancheng33/dsh-spill-s3](https://github.com/tancheng33/dsh-spill-s3) — spill seam 的 S3 兼容后端：超长工具输出写入对象存储（S3、MinIO、R2），会话前缀经哈希、键不可猜测，而不是落在 agent 的本地磁盘上。
 
 ### 🛒 插件市场与管理
 


### PR DESCRIPTION
Adds three plugins to **Development & Runtime**. Each implements one official capability seam that currently has a single shipped implementation, and each declares a `dsh.bundle` manifest with a `cordis.patch.yml`.

| Plugin | Seam | What it does |
|---|---|---|
| [dsh-code-runtime-container](https://github.com/tancheng33/dsh-code-runtime-container) | `ctx.codeRuntime` | Runs each Code Mode program in a fresh container: no network, read-only rootfs, dropped capabilities, kernel-enforced memory/CPU/pid ceilings. The seam declares `isolation: 'container'` with no implementation. |
| [dsh-credentials-vault](https://github.com/tancheng33/dsh-credentials-vault) | `ctx.credentials` | HashiCorp Vault backend: KV v2/v1, AppRole machine auth, per-operation reads so rotation needs no restart, compare-and-swap writes. |
| [dsh-spill-s3](https://github.com/tancheng33/dsh-spill-s3) | `ctx.spillStore` | S3-compatible backend so oversized tool output lands in object storage instead of the agent's local disk. |

Checklist:

- [x] Each repo declares `dsh.bundle` in `package.json` with a `cordis.patch.yml` beside it
- [x] Real, working code — 63 / 56 / 50 tests respectively, including suites against a live container engine, a live Vault, and a live MinIO
- [x] `dsh-plugin` topic added to each repo
- [x] One line added to each of `README.md` and `README.zh.md`, same order in both
- [x] `npx awesome-lint` clean (0 errors; the 21 warnings are pre-existing on other entries) and `node scripts/build-site.mjs` builds — both run locally against this branch

Note: my `dsh-egress-guard` is already listed under Tools & Capabilities, so it is not re-added here.

npm publication is pending; the repos are installable from source in the meantime.