### PR TITLE
Add SingleOne/dsh-notify-center

### DIFF
--- a/README.md
+++ b/README.md
@@ -730,6 +730,7 @@ dsh plugin --profile web add dshmarket
 
 ### Notifications & Integrations
 
+- [SingleOne/dsh-notify-center](https://github.com/SingleOne/dsh-notify-center) - Native desktop and webhook notifications for turn completions, failures, and approval requests, with outcome filters, content rules, privacy controls, and retrying delivery.
 - [cerebrixos-org/tuning-engines-cli#tuningengines-dsh-plugin](https://github.com/cerebrixos-org/tuning-engines-cli/tree/main/packages/tuningengines-dsh-plugin) - Exports metadata-only DSH turn, model, tool, approval, retry, and error events to Tuning Engines for governed traces, policy evaluation, cost analysis, and Work Session review, with a disk-backed retry queue.
 - [PandaPolo/dsh-voice-call](https://github.com/PandaPolo/dsh-voice-call) - Agent-initiated voice calls: `offer_call` rings the human (接听/拒接/稍后再说); accepted calls synthesize and play locally via CrispASR + Qwen3-TTS (9 speakers, 2 Chinese dialects), rejected calls return the decision to the agent.
 - [STARDUSTLC666/dsh-slack](https://github.com/STARDUSTLC666/dsh-slack) - Two-way Slack messaging (notify/channels/inbox/reply) over Socket Mode, no public callback needed.

--- a/README.zh.md
+++ b/README.zh.md
@@ -730,6 +730,7 @@ dsh plugin --profile web add dshmarket
 
 ### 🔔 通知与集成
 
+- [SingleOne/dsh-notify-center](https://github.com/SingleOne/dsh-notify-center) — 回合完成、失败和待审批时发送跨平台本机通知与 Webhook，支持结果过滤、内容规则、隐私控制和失败重试。
 - [cerebrixos-org/tuning-engines-cli#tuningengines-dsh-plugin](https://github.com/cerebrixos-org/tuning-engines-cli/tree/main/packages/tuningengines-dsh-plugin) — 将不含原始内容的 DSH 回合、模型、工具、审批、重试和错误事件导出到 Tuning Engines，用于受治理的追踪、策略评估、成本分析和 Work Session 审阅，并提供磁盘持久化重试队列。
 - [PandaPolo/dsh-voice-call](https://github.com/PandaPolo/dsh-voice-call) — agent 主动打来的语音电话：`offer_call` 向人类振铃（接听/拒接/稍后再说），接听后由本地 CrispASR + Qwen3-TTS 合成并播放（9 个音色，含 2 个中文方言）；拒接则把决定返回给 agent。
 - [STARDUSTLC666/dsh-slack](https://github.com/STARDUSTLC666/dsh-slack) — Slack 双向通信（notify/channels/inbox/reply，Socket Mode 免公网回调）。


### PR DESCRIPTION
## Summary

Adds SingleOne/dsh-notify-center to **Notifications & Integrations** in both catalog languages.

The plugin provides native Windows/macOS/Linux notifications and configurable Feishu, WeCom, DingTalk, Slack, Discord, and custom webhook delivery for turn completions, failures, and approval requests.

## Checklist

- [x] The plugin declares dsh.bundle in package.json.
- [x] One entry was added to both README.md and README.zh.md.
- [x] The descriptions are factual and contain no superlatives.
- [x] The plugin repository has the dsh-plugin topic.
- [x] Official @deepseek-ai/* packages are declared as peer dependencies.

## Install

    dsh plugin --profile web add github:SingleOne/dsh-notify-center

## Validation

- Prebuilt dist is committed for GitHub installation.
- TypeScript type checking and build pass.
- 5 test files and 16 tests pass.
- Local directory and packaged installs were tested with DSH 0.1.0-rc.6.