### PR TITLE
Add storefront screenshots for dsh-web-mobile-fix and dsh-web-lan-access

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -356,5 +356,12 @@
  "https://github.com/TQSY114514/dsh-ui-appearance": [
   "https://raw.githubusercontent.com/TQSY114514/dsh-ui-appearance/main/docs/screenshot-settings.png",
   "https://raw.githubusercontent.com/TQSY114514/dsh-ui-appearance/main/docs/screenshot-wallpaper.png"
+ ],
+ "https://github.com/AcidGr/dsh-web-mobile-fix": [
+  "https://raw.githubusercontent.com/AcidGr/dsh-web-mobile-fix/main/assets/screenshot-1.jpg",
+  "https://raw.githubusercontent.com/AcidGr/dsh-web-mobile-fix/main/assets/screenshot-2.jpg"
+ ],
+ "https://github.com/AcidGr/dsh-web-lan-access": [
+  "https://raw.githubusercontent.com/AcidGr/dsh-web-lan-access/main/assets/screenshot-lan-access.jpg"
  ]
 }


### PR DESCRIPTION
Storefront screenshots for both plugins:
- [dsh-web-mobile-fix](https://github.com/AcidGr/dsh-web-mobile-fix) — 2 shots of the mobile-adapted Web UI
- [dsh-web-lan-access](https://github.com/AcidGr/dsh-web-lan-access) — 1 shot of the UI reached via 0.0.0.0 binding

Images live in each plugin repo's `assets/` so they stay in sync with releases.