### PR TITLE
gate: don't read a truncated tree as a missing manifest

### DIFF
--- a/scripts/check-submission.mjs
+++ b/scripts/check-submission.mjs
@@ -88,8 +88,17 @@ async function hasBundle(repo, sub) {
 
   const tree = await api(`repos/${repo}/git/trees/HEAD?recursive=1`)
   if (tree.status !== 200) return { ok: null, why: `could not read the repository tree (HTTP ${tree.status})` }
-  const pkgs = (tree.body?.tree ?? []).filter((t) => t.path?.endsWith('package.json')).map((t) => t.path).slice(0, MAX_TREE_PKGS)
-  if (!pkgs.length) return { ok: false, why: 'no `package.json` anywhere in the repository' }
+  // A recursive tree is capped by the API (~100k entries / 7MB) and the
+  // response says so with `truncated`, while still being a 200. Reading a
+  // partial listing as the whole repository turns "we could not see all of it"
+  // into "there is no manifest", which is a definite rejection drawn from an
+  // admittedly incomplete answer. Unknown, not absent — same as a failed fetch.
+  if (tree.body?.truncated) {
+    return { ok: null, why: 'the repository tree is too large for the API to return in full' }
+  }
+  const found = (tree.body?.tree ?? []).filter((t) => t.path?.endsWith('package.json')).map((t) => t.path)
+  if (!found.length) return { ok: false, why: 'no `package.json` anywhere in the repository' }
+  const pkgs = found.slice(0, MAX_TREE_PKGS)
 
   let sawClient = false
   for (const p of pkgs) {
@@ -101,12 +110,13 @@ async function hasBundle(repo, sub) {
     if (dsh.bundle) return { ok: true, at: p }
     if (dsh.client) sawClient = true
   }
-  return {
-    ok: false,
-    why: sawClient
-      ? 'declares only `dsh.client` — that alone is not installable'
-      : `no \`dsh.bundle\` in any of ${pkgs.length} package.json file(s)`,
+  if (sawClient) return { ok: false, why: 'declares only `dsh.client` — that alone is not installable' }
+  // Same reasoning as a truncated tree: with more manifests than the cap, the
+  // ones past it were never read, so absence here is not established.
+  if (found.length > pkgs.length) {
+    return { ok: null, why: `the repository has ${found.length} package.json files, more than the ${MAX_TREE_PKGS} this check reads` }
   }
+  return { ok: false, why: `no \`dsh.bundle\` in any of ${pkgs.length} package.json file(s)` }
 }
 
 async function commitCount(repo) {


### PR DESCRIPTION
`hasBundle()` reads a truncated tree as a complete one, so a submission can be rejected for a manifest the check never actually looked for.

`git/trees/HEAD?recursive=1` is capped by the API at roughly 100k entries or 7MB. When it hits the cap it still returns **200**, with `truncated: true` in the body. The check only looks at the status:

```js
const tree = await api(`repos/${repo}/git/trees/HEAD?recursive=1`)
if (tree.status !== 200) return { ok: null, why: `could not read the repository tree (HTTP ${tree.status})` }
const pkgs = (tree.body?.tree ?? []).filter(...).slice(0, MAX_TREE_PKGS)
```

so everything past the cut is invisible, and the entry fails with a definite message:

```
$ node scripts/check-submission.mjs --dir … --only-list …
  NixOS/nixpkgs → no `dsh.bundle` in any of 4 package.json file(s)
```

nixpkgs has far more than four `package.json` files. Four is where the API stopped — the number in the message is itself the evidence that the answer was partial.

### The change

Treat truncation exactly the way a failed tree fetch is already treated — `ok: null`, "manifest check skipped" — because both mean *not seen*, rather than *not there*. The distinction already exists in the code; truncation just was not routed into it.

`MAX_TREE_PKGS` has the same shape: when a repository carries more manifests than the cap reads, the ones past it were never opened, so absence is not established there either. That now reports as unchecked rather than as a failure.

### Verified

Before and after, on the same entry:

| repo | before | after |
|---|---|---|
| `NixOS/nixpkgs` (`truncated: true`) | rejected — "no `dsh.bundle` in any of 4 package.json file(s)" | skipped — "the repository tree is too large for the API to return in full" |
| `01Virex/dsh-status-rotator` (listed) | ok | ok |
| `expressjs/express` (no manifest, small tree) | rejected — "no `dsh.bundle` in any of 1 package.json file(s)" | rejected, unchanged |

So a repository whose tree comes back whole still fails when nothing declares `dsh.bundle`, and still passes when something does. Only the incomplete-view case moves.

### Scope, honestly

I have not seen this fire on a real submission. Plugin repositories are small, and the cap is high — I had to reach for nixpkgs to trigger it. So this is a correctness fix for a rare input, not a report of a live incident.

What made it seem worth sending anyway: the gate runs on every submission, and the failure mode is the one the workflow comments already take care to avoid — an entry judged on something other than what was actually checked. A false rejection here reads to a contributor as "your manifest is missing" when the check simply could not see it, and the suggested fix (add `dsh.bundle`) would not help because it is already there.
