### PR TITLE
Add screenshot for dsh-desktop-shortcut

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -305,5 +305,8 @@
  "https://github.com/yunxiiQwQ/dsh-maid-whale-webUI/tree/main/maid-whale-webui": [
   "https://raw.githubusercontent.com/yunxiiQwQ/dsh-maid-whale-webUI/main/maid-whale-webui/preview/light.webp",
   "https://raw.githubusercontent.com/yunxiiQwQ/dsh-maid-whale-webUI/main/maid-whale-webui/preview/dark.webp"
+ ],
+ "https://github.com/fuyue521/dsh-desktop-shortcut": [
+  "https://raw.githubusercontent.com/fuyue521/dsh-desktop-shortcut/main/assets/screenshots/screenshot-web-ui.png"
  ]
 }


### PR DESCRIPTION
## Description

Add a screenshot entry for [fuyue521/dsh-desktop-shortcut](https://github.com/fuyue521/dsh-desktop-shortcut) in `data/screenshots.json`.

This is a screenshots-only PR. It does not add a new plugin, so the plugin-addition checklist items below are marked N/A.

## Changes

- `data/screenshots.json`: add one screenshot URL for the existing plugin entry.

<!-- Thanks for contributing! Quick checklist / 提交前快速自查 -->

- [ ] I added **one file** at `data/plugins/<owner>__<repo>.yml` — N/A (screenshots-only PR) / 不适用：本次只修改 screenshots.json
- [ ] I ran `node scripts/generate-readme.mjs` and committed the regenerated READMEs — N/A (no README regeneration needed) / 不适用：无需重新生成 README
- [x] My repo's `package.json` declares **`dsh.bundle`** (not just `dsh.client`) / 仓库 `package.json` 已声明 `dsh.bundle`
- [x] My repo is at least **1 day old** with **10+ commits** (created 2026-08-15, 37 commits) / 仓库已满 1 天且提交数 37
- [ ] `category` is one of ... — N/A (not adding a plugin) / 不适用：不是新增插件
- [x] Description states what the plugin does, no superlatives / 描述只说功能，不带营销词
- [x] My repo has the `dsh-plugin` topic / 仓库已打 `dsh-plugin` topic

**Recommended (not required) / 推荐但不强制：**

- [x] 📦 Publish to npm — npm installs are prebuilt and skip the `allowBuilds` approval / 已发布 npm
- [x] 🔗 Declare official `@deepseek-ai/*` packages as `peerDependencies` / 已使用 peerDependencies
- [x] 🖼️ Add screenshots to `data/screenshots.json` / 本次 PR 已添加截图
