### PR TITLE
docs: add screenshots for dsh-science (dsh-market storefront)

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -238,5 +238,13 @@
  ],
  "https://github.com/MangMax/dsh-themes": [
   "https://raw.githubusercontent.com/MangMax/dsh-themes/main/assets/screenshot.png"
+ ],
+ "https://github.com/biociao/dsh-science": [
+  "https://raw.githubusercontent.com/biociao/dsh-science/main/assets/screenshots/research-loop.png",
+  "https://raw.githubusercontent.com/biociao/dsh-science/main/assets/screenshots/artifact-provenance.png",
+  "https://raw.githubusercontent.com/biociao/dsh-science/main/assets/screenshots/research-report.png",
+  "https://raw.githubusercontent.com/biociao/dsh-science/main/assets/screenshots/remote-compute.png",
+  "https://raw.githubusercontent.com/biociao/dsh-science/main/assets/screenshots/plugin-inventory.png",
+  "https://raw.githubusercontent.com/biociao/dsh-science/main/assets/screenshots/topology.png"
  ]
 }


### PR DESCRIPTION
Following up on [the review comment](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/pull/26#issuecomment-5305916489) — adding 6 AppStore-style screenshots for the [dsh-science](https://github.com/biociao/dsh-science) entry, keyed by its README URL as required.

Images are hosted in the plugin repo under `assets/screenshots/` (already on `main`):

1. `research-loop.png` — science-mode research loop: research_init / research_hypothesis / research_experiment
2. `artifact-provenance.png` — versioned artifact with SHA-256 provenance (wastewater-amr-v1 v1)
3. `research-report.png` — full project report with tool-call summary
4. `remote-compute.png` — SSH remote compute: server load check on c4g.tun (256 cores / 4×RTX 3080)
5. `plugin-inventory.png` — dsh-science engines enabled in the plugin inventory
6. `topology.png` — architecture topology diagram

All URLs are raw.githubusercontent.com (GitHub-hosted), 1-8 images, key matches the README entry exactly.