### PR TITLE
data: add screenshots for dsh-plugin-hub and dsh-github-login

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -331,5 +331,13 @@
   "https://raw.githubusercontent.com/GOU-GEE/deepseek-vision/main/docs/screenshots/03-clipboard.png",
   "https://raw.githubusercontent.com/GOU-GEE/deepseek-vision/main/docs/screenshots/04-result.png",
   "https://raw.githubusercontent.com/GOU-GEE/deepseek-vision/main/docs/screenshots/05-market.png"
+ ],
+ "https://github.com/Noob-stupid/dsh-plugin-hub": [
+  "https://github.com/user-attachments/assets/b802d606-14ba-4151-9956-ff642ed12b0a"
+ ],
+ "https://github.com/Noob-stupid/dsh-github-login": [
+  "https://github.com/user-attachments/assets/bb7c1991-9346-4c20-8dc2-5d884515c522",
+  "https://github.com/user-attachments/assets/45a31794-ab56-4e34-8826-fb362deef3dc",
+  "https://github.com/user-attachments/assets/e23560ca-41d3-4a83-bc14-1d20f884cd8a"
  ]
 }


### PR DESCRIPTION
Add curated screenshots for the two Noob-stupid entries so they display AppStore-style in dsh-market 1.8.0+.

- https://github.com/Noob-stupid/dsh-plugin-hub: 1 promo screenshot
- https://github.com/Noob-stupid/dsh-github-login: 3 in-window screenshots

Images are the repos' existing README assets (github.com/user-attachments), no new uploads.