### PR TITLE
screenshots: add dsh-commandcode-provider

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -168,5 +168,9 @@
   "https://raw.githubusercontent.com/LeemanCheung/dsh-whale-animation/main/docs/screenshots/launch.png",
   "https://raw.githubusercontent.com/LeemanCheung/dsh-whale-animation/main/docs/screenshots/apex.png",
   "https://raw.githubusercontent.com/LeemanCheung/dsh-whale-animation/main/docs/screenshots/deep-dive.png"
+ ],
+ "https://github.com/Mars-Sea/dsh-commandcode-provider": [
+  "https://raw.githubusercontent.com/Mars-Sea/dsh-commandcode-provider/main/assets/screenshots/model-picker.png",
+  "https://raw.githubusercontent.com/Mars-Sea/dsh-commandcode-provider/main/assets/screenshots/usage-dashboard.png"
  ]
 }


### PR DESCRIPTION
## What

Adds an entry to `data/screenshots.json` for [Mars-Sea/dsh-commandcode-provider](https://github.com/Mars-Sea/dsh-commandcode-provider), keyed by its README entry URL:

- `assets/screenshots/model-picker.png` — model picker showing the live Command Code catalog with plan-tier / deal / Image / context annotations
- `assets/screenshots/usage-dashboard.png` — the `/commandcode` usage dashboard

Both images are hosted on `raw.githubusercontent.com` in the plugin's own repo (per [contributing.md](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/main/contributing.md#screenshots--截图optional-recommended--可选推荐)).

## Checklist

- [x] Key matches the README entry URL exactly
- [x] 1-8 image URLs, all on GitHub hosting (`raw.githubusercontent.com`)
- [x] `node scripts/build-site.mjs` passes locally (839 entries, no screenshot errors)
