### PR TITLE
Add LaoYueHanNi/dsh-git-worktree to Development & Runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -808,6 +808,7 @@ dsh plugin --profile web add dshmarket
 - [omdsh-dev/fabric](https://github.com/omdsh-dev/fabric) - An MC-Fabric-style hook processor.
 - [CH4ACKO3/dsh-harmony](https://github.com/CH4ACKO3/dsh-harmony) - Modifies DSH plugin code at runtime, with ordered patches, inspection, and hot reload.
 - [LoserFox/dsh-git-identity](https://github.com/LoserFox/dsh-git-identity) - Pin Git commits to the environment's own author identity; env-var injection overrides all `git config` settings.
+- [LaoYueHanNi/dsh-git-worktree](https://github.com/LaoYueHanNi/dsh-git-worktree) - Branch switching and isolated git worktrees as real workspaces, from the Web UI composer.
 - [Zhenyu98/dsh-context-doctor](https://github.com/Zhenyu98/dsh-context-doctor) - Context injection audit: token costs of instruction chains / skill catalogs / tool schemas, duplicate and conflict detection.
 - [lucky8197/dsh-doc-guard](https://github.com/lucky8197/dsh-doc-guard) - Document-code consistency guard: audits version headers / changelog tables / directory trees / module & test counts / cross-doc references for drift, with severity-sorted, read-only fix suggestions.
 - [labmimors/dsh-mcp-lens](https://github.com/labmimors/dsh-mcp-lens) - Progressive-disclosure MCP gateway that searches large remote catalogs through `mcp_search`, then invokes exact schemas through `mcp_call` with lazy connections and bounded caches.

--- a/README.zh.md
+++ b/README.zh.md
@@ -808,6 +808,7 @@ dsh plugin --profile web add dshmarket
 - [omdsh-dev/fabric](https://github.com/omdsh-dev/fabric) — 类似 MC Fabric 的 hook 处理器。
 - [CH4ACKO3/dsh-harmony](https://github.com/CH4ACKO3/dsh-harmony) — 在运行时修改 DSH 插件代码，并提供 Patch 排序、检查和热重载。
 - [LoserFox/dsh-git-identity](https://github.com/LoserFox/dsh-git-identity) — git 提交固定使用环境自身作者身份，环境变量注入压过一切 `git config` 设置。
+- [LaoYueHanNi/dsh-git-worktree](https://github.com/LaoYueHanNi/dsh-git-worktree) — 在 Web 输入框切换分支、以真实工作区方式创建隔离的 git worktree。
 - [Zhenyu98/dsh-context-doctor](https://github.com/Zhenyu98/dsh-context-doctor) — 上下文注入审计：统计指令链/技能目录/工具 schema 的 token 成本，检测重复与冲突。
 - [lucky8197/dsh-doc-guard](https://github.com/lucky8197/dsh-doc-guard) — 文档与代码一致性守护：版本号/更新记录表/结构树/模块清单/测试计数/交叉引用漂移审计与修复建议，全程只读。
 - [labmimors/dsh-mcp-lens](https://github.com/labmimors/dsh-mcp-lens) — 渐进披露 MCP 网关：用 `mcp_search` 检索大型远程工具目录，再由 `mcp_call` 按精确 schema 调用，并采用惰性连接与有界缓存。


### PR DESCRIPTION
## What

Add [LaoYueHanNi/dsh-git-worktree](https://github.com/LaoYueHanNi/dsh-git-worktree) to the **Development & Runtime** category in both `README.md` and `README.zh.md`.

(Replaces #879, which was closed during the #905 branch mix-up. This is a fresh branch with the same two-line change.)

## About the plugin

A git branch & worktree plugin for the dsh Web UI: the composer tool row shows the current branch — pick another to switch in place, or flip the Worktree toggle to get an isolated `git worktree add` folder registered as a real workspace with a fresh blank session. Storage root is configurable in Settings, with stale-worktree auto recovery.

## Not a duplicate of wloops/dsh-git-worktree

The similar name overlaps, but the scope complements it rather than duplicating it:

| | LaoYueHanNi/dsh-git-worktree | wloops/dsh-git-worktree |
|---|---|---|
| Focus | Session environment selection in the Web UI | Delivery lifecycle of agent changes |
| Interaction | Composer chip: pick branch / toggle worktree | `ready-for-review / apply / finish / discard` commands |
| Storage | Outside the project (`~/.dsh/gitworktree/<repo>-<branch>/`) | Inside the project (`.dsh-worktrees/`) |
| Branch switching | In-place `git switch` from any session | — |

Coexisting same-name plugins already have precedent in this list (`Jesse-njx/dsh-memory` + `flymysql/dsh-memory`, two `dsh-cost-meter` entries).

- Repo declares a `dsh.bundle` manifest (`dsh.bundle.patch` + `cordis.patch.yml`) and is installable via `dsh plugin --profile web add github:LaoYueHanNi/dsh-git-worktree`.
- The `dsh-plugin` topic is set on the repo.