### PR TITLE
Add Codex Connect marketplace screenshots

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -394,5 +394,15 @@
  ],
  "https://github.com/SamizuHM/dsh-client-ui-theme-xp": [
   "https://raw.githubusercontent.com/SamizuHM/dsh-client-ui-theme-xp/main/docs/screenshot.png"
+ ],
+ "https://github.com/franksong2702/dsh-codex-connect": [
+  "https://raw.githubusercontent.com/franksong2702/dsh-codex-connect/main/docs/assets/en/plugin-entry.jpg",
+  "https://raw.githubusercontent.com/franksong2702/dsh-codex-connect/main/docs/assets/en/oauth-status.jpg",
+  "https://raw.githubusercontent.com/franksong2702/dsh-codex-connect/main/docs/assets/en/plugin-configuration.jpg",
+  "https://raw.githubusercontent.com/franksong2702/dsh-codex-connect/main/docs/assets/en/model-selector.jpg",
+  "https://raw.githubusercontent.com/franksong2702/dsh-codex-connect/main/docs/assets/zh/hero.jpg",
+  "https://raw.githubusercontent.com/franksong2702/dsh-codex-connect/main/docs/assets/zh/plugin-entry.jpg",
+  "https://raw.githubusercontent.com/franksong2702/dsh-codex-connect/main/docs/assets/zh/oauth-status.jpg",
+  "https://raw.githubusercontent.com/franksong2702/dsh-codex-connect/main/docs/assets/zh/plugin-configuration.jpg"
  ]
 }


### PR DESCRIPTION
## What changed

- Add eight curated Codex Connect screenshots to `data/screenshots.json`.
- Use four English and four Chinese assets from the plugin's own GitHub repository.
- Order the images around the plugin entry, OAuth status, configuration, and model-selection flow.

## Why

The plugin is already listed, and the maintainer invited a small follow-up PR in #39 so dsh-market 1.8.0+ can show an author-controlled AppStore-style gallery instead of relying only on README extraction.

## Verification

- `node -e '<JSON schema assertions>'` — exit 0; key matched the listed repository URL, with 8 unique GitHub-hosted URLs.
- `curl -fsSIL ...` — all 8 assets returned `HTTP 200 image/jpeg`.
- GitHub PR check (`npm ci`, stale-fork guard, README sync, `awesome-lint`, and site build) — success on the rebased head; 1002 entries parsed across 2 locales and the site built successfully.

## Out of scope

- No plugin metadata or generated README changes.
- No Codex Connect source or runtime changes.
- No third-party image hosting.
