### PR TITLE
Add screenshot for superagents-lab/dsh-s1

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -351,5 +351,8 @@
   "https://raw.githubusercontent.com/qjcnmd/dsh-reasoning-slider/main/assets/screenshots/kimi-k3-max.png",
   "https://raw.githubusercontent.com/qjcnmd/dsh-reasoning-slider/main/assets/screenshots/qwen3-7-max-off.png",
   "https://raw.githubusercontent.com/qjcnmd/dsh-reasoning-slider/main/assets/screenshots/qwen3-7-max-high.png"
+ ],
+ "https://github.com/superagents-lab/dsh-s1": [
+  "https://raw.githubusercontent.com/superagents-lab/dsh-s1/main/assets/dsh-s1.png"
  ]
 }


### PR DESCRIPTION
Add a curated screenshot entry for superagents-lab/dsh-s1 to data/screenshots.json. The screenshot shows s1_crawl in action inside DeepSeek Harness, hosted in the plugin own assets directory on GitHub. Per the contributing guide: keyed by the entry GitHub URL, image is a raw.githubusercontent.com URL from the plugin own repo.