### PR TITLE
Add dsh-opencode-zen to Models & Providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -566,6 +566,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 - [WNJXYK/dsh-codex-oauth](https://github.com/WNJXYK/dsh-codex-oauth) - Use a ChatGPT/Codex subscription in DeepSeek Harness with GPT models, image generation, web search, subscription quota reporting, model and feature controls, and browser or device-code OAuth sign-in.
 - [WSL043/dsh-codex-subscription](https://github.com/WSL043/dsh-codex-subscription) - Built-in ChatGPT OAuth provider for Codex models, selectable subscription web search, backend quota for standard Codex and Spark, and a DSH settings UI; no API key or Codex CLI required.
 - [wss534857356/dsh-plugin-codex](https://github.com/wss534857356/dsh-plugin-codex) - Codex App Server model provider using a local Codex login, with session reuse, Harness tool bridging, native action traces, and durable generated-image projection.
+- [xiaozhe7772222/dsh-opencode-zen](https://github.com/xiaozhe7772222/dsh-opencode-zen) - Zero-cost access to 6 free large models. No registration, no recharge, 6 free models built-in, multi-key rotation and rate-limit backoff.
 - [zeng6125-rgb/dsh-llm-retry-settings](https://github.com/zeng6125-rgb/dsh-llm-retry-settings) - Settings card to tune the DSH LLM auto-retry policy (retry count, backoff, jitter) live from Settings → General.
 
 ### Identity & Communication

--- a/README.zh.md
+++ b/README.zh.md
@@ -566,6 +566,7 @@ dsh plugin --profile web add dshmarket
 - [WNJXYK/dsh-codex-oauth](https://github.com/WNJXYK/dsh-codex-oauth) — 在 DeepSeek Harness 中使用 ChatGPT/Codex 订阅接入 GPT 模型、图像生成与 Web 搜索，并支持订阅额度显示、模型与功能控制，以及浏览器或设备码 OAuth 登录。
 - [WSL043/dsh-codex-subscription](https://github.com/WSL043/dsh-codex-subscription) — 内置 ChatGPT OAuth 的 Codex 模型提供方：可切换订阅联网搜索，在设置页显示普通 Codex 与 Spark 独立额度；无需 API Key 或 Codex CLI。
 - [wss534857356/dsh-plugin-codex](https://github.com/wss534857356/dsh-plugin-codex) — 使用本地 Codex 登录的 Codex App Server 模型提供方，支持会话复用、Harness 工具桥接、原生动作轨迹和生成图片持久化。
+- [xiaozhe7772222/dsh-opencode-zen](https://github.com/xiaozhe7772222/dsh-opencode-zen) — 0元接入6个免费大模型，免注册免充值，内置6个免费模型，多Key轮换与限流退避。
 - [zeng6125-rgb/dsh-llm-retry-settings](https://github.com/zeng6125-rgb/dsh-llm-retry-settings) — 在 DSH 设置里调整 LLM 自动重试的次数与退避时间并实时生效的设置卡片。
 
 ### 🆔 身份与通信

--- a/data/plugins/xiaozhe7772222__dsh-opencode-zen.yml
+++ b/data/plugins/xiaozhe7772222__dsh-opencode-zen.yml
@@ -1,0 +1,6 @@
+url: https://github.com/xiaozhe7772222/dsh-opencode-zen
+name: xiaozhe7772222/dsh-opencode-zen
+category: model
+description:
+  zh: "0元接入6个免费大模型，免注册免充值，内置6个免费模型，多Key轮换与限流退避。"
+  en: "Zero-cost access to 6 free large models. No registration, no recharge, 6 free models built-in, multi-key rotation and rate-limit backoff."


### PR DESCRIPTION
Add [dsh-opencode-zen](https://github.com/xiaozhe7772222/dsh-opencode-zen) - OpenCode Zen free-tier models for DeepSeek Harness: six zero-config free models with public-key auth, key rotation, and rate-limit backoff.

- Requires dsh.bundle manifest in package.json ✅
- Real working code ✅
- dsh-plugin topic set ✅
- Bilingual README ✅
- MIT License ✅