### PR TITLE
docs: add screenshots for dsh-visual-plugin

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -176,5 +176,12 @@
  "https://github.com/PC2005-cloud/dsh-pet/tree/main/dsh-pet": [
   "https://raw.githubusercontent.com/PC2005-cloud/dsh-pet/main/assets/screenshots/dsh-pet-running-1.png",
   "https://raw.githubusercontent.com/PC2005-cloud/dsh-pet/main/assets/screenshots/dsh-pet-running-2.png"
+ ],
+ "https://github.com/jyh20030112/dsh-visual-plugin": [
+  "https://raw.githubusercontent.com/jyh20030112/dsh-visual-plugin/main/assets/screenshots/screenshot-1.png",
+  "https://raw.githubusercontent.com/jyh20030112/dsh-visual-plugin/main/assets/screenshots/screenshot-2.png",
+  "https://raw.githubusercontent.com/jyh20030112/dsh-visual-plugin/main/assets/screenshots/screenshot-3.png",
+  "https://raw.githubusercontent.com/jyh20030112/dsh-visual-plugin/main/assets/screenshots/screenshot-4.png",
+  "https://raw.githubusercontent.com/jyh20030112/dsh-visual-plugin/main/assets/screenshots/screenshot-5.png"
  ]
 }


### PR DESCRIPTION
Adds AppStore-style screenshots for [`jyh20030112/dsh-visual-plugin`](https://github.com/jyh20030112/dsh-visual-plugin) to `data/screenshots.json`.

- 5 screenshots, keyed by the entry's GitHub URL.
- Images hosted in the plugin's own repo (`assets/screenshots/`), all GitHub-hosted https URLs (`raw.githubusercontent.com`).

为 [`jyh20030112/dsh-visual-plugin`](https://github.com/jyh20030112/dsh-visual-plugin) 在 `data/screenshots.json` 添加 5 张展示截图，key 为条目 URL，图片存放于插件自身仓库（`assets/screenshots/`），均为 GitHub 托管的 https 链接。