### PR TITLE
Add dsh-reasoning-slider screenshots

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -344,5 +344,12 @@
   "https://raw.githubusercontent.com/sjh9714/dsh-movein/main/docs/report.png",
   "https://raw.githubusercontent.com/sjh9714/dsh-movein/main/docs/demo.gif",
   "https://raw.githubusercontent.com/sjh9714/dsh-movein/main/docs/social.png"
+ ],
+ "https://github.com/qjcnmd/dsh-reasoning-slider": [
+  "https://raw.githubusercontent.com/qjcnmd/dsh-reasoning-slider/main/assets/screenshots/deepseek-v4-flash-high.png",
+  "https://raw.githubusercontent.com/qjcnmd/dsh-reasoning-slider/main/assets/screenshots/deepseek-v4-flash-max.png",
+  "https://raw.githubusercontent.com/qjcnmd/dsh-reasoning-slider/main/assets/screenshots/kimi-k3-max.png",
+  "https://raw.githubusercontent.com/qjcnmd/dsh-reasoning-slider/main/assets/screenshots/qwen3-7-max-off.png",
+  "https://raw.githubusercontent.com/qjcnmd/dsh-reasoning-slider/main/assets/screenshots/qwen3-7-max-high.png"
  ]
 }


### PR DESCRIPTION
## What changed

Adds five curated marketplace screenshots for [`qjcnmd/dsh-reasoning-slider`](https://github.com/qjcnmd/dsh-reasoning-slider) to `data/screenshots.json`.

The gallery shows the reasoning-effort selector across supported models and levels, ordered as DeepSeek High, DeepSeek Max, Kimi Max, Qwen Off, and Qwen High. All images are hosted in the plugin repository under `assets/screenshots/`.

## Validation

- `node scripts/generate-readme.mjs --check`
- `node scripts/build-site.mjs` — 961 entries parsed across 2 locales
- Confirmed all five `raw.githubusercontent.com` URLs return HTTP 200 with `image/png`
