### PR TITLE
Add screenshots for dsh-anchored-standard

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -67,5 +67,10 @@
   "https://raw.githubusercontent.com/haiziyao/dsh-vision-mix/main/docs/vision-history.png",
   "https://raw.githubusercontent.com/haiziyao/dsh-vision-mix/main/docs/generation-history.png",
   "https://raw.githubusercontent.com/haiziyao/dsh-vision-mix/main/docs/benchmark-mix.png"
+ ],
+ "https://github.com/Jungod1121/dsh-anchored-standard": [
+  "https://raw.githubusercontent.com/Jungod1121/dsh-anchored-standard/main/screenshots/market-1.png",
+  "https://raw.githubusercontent.com/Jungod1121/dsh-anchored-standard/main/screenshots/market-2.png",
+  "https://raw.githubusercontent.com/Jungod1121/dsh-anchored-standard/main/screenshots/market-3.png"
  ]
 }


### PR DESCRIPTION
Adds 3 marketplace screenshots for https://github.com/Jungod1121/dsh-anchored-standard, keyed by its entry URL as described in the data/screenshots.json format.

Images are hosted in the plugin repo under screenshots/ (market-1/2/3.png).