### PR TITLE
docs: add curated screenshots for dsh-voice

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -232,5 +232,8 @@
   "https://raw.githubusercontent.com/Blank-not-black/dsh-Remote/main/docs/screenshots/settings-mobile.png",
   "https://raw.githubusercontent.com/Blank-not-black/dsh-Remote/main/docs/screenshots/sessions.png",
   "https://raw.githubusercontent.com/Blank-not-black/dsh-Remote/main/docs/screenshots/files.png"
+ ],
+ "https://github.com/haoku123/dsh-voice": [
+  "https://raw.githubusercontent.com/haoku123/dsh-voice/main/docs/demo.gif"
  ]
 }


### PR DESCRIPTION
Adds the dsh-voice entry to `data/screenshots.json`, keyed by its GitHub URL, pointing to the demo GIF already shipped in the repo (`docs/demo.gif`).

- URL follows the [screenshots guide](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/main/contributing.md#screenshots--截图optional-recommended--可选推荐): GitHub-hosted `raw.githubusercontent.com`, image lives in my own repo so it updates with releases.
- Thanks @fkysly for the invite!