### PR TITLE
screenshots: curated previews for NoNameLeGo/dsh-catppuccin

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -279,5 +279,11 @@
   "https://raw.githubusercontent.com/kaixinbaba/dsh-vision-recognizer/main/screenshots/model-picker.png",
   "https://raw.githubusercontent.com/kaixinbaba/dsh-vision-recognizer/main/screenshots/chat-demo.png",
   "https://raw.githubusercontent.com/kaixinbaba/dsh-vision-recognizer/main/screenshots/plugin-list.png"
+ ],
+ "https://github.com/NoNameLeGo/dsh-catppuccin": [
+  "https://raw.githubusercontent.com/NoNameLeGo/dsh-catppuccin/main/assets/previews/latte.png",
+  "https://raw.githubusercontent.com/NoNameLeGo/dsh-catppuccin/main/assets/previews/frappe.png",
+  "https://raw.githubusercontent.com/NoNameLeGo/dsh-catppuccin/main/assets/previews/macchiato.png",
+  "https://raw.githubusercontent.com/NoNameLeGo/dsh-catppuccin/main/assets/previews/mocha.png"
  ]
 }


### PR DESCRIPTION
Add curated previews for **NoNameLeGo/dsh-catppuccin** to [`data/screenshots.json`](data/screenshots.json), keyed by the entry URL exactly as listed in the README.

4 images (GitHub-hosted raw URLs, in the plugin repo under `assets/previews/`), light→dark order matching the themes:

1. Latte (light)
2. Frappé
3. Macchiato
4. Mocha

Per [contributing.md — Screenshots](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/main/contributing.md#screenshots--截图optional-recommended--可选推荐): all URLs are https on GitHub hosting; no third-party hosts. Within the 1-8 limit (and dsh-market's client cap of 6).

---

中文：为条目 **NoNameLeGo/dsh-catppuccin** 添加精选截图（key 与 README 条目 URL 完全一致），4 张图均托管在插件仓库 `assets/previews/`，按 Latte → Frappé → Macchiato → Mocha（浅色到深色）排序。
