### PR TITLE
Add AppStore-style screenshots for dsh-vision-recognizer

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -273,5 +273,11 @@
   "https://raw.githubusercontent.com/pengyue-polaron/deepseek-harness-genui/main/screenshots/en/photosynthesis-explorer.png",
   "https://raw.githubusercontent.com/pengyue-polaron/deepseek-harness-genui/main/screenshots/en/calendar-planner.png",
   "https://raw.githubusercontent.com/pengyue-polaron/deepseek-harness-genui/main/screenshots/en/code-path-explorer.png"
+ ],
+ "https://github.com/kaixinbaba/dsh-vision-recognizer": [
+  "https://raw.githubusercontent.com/kaixinbaba/dsh-vision-recognizer/main/screenshots/vision-config.png",
+  "https://raw.githubusercontent.com/kaixinbaba/dsh-vision-recognizer/main/screenshots/model-picker.png",
+  "https://raw.githubusercontent.com/kaixinbaba/dsh-vision-recognizer/main/screenshots/chat-demo.png",
+  "https://raw.githubusercontent.com/kaixinbaba/dsh-vision-recognizer/main/screenshots/plugin-list.png"
  ]
 }


### PR DESCRIPTION
Hi @fkysly 👋 — per your suggestion on #296, here's a small PR adding curated screenshots for the **dsh-vision-recognizer** entry so it shows 4 AppStore-style images in dsh-market (1.8.0+).

Key: `https://github.com/kaixinbaba/dsh-vision-recognizer` (the entry URL), images hosted in the plugin's own repo:

| Screenshot | What it shows |
|---|---|
| `vision-config.png` | Settings → Plugins → Vision config page |
| `model-picker.png` | Model picker with the **DeepSeek + 识图** route |
| `chat-demo.png` | Live demo: pasted menu image transcribed → DeepSeek answers |
| `plugin-list.png` | Plugin list showing vision-recognizer enabled |

All four URLs verified live (HTTP 200).