### PR TITLE
docs: add qiushi evidence audit screenshot

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -213,5 +213,8 @@
  "https://github.com/zer0zio-stack/dsh-opencode-go-quota": [
   "https://raw.githubusercontent.com/zer0zio-stack/dsh-opencode-go-quota/main/assets/screenshot-deepseek-balance.png",
   "https://raw.githubusercontent.com/zer0zio-stack/dsh-opencode-go-quota/main/assets/screenshot-opencode-go-limit.png"
+ ],
+ "https://github.com/030611/qiushi-dsh-evidence-audit": [
+  "https://raw.githubusercontent.com/030611/qiushi-dsh-evidence-audit/main/docs/evidence-flow.svg"
  ]
 }


### PR DESCRIPTION
## Summary

- add the existing Qiushi DSH Evidence Audit data-flow image to data/screenshots.json
- key the image list to the exact GitHub URL already present in both READMEs
- keep the image in the plugin's own GitHub repository

This is a curated architecture image for the market detail page; it is not presented as a live UI screenshot.

## Validation

- duplicate open-PR search: no match
- JSON parse: passed
- git diff --check: passed
- scope: 1 file, 3 insertions
- image URL resolves on raw.githubusercontent.com as image/svg+xml

The full site build was attempted locally, but this Windows sparse checkout converts README files to CRLF while the parser splits on LF and expects headings at end-of-line, so it parsed zero entries. I am leaving the authoritative build result to the repository's Ubuntu CI rather than claiming a local pass.

AI assistance disclosure: OpenAI Codex assisted with the invitation review, duplicate check, small JSON edit, and validation. I reviewed the final diff and image/claim boundary.