### PR TITLE
Add 82c86b8z86-stack/dsh-engineering-workflow (workflow)

### DIFF
--- a/README.md
+++ b/README.md
@@ -765,6 +765,7 @@ dsh plugin --profile web add dshmarket
 
 ### Workflow & Automation
 
+- [82c86b8z86-stack/dsh-engineering-workflow](https://github.com/82c86b8z86-stack/dsh-engineering-workflow) - Engineering workflow agent preset for dsh: five gated phases (requirements clarification, plan approval, TDD, parallel subagents, verified finishing) with six workflow skills adapted from obra/superpowers.
 - [940842546/dsh-permissions](https://github.com/940842546/dsh-permissions) - Claude Code-style permission rules engine: hard/deny/ask/allow tiers with a hard tier above full access, workspace-scoped rules, wildcard path protection, and a visual staged editor; rules persist in settings.yaml.
 - [alib8b8/dsh-plugin-aflare](https://github.com/alib8b8/dsh-plugin-aflare) - Workflow tools for the local aflare binary: generate, validate and run local-first deterministic YAML workflow DAGs (WAL crash recovery, Saga compensation) through the local aflare binary, with 300+ templates built in.
 - [apheli0os/deepseek-harness-orchestrate](https://github.com/apheli0os/deepseek-harness-orchestrate) - Declarative task-DAG orchestration for DSH: validates dependency graphs, runs topological task layers in parallel through workflow-backed subagents, and propagates failures deterministically.

--- a/README.zh.md
+++ b/README.zh.md
@@ -765,6 +765,7 @@ dsh plugin --profile web add dshmarket
 
 ### 🔁 工作流与自动化
 
+- [82c86b8z86-stack/dsh-engineering-workflow](https://github.com/82c86b8z86-stack/dsh-engineering-workflow) — 工程化工作流 agent preset：五阶段硬门禁（需求澄清、计划审批、TDD、子 Agent 并行、验证收尾），附 6 个改编自 obra/superpowers 的工作流技能。
 - [940842546/dsh-permissions](https://github.com/940842546/dsh-permissions) — Claude Code 风格权限规则引擎：hard/deny/ask/allow 四级规则（hard 高于全访问、不可豁免）、workspace 作用域、通配符路径保护、可视化草稿式编辑器，规则持久化于 settings.yaml。
 - [alib8b8/dsh-plugin-aflare](https://github.com/alib8b8/dsh-plugin-aflare) — aflare 工作流工具：通过本地 aflare 二进制生成、校验并执行本地优先的确定性 YAML 工作流 DAG（WAL 崩溃恢复、Saga 补偿），内置 300+ 模板。
 - [apheli0os/deepseek-harness-orchestrate](https://github.com/apheli0os/deepseek-harness-orchestrate) — DSH 声明式任务 DAG 编排：校验依赖图，通过工作流子智能体并行执行拓扑任务层，并确定性传播失败。

--- a/data/plugins/82c86b8z86-stack__dsh-engineering-workflow.yml
+++ b/data/plugins/82c86b8z86-stack__dsh-engineering-workflow.yml
@@ -1,0 +1,6 @@
+url: https://github.com/82c86b8z86-stack/dsh-engineering-workflow
+name: 82c86b8z86-stack/dsh-engineering-workflow
+category: workflow
+description:
+  en: Engineering workflow agent preset for dsh: five gated phases (requirements clarification, plan approval, TDD, parallel subagents, verified finishing) with six workflow skills adapted from obra/superpowers.
+  zh: 工程化工作流 agent preset：五阶段硬门禁（需求澄清、计划审批、TDD、子 Agent 并行、验证收尾），附 6 个改编自 obra/superpowers 的工作流技能。

--- a/data/plugins/82c86b8z86-stack__dsh-engineering-workflow.yml
+++ b/data/plugins/82c86b8z86-stack__dsh-engineering-workflow.yml
@@ -2,5 +2,5 @@ url: https://github.com/82c86b8z86-stack/dsh-engineering-workflow
 name: 82c86b8z86-stack/dsh-engineering-workflow
 category: workflow
 description:
-  en: Engineering workflow agent preset for dsh: five gated phases (requirements clarification, plan approval, TDD, parallel subagents, verified finishing) with six workflow skills adapted from obra/superpowers.
+  en: 'Engineering workflow agent preset for dsh: five gated phases (requirements clarification, plan approval, TDD, parallel subagents, verified finishing) with six workflow skills adapted from obra/superpowers.'
   zh: 工程化工作流 agent preset：五阶段硬门禁（需求澄清、计划审批、TDD、子 Agent 并行、验证收尾），附 6 个改编自 obra/superpowers 的工作流技能。


### PR DESCRIPTION
<!-- Thanks for contributing! Quick checklist / 提交前快速自检: -->

- [x] I added **one file** at `data/plugins/<owner>__<repo>.yml` — the READMEs are generated, don't edit them by hand / 我新增了一个 `data/plugins/<owner>__<repo>.yml` 文件（两个 README 由脚本生成，不要手工编辑）
- [x] I ran `node scripts/generate-readme.mjs` and committed the regenerated READMEs / 我已执行 `node scripts/generate-readme.mjs` 并提交了重新生成的 README
- [x] My repo's `package.json` declares **`dsh.bundle`** (not just `dsh.client`) — [example](../blob/main/contributing.md) / 仓库 `package.json` 已声明 `dsh.bundle`（只有 `dsh.client` 无法安装）
- [x] My repo is at least **1 day old** with **10+ commits** / 仓库创建满 1 天且提交数 ≥ 10
  - ⚠️ The repo was created today (2026-08-16) with 18 commits, so the automated submission gate will report the age check until it turns 1 day old (~2026-08-17 14:00 UTC). Everything else passes. Please re-run the gate after that time (or I'll push a trivial commit to re-trigger).
- [x] `category` is one of `ui theme model session memory tools skill workflow notify dev market fun`, and themes/skins go under `theme` / `category` 取值正确，主题/皮肤类请用 `theme`
- [x] Description states what the plugin does, no superlatives / 描述只说功能，不带营销词
- [ ] My repo has the `dsh-plugin` topic / 仓库已打 `dsh-plugin` topic
  - ⚠️ Topics cannot be set through the API used for this submission; the owner will add the `dsh-plugin` topic in the repo settings right after opening this PR.

## What this adds

[dsh-engineering-workflow](https://github.com/82c86b8z86-stack/dsh-engineering-workflow) — an engineering workflow layer for dsh:

- An `engineering-workflow` agent preset (工程工作流 / disciplined-engineer mode) with five hard-gated phases: ① requirements clarification → ② plan approval (plan mode + `exit_plan_mode`) → ③ TDD implementation → ④ parallel subagent execution → ⑤ verified finishing.
- Six workflow skills adapted from [obra/superpowers](https://github.com/obra/superpowers) (MIT) and reworked for dsh's native tools: `engineering-workflow` (master router), `workflow-requirements`, `workflow-planning`, `workflow-tdd`, `workflow-subagents`, `workflow-verification`.
- Installs via `dsh plugin --profile <name> add github:82c86b8z86-stack/dsh-engineering-workflow`; the host plugin syncs the preset into `~/.dsh/.agent-presets` on startup (idempotent, auto-updates on plugin upgrade).

Verified live against a running dsh: the preset mounts cleanly, appears in the roster, and all six skills load into the session skill catalog. Unit tests and a structural preset validator ship in the repo.