### PR TITLE
Add AmeKrance/anan-thermal-monitor (Just for Fun)

### DIFF
--- a/README.md
+++ b/README.md
@@ -984,6 +984,7 @@ dsh plugin --profile web add dshmarket
 ### Just for Fun
 
 - [609476965/dsh-LorebookMD](https://github.com/609476965/dsh-LorebookMD) - Import SillyTavern/TavernAI character cards and world books, save them as local Markdown lore documents, and generate novel prose from your prompts with the world settings as reference.
+- [AmeKrance/anan-thermal-monitor](https://github.com/AmeKrance/anan-thermal-monitor) - Purple-white desktop pet that docks to the screen edge and shows real-time CPU, RAM, GPU and NVMe temperatures with hardware info.
 - [AnacondaKC/dsh-douyin](https://github.com/AnacondaKC/dsh-douyin) - Short-video sidebar: native player, series navigation, precise history replay.
 - [AnacondaKC/dsh-stock-market](https://github.com/AnacondaKC/dsh-stock-market) - Fixes the bug where your account can't lose money while you code.
 - [Awu12277/dsh-stock-watch](https://github.com/Awu12277/dsh-stock-watch) - A-share watchlist real-time market monitoring plugin: a collapsible popup in the top-right corner of the DeepSeek Harness (DSH) web interface for real-time quote monitoring, group switching, intraday and candlestick (K-line) charts, and buy/sell target price settings.

--- a/README.zh.md
+++ b/README.zh.md
@@ -984,6 +984,7 @@ dsh plugin --profile web add dshmarket
 ### 🎮 娱乐
 
 - [609476965/dsh-LorebookMD](https://github.com/609476965/dsh-LorebookMD) — 导入酒馆（SillyTavern/TavernAI）角色卡与世界书，落地为本地 Markdown 设定文档，激活创作模式后根据用户输入、参考世界书创作小说。
+- [AmeKrance/anan-thermal-monitor](https://github.com/AmeKrance/anan-thermal-monitor) — 紫白桌宠悬浮球，贴边停靠实时显示 CPU/内存/GPU/NVMe 温度与硬件信息。
 - [AnacondaKC/dsh-douyin](https://github.com/AnacondaKC/dsh-douyin) — 侧栏短视频：原生播放器、系列导航、精确历史回放。
 - [AnacondaKC/dsh-stock-market](https://github.com/AnacondaKC/dsh-stock-market) — 有效解决了写代码的时候账户不能同时亏钱的 BUG。
 - [Awu12277/dsh-stock-watch](https://github.com/Awu12277/dsh-stock-watch) — A 股自选股实时行情盯盘插件：在 DeepSeek Harness（DSH）Web 界面的右上角显示一个可折叠弹窗，实时监控自选股行情、切换分组、查看分时与 K 线、设置买卖目标价。

--- a/data/plugins/AmeKrance__anan-thermal-monitor.yml
+++ b/data/plugins/AmeKrance__anan-thermal-monitor.yml
@@ -1,0 +1,6 @@
+url: https://github.com/AmeKrance/anan-thermal-monitor
+name: AmeKrance/anan-thermal-monitor
+category: fun
+description:
+  en: Purple-white desktop pet that docks to the screen edge and shows real-time CPU, RAM, GPU and NVMe temperatures with hardware info.
+  zh: 紫白桌宠悬浮球，贴边停靠实时显示 CPU/内存/GPU/NVMe 温度与硬件信息。

--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -51,5 +51,10 @@
  "https://github.com/chouyong/dsh-fork-graph": [
   "https://raw.githubusercontent.com/chouyong/dsh-fork-graph/main/assets/screenshot-trigger.png",
   "https://raw.githubusercontent.com/chouyong/dsh-fork-graph/main/assets/screenshot-panel.png"
+ ],
+ "https://github.com/AmeKrance/anan-thermal-monitor": [
+  "https://raw.githubusercontent.com/AmeKrance/anan-thermal-monitor/main/assets/screenshots/screenshot-1.png",
+  "https://raw.githubusercontent.com/AmeKrance/anan-thermal-monitor/main/assets/screenshots/screenshot-2.png",
+  "https://raw.githubusercontent.com/AmeKrance/anan-thermal-monitor/main/assets/screenshots/demo.gif"
  ]
 }


### PR DESCRIPTION
Add [anan-thermal-monitor](https://github.com/AmeKrance/anan-thermal-monitor) to the **Just for Fun / 娱乐** category.

Purple-white desktop pet that docks to the screen edge showing real-time CPU / RAM / GPU / NVMe temperatures and hardware info. Installed via dsh plugin --profile web add anan-thermal-monitor (published on npm), or github:AmeKrance/anan-thermal-monitor.