### PR TITLE
Add screenshots for dsh-store, dsh-plugin-notify, dsh-plugin-session-import

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -363,5 +363,14 @@
  ],
  "https://github.com/AcidGr/dsh-web-lan-access": [
   "https://raw.githubusercontent.com/AcidGr/dsh-web-lan-access/main/assets/screenshot-lan-access.jpg"
+ ],
+ "https://github.com/huguangyu666/dsh-plugin-notify": [
+  "https://raw.githubusercontent.com/huguangyu666/dsh-plugin-notify/main/assets/screenshot.png"
+ ],
+ "https://github.com/huguangyu666/dsh-plugin-session-import": [
+  "https://raw.githubusercontent.com/huguangyu666/dsh-plugin-session-import/main/assets/screenshot.png"
+ ],
+ "https://github.com/huguangyu666/dsh-store": [
+  "https://raw.githubusercontent.com/huguangyu666/dsh-plugin-store/main/assets/screenshot.png"
  ]
 }


### PR DESCRIPTION
Adds AppStore-style screenshot entries to `data/screenshots.json` for three plugins:\n\n- [dsh-store](https://github.com/huguangyu666/dsh-plugin-store)\n- [dsh-plugin-notify](https://github.com/huguangyu666/dsh-plugin-notify)\n- [dsh-plugin-session-import](https://github.com/huguangyu666/dsh-plugin-session-import)\n\nImages in each repo's `assets/screenshot.png`.