### PR TITLE
docs(screenshots): add omdsh-dev/dsh-genui and dsh-annotation

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -308,5 +308,17 @@
  ],
  "https://github.com/fuyue521/dsh-desktop-shortcut": [
   "https://raw.githubusercontent.com/fuyue521/dsh-desktop-shortcut/main/assets/screenshots/screenshot-web-ui.png"
+ ],
+ "https://github.com/omdsh-dev/dsh-genui": [
+  "https://raw.githubusercontent.com/omdsh-dev/dsh-genui/main/assets/showcase-panel.png",
+  "https://raw.githubusercontent.com/omdsh-dev/dsh-genui/main/assets/showcase-plot.png",
+  "https://raw.githubusercontent.com/omdsh-dev/dsh-genui/main/assets/showcase.png",
+  "https://raw.githubusercontent.com/omdsh-dev/dsh-genui/main/assets/demo-thumb.png"
+ ],
+ "https://github.com/omdsh-dev/dsh-annotation": [
+  "https://github.com/user-attachments/assets/c3186efc-44d3-4e7f-9523-1902d9d037e9",
+  "https://github.com/user-attachments/assets/0b48ac02-4648-4b94-8d8f-344f8b7c25b4",
+  "https://github.com/user-attachments/assets/8b2610d0-3d00-41be-b314-bac2fe616787",
+  "https://github.com/user-attachments/assets/9b66deea-3786-4296-9b0d-52873a15f5e1"
  ]
 }


### PR DESCRIPTION
## Summary

Add AppStore-style screenshots to `data/screenshots.json` for two plugins that are already listed on this awesome list:

- `omdsh-dev/dsh-genui` — 4 images from the repo's `assets/`
- `omdsh-dev/dsh-annotation` — 4 images already used by its README (GitHub-hosted attachments)

No `data/plugins/` entries are added or changed, and the generated READMEs are untouched.

## Checklist

- [x] Keys match the existing README entry URLs exactly (`https://github.com/omdsh-dev/dsh-genui` and `https://github.com/omdsh-dev/dsh-annotation`)
- [x] Images are https URLs on GitHub hosting only (`raw.githubusercontent.com` / `github.com`)
- [x] Each entry maps to 1-8 image URL strings (4 each)
- [x] All 8 image URLs verified to return HTTP 200
- [ ] I added a new `data/plugins/<owner>__<repo>.yml` file — N/A, this PR only adds screenshots for already-listed entries
- [ ] My repo declares `dsh.bundle` — N/A for this PR; both plugin repos already passed the submission gate when listed

## Screenshots

### omdsh-dev/dsh-genui

| Image |
| --- |
| https://raw.githubusercontent.com/omdsh-dev/dsh-genui/main/assets/showcase-panel.png |
| https://raw.githubusercontent.com/omdsh-dev/dsh-genui/main/assets/showcase-plot.png |
| https://raw.githubusercontent.com/omdsh-dev/dsh-genui/main/assets/showcase.png |
| https://raw.githubusercontent.com/omdsh-dev/dsh-genui/main/assets/demo-thumb.png |

### omdsh-dev/dsh-annotation

| Image |
| --- |
| https://github.com/user-attachments/assets/c3186efc-44d3-4e7f-9523-1902d9d037e9 |
| https://github.com/user-attachments/assets/0b48ac02-4648-4b94-8d8f-344f8b7c25b4 |
| https://github.com/user-attachments/assets/8b2610d0-3d00-41be-b314-bac2fe616787 |
| https://github.com/user-attachments/assets/9b66deea-3786-4296-9b0d-52873a15f5e1 |

## Local validation

- `npm ci` — success
- `node scripts/generate-readme.mjs --check` — pass (935 entries, both locales up to date)
- `node scripts/build-site.mjs` — pass (935 rows x 2 locales, screenshot host/size validation included)
- `npx awesome-lint` — only the 24 pre-existing spell-check warnings; the two `awesome` / `awesome-list` topic errors are artifacts of running against the fork (this fork lacks the base repo's topics) and are not introduced by this change.

The branch is rebased on latest upstream `main` (`0d58a9e7`) and only touches `data/screenshots.json` (+12 lines).
