### PR TITLE
Add AKS1st/dsh-skill-manager: Skill Manager page for DSH settings panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -736,6 +736,7 @@ dsh plugin --profile web add dshmarket
 
 ### Skills
 
+- [AKS1st/dsh-skill-manager](https://github.com/AKS1st/dsh-skill-manager) - Skill Manager page in the DSH settings panel: browse system / user / workspace / preset skills, expand a skill to its file tree, view and edit files, import skills from a zip, and export or delete them (system skills read-only).
 - [Cavan-Ou/hermes-dsh-collab](https://github.com/Cavan-Ou/hermes-dsh-collab) - Hook DeepSeek Harness into a Hermes pipeline: dispatch-spec template, model-tier routing, orchestrator-run quality gates, git single-writer rule, as a SKILL.md pack (bundle installable).
 - [Chu-Xin-r/wanjiqi-meme](https://github.com/Chu-Xin-r/wanjiqi-meme) - Barrage-meme skill distilled from 22,771 real messages in the 6657 live room: wanjiqi-style banter, CS and DOTA cross-memes, player roasting and casting commentary.
 - [creght-dev/skills](https://github.com/creght-dev/skills) - Skills for building websites on the Creght platform: CLI pull/push sync, page and component conventions, CMS, forms, auth, SEO, publishing and version rollback.

--- a/README.zh.md
+++ b/README.zh.md
@@ -736,6 +736,7 @@ dsh plugin --profile web add dshmarket
 
 ### 🧩 技能包
 
+- [AKS1st/dsh-skill-manager](https://github.com/AKS1st/dsh-skill-manager) — DSH 设置面板内的「技能管理」页面：按系统 / 用户 / 工作区 / 预设浏览技能，展开技能查看文件树、查看和编辑文件，支持从 zip 导入技能，以及导出、删除（系统技能只读）。
 - [Cavan-Ou/hermes-dsh-collab](https://github.com/Cavan-Ou/hermes-dsh-collab) — 把 DeepSeek Harness 接进 Hermes 管线：派单 spec 模板、模型档位路由、质量门、git 唯一写者约定，SKILL.md 技能包（bundle 可安装）。
 - [Chu-Xin-r/wanjiqi-meme](https://github.com/Chu-Xin-r/wanjiqi-meme) — 玩机器（6657 直播间）烂梗技能包：22771 条真实弹幕蒸馏而成，涵盖玩机器式弹幕烂梗、CS×DOTA 双料梗、选手锐评与解说吐槽。
 - [creght-dev/skills](https://github.com/creght-dev/skills) — Creght 平台建站技能包：CLI 拉取/推送同步、页面与组件规范、CMS、表单、Auth、SEO、发布与版本回滚。

--- a/data/plugins/AKS1st__dsh-skill-manager.yml
+++ b/data/plugins/AKS1st__dsh-skill-manager.yml
@@ -1,0 +1,6 @@
+url: https://github.com/AKS1st/dsh-skill-manager
+name: AKS1st/dsh-skill-manager
+category: skill
+description:
+  en: 'Skill Manager page in the DSH settings panel: browse system / user / workspace / preset skills, expand a skill to its file tree, view and edit files, import skills from a zip, and export or delete them (system skills read-only).'
+  zh: DSH 设置面板内的「技能管理」页面：按系统 / 用户 / 工作区 / 预设浏览技能，展开技能查看文件树、查看和编辑文件，支持从 zip 导入技能，以及导出、删除（系统技能只读）。


### PR DESCRIPTION
Adds [AKS1st/dsh-skill-manager](https://github.com/AKS1st/dsh-skill-manager) to the **Skills** category.

A DSH web plugin that adds a **Skill Manager** page to the settings panel: browse system / user / workspace / preset skills, expand a skill to its file tree, view and edit files, import skills from a zip (user or workspace), and export or delete them. System (bundled) skills are read-only.

- [x] `dsh.bundle` manifest declared in `package.json` (`bundle.patch: ./cordis.patch.yml`)
- [x] `cordis.patch.yml` at repo root
- [x] `dsh-plugin` topic added
- [x] Bilingual (en/zh) description, no marketing words
- [x] Both READMEs regenerated via `node scripts/generate-readme.mjs`