### PR TITLE
Add zhengjy01/dsh-ticktick under Notifications & Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -784,6 +784,7 @@ dsh plugin --profile web add dshmarket
 - [YuMo226/dsh-task-notify](https://github.com/YuMo226/dsh-task-notify) - Native Windows system notification (Notification Center toast) when a task completes: goal completion or agent turn end.
 - [YZz-S/dsh-notifier](https://github.com/YZz-S/dsh-notifier) - System-native notifications when a task finishes or needs your confirmation: Windows toast, macOS osascript, and Linux notify-send.
 - [zhengjy01/dsh-notify](https://github.com/zhengjy01/dsh-notify) - System-level desktop notifications: turn-completion and workflow-end banners, plus a modal alert when an approval is needed (macOS osascript / Linux notify-send).
+- [zhengjy01/dsh-ticktick](https://github.com/zhengjy01/dsh-ticktick) - Two-way TickTick/Dida365 (滴答清单) task sync via the official OAuth Open API: pull tasks across lists, create/update/complete/delete tasks, and one-shot title-deduped sync, with a web settings panel.
 
 ### Development & Runtime
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -784,6 +784,7 @@ dsh plugin --profile web add dshmarket
 - [YuMo226/dsh-task-notify](https://github.com/YuMo226/dsh-task-notify) — 任务完成时弹出 Windows 原生系统通知（通知中心横幅）：目标完成或 Agent 结束一轮。
 - [YZz-S/dsh-notifier](https://github.com/YZz-S/dsh-notifier) — 任务完成或需要确认/输入时发送操作系统原生通知：Windows toast、macOS osascript、Linux notify-send。
 - [zhengjy01/dsh-notify](https://github.com/zhengjy01/dsh-notify) — 系统级桌面通知：回合完成 / 工作流完成横幅，需要审批时弹出模态提醒（macOS osascript / Linux notify-send）。
+- [zhengjy01/dsh-ticktick](https://github.com/zhengjy01/dsh-ticktick) — 基于官方 OAuth Open API 双向同步滴答清单（TickTick/Dida365）任务：拉取各清单任务、创建/更新/完成/删除、按标题去重的一键同步，带 Web 设置面板。
 
 ### 🧑‍💻 开发与运行时
 

--- a/data/plugins/zhengjy01__dsh-ticktick.yml
+++ b/data/plugins/zhengjy01__dsh-ticktick.yml
@@ -1,0 +1,6 @@
+url: https://github.com/zhengjy01/dsh-ticktick
+name: zhengjy01/dsh-ticktick
+category: notify
+description:
+  en: 'Two-way TickTick/Dida365 (滴答清单) task sync via the official OAuth Open API: pull tasks across lists, create/update/complete/delete tasks, and one-shot title-deduped sync, with a web settings panel.'
+  zh: 基于官方 OAuth Open API 双向同步滴答清单（TickTick/Dida365）任务：拉取各清单任务、创建/更新/完成/删除、按标题去重的一键同步，带 Web 设置面板。


### PR DESCRIPTION
## 收录申请：zhengjy01/dsh-ticktick

TickTick / Dida365（滴答清单）双向任务同步插件，符合收录规范：

- ✅ `package.json` 声明 `dsh.bundle` manifest（`cordis.patch.yml`，可通过 `dsh plugin add` 安装）
- ✅ 真实可用的代码：11 个模型工具（status / config / oauth_start / oauth_finish / lists / tasks / add / update / complete / delete / sync）+ Web 设置面板（settings.section），基于官方 OAuth 2.0 Open API（/open/v1），401 自动刷新令牌
- ✅ 零运行时依赖（Node 内置 fetch/crypto），12 项冒烟测试通过（tests/smoke.mjs）
- ✅ 已打 [`dsh-plugin`](https://github.com/topics/dsh-plugin) topic
- ✅ 官方 `@deepseek-ai/*` 包以 `peerDependencies` 声明
- ✅ 中英双语 README（README.md / README.zh.md），MIT License
- 📦 npm 包 `dsh-ticktick@0.1.0` 已发布（预构建安装，免 allowBuilds 构建授权）

安装方式：
```sh
dsh plugin --profile web add dsh-ticktick        # npm
dsh plugin --profile web add github:zhengjy01/dsh-ticktick
```