### PR TITLE
Add OpenTritium/dsh-codex-shim

### DIFF
--- a/README.md
+++ b/README.md
@@ -631,6 +631,7 @@ dsh plugin --profile web add dshmarket
 - [omdsh-dev/dsh-tool-stat](https://github.com/omdsh-dev/dsh-tool-stat) - Descriptive statistics, percentiles, frequency distributions, and correlation.
 - [omdsh-dev/dsh-tool-time](https://github.com/omdsh-dev/dsh-tool-time) - Strict ISO 8601 parsing, IANA timezone conversion, and UTC calendar arithmetic.
 - [omdsh-dev/dsh-toolkit](https://github.com/omdsh-dev/dsh-toolkit) - Zero-dependency toolkit: time / encoding / json / calculator / csv / regex / markdown / diff / stat / schema — ten deterministic tools in one install.
+- [OpenTritium/dsh-codex-shim](https://github.com/OpenTritium/dsh-codex-shim) - Simulates a Codex environment for selected model routes to improve GPT-family model tool-call success.
 - [pengpengyi92/dsh-quant](https://github.com/pengpengyi92/dsh-quant) - Quantitative R&D toolkit for DeepSeek Harness — 37 tools across six domains covering market data, technical indicators, factor evaluation, backtests, risk metrics and fund simulation.
 - [pengxuding/dsh-plugin-judge](https://github.com/pengxuding/dsh-plugin-judge) - Plugin value auditor: pre-install review (source scan + LLM judge) and post-install audit of installed bundles, with model-switch re-audit reminders.
 - [pengzhou267-ai/dsh-shop-assistant](https://github.com/pengzhou267-ai/dsh-shop-assistant) - Ecommerce operator workbench: CSV batch preview with marketplace column adapters, reproducible profit/six-dimension scoring, public product-page snapshots, Chinese skills, and a replaceable store-policy KB.

--- a/README.zh.md
+++ b/README.zh.md
@@ -631,6 +631,7 @@ dsh plugin --profile web add dshmarket
 - [omdsh-dev/dsh-tool-stat](https://github.com/omdsh-dev/dsh-tool-stat) — 描述统计/百分位数/频数分布/相关性。
 - [omdsh-dev/dsh-tool-time](https://github.com/omdsh-dev/dsh-tool-time) — 严格 ISO 8601 解析、IANA 时区转换、UTC 日历运算。
 - [omdsh-dev/dsh-toolkit](https://github.com/omdsh-dev/dsh-toolkit) — 零依赖工具包：time / encoding / json / calculator / csv / regex / markdown / diff / stat / schema 十件套一键安装。
+- [OpenTritium/dsh-codex-shim](https://github.com/OpenTritium/dsh-codex-shim) — 为选定的模型路由模拟 Codex 环境，以提升 GPT 系列模型的工具调用成功率。
 - [pengpengyi92/dsh-quant](https://github.com/pengpengyi92/dsh-quant) — 面向 DeepSeek Harness 的量化研究工具箱，37 个工具覆盖行情、指标、因子评价、回测、风控与基金模拟。
 - [pengxuding/dsh-plugin-judge](https://github.com/pengxuding/dsh-plugin-judge) — 插件价值裁判：装前审核（源码静态扫描 + LLM 裁判）与装后审计已装插件，模型切换时弹窗提醒复核；判断插件对当前模型是增强还是压制。
 - [pengzhou267-ai/dsh-shop-assistant](https://github.com/pengzhou267-ai/dsh-shop-assistant) — 电商店主工作台：CSV 批量预览（多平台列适配）、可复算利润与六维评分、公开商品页快照、中文 skills、可替换售后政策知识库。

--- a/data/plugins/OpenTritium__dsh-codex-shim.yml
+++ b/data/plugins/OpenTritium__dsh-codex-shim.yml
@@ -1,0 +1,6 @@
+url: https://github.com/OpenTritium/dsh-codex-shim
+name: OpenTritium/dsh-codex-shim
+category: tools
+description:
+  en: Simulates a Codex environment for selected model routes to improve GPT-family model tool-call success.
+  zh: 为选定的模型路由模拟 Codex 环境，以提升 GPT 系列模型的工具调用成功率。


### PR DESCRIPTION
Add **OpenTritium/dsh-codex-shim** to the Tools & Capabilities category.

GPT-family models do better when exposed to the coding-harness tool vocabulary they expect. This bundle simulates a Codex environment on selected model routes, improving their tool-call success with existing DSH capabilities.

- Declares `dsh.bundle.patch` in `package.json` and has the `dsh-plugin` topic.
- Repository: https://github.com/OpenTritium/dsh-codex-shim
- Release: https://github.com/OpenTritium/dsh-codex-shim/releases/tag/v0.1.1
- `node scripts/generate-readme.mjs --check` passed.