### PR TITLE
docs: add dsh-whale-arcade screenshots

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -430,5 +430,12 @@
   "https://raw.githubusercontent.com/pyf2818/dsh-bili-widget/main/assets/hot.png",
   "https://raw.githubusercontent.com/pyf2818/dsh-bili-widget/main/assets/help.png",
   "https://raw.githubusercontent.com/pyf2818/dsh-bili-widget/main/assets/mini.png"
+ ],
+ "https://github.com/jitengfei/dsh-whale-arcade": [
+  "https://raw.githubusercontent.com/jitengfei/dsh-whale-arcade/main/assets/screenshots/01-catalog.png",
+  "https://raw.githubusercontent.com/jitengfei/dsh-whale-arcade/main/assets/screenshots/02-whale-jump.png",
+  "https://raw.githubusercontent.com/jitengfei/dsh-whale-arcade/main/assets/screenshots/03-blue-whale-treasure.png",
+  "https://raw.githubusercontent.com/jitengfei/dsh-whale-arcade/main/assets/screenshots/04-coast-runner.png",
+  "https://raw.githubusercontent.com/jitengfei/dsh-whale-arcade/main/assets/screenshots/05-ocean-gomoku.png"
  ]
 }


### PR DESCRIPTION
## Summary

- Add five curated screenshots for `jitengfei/dsh-whale-arcade`.
- Cover the catalog, three score games, and Ocean Gomoku in display order.
- Use GitHub-hosted Raw URLs keyed by the plugin's exact entry URL.

## Checks

- [x] 1-8 images from GitHub hosting
- [x] `node scripts/generate-readme.mjs --check`
- [x] `npx awesome-lint`
- [x] `node scripts/build-site.mjs`