### PR TITLE
docs: add dsh-message-rail market screenshots

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -297,5 +297,9 @@
  ],
  "https://github.com/PeterBon/dsh-hooks": [
   "https://raw.githubusercontent.com/PeterBon/dsh-hooks/main/assets/screenshot-1.jpg"
+ ],
+ "https://github.com/wx-yss/dsh-message-rail": [
+  "https://raw.githubusercontent.com/wx-yss/dsh-message-rail/main/assets/rail-hover-preview.png",
+  "https://raw.githubusercontent.com/wx-yss/dsh-message-rail/main/assets/rail-market-2.png"
  ]
 }


### PR DESCRIPTION
Hi @fkysly 👋

为 dsh-message-rail 添加市场展示截图（2 张，对应 UI Enhancements 条目）：

- `assets/rail-hover-preview.png` — 悬停预览：每条用户消息一个刻度，hover 显示消息摘要
- `assets/rail-market-2.png` — 轨道在实际界面中的效果

图片存放在 https://github.com/wx-yss/dsh-message-rail 仓库的 `assets/` 目录，key 使用条目 GitHub URL。

/ Add 2 AppStore-style screenshots for dsh-message-rail in dsh-market, keyed by the entry URL. Images live in the plugin repo's `assets/`.