### PR TITLE
docs: update dsh-chinese-mode description to v0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ dsh plugin --profile web add dshmarket
 
 - [BruceLanLan/dsh-tier-router](https://github.com/BruceLanLan/dsh-tier-router) - Two-tier model routing: a strong tier plans, advises and reviews while a cheap tier implements, with plan-mode-aware auto routing, a high-impact escalation guard, failure auto-escalation, and subagent tiering.
 - [btspoony/dsh-llm-fallbacks](https://github.com/btspoony/dsh-llm-fallbacks) - Role-based LLM retry & fallback strategies.
-- [dawnliming/dsh-chinese-mode](https://github.com/dawnliming/dsh-chinese-mode) - Global Simplified-Chinese mode: a 中 switch in the input box that injects a Chinese-language requirement into every session's system prompt when enabled, skipping anchored presets' pre-promotion round.
+- [dawnliming/dsh-chinese-mode](https://github.com/dawnliming/dsh-chinese-mode) - Global Simplified-Chinese mode: a 中 switch in the input box that injects language requirements (Chinese or English per region) into every session's system prompt; anchored mode forces English thinking for anchored presets.
 - [dylan121322/llm-adaptive](https://github.com/dylan121322/llm-adaptive) - Adaptive model routing: per-request complexity classification with automatic provider routing.
 - [fieldnote-ops/keyringseam](https://github.com/fieldnote-ops/keyringseam) - macOS Keychain credential provider that replaces the local-file provider and uses a signed, notarized universal helper.
 - [franksong2702/dsh-codex-connect](https://github.com/franksong2702/dsh-codex-connect) - Connect ChatGPT OAuth and OpenAI Codex models to DeepSeek Harness, with opt-in search and image tools.

--- a/README.zh.md
+++ b/README.zh.md
@@ -353,7 +353,7 @@ dsh plugin --profile web add dshmarket
 
 - [BruceLanLan/dsh-tier-router](https://github.com/BruceLanLan/dsh-tier-router) — 双档模型路由：强档负责规划/咨询/评审、弱档负责实现；含计划模式自动路由、高危操作守卫、失败自动升级与子代理分层。
 - [btspoony/dsh-llm-fallbacks](https://github.com/btspoony/dsh-llm-fallbacks) — 基于角色的模型重试与备用策略。
-- [dawnliming/dsh-chinese-mode](https://github.com/dawnliming/dsh-chinese-mode) — 全局中文模式：输入框「中」字开关，开启即向任意 preset 的 system prompt 注入中文要求，锚定模式晋升后自动生效。
+- [dawnliming/dsh-chinese-mode](https://github.com/dawnliming/dsh-chinese-mode) — 全局中文模式：输入框旁的「中」字开关，开启后向任意预设的系统提示注入语言要求，各区域可分别设为中文或英文；锚定模式下，锚定预设的思考强制为英文。
 - [dylan121322/llm-adaptive](https://github.com/dylan121322/llm-adaptive) — 自适应模型路由：请求级复杂度分类，按配置链自动选择后端 provider。
 - [fieldnote-ops/keyringseam](https://github.com/fieldnote-ops/keyringseam) — macOS Keychain 凭据提供器：替换本地文件提供器，并使用已签名、公证的通用二进制辅助程序。
 - [franksong2702/dsh-codex-connect](https://github.com/franksong2702/dsh-codex-connect) — 通过 ChatGPT OAuth 将 OpenAI Codex 模型接入 DeepSeek Harness，并提供可选的搜索与图片工具。

--- a/data/plugins/dawnliming__dsh-chinese-mode.yml
+++ b/data/plugins/dawnliming__dsh-chinese-mode.yml
@@ -2,5 +2,5 @@ url: https://github.com/dawnliming/dsh-chinese-mode
 name: dawnliming/dsh-chinese-mode
 category: model
 description:
-  en: 'Global Simplified-Chinese mode: a 中 switch in the input box that injects a Chinese-language requirement into every session''s system prompt when enabled, skipping anchored presets'' pre-promotion round.'
-  zh: 全局中文模式：输入框「中」字开关，开启即向任意 preset 的 system prompt 注入中文要求，锚定模式晋升后自动生效。
+  en: 'Global Simplified-Chinese mode: a 中 switch in the input box that injects language requirements (Chinese or English per region) into every session''s system prompt; anchored mode forces English thinking for anchored presets.'
+  zh: 全局中文模式：输入框旁的「中」字开关，开启后向任意预设的系统提示注入语言要求，各区域可分别设为中文或英文；锚定模式下，锚定预设的思考强制为英文。


### PR DESCRIPTION
dsh-chinese-mode v0.2.0 重构了锚定模式：新增 anchoredMode 开关（锚定预设思考用英文），移除旧的「首轮跳过/晋升」行为，条目描述已同步。