### PR TITLE
Add curated screenshots for dsh-opencode-go-usage

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -513,5 +513,10 @@
  ],
  "https://github.com/2768651338/dsh-plugin-manager": [
   "https://raw.githubusercontent.com/2768651338/dsh-plugin-manager/main/assets/preview.png"
+ ],
+ "https://github.com/v587d/dsh-opencode-go-usage": [
+  "https://raw.githubusercontent.com/v587d/dsh-opencode-go-usage/main/assets/custom-footer.png",
+  "https://raw.githubusercontent.com/v587d/dsh-opencode-go-usage/main/assets/usage-detail.png",
+  "https://raw.githubusercontent.com/v587d/dsh-opencode-go-usage/main/assets/set-cookie-wid.png"
  ]
 }


### PR DESCRIPTION
Add curated App Store-style screenshots for
[v587d/dsh-opencode-go-usage](https://github.com/v587d/dsh-opencode-go-usage).

Images are hosted in the plugin repo under `assets/` and referenced via
`raw.githubusercontent.com` on the `main` branch.

Screenshots included:

- `assets/custom-footer.png` — usage chip in the composer tool row
- `assets/usage-detail.png` — expanded usage detail panel
- `assets/set-cookie-wid.png` — built-in credential editor
