### PR TITLE
docs: add curated screenshots for dsh-themes

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -235,5 +235,8 @@
  ],
  "https://github.com/haoku123/dsh-voice": [
   "https://raw.githubusercontent.com/haoku123/dsh-voice/main/docs/demo.gif"
+ ],
+ "https://github.com/MangMax/dsh-themes": [
+  "https://raw.githubusercontent.com/MangMax/dsh-themes/main/assets/screenshot.png"
  ]
 }


### PR DESCRIPTION
Add curated screenshots for [MangMax/dsh-themes](https://github.com/MangMax/dsh-themes) to `data/screenshots.json` so the [dsh-market](https://github.com/dsh-market/dsh-market) detail view shows AppStore-style screenshots.

- Key: `https://github.com/MangMax/dsh-themes` (matches the README entry added in #529)
- 1 image: `assets/screenshot.png` (2560×1659), hosted in the plugin repo's own `assets/` folder on `raw.githubusercontent.com`

Validated locally with `node scripts/build-site.mjs` (839 entries, exit 0) — the screenshots pass the GitHub-hosting URL check.
