### PR TITLE
🖼️ Add screenshots for dsh-auto-collapse

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -263,5 +263,8 @@
   "https://raw.githubusercontent.com/wz-heng/dsh-feishu-bridge/main/docs/screenshots/fail-closed-boot.png",
   "https://raw.githubusercontent.com/wz-heng/dsh-feishu-bridge/main/docs/screenshots/dsh-plugin-add.png",
   "https://raw.githubusercontent.com/wz-heng/dsh-feishu-bridge/main/docs/screenshots/architecture.png"
+ ],
+ "https://github.com/a179-sanae/dsh-auto-collapse": [
+  "https://raw.githubusercontent.com/a179-sanae/dsh-auto-collapse/main/assets/screenshot.png"
  ]
 }


### PR DESCRIPTION
Add AppStore-style screenshots entry for [dsh-auto-collapse](https://github.com/a179-sanae/dsh-auto-collapse) per the maintainer's request.

- Key: `https://github.com/a179-sanae/dsh-auto-collapse` (matches the registry entry URL)
- 1 screenshot: `assets/screenshot.png` from the plugin's own repo (the same one referenced in its README)

按维护者要求为 dsh-auto-collapse 添加市场截图条目：key 与注册表条目 GitHub URL 一致，图片放在插件自己的仓库里。