### PR TITLE
screenshots.json: dsh-movein 三张图

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -339,5 +339,10 @@
   "https://github.com/user-attachments/assets/bb7c1991-9346-4c20-8dc2-5d884515c522",
   "https://github.com/user-attachments/assets/45a31794-ab56-4e34-8826-fb362deef3dc",
   "https://github.com/user-attachments/assets/e23560ca-41d3-4a83-bc14-1d20f884cd8a"
+ ],
+ "https://github.com/sjh9714/dsh-movein": [
+  "https://raw.githubusercontent.com/sjh9714/dsh-movein/main/docs/report.png",
+  "https://raw.githubusercontent.com/sjh9714/dsh-movein/main/docs/demo.gif",
+  "https://raw.githubusercontent.com/sjh9714/dsh-movein/main/docs/social.png"
  ]
 }


### PR DESCRIPTION
为 dsh-movein 补充市场安装弹窗截图，依次为搬家清单终端报告（dry run 全功能）、演示 GIF、社交预览卡。全部 raw.githubusercontent.com 直链，仓库自有资源。