### PR TITLE
Add Prompt for Me

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ dsh plugin --profile web add dshmarket
 
 - [Fishsb/dsh-prompt-enhancer](https://github.com/Fishsb/dsh-prompt-enhancer) - One-click prompt enhancement: an independent LLM call rewrites your rough draft in the composer, fully undoable.
 
+- [ChuanTianML/prompt-for-me](https://github.com/ChuanTianML/prompt-for-me) - Context-aware next-message suggestions in the DSH composer, with repeated Trigger cycling and explicit user review before sending.
+
 - [huiliyi37/dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) - A terminal UI (TUI) for DeepSeek Harness.
 - [openma-ai/deepseek-harness-tui](https://github.com/openma-ai/deepseek-harness-tui) - A Rust/ratatui terminal client that speaks the DSH SDK JSON-RPC protocol directly and runs standalone or as a profile bundle.
 - [WhitePlusMS/dsh-input-plus](https://github.com/WhitePlusMS/dsh-input-plus) - Search and insert workspace file and directory paths with `@`, plus a `/h` menu for reusing prompts from the current session.

--- a/README.zh.md
+++ b/README.zh.md
@@ -91,6 +91,8 @@ dsh plugin --profile web add dshmarket
 
 - [Fishsb/dsh-prompt-enhancer](https://github.com/Fishsb/dsh-prompt-enhancer) — 一键提示词增强：独立 LLM 调用把模糊草稿改写为更强的提示词，不满意可撤回。
 
+- [ChuanTianML/prompt-for-me](https://github.com/ChuanTianML/prompt-for-me) — DSH 输入框的上下文感知下一句建议：重复 Trigger 可持续换一条，发送前始终由用户确认。
+
 - [huiliyi37/dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) — DeepSeek Harness 的终端 UI（TUI）。
 
 - [openma-ai/deepseek-harness-tui](https://github.com/openma-ai/deepseek-harness-tui) — Rust/ratatui 终端客户端，直接使用 DSH SDK JSON-RPC 协议，支持独立运行或作为 profile bundle 加载。


### PR DESCRIPTION
Adds Prompt for Me / Prompt 嘴替 to UI Enhancements in both English and Chinese. The plugin declares dsh.bundle and dsh.client, ships prebuilt host and browser artifacts, has the dsh-plugin topic, and was validated against DeepSeek Harness 0.1.0-rc.6. Release: https://github.com/ChuanTianML/prompt-for-me/releases/tag/v0.1.0