### PR TITLE
add: screenshots and updated description for dsh-session-flow

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -471,5 +471,13 @@
   "https://raw.githubusercontent.com/jiezeng2004-design/dsh-chatgpt-bridge/main/assets/screenshots/03-native-dsh-execution.png",
   "https://raw.githubusercontent.com/jiezeng2004-design/dsh-chatgpt-bridge/main/assets/screenshots/04-workspace-security.png",
   "https://raw.githubusercontent.com/jiezeng2004-design/dsh-chatgpt-bridge/main/assets/screenshots/05-bridge-health.png"
+ ],
+ "https://github.com/YeqingTang/dsh-session-flow": [
+  "https://raw.githubusercontent.com/YeqingTang/dsh-session-flow/main/assets/screenshots/overview.png",
+  "https://raw.githubusercontent.com/YeqingTang/dsh-session-flow/main/assets/screenshots/session-flow-tab.png",
+  "https://raw.githubusercontent.com/YeqingTang/dsh-session-flow/main/assets/screenshots/turn-rail.png",
+  "https://raw.githubusercontent.com/YeqingTang/dsh-session-flow/main/assets/screenshots/fulltext-search.png",
+  "https://raw.githubusercontent.com/YeqingTang/dsh-session-flow/main/assets/screenshots/dock-right.png",
+  "https://raw.githubusercontent.com/YeqingTang/dsh-session-flow/main/assets/screenshots/folded-detail.png"
  ]
 }


### PR DESCRIPTION
## Summary

Add storefront screenshots for `dsh-session-flow` (keyed by its entry URL) and refresh its description to cover the v1.0.0 feature set.

- `data/screenshots.json`: 6 screenshots from the plugin repo (`assets/screenshots/`), showing the overview workbench, embedded Session Flow tab, turn rail, cross-session full-text search, docked right panel, and folded detail view.
- `data/plugins/YeqingTang__dsh-session-flow.yml`: description updated (session rename, cross-session full-text recall added).

## Validation

- `data/screenshots.json` parses as valid JSON; all 6 URLs are `raw.githubusercontent.com` (GitHub hosting, per contributing rules) and resolve (repo `main` branch, already pushed with v1.0.0).
- Screenshots were verified locally against the live plugin UI before capture.
