### PR TITLE
Add screenshots for cirelir/dsh-change-review

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -2,5 +2,12 @@
  "https://github.com/dsh-market/dsh-market": [
   "https://raw.githubusercontent.com/dsh-market/dsh-market/main/assets/demo-en.png",
   "https://raw.githubusercontent.com/dsh-market/dsh-market/main/assets/themes-en.png"
+ ],
+ "https://github.com/cirelir/dsh-change-review": [
+  "https://raw.githubusercontent.com/cirelir/dsh-change-review/main/assets/screenshots/review-tab.png",
+  "https://raw.githubusercontent.com/cirelir/dsh-change-review/main/assets/screenshots/per-turn-card.png",
+  "https://raw.githubusercontent.com/cirelir/dsh-change-review/main/assets/screenshots/diff-detail.png",
+  "https://raw.githubusercontent.com/cirelir/dsh-change-review/main/assets/screenshots/color-settings.png",
+  "https://raw.githubusercontent.com/cirelir/dsh-change-review/main/assets/screenshots/plugin-market.png"
  ]
 }


### PR DESCRIPTION
Adds AppStore-style screenshots for [cirelir/dsh-change-review](https://github.com/cirelir/dsh-change-review) in `data/screenshots.json`, per the [contributing guide](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/main/contributing.md#screenshots--截图optional-recommended--可选推荐).

The README entries already landed in #602 — this PR only adds the storefront screenshots:

- Review tab (file list + diff preview)
- Per-turn review card
- Expanded diff with per-change revert
- Color customization (Settings → 修改审查)
- Installed from the plugin market

All images are hosted in the plugin's own repo (`assets/screenshots/`) as GitHub-hosted raw URLs, so they update with the plugin's releases. The plugin README now shows the same screenshots.

- [x] My repo's `package.json` declares **`dsh.bundle`** (already the case — see #602)
- [x] One line added to **both** `README.md` and `README.zh.md` (already the case — see #602)
- [x] Description states what the plugin does, no superlatives
- [x] My repo has the `dsh-plugin` topic
- [x] 🖼️ Screenshots added to `data/screenshots.json`
