### PR TITLE
docs: add dsh-plugin-llm-balance screenshot

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -123,5 +123,8 @@
   "https://raw.githubusercontent.com/zljr/dsh-share/master/assets/share-dialog.png",
   "https://raw.githubusercontent.com/zljr/dsh-share/master/assets/share-page-light.png",
   "https://raw.githubusercontent.com/zljr/dsh-share/master/assets/share-page-dark.png"
+ ],
+ "https://github.com/FengHuoLinShan/dsh-plugin-llm-balance": [
+  "https://raw.githubusercontent.com/FengHuoLinShan/dsh-plugin-llm-balance/main/assets/llm-balance-preview.png"
  ]
 }


### PR DESCRIPTION
## Summary

- add a curated screenshot for `dsh-plugin-llm-balance`
- use a GitHub-hosted image from the plugin repository

## Validation

- `node scripts/build-site.mjs`
- verified the image URL returns HTTP 200 with `image/png`

Follow-up to the screenshot invitation on #259.