### PR TITLE
Add screenshots for PC2005-cloud/dsh-pet

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -172,5 +172,9 @@
  "https://github.com/Mars-Sea/dsh-commandcode-provider": [
   "https://raw.githubusercontent.com/Mars-Sea/dsh-commandcode-provider/main/assets/screenshots/model-picker.png",
   "https://raw.githubusercontent.com/Mars-Sea/dsh-commandcode-provider/main/assets/screenshots/usage-dashboard.png"
+ ],
+ "https://github.com/PC2005-cloud/dsh-pet/tree/main/dsh-pet": [
+  "https://raw.githubusercontent.com/PC2005-cloud/dsh-pet/main/assets/screenshots/dsh-pet-running-1.png",
+  "https://raw.githubusercontent.com/PC2005-cloud/dsh-pet/main/assets/screenshots/dsh-pet-running-2.png"
  ]
 }


### PR DESCRIPTION
Add AppStore-style screenshots for the [PC2005-cloud/dsh-pet](https://github.com/PC2005-cloud/dsh-pet) entry, per [contributing.md](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/main/contributing.md#screenshots--截图optional-recommended--可选推荐).

- Key: the entry's GitHub URL, exactly as in the README line
- 2 screenshots hosted in my own repo (running in the DSH Web UI)

为 [PC2005-cloud/dsh-pet](https://github.com/PC2005-cloud/dsh-pet) 条目添加市场展示截图（按 contributing.md 说明）：
- key 与 README 行完全一致
- 2 张截图放在我自己仓库中（宠物运行在 DSH Web 界面中的实机图）