### PR TITLE
Add screenshots for dsh-chatgpt-bridge

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -461,5 +461,12 @@
  ],
  "https://github.com/pengpengyi92/dsh-quant": [
   "https://raw.githubusercontent.com/pengpengyi92/dsh-quant/master/demos/ui-demo-preview.png"
+ ],
+ "https://github.com/jiezeng2004-design/dsh-chatgpt-bridge": [
+  "https://raw.githubusercontent.com/jiezeng2004-design/dsh-chatgpt-bridge/main/assets/screenshots/01-human-in-the-loop.png",
+  "https://raw.githubusercontent.com/jiezeng2004-design/dsh-chatgpt-bridge/main/assets/screenshots/02-runtime-goal-update.png",
+  "https://raw.githubusercontent.com/jiezeng2004-design/dsh-chatgpt-bridge/main/assets/screenshots/03-native-dsh-execution.png",
+  "https://raw.githubusercontent.com/jiezeng2004-design/dsh-chatgpt-bridge/main/assets/screenshots/04-workspace-security.png",
+  "https://raw.githubusercontent.com/jiezeng2004-design/dsh-chatgpt-bridge/main/assets/screenshots/05-bridge-health.png"
  ]
 }


### PR DESCRIPTION
## What

Adds curated dsh-market screenshots for:

https://github.com/jiezeng2004-design/dsh-chatgpt-bridge

The screenshots cover:

- ChatGPT `↔` DSH native human-in-the-loop interaction
- runtime supervised Goal updates
- native DSH execution
- workspace security enforcement
- Bridge health and capabilities

All images are hosted in the plugin's own GitHub repository.

## Scope

- Updates `data/screenshots.json` only
- Adds 5 GitHub-hosted screenshots
- Preserves the intended storefront display order
- No plugin-list or description changes

## Screenshot order

1. Human-in-the-loop
2. Runtime Goal update
3. Native DSH execution
4. Workspace security boundary
5. Bridge health