### PR TITLE
Add volcengine/OpenViking dsh-memory-plugin to Memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,6 +443,7 @@ dsh plugin --profile web add dshmarket
 - [vectorize-io/hindsight#coding-agents](https://github.com/vectorize-io/hindsight/tree/main/hindsight-integrations/coding-agents) - Hindsight, agent memory that learns: long-term project memory with auto recall and retain, knowledge pages, deep reflection, and per-repo memory banks.
 
 - [scd13150/dsh-cognition](https://github.com/scd13150/dsh-cognition) - Project memory for coding agents on DeepSeek Harness: similar past edits surface as precedents, out-of-scope edits are blocked, and cognition persists across sessions (47 upstream-verified fixes, gold-free 20-task run).
+- [volcengine/OpenViking#examples/dsh-memory-plugin](https://github.com/volcengine/OpenViking/tree/main/examples/dsh-memory-plugin) - OpenViking memory and context bundle for DeepSeek Harness: pre-step auto-recall and profile injection, session capture, `viking://` URI guarding, and recall/write memory tools backed by an OpenViking server.
 
 ### Tools & Capabilities
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -443,6 +443,7 @@ dsh plugin --profile web add dshmarket
 
 - [scd13150/dsh-cognition](https://github.com/scd13150/dsh-cognition) — 给 DSH agent 的项目记忆:历史相似编辑作为先例出现、越界修改被 scope 锁拦下、认知跨会话持续积累(47 次上游验收修复、去 gold 化 20/20)。
 - [nanpaidashi/dsh-honcho-sync](https://github.com/nanpaidashi/dsh-honcho-sync) — Honcho 记忆桥接：每轮对话自动同步到自建 Honcho 记忆服务（NAS/服务器/云），提供 recall/search/remember/context/status 工具，会话启动自动注入上下文，内置可视化设置面板。
+- [volcengine/OpenViking#examples/dsh-memory-plugin](https://github.com/volcengine/OpenViking/tree/main/examples/dsh-memory-plugin) — 面向 DeepSeek Harness 的 OpenViking 记忆与上下文插件：pre-step 自动召回与画像注入、会话捕获、`viking://` URI 防护，以及对接 OpenViking 服务端的 recall/write 记忆工具。
 
 ### 🛠️ 工具与能力
 


### PR DESCRIPTION
Adds `volcengine/OpenViking#examples/dsh-memory-plugin` to the Memory section of README.md and README.zh.md.

What it is: an installable DSH bundle (declares `dsh.bundle` in `package.json`, with `cordis.patch.yml`) that gives DSH sessions persistent memory via an OpenViking server — pre-step auto-recall/profile injection, session capture, `viking://` URI guarding, and model-invocable recall/write memory tools. Merged upstream via volcengine/OpenViking#3993.

Checklist per contributing.md:
- [x] One line added to both README.md and README.zh.md under Memory, same format as existing monorepo-subpath entries (e.g. `modusensus/dsh-mneme#dsh-mneme`).
- [x] Repo declares `dsh.bundle` (not just `dsh.client`) in `examples/dsh-memory-plugin/package.json`, with `cordis.patch.yml` alongside it.
- [x] Real, working code with tests, actively maintained.
- [x] Added the `dsh-plugin` topic to volcengine/OpenViking.
- [x] Description states functionality only, no marketing language.