### PR TITLE
Add screenshots for dsh-go-balance

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -113,5 +113,10 @@
   "https://raw.githubusercontent.com/nzl153/dsh-pet-whale/main/docs/screenshots/04-celebrate.png",
   "https://raw.githubusercontent.com/nzl153/dsh-pet-whale/main/docs/screenshots/05-error.png",
   "https://raw.githubusercontent.com/nzl153/dsh-pet-whale/main/docs/screenshots/06-feed.png"
+ ],
+ "https://github.com/iamfromchangsha/dsh-go-balance": [
+  "https://raw.githubusercontent.com/iamfromchangsha/dsh-go-balance/main/docs/screenshot-composer.png",
+  "https://raw.githubusercontent.com/iamfromchangsha/dsh-go-balance/main/docs/screenshot-tooltip.png",
+  "https://raw.githubusercontent.com/iamfromchangsha/dsh-go-balance/main/docs/screenshot-warn.png"
  ]
 }


### PR DESCRIPTION
Marketplace screenshots for [dsh-go-balance](https://github.com/iamfromchangsha/dsh-go-balance) (listed in #628).

Three images hosted in the plugin repo:
1. The balance pill at the right end of the composer tool row
2. Hover detail tooltip
3. Warn coloring on low remaining

The plugin is published on npm: `dsh plugin --profile web add dsh-go-balance`.