### PR TITLE
Add dsh-testkit marketplace screenshot

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -126,5 +126,8 @@
  ],
  "https://github.com/FengHuoLinShan/dsh-plugin-llm-balance": [
   "https://raw.githubusercontent.com/FengHuoLinShan/dsh-plugin-llm-balance/main/assets/llm-balance-preview.png"
+ ],
+ "https://github.com/iiwish/dsh-testkit": [
+  "https://raw.githubusercontent.com/iiwish/dsh-testkit/main/docs/assets/dsh-testkit-showcase.png"
  ]
 }


### PR DESCRIPTION
## Summary

- Add a curated marketplace screenshot for `iiwish/dsh-testkit`.
- Use the lifecycle test result image hosted in the plugin repository.

## Why

This follows the screenshot support suggested after #562. The explicit mapping keeps storefronts from selecting README badges instead of the product screenshot.

## Validation

- Screenshot URL returns HTTP 200 with `image/png`.
- `npx awesome-lint` passes (warnings only).
- `node scripts/build-site.mjs` passes.