### PR TITLE
Update dsh-lark-bridge → dsh-im-channel: unified multi-channel IM plugin

### DIFF
--- a/data/plugins/shrekcg__dsh-lark-bridge.yml
+++ b/data/plugins/shrekcg__dsh-lark-bridge.yml
@@ -3,4 +3,4 @@ name: shrekcg/dsh-lark-bridge
 category: notify
 description:
   en: 'Bidirectional Feishu/Lark channel for DeepSeek Harness: persistent conversations, true streaming replies, 40 MCP Feishu tools, slash commands, and an IM-bot status tab in the plugin settings.'
-  zh: 'DeepSeek Harness 的飞书/Lark 双向通道：持久会话、真流式回复、40 个飞书 MCP 工具、斜杠命令，以及插件设置页中的 IM 机器人状态页。'
+  zh: DeepSeek Harness 的飞书/Lark 双向通道：持久会话、真流式回复、40 个飞书 MCP 工具、斜杠命令，以及插件设置页中的 IM 机器人状态页。


### PR DESCRIPTION
## 更新插件条目

原条目 `dsh-lark-bridge`（Feishu/Lark channel）已升级为 **`dsh-im-channel`**（统一多渠道 IM 通道）：

- **仓库改名**: https://github.com/shrekcg/dsh-im-channel （旧 URL 自动重定向）
- **npm 包**: `dsh-im-channel`
- **支持渠道**: 飞书（完整）、Telegram、钉钉、Slack、Discord
- **能力**: 持久会话、真流式回复、40 个飞书 MCP 工具、斜杠命令、渠道接入向导（/channels）、设置页 IM 机器人状态 tab

请合并此更新，感谢！