### PR TITLE
Add screenshots for Vibe Mathematics (dsh-market storefront)

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -364,4 +364,9 @@
  "https://github.com/AcidGr/dsh-web-lan-access": [
   "https://raw.githubusercontent.com/AcidGr/dsh-web-lan-access/main/assets/screenshot-lan-access.jpg"
  ]
+,
+ "https://github.com/ChongCyrus/Vibe-Mathematics": [
+  "https://raw.githubusercontent.com/ChongCyrus/Vibe-Mathematics/main/%E7%A4%BA%E4%BE%8B%E5%9B%BE/%E6%A1%86%E6%9E%B6%E5%9B%BE.png",
+  "https://raw.githubusercontent.com/ChongCyrus/Vibe-Mathematics/main/%E7%A4%BA%E4%BE%8B%E5%9B%BE/%E5%AE%9E%E9%99%85%E4%BD%BF%E7%94%A8%E7%A4%BA%E4%BE%8B-%E9%95%BF%E6%88%AA%E5%9B%BE.png"
+ ]
 }


### PR DESCRIPTION
Adds 2 screenshots for [Vibe Mathematics](https://github.com/ChongCyrus/Vibe-Mathematics) to data/screenshots.json, keyed by the entry URL as requested:

1. Framework architecture diagram (??????????png)
2. End-to-end usage example (??????????????-?????png)

Both images are hosted in the plugin's own repo (raw.githubusercontent.com).