### PR TITLE
Add screenshots for disyli/dsh-tool-call-stats

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -288,5 +288,11 @@
  ],
  "https://github.com/LKMeng2001/dsh-mcp-market": [
   "https://raw.githubusercontent.com/LKMeng2001/dsh-mcp-market/main/assets/market-discover.png"
+ ],
+ "https://github.com/disyli/dsh-tool-call-stats": [
+  "https://raw.githubusercontent.com/disyli/dsh-tool-call-stats/main/assets/screenshots/01-session.png",
+  "https://raw.githubusercontent.com/disyli/dsh-tool-call-stats/main/assets/screenshots/02-tool-stats.png",
+  "https://raw.githubusercontent.com/disyli/dsh-tool-call-stats/main/assets/screenshots/03-install.png",
+  "https://raw.githubusercontent.com/disyli/dsh-tool-call-stats/main/assets/screenshots/04-config.png"
  ]
 }


### PR DESCRIPTION
Adds 4 screenshots for `disyli/dsh-tool-call-stats` to `data/screenshots.json`,
keyed by the entry URL (https://github.com/disyli/dsh-tool-call-stats).

Images live in the plugin repo under `assets/screenshots/`:
- `01-session.png` — a live dsh web session exercising read / glob / grep and a failed read, then calling `tool_stats`
- `02-tool-stats.png` — the `tool_stats` result table (calls / errors / avg_ms)
- `03-install.png` — `dsh plugin add github:disyli/dsh-tool-call-stats`
- `04-config.png` — `dsh --dump-config` showing the plugin layer