### PR TITLE
add dsh-vision-proxy screenshots (dsh-market AppStore-style)

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -1,4 +1,8 @@
 {
+ "https://github.com/Flyvhidbwo/dsh-vision-proxy": [
+  "https://raw.githubusercontent.com/Flyvhidbwo/dsh-vision-proxy/main/assets/demo-reply.png",
+  "https://raw.githubusercontent.com/Flyvhidbwo/dsh-vision-proxy/main/assets/demo-selector.png"
+ ],
  "https://github.com/dsh-market/dsh-market": [
   "https://raw.githubusercontent.com/dsh-market/dsh-market/main/assets/demo-en.png",
   "https://raw.githubusercontent.com/dsh-market/dsh-market/main/assets/themes-en.png"


### PR DESCRIPTION
为 dsh-vision-proxy 添加两张市场截图（模型选择器路由 + 完整回复演示），图片托管在插件仓库 assets/ 下。