### PR TITLE
Add literaf/dsh-research (AI4Scholar research pack)

### DIFF
--- a/README.md
+++ b/README.md
@@ -804,6 +804,7 @@ dsh plugin --profile web add dshmarket
 - [zjsthmjialin/inspiration-deck-workshop](https://github.com/zjsthmjialin/inspiration-deck-workshop) - Registers the Inspiration Deck Workshop skill for DSH: local static HTML presentation decks (6 deck templates, 25+ layouts, 23 themes & motion showroom) with a validate + PNG/PDF export CLI and smoke tests, zero runtime dependencies.
 - [zjsthmjialin/pdf-background-gray-codex-skill](https://github.com/zjsthmjialin/pdf-background-gray-codex-skill) - Registers the remove-pdf-background-gray skill for DSH: whitens gray/off-white scan backgrounds in image-based PDFs while preserving resolution, page geometry, and anti-aliased text edges (lossless Flate write-back), via a single Python script (pypdf + Pillow + numpy).
 - [zsxh1990/pr-genius](https://github.com/zsxh1990/pr-genius) - PR evaluation and improvement consultant: assesses PR success probability based on historical anti-patterns and success patterns, with one-click scoring and actionable suggestions.
+- [literaf/dsh-research](https://github.com/literaf/dsh-research) - Research pack: four embedded skills (pre-submission peer review, introduction writing, formatting and re-submission, reference audit) plus workflow guidance that adapts to whether literature tools are installed, and workspace conventions for papers, citations and reading notes.
 
 ### Workflow & Automation
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -804,6 +804,7 @@ dsh plugin --profile web add dshmarket
 - [zjsthmjialin/inspiration-deck-workshop](https://github.com/zjsthmjialin/inspiration-deck-workshop) — 注册灵感演示工坊技能：本地静态 HTML 演示文稿（6 套 deck 模板、25+ 布局、23 套主题与动效展示馆），带 validate 校验与 PNG/PDF 导出 CLI 和 smoke 测试，零运行时依赖。
 - [zjsthmjialin/pdf-background-gray-codex-skill](https://github.com/zjsthmjialin/pdf-background-gray-codex-skill) — 注册 remove-pdf-background-gray 技能：去除扫描 PDF 的灰色/米白底色，保持分辨率、页面几何与抗锯齿文字边缘（无损 Flate 写回），核心为单文件 Python 脚本（pypdf + Pillow + numpy）。
 - [zsxh1990/pr-genius](https://github.com/zsxh1990/pr-genius) — PR 评估和改进顾问：基于历史反模式和成功模式评估 PR 成功率，一键评分并提供可操作的改进建议。
+- [literaf/dsh-research](https://github.com/literaf/dsh-research) — 科研套件：内嵌四个技能（投稿前预审、引言写作、排版与换投、参考文献审计），外加会根据是否安装文献工具自动调整的工作流指令，以及论文、引用与阅读笔记的工作区约定。
 
 ### 🔁 工作流与自动化
 


### PR DESCRIPTION
Adds **dsh-research** under *Skills* (EN + ZH).

- Repo: https://github.com/literaf/dsh-research (topic `dsh-plugin`, MIT, CI on Node 22/24)
- npm: `dsh-research` — prebuilt, installs with `dsh plugin --profile web add dsh-research`
- `package.json` declares `dsh.bundle`; `cordis.patch.yml` inserts one row; `@deepseek-ai/*` are `peerDependencies`
- What it does: registers four research skills through `ctx.skills.register` (nothing for the user to download or configure), a system-prompt section that adapts to whether `dsh-ai4scholar`'s search tools are present, and workspace conventions so a research session resumes where the last one stopped. It registers no tools of its own — capabilities come from plugins installed beside it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)