### PR TITLE
docs: add dsh-notion screenshots

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -479,5 +479,9 @@
   "https://raw.githubusercontent.com/YeqingTang/dsh-session-flow/main/assets/screenshots/fulltext-search.png",
   "https://raw.githubusercontent.com/YeqingTang/dsh-session-flow/main/assets/screenshots/dock-right.png",
   "https://raw.githubusercontent.com/YeqingTang/dsh-session-flow/main/assets/screenshots/folded-detail.png"
+ ],
+ "https://github.com/mingzeng21/dsh-notion": [
+  "https://raw.githubusercontent.com/mingzeng21/dsh-notion/master/docs/screenshots/dsh-notion-sc1.png",
+  "https://raw.githubusercontent.com/mingzeng21/dsh-notion/master/docs/screenshots/dsh-notion-sc2.png"
  ]
 }


### PR DESCRIPTION
Add AppStore-style screenshots for [mingzeng21/dsh-notion](https://github.com/mingzeng21/dsh-notion) to `data/screenshots.json`.

- `dsh-notion-sc1.png` — dsh agent asked to summarize a technical architecture and write it into Notion
- `dsh-notion-sc2.png` — the resulting Notion page

Images are hosted in the plugin repo under `docs/screenshots/`.