### PR TITLE
data: add AppStore-style screenshots for TZHR-invest dsh-plugins entries

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -246,5 +246,14 @@
   "https://raw.githubusercontent.com/biociao/dsh-science/main/assets/screenshots/remote-compute.png",
   "https://raw.githubusercontent.com/biociao/dsh-science/main/assets/screenshots/plugin-inventory.png",
   "https://raw.githubusercontent.com/biociao/dsh-science/main/assets/screenshots/topology.png"
+ ],
+ "https://github.com/TZHR-invest/dsh-plugins/tree/main/packages/dsh-mobile-ui": [
+  "https://raw.githubusercontent.com/TZHR-invest/dsh-plugins/main/packages/dsh-mobile-ui/assets/screenshot-1-home.png",
+  "https://raw.githubusercontent.com/TZHR-invest/dsh-plugins/main/packages/dsh-mobile-ui/assets/screenshot-2-composer.png",
+  "https://raw.githubusercontent.com/TZHR-invest/dsh-plugins/main/packages/dsh-mobile-ui/assets/screenshot-3-chat.png",
+  "https://raw.githubusercontent.com/TZHR-invest/dsh-plugins/main/packages/dsh-mobile-ui/assets/screenshot-4-sessions.png"
+ ],
+ "https://github.com/TZHR-invest/dsh-plugins/tree/main/packages/dsh-lan-access": [
+  "https://raw.githubusercontent.com/TZHR-invest/dsh-plugins/main/packages/dsh-lan-access/assets/screenshot-1-token-gate.png"
  ]
 }


### PR DESCRIPTION
Adds AppStore-style screenshots for the two UI plugins from TZHR-invest/dsh-plugins, per the [screenshots section](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/main/contributing.md#screenshots--截图optional-recommended--可选推荐) of contributing.md.

- **dsh-mobile-ui** — 4 screenshots (home / composer / chat / session drawer), keyed by 
- **dsh-lan-access** — 1 screenshot (token gate login page), keyed by 

Images live in the plugin repo (, raw.githubusercontent.com), so they update with releases.  and  are provider plugins without UI and are intentionally omitted — storefronts fall back to README images for them.

/ 为 TZHR-invest/dsh-plugins 的两个 UI 插件添加 App Store 风格截图：dsh-mobile-ui 4 张（首页/输入/对话/会话抽屉）、dsh-lan-access 1 张（令牌登录页）。图片放在插件仓库 assets/ 下随版本维护；dsh-web-search-metaso 与 dsh-vision 为无 UI 的 provider 插件，未添加（市场将回退到 README 抽图）。