### PR TITLE
Add screenshots for dsh-mic-input (voice input plugin)

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -437,5 +437,12 @@
   "https://raw.githubusercontent.com/jitengfei/dsh-whale-arcade/main/assets/screenshots/03-blue-whale-treasure.png",
   "https://raw.githubusercontent.com/jitengfei/dsh-whale-arcade/main/assets/screenshots/04-coast-runner.png",
   "https://raw.githubusercontent.com/jitengfei/dsh-whale-arcade/main/assets/screenshots/05-ocean-gomoku.png"
+ ],
+ "https://github.com/QT-Chen/dsh-mic-input": [
+  "https://raw.githubusercontent.com/QT-Chen/dsh-mic-input/main/assets/shot-1-composer.png",
+  "https://raw.githubusercontent.com/QT-Chen/dsh-mic-input/main/assets/shot-2-listening.png",
+  "https://raw.githubusercontent.com/QT-Chen/dsh-mic-input/main/assets/shot-4-punctuation.png",
+  "https://raw.githubusercontent.com/QT-Chen/dsh-mic-input/main/assets/shot-3-settings.png",
+  "https://raw.githubusercontent.com/QT-Chen/dsh-mic-input/main/assets/shot-5-error.png"
  ]
 }


### PR DESCRIPTION
Adds AppStore-style screenshots for [QT-Chen/dsh-mic-input](https://github.com/QT-Chen/dsh-mic-input) (keyed by its registry URL) in `data/screenshots.json` — 5 images:

1. `shot-1-composer.png` — mic button in the composer tool row
2. `shot-2-listening.png` — live dictation with auto-continue
3. `shot-4-punctuation.png` — smart punctuation (？/！/。 auto-complete)
4. `shot-3-settings.png` — settings row (language / punctuation / auto-send)
5. `shot-5-error.png` — visible error hints (permission / network)

Images are hosted in the plugin repo's `assets/` and served via raw.githubusercontent.com. Per the dsh-market 1.8.0+ screenshot convention.