### PR TITLE
Add dsh-svg-motion to Tools & Capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -647,6 +647,7 @@ dsh plugin --profile web add dshmarket
 - [Vncntvx/dsh-zotero](https://github.com/Vncntvx/dsh-zotero) - Let agents search, read, and cite your local Zotero library: find papers, view notes and annotations, pull evidence by question, open the source document, and generate citations.
 - [wade20250715/dsh-pubmed](https://github.com/wade20250715/dsh-pubmed) - PubMed deep-research toolset: literature search, author investigation, same-name disambiguation, institution statistics and mentor-student matching.
 - [Walvez/dsh-codex-sync](https://github.com/Walvez/dsh-codex-sync) - One-stop bidirectional sync between OpenAI Codex and DeepSeek Harness: first-class skills from ~/.codex/skills, codex session import with workspace attach, live MCP auto-mirror of codex's mcp_servers, and a Codex-side reverse MCP installer.
+- [weike-zhang/dsh-svg-motion](https://github.com/weike-zhang/dsh-svg-motion) - Turn any SVG logo into a motion video inside DSH: an `animate_svg` tool renders a transparent 30fps assembly animation (parts fly in, or the whole mark settles) and synthesizes an MP4 with ffmpeg.
 - [whitefirer/dsh-browser-fs](https://github.com/whitefirer/dsh-browser-fs) - Give agents access to files on the machine where the browser runs: user authorizes a local directory via File System Access, tool calls relay over the plugin's own WebSocket; read-only compat mode for mobile/insecure contexts.
 - [wloops/dsh-git-worktree](https://github.com/wloops/dsh-git-worktree) - Domi-grade git worktree isolation and delivery: permanent worktrees under .dsh-worktrees, ready-for-review / apply / finish / discard lifecycle with conflict handling and safe cleanup (ported from Domi's production system).
 - [wly8691-jpg/knowlp-rag](https://github.com/wly8691-jpg/knowlp-rag) - Dual knowledge-graph RAG for Markdown notes: prerequisite + similarity graphs (P/S-Agent traversal), paragraph chunking, n-gram/embedding hybrid search, and an explicit weight feedback loop — via MCP.
@@ -688,8 +689,6 @@ dsh plugin --profile web add dshmarket
 - [zoahdev/dsh-github-release-radar](https://github.com/zoahdev/dsh-github-release-radar) - Track releases and stars of any public GitHub repository from inside dsh agents — no API key needed.
 - [zp-home/dsh-recommend](https://github.com/zp-home/dsh-recommend) - Transparent rankings and recommendations for the DSH plugin ecosystem: daily auto-fetched topic data, an open scoring model, and rank/search/recommend tools with a settings-page leaderboard.
 - [ZRui-C/dsh-computer-use](https://github.com/ZRui-C/dsh-computer-use) - Text-first computer use for DSH: background Chromium control via Playwright/CDP plus accessibility-first macOS control; actions stay pinned to the right process and window without taking the user's pointer, ships a Developer ID signed, notarized Universal 2 DMG.
-- [weike-zhang/dsh-svg-motion](https://github.com/weike-zhang/dsh-svg-motion) - Turn any SVG logo into a motion video inside DSH: an `animate_svg` tool renders a transparent 30fps assembly animation (parts fly in, or the whole mark settles) and synthesizes an MP4 with ffmpeg.
-
 
 ### Skills
 

--- a/README.md
+++ b/README.md
@@ -688,6 +688,8 @@ dsh plugin --profile web add dshmarket
 - [zoahdev/dsh-github-release-radar](https://github.com/zoahdev/dsh-github-release-radar) - Track releases and stars of any public GitHub repository from inside dsh agents — no API key needed.
 - [zp-home/dsh-recommend](https://github.com/zp-home/dsh-recommend) - Transparent rankings and recommendations for the DSH plugin ecosystem: daily auto-fetched topic data, an open scoring model, and rank/search/recommend tools with a settings-page leaderboard.
 - [ZRui-C/dsh-computer-use](https://github.com/ZRui-C/dsh-computer-use) - Text-first computer use for DSH: background Chromium control via Playwright/CDP plus accessibility-first macOS control; actions stay pinned to the right process and window without taking the user's pointer, ships a Developer ID signed, notarized Universal 2 DMG.
+- [weike-zhang/dsh-svg-motion](https://github.com/weike-zhang/dsh-svg-motion) - Turn any SVG logo into a motion video inside DSH: an `animate_svg` tool renders a transparent 30fps assembly animation (parts fly in, or the whole mark settles) and synthesizes an MP4 with ffmpeg.
+
 
 ### Skills
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -647,6 +647,7 @@ dsh plugin --profile web add dshmarket
 - [Vncntvx/dsh-zotero](https://github.com/Vncntvx/dsh-zotero) — 让 Agent 搜索、阅读并引用本地 Zotero 文献库：找文献、查看笔记与批注、按问题取证、打开原文、生成引用。
 - [wade20250715/dsh-pubmed](https://github.com/wade20250715/dsh-pubmed) — PubMed 深度科研工具集：文献检索、作者调查、同名消歧、机构统计与师承匹配。
 - [Walvez/dsh-codex-sync](https://github.com/Walvez/dsh-codex-sync) — OpenAI Codex 与 DeepSeek Harness 一站式双向同步：一等公民技能、codex 会话导入与工作区挂载、codex mcp_servers 实时 MCP 自动镜像、Codex 侧反向 MCP 一键安装器。
+- [weike-zhang/dsh-svg-motion](https://github.com/weike-zhang/dsh-svg-motion) — 在 DSH 里把任意 SVG logo 变成动效视频：`animate_svg` 工具渲染透明背景 30fps 组装动画（零件飞入或整体落位），并用 ffmpeg 合成 MP4。
 - [whitefirer/dsh-browser-fs](https://github.com/whitefirer/dsh-browser-fs) — 让 agent 读写浏览器所在电脑上的文件：浏览器授权本地目录（File System Access），工具调用经插件自建 WebSocket 中继；移动端/非安全上下文自动降级只读兼容模式。
 - [wloops/dsh-git-worktree](https://github.com/wloops/dsh-git-worktree) — Domi 级 git worktree 隔离与交付：.dsh-worktrees 永久 worktree，ready-for-review / apply / finish / discard 完整生命周期，冲突处理与安全清理（移植自 Domi 生产系统）。
 - [wly8691-jpg/knowlp-rag](https://github.com/wly8691-jpg/knowlp-rag) — Markdown 笔记的双知识图谱 RAG：前置依赖 + 相似关联双图（P/S-Agent 遍历）、段落级匹配、ngram/embedding 混合检索、显式权重反馈闭环，以 MCP 接入。
@@ -688,7 +689,6 @@ dsh plugin --profile web add dshmarket
 - [zoahdev/dsh-github-release-radar](https://github.com/zoahdev/dsh-github-release-radar) — 让 dsh agent 直接查询任意 GitHub 公开仓库的 Release 与星标变化，无需 API Key。
 - [zp-home/dsh-recommend](https://github.com/zp-home/dsh-recommend) — DSH 插件透明排行与推荐：每日自动抓取 `dsh-plugin` 话题生态，公开评分模型，提供 rank/search/recommend 工具与设置页榜单。
 - [ZRui-C/dsh-computer-use](https://github.com/ZRui-C/dsh-computer-use) — DSH 电脑控制：Playwright/CDP 后台操作 Chromium，Accessibility 优先控制 macOS；动作锁定到正确进程与窗口，不抢前台、不移动鼠标，提供已签名公证的 Universal 2 DMG 安装包。
-- [weike-zhang/dsh-svg-motion](https://github.com/weike-zhang/dsh-svg-motion) — 在 DSH 里把任意 SVG logo 变成动效视频：`animate_svg` 工具渲染透明背景 30fps 组装动画（零件飞入或整体落位），并用 ffmpeg 合成 MP4。
 
 ### 🧩 技能包
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -688,6 +688,7 @@ dsh plugin --profile web add dshmarket
 - [zoahdev/dsh-github-release-radar](https://github.com/zoahdev/dsh-github-release-radar) — 让 dsh agent 直接查询任意 GitHub 公开仓库的 Release 与星标变化，无需 API Key。
 - [zp-home/dsh-recommend](https://github.com/zp-home/dsh-recommend) — DSH 插件透明排行与推荐：每日自动抓取 `dsh-plugin` 话题生态，公开评分模型，提供 rank/search/recommend 工具与设置页榜单。
 - [ZRui-C/dsh-computer-use](https://github.com/ZRui-C/dsh-computer-use) — DSH 电脑控制：Playwright/CDP 后台操作 Chromium，Accessibility 优先控制 macOS；动作锁定到正确进程与窗口，不抢前台、不移动鼠标，提供已签名公证的 Universal 2 DMG 安装包。
+- [weike-zhang/dsh-svg-motion](https://github.com/weike-zhang/dsh-svg-motion) — 在 DSH 里把任意 SVG logo 变成动效视频：`animate_svg` 工具渲染透明背景 30fps 组装动画（零件飞入或整体落位），并用 ffmpeg 合成 MP4。
 
 ### 🧩 技能包
 

--- a/data/plugins/weike-zhang__dsh-svg-motion.yml
+++ b/data/plugins/weike-zhang__dsh-svg-motion.yml
@@ -1,0 +1,6 @@
+url: https://github.com/weike-zhang/dsh-svg-motion
+name: weike-zhang/dsh-svg-motion
+category: tools
+description:
+  en: 'Turn any SVG logo into a motion video inside DSH: an `animate_svg` tool renders a transparent 30fps assembly animation (parts fly in, or the whole mark settles) and synthesizes an MP4 with ffmpeg.'
+  zh: '在 DSH 里把任意 SVG logo 变成动效视频：`animate_svg` 工具渲染透明背景 30fps 组装动画（零件飞入或整体落位），并用 ffmpeg 合成 MP4。'


### PR DESCRIPTION
## Adding a plugin / 收录插件

Adds `weike-zhang/dsh-svg-motion` to **Tools & Capabilities** in both `README.md` and `README.zh.md`.

**What it does:** turn any SVG logo into a motion video inside DeepSeek Harness. The plugin registers an `animate_svg` tool that renders a transparent 30fps assembly animation in headless Chromium (parts fly in, or the whole mark settles with `intent: logo`) and synthesizes an MP4 with ffmpeg.

**收录内容:** 在 `README.md` 与 `README.zh.md` 的「工具与能力 / Tools & Capabilities」分类下各新增一行,收录 `weike-zhang/dsh-svg-motion`。

**Requirements checked / 已满足收录要求:**
- Declares `dsh.bundle.patch` in `package.json` ✓ (`{"bundle": {"patch": "./cordis.patch.yml"}}`)
- Ships a real `cordis.patch.yml` ✓
- Has the `dsh-plugin` GitHub topic ✓
- Real working code, actively maintained ✓

**Verification:** the plugin has been validated end to end through the real dsh harness tool pipeline (`ctx.tools.execute`), rendering the 循智共创 and 境间 brand logos into animated MP4 + transparent frame sequences. Interactive motion kits for both brands live in the repo's `examples/`.
