### PR TITLE
Add dsh-perlica-ding (Perlica-themed tiered sound notifications) to Notifications & Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -763,6 +763,7 @@ dsh plugin --profile web add dshmarket
 
 ### Notifications & Integrations
 
+- [117BS/dsh-perlica-ding](https://github.com/117BS/dsh-perlica-ding) - Perlica (Arknights: Endfield) themed tiered sound notifications: plan-ready, task-done, needs-your-input, and error tones; silent for plain chat, system-level playback (works in background), cross-platform (Windows/macOS/Linux), custom TTS sounds.
 - [AbcdefgXW/dsh-msg-hub](https://github.com/AbcdefgXW/dsh-msg-hub) - IM channel bridge: WeChat (ilinkai) / QQ / Feishu with proactive push — wake the channel bot from scheduled tasks and deliver AI replies to your phone.
 - [AI-Galaxy-GPU/dsh-sound](https://github.com/AI-Galaxy-GPU/dsh-sound) - Per-event sound notifications: turn completion, approval, question, plan-review, goal-blocked, and task-failure each get their own sound and volume, configurable in the Web UI (built-in synth, mute, or local audio file).
 - [Alan2Z/dsh-speak](https://github.com/Alan2Z/dsh-speak) - Voice-announce the final reply on Windows (SAPI5 natural voices) and macOS (system voice); skips reasoning and tool calls, one-line npm install.

--- a/README.zh.md
+++ b/README.zh.md
@@ -763,6 +763,7 @@ dsh plugin --profile web add dshmarket
 
 ### 🔔 通知与集成
 
+- [117BS/dsh-perlica-ding](https://github.com/117BS/dsh-perlica-ding) — 明日方舟终末地佩丽卡主题分级提示音：计划出方案 / 任务完成 / 需要你回应 / 出错四档独立音效，普通问答保持安静；系统级播放（窗口在后台也响），跨平台（Windows/macOS/Linux），支持自定义 TTS 语音。
 - [AbcdefgXW/dsh-msg-hub](https://github.com/AbcdefgXW/dsh-msg-hub) — IM 渠道桥：微信（ilinkai）/ QQ / 飞书接入，支持主动推送——定时任务可唤醒渠道 bot 并把 AI 回复推送到手机。
 - [AI-Galaxy-GPU/dsh-sound](https://github.com/AI-Galaxy-GPU/dsh-sound) — 六类事件独立提示音：回合完成、审批、提问、计划评审、目标受阻、任务失败各有独立声音与音量，可在 Web 设置面板配置（内置合成音 / 静音 / 本地音频文件）。
 - [Alan2Z/dsh-speak](https://github.com/Alan2Z/dsh-speak) — 语音播报 agent 最终回复：Windows SAPI5 自然语音 / macOS 系统语音，自动跳过思考与工具调用，npm 一行安装。

--- a/data/plugins/117BS__dsh-perlica-ding.yml
+++ b/data/plugins/117BS__dsh-perlica-ding.yml
@@ -1,0 +1,6 @@
+url: https://github.com/117BS/dsh-perlica-ding
+name: 117BS/dsh-perlica-ding
+category: notify
+description:
+  en: 'Perlica (Arknights: Endfield) themed tiered sound notifications: plan-ready, task-done, needs-your-input, and error tones; silent for plain chat, system-level playback (works in background), cross-platform (Windows/macOS/Linux), custom TTS sounds.'
+  zh: 明日方舟终末地佩丽卡主题分级提示音：计划出方案 / 任务完成 / 需要你回应 / 出错四档独立音效，普通问答保持安静；系统级播放（窗口在后台也响），跨平台（Windows/macOS/Linux），支持自定义 TTS 语音。


### PR DESCRIPTION
## 新增插件 / New plugin

**dsh-perlica-ding** — 佩丽卡主题（明日方舟终末地）分级任务提示音插件 / Perlica-themed (Arknights: Endfield) tiered sound notification plugin

- **四档音效**：计划出方案 / 任务完成 / 需要你回应 / 出错，各自独立声音
- **普通问答静音**：纯对话或只用查询类工具（web_search/read 等）不响
- **系统级播放**：窗口切后台/最小化也能听到（非浏览器声音）
- **跨平台**：Windows (SoundPlayer) / macOS (afplay) / Linux (paplay/aplay)
- **可配置**：总开关、防抖间隔、音效目录、执行类工具白名单
- **自定义 TTS 语音**：替换 wav 文件即生效，无需重启
- **可安装**：dsh plugin --profile web add dsh-perlica-ding（或本地路径 / GitHub 仓库）

仓库已打 dsh-plugin topic。

---

- Tiered sounds: plan-ready / task-done / needs-your-input / error
- Silent for plain chat (lookup tools like web_search/read do not trigger)
- System-level playback: audible even with the window in the background
- Cross-platform: Windows / macOS / Linux
- Configurable: master switch, debounce, sound dir, exec-tool whitelist
- Custom TTS voice: drop in wav files, no restart needed