### PR TITLE
feat: add OpenBiliClaw DSH plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ dsh plugin --profile web add dshmarket
 - [vvvspec/better-reasoning-slider](https://github.com/vvvspec/better-reasoning-slider) - Official-style composer model trigger with a floating reasoning-effort slider popup.
 - [warmwine/dsh-ui-font](https://github.com/warmwine/dsh-ui-font) - Font engine for the Web GUI: system font enumeration, global and per-component font-size tuning with a Spy++-style picker, settings page.
 - [wefio/dsh-cache-miss](https://github.com/wefio/dsh-cache-miss) - Yellow one-line prompt-cache-miss notice under assistant replies that rebuilt the prompt cache.
+- [whiteguo233/dsh-openbiliclaw](https://github.com/whiteguo233/dsh-openbiliclaw) - OpenBiliClaw consumer panel for DSH: recommendations, saved lists, Socratic dialogue, profile views, and Agent Bridge tools.
 - [WhitePlusMS/dsh-git-graph](https://github.com/WhitePlusMS/dsh-git-graph) - Dedicated read-only Git Graph view beside Chat and Trajectory: commit topology, local/remote/tag refs, HEAD and working-tree status, search, filtering, first-parent mode, refresh, and load more.
 - [WhitePlusMS/dsh-input-plus](https://github.com/WhitePlusMS/dsh-input-plus) - Search and insert workspace file and directory paths with `@`, plus a `/h` menu for reusing prompts from the current session.
 - [Wine-Red/dsh-codex-timeline](https://github.com/Wine-Red/dsh-codex-timeline) - Left-edge user-Turn navigation rail with reading-position highlighting, hover previews of per-turn metrics and model-answer excerpts, keyboard and click-to-jump controls, and local conversation search.

--- a/README.zh.md
+++ b/README.zh.md
@@ -210,6 +210,7 @@ dsh plugin --profile web add dshmarket
 - [vvvspec/better-reasoning-slider](https://github.com/vvvspec/better-reasoning-slider) — 官方风格输入框 + 浮动推理能力滑块弹窗，节点与滑块对齐，弹窗跟随 Harness 主题自适应。
 - [warmwine/dsh-ui-font](https://github.com/warmwine/dsh-ui-font) — 网页界面字体引擎：系统字体枚举、准星点选的全局与逐组件字号微调、设置页。老花眼友好，自定义字体和页面部件字体和字体大小，支持SPY模式扫UI和其他插件。
 - [wefio/dsh-cache-miss](https://github.com/wefio/dsh-cache-miss) — 在重建了提示缓存的 assistant 回复下方显示一条黄色的缓存未命中提示。
+- [whiteguo233/dsh-openbiliclaw](https://github.com/whiteguo233/dsh-openbiliclaw) — OpenBiliClaw 的 DSH 消费侧插件：提供推荐、收藏列表、苏格拉底式对话、画像面板和 Agent Bridge 工具。
 - [WhitePlusMS/dsh-git-graph](https://github.com/WhitePlusMS/dsh-git-graph) — Chat 和 Trajectory 旁的独立 Git Graph 视图：提交拓扑、本地/远程/tag 引用、HEAD 与工作区状态、搜索、筛选、首父模式、刷新和加载更多。
 - [WhitePlusMS/dsh-input-plus](https://github.com/WhitePlusMS/dsh-input-plus) — 在组合框中使用 `@` 搜索并插入工作区文件和目录路径，并通过 `/h` 菜单复用当前会话的问题。
 - [Wine-Red/dsh-codex-timeline](https://github.com/Wine-Red/dsh-codex-timeline) — 左侧用户轮次导航轨道：随阅读位置高亮，悬停预览单轮指标与模型回答摘要，支持键盘和点击跳转及本地会话搜索。

--- a/data/plugins/whiteguo233__dsh-openbiliclaw.yml
+++ b/data/plugins/whiteguo233__dsh-openbiliclaw.yml
@@ -1,0 +1,6 @@
+url: https://github.com/whiteguo233/dsh-openbiliclaw
+name: whiteguo233/dsh-openbiliclaw
+category: ui
+description:
+  en: 'OpenBiliClaw consumer panel for DSH: recommendations, saved lists, Socratic dialogue, profile views, and Agent Bridge tools.'
+  zh: OpenBiliClaw 的 DSH 消费侧插件：提供推荐、收藏列表、苏格拉底式对话、画像面板和 Agent Bridge 工具。


### PR DESCRIPTION
## Summary

- add `whiteguo233/dsh-openbiliclaw` under UI plugins
- regenerate the English and Chinese READMEs from the new YAML entry

## Validation

- `npm ci`
- `node scripts/generate-readme.mjs --check`
- `awesome-lint` passed against the upstream repository metadata (29 existing spelling warnings)
- `node scripts/build-site.mjs`
- the submission gate passed: `dsh.bundle`, repository age, and commit count
