### PR TITLE
Add screenshots for dsh-feishu-bridge

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -258,5 +258,10 @@
  ],
  "https://github.com/AI-Galaxy-GPU/dsh-sound": [
   "https://raw.githubusercontent.com/AI-Galaxy-GPU/dsh-sound/main/assets/screenshots/sound-image.png"
+ ],
+ "https://github.com/wz-heng/dsh-feishu-bridge": [
+  "https://raw.githubusercontent.com/wz-heng/dsh-feishu-bridge/main/docs/screenshots/fail-closed-boot.png",
+  "https://raw.githubusercontent.com/wz-heng/dsh-feishu-bridge/main/docs/screenshots/dsh-plugin-add.png",
+  "https://raw.githubusercontent.com/wz-heng/dsh-feishu-bridge/main/docs/screenshots/architecture.png"
  ]
 }


### PR DESCRIPTION
Follow-up to #129, per @fkysly's invitation there: adds three screenshots for the dsh-feishu-bridge entry to `data/screenshots.json` (images hosted in the plugin repo under `docs/screenshots/`, also embedded in its README).

Order: ① fail-closed boot + allowlist reject/accept flow (real log output), ② `dsh plugin add` install flow, ③ architecture (Feishu → fail-closed boundary → dsh runtime).

🤖 Generated with [Claude Code](https://claude.com/claude-code)