### PR TITLE
data: curated screenshots for dsh-archived-chats and dsh-liquid-glass

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -129,5 +129,16 @@
  ],
  "https://github.com/iiwish/dsh-testkit": [
   "https://raw.githubusercontent.com/iiwish/dsh-testkit/main/docs/assets/dsh-testkit-showcase.png"
+ ],
+ "https://github.com/Ultronen/dsh-archived-chats": [
+  "https://raw.githubusercontent.com/Ultronen/dsh-archived-chats/main/assets/screenshots/1-archived-chats.png",
+  "https://raw.githubusercontent.com/Ultronen/dsh-archived-chats/main/assets/screenshots/2-search.png",
+  "https://raw.githubusercontent.com/Ultronen/dsh-archived-chats/main/assets/screenshots/3-delete-confirm.png",
+  "https://raw.githubusercontent.com/Ultronen/dsh-archived-chats/main/assets/screenshots/4-group-menu.png"
+ ],
+ "https://github.com/Ultronen/dsh-liquid-glass": [
+  "https://raw.githubusercontent.com/Ultronen/dsh-liquid-glass/main/assets/screenshots/1-settings.png",
+  "https://raw.githubusercontent.com/Ultronen/dsh-liquid-glass/main/assets/screenshots/2-glass-shell.png",
+  "https://raw.githubusercontent.com/Ultronen/dsh-liquid-glass/main/assets/screenshots/3-settings-wallpaper.png"
  ]
 }


### PR DESCRIPTION
Hi 👋 — following up on the [screenshot invitation on #797](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/issues/797#issuecomment-2620851000): adding curated AppStore-style screenshots for both my listed plugins.

## Changes

Adds two entries to `data/screenshots.json`:

- **Ultronen/dsh-archived-chats** — 4 shots: the grouped archived-chats list, search filtering, delete confirmation, and the per-group menu (unarchive-all / delete-all).
- **Ultronen/dsh-liquid-glass** — 3 shots: the settings section with the transparency slider, the full-shell liquid-glass effect over a photo wallpaper, and the settings panel over the same wallpaper.

Images live in each plugin's own repo (`assets/screenshots/`, raw.githubusercontent.com), so they update with releases and pass the host allowlist.

Keys match the README entry links exactly; local re-run of the build's screenshots checks passes (3 entries, 9 images).

/ 为我的两个插件补充市场截图（详见 #797 上的邀请）：dsh-archived-chats 4 张（分组列表、搜索、删除确认、分组菜单），dsh-liquid-glass 3 张（设置面板、毛玻璃全界面效果、壁纸上的设置面板）。图片放在各自仓库的 `assets/screenshots/` 下，随版本更新。