### PR TITLE
Add zhengjy01/dsh-notion-connector under Memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,6 +437,7 @@ dsh plugin --profile web add dshmarket
 - [yangyongzhen/dsh-memory](https://github.com/yangyongzhen/dsh-memory) - Long-term memory injected at session start: preferences/facts/summaries/knowledge in global and per-project scopes, budgeted recall via `agent/pre-step`, durable JSON store.
 - [Yiipu/dsh-agentmemory](https://github.com/Yiipu/dsh-agentmemory) - DSH ↔ agentmemory session-memory bridge: mirrors session lifecycle into a local agentmemory daemon (REST), exposes memory_recall / memory_remember tools, and injects a per-session memory context window via agent/pre-step.
 - [zhengjy01/dsh-flomo](https://github.com/zhengjy01/dsh-flomo) - Write notes and memos to flomo (浮墨笔记) from any agent via the flomo_send tool, configured once with the flomo API URL or API Key.
+- [zhengjy01/dsh-notion-connector](https://github.com/zhengjy01/dsh-notion-connector) - Notion connector for DeepSeek Harness: search, read, query, create, update, and append Notion pages and databases via six agent tools, with a Web settings page — configured once with an Integration Token.
 
 ### Tools & Capabilities
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -437,6 +437,7 @@ dsh plugin --profile web add dshmarket
 - [yangyongzhen/dsh-memory](https://github.com/yangyongzhen/dsh-memory) — 会话开始自动注入的长期记忆：preference/fact/summary/knowledge 四类、global/project 双作用域，`agent/pre-step` 字节预算召回，JSON 原子持久化。
 - [Yiipu/dsh-agentmemory](https://github.com/Yiipu/dsh-agentmemory) — DSH ↔ agentmemory 会话记忆桥：把会话生命周期镜像到本地 agentmemory 守护进程（REST），提供 memory_recall / memory_remember 工具，并通过 agent/pre-step 按会话注入记忆上下文窗口。
 - [zhengjy01/dsh-flomo](https://github.com/zhengjy01/dsh-flomo) — 配置一次 flomo API URL / API Key，Agent 即可用 flomo_send 把笔记、摘要、待办写进 flomo（浮墨笔记）。
+- [zhengjy01/dsh-notion-connector](https://github.com/zhengjy01/dsh-notion-connector) — 配置一次 Notion Integration Token，Agent 即可搜索、读取、查询、创建、更新、追加 Notion 页面与数据库内容，并提供 Web 设置页。
 
 ### 🛠️ 工具与能力
 

--- a/data/plugins/zhengjy01__dsh-notion-connector.yml
+++ b/data/plugins/zhengjy01__dsh-notion-connector.yml
@@ -1,0 +1,6 @@
+url: https://github.com/zhengjy01/dsh-notion-connector
+name: zhengjy01/dsh-notion-connector
+category: memory
+description:
+  en: 'Notion connector for DeepSeek Harness: search, read, query, create, update, and append Notion pages and databases via six agent tools, with a Web settings page — configured once with an Integration Token.'
+  zh: 配置一次 Notion Integration Token，Agent 即可搜索、读取、查询、创建、更新、追加 Notion 页面与数据库内容，并提供 Web 设置页。


### PR DESCRIPTION
Adds [zhengjy01/dsh-notion-connector](https://github.com/zhengjy01/dsh-notion-connector) to the **Memory** category (next to `zhengjy01/dsh-flomo`).

- Declares `dsh.bundle` manifest (`cordis.patch.yml`) — installable via `dsh plugin --profile web add github:zhengjy01/dsh-notion-connector`
- Real working code: Notion REST client (Node fetch), six agent tools (search / read page / query database / create page / update page / append blocks), loopback-fenced `/api/dsh-notion/*` routes, token store `~/.dsh/notion.json` (0600), Web settings page (`settings.section`)
- `dsh-plugin` topic added
- Named `dsh-notion-connector` to avoid clashing with the existing MCP-based `mingzeng21/dsh-notion`