### PR TITLE
Add dsh-harness-zh-cn: Chinese localization plugin for DeepSeek Harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -661,6 +661,7 @@ dsh plugin --profile web add dshmarket
 - [somnusovis/dsh-multi-workspace](https://github.com/somnusovis/dsh-multi-workspace) - Multi-workspace sandbox: grants file-write access to every registered workspace automatically — add a workspace, write to it immediately, no config or escalation needed.
 
 - [zjl1989-li/dsh-harness-zh](https://github.com/zjl1989-li/dsh-harness-zh) - Chinese localization for DeepSeek Harness: translates all system prompts, tool descriptions, and runtime contexts into Chinese at runtime via the system-prompt/assemble waterfall (1788 entries, zero source modification, uninstall restores English).
+- [zjl1989-li/dsh-harness-zh-cn](https://github.com/zjl1989-li/dsh-harness-zh-cn) - Chinese localization for DeepSeek Harness: translates all system prompts, tool descriptions, and runtime contexts into Chinese at runtime via the system-prompt/assemble waterfall (1788 entries, zero source modification, uninstall restores English).
 ### Skills
 
 - [mudden2380078550-creator/write-chinese-long-screenplay](https://github.com/mudden2380078550-creator/write-chinese-long-screenplay) - Chinese long-form screenwriting skill: two input blocks (background + character bible) feeding a causal-value engine, anti-AI-flavor review, and a continuity ledger; works on Codex / Claude Code / dsh / zcode.

--- a/README.md
+++ b/README.md
@@ -660,6 +660,7 @@ dsh plugin --profile web add dshmarket
 - [mingzeng21/dsh-obsidian](https://github.com/mingzeng21/dsh-obsidian) - Connect dsh to a local Obsidian vault: search, read, write, move, and trash notes through `obsidian_*` tools.
 - [somnusovis/dsh-multi-workspace](https://github.com/somnusovis/dsh-multi-workspace) - Multi-workspace sandbox: grants file-write access to every registered workspace automatically — add a workspace, write to it immediately, no config or escalation needed.
 
+- [zjl1989-li/dsh-harness-zh](https://github.com/zjl1989-li/dsh-harness-zh) - Chinese localization for DeepSeek Harness: translates all system prompts, tool descriptions, and runtime contexts into Chinese at runtime via the system-prompt/assemble waterfall (1788 entries, zero source modification, uninstall restores English).
 ### Skills
 
 - [mudden2380078550-creator/write-chinese-long-screenplay](https://github.com/mudden2380078550-creator/write-chinese-long-screenplay) - Chinese long-form screenwriting skill: two input blocks (background + character bible) feeding a causal-value engine, anti-AI-flavor review, and a continuity ledger; works on Codex / Claude Code / dsh / zcode.

--- a/README.zh.md
+++ b/README.zh.md
@@ -660,6 +660,7 @@ dsh plugin --profile web add dshmarket
 - [mingzeng21/dsh-obsidian](https://github.com/mingzeng21/dsh-obsidian) — 把 dsh 连接到本地 Obsidian vault：通过 `obsidian_*` 工具搜索、读取、写入、移动与回收笔记。
 
 - [somnusovis/dsh-multi-workspace](https://github.com/somnusovis/dsh-multi-workspace) — 多工作区沙箱：自动赋予所有已注册工作区的文件写入权限——添加工作区后即可直接写入，无需配置或提权。
+- [zjl1989-li/dsh-harness-zh](https://github.com/zjl1989-li/dsh-harness-zh) — DeepSeek Harness 中文汉化插件：通过 system-prompt/assemble 瀑布钩子在运行时把全部系统提示词、工具描述与运行时上下文翻译成中文（1788 条译文，零源码修改，卸载即还原英文）。
 
 ### 🧩 技能包
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -661,6 +661,7 @@ dsh plugin --profile web add dshmarket
 
 - [somnusovis/dsh-multi-workspace](https://github.com/somnusovis/dsh-multi-workspace) — 多工作区沙箱：自动赋予所有已注册工作区的文件写入权限——添加工作区后即可直接写入，无需配置或提权。
 - [zjl1989-li/dsh-harness-zh](https://github.com/zjl1989-li/dsh-harness-zh) — DeepSeek Harness 中文汉化插件：通过 system-prompt/assemble 瀑布钩子在运行时把全部系统提示词、工具描述与运行时上下文翻译成中文（1788 条译文，零源码修改，卸载即还原英文）。
+- [zjl1989-li/dsh-harness-zh-cn](https://github.com/zjl1989-li/dsh-harness-zh-cn) — DeepSeek Harness 中文汉化插件：通过 system-prompt/assemble 瀑布钩子在运行时把全部系统提示词、工具描述与运行时上下文翻译成中文（1788 条译文，零源码修改，卸载即还原英文）。
 
 ### 🧩 技能包
 


### PR DESCRIPTION
## 收录插件 / Adding a plugin

在 \Tools & Capabilities\（工具与能力）分类下新增一行（已更新为改名后的新仓库）：

**dsh-harness-zh-cn** — DeepSeek Harness 中文汉化插件：通过 \system-prompt/assemble\ 瀑布钩子在运行时把全部系统提示词、工具描述与运行时上下文翻译成中文（1788 条译文，零源码修改，卸载即还原英文）。

### 收录要求核对 / Requirements check

- ✅ 仓库 \package.json\ 声明了 \dsh.bundle\ manifest（\./cordis.patch.yml\）— installable via \dsh plugin add\
- ✅ 仓库根目录有 \cordis.patch.yml\（\insert\ 插件行）
- ✅ 真实可用的代码（插件已在运行中的 DSH 部署验证生效）
- ✅ 已发布到 npm（\dsh-harness-zh-cn@0.1.0\）与 GitHub（带 \dsh-plugin\ topic）

### 中文 README / Chinese README

同步在 \README.zh.md\ 的工具与能力分类下添加了对应行。

> 注：原仓库 \dsh-harness-zh\ 已删除并改名为 \dsh-harness-zh-cn\，本 PR 已更新为新仓库链接。