### PR TITLE
screenshots: add dsh-spend market screenshots

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -502,9 +502,13 @@
   "https://raw.githubusercontent.com/Physicolor/harness-widgets/main/docs/screenshots/add-panel.png",
   "https://raw.githubusercontent.com/Physicolor/harness-widgets/main/docs/screenshots/widget-cards.png"
  ],
-  "https://github.com/ayahunter/dsh-trail": [
-   "https://raw.githubusercontent.com/ayahunter/dsh-trail/main/docs/screenshot.png",
-   "https://raw.githubusercontent.com/ayahunter/dsh-trail/main/docs/screenshots/rounds-view.png",
-   "https://raw.githubusercontent.com/ayahunter/dsh-trail/main/docs/screenshots/tool-details.png"
-  ]
+ "https://github.com/ayahunter/dsh-trail": [
+  "https://raw.githubusercontent.com/ayahunter/dsh-trail/main/docs/screenshot.png",
+  "https://raw.githubusercontent.com/ayahunter/dsh-trail/main/docs/screenshots/rounds-view.png",
+  "https://raw.githubusercontent.com/ayahunter/dsh-trail/main/docs/screenshots/tool-details.png"
+ ],
+ "https://github.com/nonewind/dsh-spend": [
+  "https://raw.githubusercontent.com/nonewind/dsh-spend/main/docs/screenshots/dashboard.png",
+  "https://raw.githubusercontent.com/nonewind/dsh-spend/main/docs/screenshots/details-window.png"
+ ]
 }


### PR DESCRIPTION
按照 #62 评论的建议，为 [dsh-spend](https://github.com/nonewind/dsh-spend) 添加市场截图（2 张）：仪表盘总览与调用明细窗口。图片托管在插件仓库 `docs/screenshots/` 下。

As suggested in the #62 comment, add market screenshots (2) for [dsh-spend](https://github.com/nonewind/dsh-spend): dashboard overview and the call-details window. Images live in the plugin repo under `docs/screenshots/`.