### PR TITLE
Add dsh-wecom: WeCom Smart Robot bridge (aibot WebSocket, no public endpoint)

### DIFF
--- a/README.md
+++ b/README.md
@@ -811,6 +811,8 @@ dsh plugin --profile web add dshmarket
 - [mingzeng21/dsh-notion](https://github.com/mingzeng21/dsh-notion) - Connect dsh to Notion via the official Notion MCP (OAuth + PKCE): search, read, and write pages, databases, and comments through `mcp__notion__*` tools.
 - [cdxiaodong/dsh-island](https://github.com/cdxiaodong/dsh-island) - Bridge DSH agent sessions, tool calls, and approvals to the CodeIsland macOS notch panel over a Unix socket, with in-panel allow/deny.
 
+- [michaelcode-wang/dsh-wecom](https://github.com/michaelcode-wang/dsh-wecom) - WeCom (Enterprise WeChat) Smart Robot bridge: two-way chat over the aibot WebSocket gateway, no public endpoint needed.
+
 ### Development & Runtime
 
 - [bainianlaoyao/windows-bash](https://github.com/bainianlaoyao/windows-bash) - Makes Git Bash the only terminal tool for DeepSeek Harness on Windows: enables the bash executor and tool, disables PowerShell everywhere, and ships standard/code/cordis bash-only agent presets with the full-access sandbox defaults Git Bash's cygwin runtime needs.

--- a/README.zh.md
+++ b/README.zh.md
@@ -812,6 +812,8 @@ dsh plugin --profile web add dshmarket
 - [mingzeng21/dsh-notion](https://github.com/mingzeng21/dsh-notion) — 通过官方 Notion MCP（OAuth + PKCE）把 dsh 连接到 Notion：通过 `mcp__notion__*` 工具搜索、读写页面、数据库与评论。
 - [cdxiaodong/dsh-island](https://github.com/cdxiaodong/dsh-island) — 通过 Unix socket 把 DSH agent 的会话、工具调用与审批实时桥接到 CodeIsland macOS 刘海面板，可直接在面板上批准/拒绝。
 
+- [michaelcode-wang/dsh-wecom](https://github.com/michaelcode-wang/dsh-wecom) — 企业微信智能机器人桥接：aibot WebSocket 双向对话（bot_id + secret），无需公网回调。
+
 ### 🧑‍💻 开发与运行时
 
 - [bainianlaoyao/windows-bash](https://github.com/bainianlaoyao/windows-bash) — 让 Windows 上 DeepSeek Harness 的终端工具只剩 Git Bash：启用 bash 执行器与工具、全局禁用 PowerShell，并附 standard/code/cordis 三个 bash-only agent 预设及配套的 full-access 沙箱默认值。


### PR DESCRIPTION
## 简介

新增插件 **`dsh-wecom`**：企业微信（WeCom）智能机器人桥接，让 DSH agent 能在企业微信里双向对话。

## 特点

- 走企业微信「智能机器人」的 **aibot WebSocket 网关**（`wss://openws.work.weixin.qq.com`），只需 `bot_id + secret`，**无需公网地址、无需自建应用回调**——补齐了社区现有 `dsh-im-hub` 只支持自建应用 AES 回调（需公网）的空缺。
- 协议移植自 Hermes Agent 的 `plugins/platforms/wecom/adapter.py`（`aibot_subscribe` 认证 → `aibot_msg_callback` 收 → `aibot_respond_msg`/`aibot_send_msg` 回）。
- 每个聊天一个独立 agent 会话、多轮上下文、空闲回收、白名单访问控制、markdown 回复 + 超长分片。

## 合规检查

- ✅ `package.json` 声明 `dsh.bundle.patch`（`cordis.patch.yml`）
- ✅ 官方 `@deepseek-ai/*` 用 `peerDependencies` 声明
- ✅ 真实可用代码（已实测双向对话）
- ✅ 已加 `dsh-plugin` topic
- ✅ 描述只说功能，无营销词

仓库：https://github.com/michaelcode-wang/dsh-wecom