### PR TITLE
Add screenshot for moguiyu/dsh-tavily

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -372,5 +372,8 @@
  ],
  "https://github.com/huguangyu666/dsh-store": [
   "https://raw.githubusercontent.com/huguangyu666/dsh-plugin-store/main/assets/screenshot.png"
+ ],
+ "https://github.com/moguiyu/dsh-tavily/tree/main/packages/dsh-tool-tavily-search": [
+  "https://raw.githubusercontent.com/moguiyu/dsh-tavily/main/assets/tavily-search.png"
  ]
 }


### PR DESCRIPTION
Adds a marketplace screenshot for [moguiyu/dsh-tavily](https://github.com/moguiyu/dsh-tavily).

- Image is hosted in the plugin repo: assets/tavily-search.png
- Keyed by the entry URL as requested in the dsh-market screenshot support comment