### PR TITLE
add dsh-quicksight (two-tier image reading: local OCR + vision fallback)

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,6 +519,7 @@ dsh plugin --profile web add dshmarket
 - [HuanLinOTO/dsh-plugin-mineru](https://github.com/HuanLinOTO/dsh-plugin-mineru) - Expose MineRU document parsing tools to the model.
 - [huey1in/trio](https://github.com/huey1in/trio) - Browser automation (Playwright) with a live view, an MCP server exposing DSH agents to any MCP client, and GitHub issue/PR/webhook review tools.
 - [Isanti2016/dsh-console](https://github.com/Isanti2016/dsh-console) - Slash-command console for dsh: /web start|stop|restart|status, /tunnel SSH forward management, one-shot /ask, and a console TUI launcher.
+- [Isanti2016/dsh-quicksight](https://github.com/Isanti2016/dsh-quicksight) - Two-tier image reading for text-only models: fast local OCR (RapidOCR, offline) first, vision-model fallback (modlens).
 - [Jamailar/beav-deepseek-harness](https://github.com/Jamailar/beav-deepseek-harness) - Connects DSH to the local Beav desktop app for durable social-media content, knowledge, image, audio, and video tasks, with approval and artifact tracking.
 - [jcaiagent7143-ui/sendpage-mcp](https://github.com/jcaiagent7143-ui/sendpage-mcp) - Publish an HTML document as a shareable link that opens in one tap and previews as a card in chat apps; publish, update, and export to PNG/PDF/Word.
 - [Jesse-njx/dsh-cowork](https://github.com/Jesse-njx/dsh-cowork) - Bounded, cell-addressed `doc_read`/`doc_write` for xlsx / pdf / docx / pptx / ipynb, plus an MCP server and CLI.

--- a/README.zh.md
+++ b/README.zh.md
@@ -519,6 +519,7 @@ dsh plugin --profile web add dshmarket
 - [HuanLinOTO/dsh-plugin-mineru](https://github.com/HuanLinOTO/dsh-plugin-mineru) — 向模型暴露 MineRU 文档解析工具。
 - [huey1in/trio](https://github.com/huey1in/trio) — 浏览器自动化（Playwright，带实时画面）+ MCP Server（把 DSH agent 暴露给任何 MCP 客户端）+ GitHub issue/PR/webhook 评审工具。
 - [Isanti2016/dsh-console](https://github.com/Isanti2016/dsh-console) — dsh 控制台命令：/web 启动/停止/重启/状态、/tunnel SSH 隧道管理、/ask 一次性问答、/console 启动控制台 TUI。
+- [Isanti2016/dsh-quicksight](https://github.com/Isanti2016/dsh-quicksight) — 纯文本模型双层识图：优先本地快速 OCR（RapidOCR，离线），不足时回落视觉模型（modlens）。
 - [Jamailar/beav-deepseek-harness](https://github.com/Jamailar/beav-deepseek-harness) — 将 DSH 连接到本机 Beav 桌面应用，用于可恢复的自媒体内容、知识、图片、音频和视频任务，并保留审批与产物追踪。
 - [jcaiagent7143-ui/sendpage-mcp](https://github.com/jcaiagent7143-ui/sendpage-mcp) — 把 HTML 文档变成一键打开、在聊天里显示预览卡的分享链接;支持发布、更新,以及导出 PNG/PDF/Word。
 - [Jesse-njx/dsh-cowork](https://github.com/Jesse-njx/dsh-cowork) — doc_read/doc_write：以有界、单元格寻址的方式读写 xlsx / pdf / docx / pptx / ipynb，另附 MCP 服务器与 CLI。

--- a/data/plugins/Isanti2016__dsh-quicksight.yml
+++ b/data/plugins/Isanti2016__dsh-quicksight.yml
@@ -1,0 +1,6 @@
+url: https://github.com/Isanti2016/dsh-quicksight
+name: Isanti2016/dsh-quicksight
+category: tools
+description:
+  en: 'Two-tier image reading for text-only models: fast local OCR (RapidOCR, offline) first, vision-model fallback (modlens).'
+  zh: 纯文本模型双层识图：优先本地快速 OCR（RapidOCR，离线），不足时回落视觉模型（modlens）。


### PR DESCRIPTION
Add **dsh-quicksight** to Tools & Capabilities: a two-tier image-reading plugin for text-only models in DeepSeek Harness.

- **Tier-1 local OCR**: RapidOCR / PP-OCR / ONNX Runtime, CPU ~2-3s, zh/en accurate, fully offline, zero API cost, images never leave the machine.
- **Tier-2 vision fallback**: when OCR yields too little text or visual understanding (layout/colors/charts/photos) is needed, falls back to any configured vision engine via modlens (~20s, structured evidence).

Highlights: zero runtime deps (Node builtins), no ports, no credentials in the repo (keys live in `~/.modlens/config.json`), all paths configurable. Published on npm (`dsh plugin --profile web add dsh-quicksight`) and GitHub: https://github.com/Isanti2016/dsh-quicksight

> Update: **v0.1.1** fixes an empty `dsh.client` declaration that crashed the dsh web client-modules compose step, and adds the required tool `output { schema, render }` so `quicksight_ocr` registers on all dsh versions. Verified on Windows (local) and Ubuntu 24.04 (remote, systemd).