### PR TITLE
docs: add screenshots for 2nd1st/dsh-plugin-open-app

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -205,5 +205,9 @@
   "https://raw.githubusercontent.com/lire1131/dsh-undo-plugin/master/docs/gui-settings.png",
   "https://raw.githubusercontent.com/lire1131/dsh-undo-plugin/master/docs/safe-mode-confirm.png",
   "https://raw.githubusercontent.com/lire1131/dsh-undo-plugin/master/docs/safe-mode-done.png"
+ ],
+ "https://github.com/2nd1st/dsh-plugin-open-app": [
+  "https://raw.githubusercontent.com/2nd1st/dsh-plugin-open-app/main/docs/screenshot-app-container.jpg",
+  "https://raw.githubusercontent.com/2nd1st/dsh-plugin-open-app/main/docs/screenshot-inline.jpg"
  ]
 }


### PR DESCRIPTION
Follows @fkysly's note on #619 — thanks for the pointer.

Adds two screenshots for [`2nd1st/dsh-plugin-open-app`](https://github.com/2nd1st/dsh-plugin-open-app) to `data/screenshots.json`, keyed by the same URL as the README entry:

1. the app container — an MCP app in its own sidebar tab, with the agent's line under it
2. inline rendering — an `open_app` tool call becoming the running app inside an ordinary chat

Both files already live in the plugin repo (`docs/*.jpg` on `main`, the ones its README embeds), served from `raw.githubusercontent.com`. Ran `node scripts/build-site.mjs` locally on this branch: exit 0 (839 entries × 2 locales); as a control, a third-party image host in the same slot fails the check by name.

按 #619 里的提示补两张截图（key 与 README 条目链接逐字一致，图片放在插件仓自己的 `docs/` 下、GitHub 托管）。本地 `build-site.mjs` 通过。
