### PR TITLE
docs: add screenshots entry for dsh-client-ui-theme-xp

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -380,8 +380,7 @@
  ],
  "https://github.com/moguiyu/dsh-tavily/tree/main/packages/dsh-tool-tavily-search": [
   "https://raw.githubusercontent.com/moguiyu/dsh-tavily/main/assets/tavily-search.png"
- ]
-,
+ ],
  "https://github.com/ChongCyrus/Vibe-Mathematics": [
   "https://raw.githubusercontent.com/ChongCyrus/Vibe-Mathematics/main/%E7%A4%BA%E4%BE%8B%E5%9B%BE/%E6%A1%86%E6%9E%B6%E5%9B%BE.png",
   "https://raw.githubusercontent.com/ChongCyrus/Vibe-Mathematics/main/%E7%A4%BA%E4%BE%8B%E5%9B%BE/%E5%AE%9E%E9%99%85%E4%BD%BF%E7%94%A8%E7%A4%BA%E4%BE%8B-%E9%95%BF%E6%88%AA%E5%9B%BE.png"
@@ -392,5 +391,8 @@
   "https://raw.githubusercontent.com/534119219/chicheng-gate/main/assets/mobile-ui-1.png",
   "https://raw.githubusercontent.com/534119219/chicheng-gate/main/assets/mobile-ui-2.png",
   "https://raw.githubusercontent.com/534119219/chicheng-gate/main/assets/mobile-ui-3.png"
+ ],
+ "https://github.com/SamizuHM/dsh-client-ui-theme-xp": [
+  "https://raw.githubusercontent.com/SamizuHM/dsh-client-ui-theme-xp/main/docs/screenshot.png"
  ]
 }


### PR DESCRIPTION
补充已收录插件 **dsh-client-ui-theme-xp** 的商店截图（推荐项）。插件本体此前已通过 `data/plugins/SamizuHM__dsh-client-ui-theme-xp.yml` 收录（category: `theme`），本 PR 仅在 `data/screenshots.json` 增加 1 张截图（指向插件仓库 README 原图）。

<!-- Thanks for contributing! Quick checklist / 提交前快速自查 -->

- [ ] I added **one file** at `data/plugins/<owner>__<repo>.yml` — N/A：插件已收录，本 PR 只补充截图 / plugin already listed, this PR only adds screenshots
- [ ] I ran `node scripts/generate-readme.mjs` — N/A：未改动插件条目，README 无需重新生成 / no plugin entry change, READMEs untouched
- [x] My repo's `package.json` declares **dsh.bundle** — 收录时已核验（bundle.patch + cordis.patch.yml）
- [x] My repo is 1 day+ old with 10+ commits
- [x] `category` is `theme`
- [x] Description states what the plugin does, no superlatives
- [x] My repo has the `dsh-plugin` topic

**Recommended:**
- [x] Published to npm（dsh-client-ui-theme-xp，预构建免 allowBuilds）
- [x] Screenshots added to `data/screenshots.json`（本 PR，1 张原图）
- [ ] peerDependencies — N/A（插件无依赖）
