### PR TITLE
feat: add harness-widgets screenshots

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -494,5 +494,11 @@
  "https://github.com/Lhy723/dsh-agent-canvas": [
   "https://raw.githubusercontent.com/Lhy723/dsh-agent-canvas/main/docs/assets/agent-canvas-overview.png",
   "https://raw.githubusercontent.com/Lhy723/dsh-agent-canvas/main/docs/assets/agent-canvas-dark-settings.png"
+ ],
+ "https://github.com/Physicolor/harness-widgets": [
+  "https://raw.githubusercontent.com/Physicolor/harness-widgets/main/docs/screenshots/rail-widgets.png",
+  "https://raw.githubusercontent.com/Physicolor/harness-widgets/main/docs/screenshots/dock-magnify.png",
+  "https://raw.githubusercontent.com/Physicolor/harness-widgets/main/docs/screenshots/add-panel.png",
+  "https://raw.githubusercontent.com/Physicolor/harness-widgets/main/docs/screenshots/widget-cards.png"
  ]
 }


### PR DESCRIPTION
Add AppStore-style screenshot entry for [harness-widgets](https://github.com/Physicolor/harness-widgets) to \data/screenshots.json\.

**Screenshots (4 images):**
- **rail-widgets.png** — 右侧栏小部件展示（每月用量 / Token 用量 / LLM 时长 / 缓存命中 / Tokens）
- **dock-magnify.png** — macOS Dock 式悬浮放大效果
- **add-panel.png** — 添加组件面板（组件配置 tab）
- **widget-cards.png** — 前五个基础统计部件卡片预览

All images are hosted in the plugin repo at \docs/screenshots/\ via \aw.githubusercontent.com\ links.