### PR TITLE
Add screenshot for dsh-hooks

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -294,5 +294,8 @@
   "https://raw.githubusercontent.com/disyli/dsh-tool-call-stats/main/assets/screenshots/02-tool-stats.png",
   "https://raw.githubusercontent.com/disyli/dsh-tool-call-stats/main/assets/screenshots/03-install.png",
   "https://raw.githubusercontent.com/disyli/dsh-tool-call-stats/main/assets/screenshots/04-config.png"
+ ],
+ "https://github.com/PeterBon/dsh-hooks": [
+  "https://raw.githubusercontent.com/PeterBon/dsh-hooks/main/assets/screenshot-1.jpg"
  ]
 }


### PR DESCRIPTION
Add the Feishu notification card screenshot for [PeterBon/dsh-hooks](https://github.com/PeterBon/dsh-hooks) (listed under Notifications & Integrations, #538). Image hosted in the plugin repo: https://raw.githubusercontent.com/PeterBon/dsh-hooks/main/assets/screenshot-1.jpg