### PR TITLE
Add screenshots for dsh-maid-whale-webUI

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -301,5 +301,9 @@
  "https://github.com/wx-yss/dsh-message-rail": [
   "https://raw.githubusercontent.com/wx-yss/dsh-message-rail/main/assets/rail-hover-preview.png",
   "https://raw.githubusercontent.com/wx-yss/dsh-message-rail/main/assets/rail-market-2.png"
+ ],
+ "https://github.com/yunxiiQwQ/dsh-maid-whale-webUI/tree/main/maid-whale-webui": [
+  "https://raw.githubusercontent.com/yunxiiQwQ/dsh-maid-whale-webUI/main/maid-whale-webui/preview/light.webp",
+  "https://raw.githubusercontent.com/yunxiiQwQ/dsh-maid-whale-webUI/main/maid-whale-webui/preview/dark.webp"
  ]
 }


### PR DESCRIPTION
## 说明

为已收录的 `dsh-maid-whale-webUI` 补充插件市场截图：

- 使用与 README 条目完全一致的子目录 URL 作为 key
- 添加亮色模式预览图
- 添加暗色模式预览图

