### PR TITLE
docs: add curated screenshots for dsh-splash-launcher

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -216,5 +216,11 @@
  ],
  "https://github.com/030611/qiushi-dsh-evidence-audit": [
   "https://raw.githubusercontent.com/030611/qiushi-dsh-evidence-audit/main/docs/evidence-flow.svg"
+ ],
+ "https://github.com/Isilsolme/dsh-splash-launcher": [
+  "https://raw.githubusercontent.com/Isilsolme/dsh-splash-launcher/main/docs/screenshots/splash-light.png",
+  "https://raw.githubusercontent.com/Isilsolme/dsh-splash-launcher/main/docs/screenshots/splash-drawing.png",
+  "https://raw.githubusercontent.com/Isilsolme/dsh-splash-launcher/main/docs/screenshots/splash-dark.png",
+  "https://raw.githubusercontent.com/Isilsolme/dsh-splash-launcher/main/docs/screenshots/main.png"
  ]
 }


### PR DESCRIPTION
Adds curated screenshots for dsh-splash-launcher to data/screenshots.json (as suggested in #649).

Images are hosted in the plugin repo:
- splash-light.png – light startup splash
- splash-drawing.png – stroke-by-stroke HARNESS animation in progress
- splash-dark.png – dark startup splash
- main.png – resulting dsh GUI

This is optional; the market will now show these 4 images in the chosen order instead of auto-extracting from README.