### PR TITLE
Add screenshots for StruggleYang/dsh-project-kanban

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -1,4 +1,7 @@
 {
+ "https://github.com/StruggleYang/dsh-project-kanban": [
+  "https://raw.githubusercontent.com/StruggleYang/dsh-project-kanban/main/assets/screenshot-board.png"
+ ],
  "https://github.com/Flyvhidbwo/dsh-vision-proxy": [
   "https://raw.githubusercontent.com/Flyvhidbwo/dsh-vision-proxy/main/assets/demo-reply.png",
   "https://raw.githubusercontent.com/Flyvhidbwo/dsh-vision-proxy/main/assets/demo-selector.png"


### PR DESCRIPTION
Adds the AppStore-style screenshot entry for [dsh-project-kanban](https://github.com/StruggleYang/dsh-project-kanban) in `data/screenshots.json` — 1 screenshot (`assets/screenshot-board.png`, hosted in the plugin repo). Site build passes locally (1002 rows × 2 locales).