### PR TITLE
docs: drop stale screenshot for dsh-visual-plugin

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -185,8 +185,7 @@
   "https://raw.githubusercontent.com/jyh20030112/dsh-visual-plugin/main/assets/screenshots/screenshot-1.png",
   "https://raw.githubusercontent.com/jyh20030112/dsh-visual-plugin/main/assets/screenshots/screenshot-2.png",
   "https://raw.githubusercontent.com/jyh20030112/dsh-visual-plugin/main/assets/screenshots/screenshot-3.png",
-  "https://raw.githubusercontent.com/jyh20030112/dsh-visual-plugin/main/assets/screenshots/screenshot-4.png",
-  "https://raw.githubusercontent.com/jyh20030112/dsh-visual-plugin/main/assets/screenshots/screenshot-5.png"
+  "https://raw.githubusercontent.com/jyh20030112/dsh-visual-plugin/main/assets/screenshots/screenshot-4.png"
  ],
  "https://github.com/Tkingxiao/dsh-any-background": [
   "https://raw.githubusercontent.com/Tkingxiao/dsh-any-background/main/example_img/image.png",


### PR DESCRIPTION
Update jyh20030112/dsh-visual-plugin's screenshot entry: the plugin's UI moved its configuration into the settings card, so it now ships 4 screenshots. Drop the removed screenshot-5.png (the other four URLs already serve the refreshed images).

更新 jyh20030112/dsh-visual-plugin 的截图条目：插件配置迁入设置卡片后现为 4 张截图，移除已删除的 screenshot-5.png（其余 4 个 URL 已指向刷新后的图片）。
