### PR TITLE
Add AppStore-style screenshots for keyiadiannao/dsh-restart-button (p…

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -3,4 +3,12 @@
   "https://raw.githubusercontent.com/dsh-market/dsh-market/main/assets/demo-en.png",
   "https://raw.githubusercontent.com/dsh-market/dsh-market/main/assets/themes-en.png"
  ]
+ ,
+  "https://github.com/keyiadiannao/dsh-restart-button": [
+   "https://raw.githubusercontent.com/keyiadiannao/dsh-power-button/master/docs/screenshots/screenshot-1.png",
+   "https://raw.githubusercontent.com/keyiadiannao/dsh-power-button/master/docs/screenshots/screenshot-2.png",
+   "https://raw.githubusercontent.com/keyiadiannao/dsh-power-button/master/docs/screenshots/screenshot-3.png",
+   "https://raw.githubusercontent.com/keyiadiannao/dsh-power-button/master/docs/screenshots/screenshot-4.png",
+   "https://raw.githubusercontent.com/keyiadiannao/dsh-power-button/master/docs/screenshots/screenshot-5.png"
+  ]
 }

--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -5,10 +5,10 @@
  ]
  ,
   "https://github.com/keyiadiannao/dsh-restart-button": [
-   "https://raw.githubusercontent.com/keyiadiannao/dsh-power-button/master/docs/screenshots/power-button.png",
-   "https://raw.githubusercontent.com/keyiadiannao/dsh-power-button/master/docs/screenshots/power-menu.png",
-   "https://raw.githubusercontent.com/keyiadiannao/dsh-power-button/master/docs/screenshots/shutdown-confirm.png",
-   "https://raw.githubusercontent.com/keyiadiannao/dsh-power-button/master/docs/screenshots/shutdown-progress.png",
-   "https://raw.githubusercontent.com/keyiadiannao/dsh-power-button/master/docs/screenshots/restart-done.png"
+   "https://raw.githubusercontent.com/keyiadiannao/dsh-power-button/master/docs/screenshots/en/power-button.png",
+   "https://raw.githubusercontent.com/keyiadiannao/dsh-power-button/master/docs/screenshots/en/power-menu.png",
+   "https://raw.githubusercontent.com/keyiadiannao/dsh-power-button/master/docs/screenshots/en/shutdown-confirm.png",
+   "https://raw.githubusercontent.com/keyiadiannao/dsh-power-button/master/docs/screenshots/en/shutdown-progress.png",
+   "https://raw.githubusercontent.com/keyiadiannao/dsh-power-button/master/docs/screenshots/en/restart-done.png"
   ]
 }

--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -5,10 +5,10 @@
  ]
  ,
   "https://github.com/keyiadiannao/dsh-restart-button": [
-   "https://raw.githubusercontent.com/keyiadiannao/dsh-power-button/master/docs/screenshots/screenshot-1.png",
-   "https://raw.githubusercontent.com/keyiadiannao/dsh-power-button/master/docs/screenshots/screenshot-2.png",
-   "https://raw.githubusercontent.com/keyiadiannao/dsh-power-button/master/docs/screenshots/screenshot-3.png",
-   "https://raw.githubusercontent.com/keyiadiannao/dsh-power-button/master/docs/screenshots/screenshot-4.png",
-   "https://raw.githubusercontent.com/keyiadiannao/dsh-power-button/master/docs/screenshots/screenshot-5.png"
+   "https://raw.githubusercontent.com/keyiadiannao/dsh-power-button/master/docs/screenshots/power-button.png",
+   "https://raw.githubusercontent.com/keyiadiannao/dsh-power-button/master/docs/screenshots/power-menu.png",
+   "https://raw.githubusercontent.com/keyiadiannao/dsh-power-button/master/docs/screenshots/shutdown-confirm.png",
+   "https://raw.githubusercontent.com/keyiadiannao/dsh-power-button/master/docs/screenshots/shutdown-progress.png",
+   "https://raw.githubusercontent.com/keyiadiannao/dsh-power-button/master/docs/screenshots/restart-done.png"
   ]
 }


### PR DESCRIPTION
Add 5 AppStore-style screenshots for the existing keyiadiannao/dsh-restart-button entry: power button + menu, shutdown confirm dialog, shutdown progress, restart done. Images are hosted in the plugin repo under docs/screenshots/. This only touches data/screenshots.json.