### PR TITLE
docs: update dsh-chat-imagine listing

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -453,5 +453,10 @@
  "https://github.com/Max-Samson/dsh-usage-chart": [
   "https://github.com/Max-Samson/dsh-usage-chart/blob/main/docs/images/usage-panel-demo-en-lightv1.0.0.png",
   "https://github.com/Max-Samson/dsh-usage-chart/blob/main/docs/images/usage-panel-demo-zh-darkv1.0.0.png"
+ ],
+ "https://github.com/corrinehu/dsh-chat-imagine": [
+  "https://raw.githubusercontent.com/corrinehu/dsh-chat-imagine/main/assets/1.png",
+  "https://raw.githubusercontent.com/corrinehu/dsh-chat-imagine/main/assets/2.png",
+  "https://raw.githubusercontent.com/corrinehu/dsh-chat-imagine/main/assets/3.png"
  ]
 }


### PR DESCRIPTION
## Summary
- update the English and Chinese descriptions for `corrinehu/dsh-chat-imagine`
- add three curated screenshots for the dsh-market listing

The screenshot order shows channel selection, generation through an OpenRouter image model, then generation through the local `mmx` CLI.

Related plugin update: `dsh-chat-imagine` v0.1.1 fixes discovery of image models from built-in DSH providers whose base URL is not explicitly configured.