### PR TITLE
screenshots: dsh-zhihu-dashboard

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -72,5 +72,11 @@
   "https://raw.githubusercontent.com/Jungod1121/dsh-anchored-standard/main/screenshots/market-1.png",
   "https://raw.githubusercontent.com/Jungod1121/dsh-anchored-standard/main/screenshots/market-2.png",
   "https://raw.githubusercontent.com/Jungod1121/dsh-anchored-standard/main/screenshots/market-3.png"
+ ],
+ "https://github.com/kexuejin/dsh-zhihu-dashboard": [
+  "https://raw.githubusercontent.com/kexuejin/dsh-zhihu-dashboard/main/assets/hot.png",
+  "https://raw.githubusercontent.com/kexuejin/dsh-zhihu-dashboard/main/assets/track.png",
+  "https://raw.githubusercontent.com/kexuejin/dsh-zhihu-dashboard/main/assets/feed.png",
+  "https://raw.githubusercontent.com/kexuejin/dsh-zhihu-dashboard/main/assets/onboarding.png"
  ]
 }


### PR DESCRIPTION
Adds AppStore-style screenshots for [kexuejin/dsh-zhihu-dashboard](https://github.com/kexuejin/dsh-zhihu-dashboard) in `data/screenshots.json` (4 images, hosted on the plugin repo via raw.githubusercontent.com):

1. Hot list with trend markers
2. Post tracking detail (NEW badges + 提炼应用创意 button)
3. Follow feed
4. First-run onboarding

Keyed by the entry URL as documented in `scripts/build-site.mjs` (keys must match README entry links; images on GitHub hosting only).