### PR TITLE
Add screenshots for LKMeng2001/dsh-mcp-market

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -285,5 +285,8 @@
   "https://raw.githubusercontent.com/NoNameLeGo/dsh-catppuccin/main/assets/previews/frappe.png",
   "https://raw.githubusercontent.com/NoNameLeGo/dsh-catppuccin/main/assets/previews/macchiato.png",
   "https://raw.githubusercontent.com/NoNameLeGo/dsh-catppuccin/main/assets/previews/mocha.png"
+ ],
+ "https://github.com/LKMeng2001/dsh-mcp-market": [
+  "https://raw.githubusercontent.com/LKMeng2001/dsh-mcp-market/main/assets/market-discover.png"
  ]
 }


### PR DESCRIPTION
Adds 1 storefront screenshot for [LKMeng2001/dsh-mcp-market](https://github.com/LKMeng2001/dsh-mcp-market) to `data/screenshots.json` (Discover page of the MCP market UI).