### PR TITLE
data: add curated screenshots for dsh-undo-plugin (dsh-market 1.8.0+)

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -197,5 +197,13 @@
   "https://raw.githubusercontent.com/truelove-dreamer/dsh-plugin-vetting/main/assets/shot-report.png",
   "https://raw.githubusercontent.com/truelove-dreamer/dsh-plugin-vetting/main/assets/shot-detail.png",
   "https://raw.githubusercontent.com/truelove-dreamer/dsh-plugin-vetting/main/assets/shot-gate.png"
+ ],
+ "https://github.com/lire1131/dsh-undo-plugin": [
+  "https://raw.githubusercontent.com/lire1131/dsh-undo-plugin/master/docs/webui-panel.png",
+  "https://raw.githubusercontent.com/lire1131/dsh-undo-plugin/master/docs/webui-settings-section.png",
+  "https://raw.githubusercontent.com/lire1131/dsh-undo-plugin/master/docs/gui-main.png",
+  "https://raw.githubusercontent.com/lire1131/dsh-undo-plugin/master/docs/gui-settings.png",
+  "https://raw.githubusercontent.com/lire1131/dsh-undo-plugin/master/docs/safe-mode-confirm.png",
+  "https://raw.githubusercontent.com/lire1131/dsh-undo-plugin/master/docs/safe-mode-done.png"
  ]
 }


### PR DESCRIPTION
Follow-up to #69 and the dsh-market 1.8.0+ screenshot feature.

Adds 6 curated screenshots for the [dsh-undo-plugin](https://github.com/lire1131/dsh-undo-plugin) entry, keyed by its GitHub URL in \data/screenshots.json\:

- WebUI snapshot panel (diff / rollback / prune / export / import / safe mode)
- WebUI settings section (sensitive mode / plugin whitelist / directory pickers)
- Offline GUI main window (toolbar + safe-mode button)
- Offline GUI settings dialog
- Safe-mode confirm dialog
- Safe-mode active status

All images live in the plugin repo under \docs/\ (referenced by its README already) and resolve via raw.githubusercontent.com (verified 200 image/png).