### PR TITLE
Add fullstack-expert

### DIFF
--- a/README.md
+++ b/README.md
@@ -781,6 +781,7 @@ dsh plugin --profile web add dshmarket
 ### Workflow & Automation
 
 - [940842546/dsh-permissions](https://github.com/940842546/dsh-permissions) - Claude Code-style permission rules engine: hard/deny/ask/allow tiers with a hard tier above full access, workspace-scoped rules, wildcard path protection, and a visual staged editor; rules persist in settings.yaml.
+- [adithya-hmt/fullstack-expert](https://github.com/adithya-hmt/fullstack-expert) - Cordis-native, evidence-driven full-stack engineering workflow: inspect-first planning, explicit verification evidence, and approval-aware gating for sensitive operations.
 - [alib8b8/dsh-plugin-aflare](https://github.com/alib8b8/dsh-plugin-aflare) - Workflow tools for the local aflare binary: generate, validate and run local-first deterministic YAML workflow DAGs (WAL crash recovery, Saga compensation) through the local aflare binary, with 300+ templates built in.
 - [apheli0os/deepseek-harness-orchestrate](https://github.com/apheli0os/deepseek-harness-orchestrate) - Declarative task-DAG orchestration for DSH: validates dependency graphs, runs topological task layers in parallel through workflow-backed subagents, and propagates failures deterministically.
 - [biociao/dsh-science](https://github.com/biociao/dsh-science) - Claude Science-style research workbench: ReAct research-loop engine (research_* tools), versioned artifacts with provenance (artifact_* tools), and 10 science skills for genomics/pathogens/bioinformatics.

--- a/README.zh.md
+++ b/README.zh.md
@@ -781,6 +781,7 @@ dsh plugin --profile web add dshmarket
 ### 🔁 工作流与自动化
 
 - [940842546/dsh-permissions](https://github.com/940842546/dsh-permissions) — Claude Code 风格权限规则引擎：hard/deny/ask/allow 四级规则（hard 高于全访问、不可豁免）、workspace 作用域、通配符路径保护、可视化草稿式编辑器，规则持久化于 settings.yaml。
+- [adithya-hmt/fullstack-expert](https://github.com/adithya-hmt/fullstack-expert) — 以证据驱动的全栈工程工作流：先勘察后规划、要求显式验证证据、敏感操作走审批门控。
 - [alib8b8/dsh-plugin-aflare](https://github.com/alib8b8/dsh-plugin-aflare) — aflare 工作流工具：通过本地 aflare 二进制生成、校验并执行本地优先的确定性 YAML 工作流 DAG（WAL 崩溃恢复、Saga 补偿），内置 300+ 模板。
 - [apheli0os/deepseek-harness-orchestrate](https://github.com/apheli0os/deepseek-harness-orchestrate) — DSH 声明式任务 DAG 编排：校验依赖图，通过工作流子智能体并行执行拓扑任务层，并确定性传播失败。
 - [biociao/dsh-science](https://github.com/biociao/dsh-science) — 面向 DSH 的 Claude Science 式科研工作台：ReAct 研究循环引擎（research_* 工具）、带溯源的版本化工件（artifact_* 工具）与面向基因组/病原体/生物信息的 10 个科研技能。

--- a/data/plugins/adithya-hmt__fullstack-expert.yml
+++ b/data/plugins/adithya-hmt__fullstack-expert.yml
@@ -1,0 +1,6 @@
+url: https://github.com/adithya-hmt/fullstack-expert
+name: adithya-hmt/fullstack-expert
+category: workflow
+description:
+  en: 'Cordis-native, evidence-driven full-stack engineering workflow: inspect-first planning, explicit verification evidence, and approval-aware gating for sensitive operations.'
+  zh: '以证据驱动的全栈工程工作流：先勘察后规划、要求显式验证证据、敏感操作走审批门控。'


### PR DESCRIPTION
## Summary

Add [`adithya-hmt/fullstack-expert`](https://github.com/adithya-hmt/fullstack-expert) to the workflow category.

The plugin provides an inspect-first, evidence-driven full-stack workflow for DeepSeek Harness agents, including vertical-slice planning, explicit verification evidence, and approval-aware gating for sensitive operations.

## Validation

- Added `data/plugins/adithya-hmt__fullstack-expert.yml`
- Regenerated `README.md` and `README.zh.md` with `node scripts/generate-readme.mjs`
- Ran `node scripts/generate-readme.mjs --check`
- Ran `git diff --check`
- Ran `npm ci --ignore-scripts` successfully

The plugin repository declares `dsh.bundle` and has the `dsh-plugin` topic.
