### PR TITLE
docs: add screenshots for AI-Galaxy-GPU/dsh-sound

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -255,5 +255,8 @@
  ],
  "https://github.com/TZHR-invest/dsh-plugins/tree/main/packages/dsh-lan-access": [
   "https://raw.githubusercontent.com/TZHR-invest/dsh-plugins/main/packages/dsh-lan-access/assets/screenshot-1-token-gate.png"
+ ],
+ "https://github.com/AI-Galaxy-GPU/dsh-sound": [
+  "https://raw.githubusercontent.com/AI-Galaxy-GPU/dsh-sound/main/assets/screenshots/sound-image.png"
  ]
 }


### PR DESCRIPTION
Add marketplace screenshots for https://github.com/AI-Galaxy-GPU/dsh-sound (1 image).

- Registry key: `https://github.com/AI-Galaxy-GPU/dsh-sound`
- Image: `assets/screenshots/sound-image.png` in the plugin repo (GitHub-hosted, png, https)
- The plugin's READMEs (README.md / README.zh.md) also embed the same image as fallback