### PR TITLE
Add zhtx2024/dsh-pdf — PDF parsing tools (pdf_info / pdf_extract_text / pdf_render_page)

### DIFF
--- a/README.md
+++ b/README.md
@@ -666,6 +666,7 @@ dsh plugin --profile web add dshmarket
 - [zhang787jun/dsh-finance](https://github.com/zhang787jun/dsh-finance) - Financial research workflow and portfolio risk tools with source discipline for current market facts.
 - [zhangzhenwen1/qmd-autosearch](https://github.com/zhangzhenwen1/qmd-autosearch) - Auto-supplement QMD semantic search when the model greps/globs a knowledge-base directory: zero-dependency DSH plugin, async injection via next-step, no manual invocation.
 - [zhaoolee/notes](https://github.com/zhaoolee/notes) - Export DSH conversations as Smartisan Notes-style PNGs, or create and update Markdown notes in a configured account-scoped workspace.
+- [zhtx2024/dsh-pdf](https://github.com/zhtx2024/dsh-pdf) - PDF parsing tools for DSH: pdf_info, pdf_extract_text, and pdf_render_page with dual pdfjs and built-in rendering engines, including system-font rendering for PDFs with non-embedded CJK fonts.
 - [zimai233/dsh-adhd-copilot](https://github.com/zimai233/dsh-adhd-copilot) - ADHD behavioral coaching skill: task breakdown, overwhelm management, launch rituals, and failure recovery.
 - [zimai233/dsh-exam-countdown](https://github.com/zimai233/dsh-exam-countdown) - Query 64 Chinese exams (高考/考研/四六级/CPA/法考…) with rule-aware date math (2nd-Saturday, 1st-Sunday) and countdowns.
 - [zimai233/dsh-figma-to-lottie](https://github.com/zimai233/dsh-figma-to-lottie) - Compile SVG paths and keyframe specs into self-contained Lottie JSON animation files.

--- a/README.zh.md
+++ b/README.zh.md
@@ -666,6 +666,7 @@ dsh plugin --profile web add dshmarket
 - [zhang787jun/dsh-finance](https://github.com/zhang787jun/dsh-finance) — 金融研究工作流与组合风控工具，对当前市场事实强制来源与时间戳边界。
 - [zhangzhenwen1/qmd-autosearch](https://github.com/zhangzhenwen1/qmd-autosearch) — 模型在知识库目录执行 grep/glob 搜索时自动补充 QMD 语义检索：零依赖 DSH 插件，异步注入下一步上下文，无需手动调用。
 - [zhaoolee/notes](https://github.com/zhaoolee/notes) — 将 DSH 对话导出为锤子便签风格 PNG，或在配置的账号工作区中新建和更新 Markdown 便签。
+- [zhtx2024/dsh-pdf](https://github.com/zhtx2024/dsh-pdf) — DSH 的 PDF 解析工具：pdf_info、pdf_extract_text、pdf_render_page 三件套，pdfjs 与自研渲染器双引擎，未内嵌 CJK 字体的 PDF 也能用系统字体渲染出图。
 - [zimai233/dsh-adhd-copilot](https://github.com/zimai233/dsh-adhd-copilot) — ADHD 行为辅导技能：任务拆解、事项过载管理、启动仪式与失败重启。
 - [zimai233/dsh-exam-countdown](https://github.com/zimai233/dsh-exam-countdown) — 查询 64 场中国考试（高考/考研/四六级/CPA/法考…）的规则日期（第二个周六、第一个周日）与倒计时。
 - [zimai233/dsh-figma-to-lottie](https://github.com/zimai233/dsh-figma-to-lottie) — 将 SVG 路径与关键帧参数编译成自包含的 Lottie JSON 动画文件。

--- a/data/plugins/zhtx2024__dsh-pdf.yml
+++ b/data/plugins/zhtx2024__dsh-pdf.yml
@@ -1,0 +1,6 @@
+url: https://github.com/zhtx2024/dsh-pdf
+name: zhtx2024/dsh-pdf
+category: tools
+description:
+  en: 'PDF parsing tools for DSH: pdf_info, pdf_extract_text, and pdf_render_page with dual pdfjs and built-in rendering engines, including system-font rendering for PDFs with non-embedded CJK fonts.'
+  zh: DSH 的 PDF 解析工具：pdf_info、pdf_extract_text、pdf_render_page 三件套，pdfjs 与自研渲染器双引擎，未内嵌 CJK 字体的 PDF 也能用系统字体渲染出图。

--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -83,5 +83,9 @@
   "https://raw.githubusercontent.com/literaf/ai4scholar-plugin-dsh/main/docs/ai4scholar-home.jpg",
   "https://raw.githubusercontent.com/literaf/ai4scholar-plugin-dsh/main/docs/settings-card.png",
   "https://raw.githubusercontent.com/literaf/ai4scholar-plugin-dsh/main/docs/balance-card.png"
+ ],
+ "https://github.com/zhtx2024/dsh-pdf": [
+  "https://raw.githubusercontent.com/zhtx2024/dsh-pdf/master/assets/screenshot-schematic.png",
+  "https://raw.githubusercontent.com/zhtx2024/dsh-pdf/master/assets/screenshot-power.png"
  ]
 }


### PR DESCRIPTION
Adds **dsh-pdf** to the Tools & Capabilities / 工具与能力 category.

- Plugin repo: https://github.com/zhtx2024/dsh-pdf (MIT, topic `dsh-plugin`)
- Ships a real `dsh.bundle` manifest (`cordis.patch.yml`, id `pdf`) and registers three tools: `pdf_info`, `pdf_extract_text`, `pdf_render_page`.
- Dual engine: pdfjs for embedded-font PDFs plus a built-in renderer with system-font fallback so non-embedded CJK PDFs (e.g. 嘉立创EDA exports) render with real glyphs.
- One entry line added to both `README.md` and `README.zh.md` per CONTRIBUTING; two GitHub-hosted screenshots added to `data/screenshots.json`.
- Already installed and verified locally via `dsh plugin --profile web add github:zhtx2024/dsh-pdf`.