### PR TITLE
docs: refresh dsh-reasoning-slider screenshots

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -346,11 +346,10 @@
   "https://raw.githubusercontent.com/sjh9714/dsh-movein/main/docs/social.png"
  ],
  "https://github.com/qjcnmd/dsh-reasoning-slider": [
-  "https://raw.githubusercontent.com/qjcnmd/dsh-reasoning-slider/main/assets/screenshots/deepseek-v4-flash-high.png",
-  "https://raw.githubusercontent.com/qjcnmd/dsh-reasoning-slider/main/assets/screenshots/deepseek-v4-flash-max.png",
+  "https://raw.githubusercontent.com/qjcnmd/dsh-reasoning-slider/main/assets/screenshots/deepseek-v4-pro-max.png",
+  "https://raw.githubusercontent.com/qjcnmd/dsh-reasoning-slider/main/assets/screenshots/deepseek-v4-pro-off.png",
   "https://raw.githubusercontent.com/qjcnmd/dsh-reasoning-slider/main/assets/screenshots/kimi-k3-max.png",
-  "https://raw.githubusercontent.com/qjcnmd/dsh-reasoning-slider/main/assets/screenshots/qwen3-7-max-off.png",
-  "https://raw.githubusercontent.com/qjcnmd/dsh-reasoning-slider/main/assets/screenshots/qwen3-7-max-high.png"
+  "https://raw.githubusercontent.com/qjcnmd/dsh-reasoning-slider/main/assets/screenshots/minimax-m3-minimal.png"
  ],
  "https://github.com/superagents-lab/dsh-s1": [
   "https://raw.githubusercontent.com/superagents-lab/dsh-s1/main/assets/dsh-s1.png"


### PR DESCRIPTION
## Summary

Refresh the `dsh-reasoning-slider` storefront screenshots after its Codex-style visual and interaction update.

The new set shows:
- DeepSeek V4 Pro at Max
- DeepSeek V4 Pro at Off
- MiniMax-M3 at Minimal
- Kimi K3's single supported Max effort

## Verification

- `data/screenshots.json` parses successfully
- All four raw GitHub image URLs return HTTP 200 with `image/png`
- Screenshot count remains within the documented 1–8 image limit
