### PR TITLE
docs: add dsh-http-tools to Tools & Capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -528,6 +528,7 @@ dsh plugin --profile web add dshmarket
 - [lsz-asd/dsh-plugin-device-info](https://github.com/lsz-asd/dsh-plugin-device-info) - Read-only Windows device information tools: one agent tool per Win32 device category (time, system, cpu, memory, disk, gpu, network, battery, processes, usb, audio, printers) via WMI/CIM and Node os collectors.
 - [Luke-Yong/dsh-plugin-knowledge-graph](https://github.com/Luke-Yong/dsh-plugin-knowledge-graph) - A read_graph tool backed by a codebase knowledge graph (CONTAINS / EXPORTS / IMPORTS / IMPORTS_SYMBOL relations).
 - [Lum1104/dsh-browser](https://github.com/Lum1104/dsh-browser) - Chrome sidebar extension that lets DSH operate your browser directly, no vision capabilities required.
+- [lussey820/dsh-http-tools](https://github.com/lussey820/dsh-http-tools) - HTTP/API debugging toolset: full-control HTTP requests (method/headers/body/auth), curl command parsing and one-step execution, and in-session request history with side-by-side response comparison.
 - [lynx-gt/dsh-subagent-cwd](https://github.com/lynx-gt/dsh-subagent-cwd) - Extends dsh-subagent-tools with a per-call cwd for subagents, shipped with the two in-process provider patches it requires.
 - [lynx-gt/dsh-subagent-tools](https://github.com/lynx-gt/dsh-subagent-tools) - Per-call model, provider, persona, and toolFilter overrides for subagent delegation, with @preset: references and provider/model composite ids.
 - [lzszq/dsh-scholar](https://github.com/lzszq/dsh-scholar) - Academic assistant plugin.

--- a/README.zh.md
+++ b/README.zh.md
@@ -528,6 +528,7 @@ dsh plugin --profile web add dshmarket
 - [lsz-asd/dsh-plugin-device-info](https://github.com/lsz-asd/dsh-plugin-device-info) — 只读的 Windows 设备信息工具：每个 Win32 设备类别一个 agent 工具（时间、系统、CPU、内存、磁盘、GPU、网络、电池、进程、USB、音频、打印机），基于 WMI/CIM 与 Node os 采集。
 - [Luke-Yong/dsh-plugin-knowledge-graph](https://github.com/Luke-Yong/dsh-plugin-knowledge-graph) — 基于代码库知识图谱的 read_graph 工具（CONTAINS / EXPORTS / IMPORTS / IMPORTS_SYMBOL 关系）。
 - [Lum1104/dsh-browser](https://github.com/Lum1104/dsh-browser) — Chrome 侧边栏扩展，让 DSH 直接操控你的浏览器，无需视觉能力。
+- [lussey820/dsh-http-tools](https://github.com/lussey820/dsh-http-tools) — HTTP/API 调试工具集：全参数 HTTP 请求（method/headers/body/auth）、curl 命令解析与一步执行、会话内请求历史与响应并排对比。
 - [lynx-gt/dsh-subagent-cwd](https://github.com/lynx-gt/dsh-subagent-cwd) — 在 dsh-subagent-tools 基础上增加子代理按调用 cwd，附带所需的两个 in-process provider 补丁。
 - [lynx-gt/dsh-subagent-tools](https://github.com/lynx-gt/dsh-subagent-tools) — 子代理委派的按调用覆盖：model/provider/persona/toolFilter、@preset: 引用与 provider/model 组合 id。
 - [lzszq/dsh-scholar](https://github.com/lzszq/dsh-scholar) — 学术助手插件。

--- a/data/plugins/lussey820__dsh-http-tools.yml
+++ b/data/plugins/lussey820__dsh-http-tools.yml
@@ -1,0 +1,6 @@
+url: https://github.com/lussey820/dsh-http-tools
+name: lussey820/dsh-http-tools
+category: tools
+description:
+  en: 'HTTP/API debugging toolset: full-control HTTP requests (method/headers/body/auth), curl command parsing and one-step execution, and in-session request history with side-by-side response comparison.'
+  zh: HTTP/API 调试工具集：全参数 HTTP 请求（method/headers/body/auth）、curl 命令解析与一步执行、会话内请求历史与响应并排对比。


### PR DESCRIPTION
Add [lussey820/dsh-http-tools](https://github.com/lussey820/dsh-http-tools) to the Tools & Capabilities section.

- HTTP/API debugging toolset for DeepSeek Harness: \http_request\, \curl_parse\, \equest_history\
- Declares \dsh.bundle\ manifest; published on npm as \dsh-http-tools\ (prebuilt, no allowBuilds step)
- Declares official \@deepseek-ai/*\ packages as peerDependencies