### PR TITLE
Add 863683348/dsh-plugin-focus (focus board for agents)

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,6 +437,7 @@ dsh plugin --profile web add dshmarket
 
 ### Memory
 
+- [863683348/dsh-plugin-focus](https://github.com/863683348/dsh-plugin-focus) - Focus board for DeepSeek Harness agents: durable, model-maintained notes in the session workspace that pin the objective, constraints, and decisions across compaction and sessions, with automatic context injection, archive on clear, and an optional web panel.
 - [aerince/dsh-active-context-pruning](https://github.com/aerince/dsh-active-context-pruning) - Model-authored context pruning for DeepSeek Harness through the official compaction API.
 - [Aik358/dsh-auto-memory](https://github.com/Aik358/dsh-auto-memory) - Auto-memory for DSH: three-layer memory (user / project notes / daily logs) with automatic injection, per-turn auto-consolidation, AI greetings, smart search, a calendar view and a settings page, plus inheritance of other AI tools' memories.
 - [akslcw/dsh-negative-ledger](https://github.com/akslcw/dsh-negative-ledger) - Evidence-bound negative-knowledge ledger: persists disproven paths (command_failed, file_missing) with their outcome and precondition evidence, then warns or blocks repeat attempts until the evidence changes.

--- a/README.zh.md
+++ b/README.zh.md
@@ -437,6 +437,7 @@ dsh plugin --profile web add dshmarket
 
 ### 🧠 记忆
 
+- [863683348/dsh-plugin-focus](https://github.com/863683348/dsh-plugin-focus) — 为 DeepSeek Harness agent 提供持久化专注板：在会话工作区维护目标、约束与决策笔记，跨压缩与会话存活，支持自动注入上下文、清空归档与可选 Web 面板。
 - [aerince/dsh-active-context-pruning](https://github.com/aerince/dsh-active-context-pruning) — 面向 DeepSeek Harness 的模型驱动上下文裁剪插件，通过官方 compaction API 释放上下文空间。
 - [Aik358/dsh-auto-memory](https://github.com/Aik358/dsh-auto-memory) — DSH 自动记忆插件：三层记忆自动注入与检索、每轮对话自动沉淀、AI 时段问候与三级抽屉、智能检索、日历视图与设置页，支持继承其他 AI 工具的记忆。
 - [akslcw/dsh-negative-ledger](https://github.com/akslcw/dsh-negative-ledger) — 证据约束的负面知识账本：记录被证伪的路径（command_failed / file_missing）及其结果与前置条件证据，重复尝试时警告或拦截，证据变化后自动解除。

--- a/data/plugins/863683348__dsh-plugin-focus.yml
+++ b/data/plugins/863683348__dsh-plugin-focus.yml
@@ -1,0 +1,6 @@
+url: https://github.com/863683348/dsh-plugin-focus
+name: 863683348/dsh-plugin-focus
+category: memory
+description:
+  en: 'Focus board for DeepSeek Harness agents: durable, model-maintained notes in the session workspace that pin the objective, constraints, and decisions across compaction and sessions, with automatic context injection, archive on clear, and an optional web panel.'
+  zh: 为 DeepSeek Harness agent 提供持久化专注板：在会话工作区维护目标、约束与决策笔记，跨压缩与会话存活，支持自动注入上下文、清空归档与可选 Web 面板。


### PR DESCRIPTION
Adds [863683348/dsh-plugin-focus](https://github.com/863683348/dsh-plugin-focus) to the **Memory** category.

A focus board for DeepSeek Harness agents: a durable, model-maintained note file (.dsh/focus.md) in the session workspace that pins the objective, constraints, and decisions across compaction and sessions. Includes the ocus tool (set/get/ppend/clear), automatic context injection at turn start (gent/pre-step snapshot), archive-on-clear, a ocusBoard session projection, and an experimental read-only web panel.

The repo declares dsh.bundle (+ dsh.client), carries the dsh-plugin topic, has 10 commits and 14 passing unit tests.

Note: the repository was created today (2026-08-16), so the CI repo-age check needs ~24h; the commit-count requirement already passes. I will push a no-op update to this branch once the age threshold is met so CI re-runs — no need to reopen the PR.