### PR TITLE
Add market screenshots for dsh-cost-tracker

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -518,5 +518,10 @@
   "https://raw.githubusercontent.com/v587d/dsh-opencode-go-usage/main/assets/custom-footer.png",
   "https://raw.githubusercontent.com/v587d/dsh-opencode-go-usage/main/assets/usage-detail.png",
   "https://raw.githubusercontent.com/v587d/dsh-opencode-go-usage/main/assets/set-cookie-wid.png"
+ ],
+ "https://github.com/yflmq001/dsh-cost-tracker": [
+  "https://raw.githubusercontent.com/yflmq001/dsh-cost-tracker/main/assets/screenshots/screenshot-main.png",
+  "https://raw.githubusercontent.com/yflmq001/dsh-cost-tracker/main/assets/screenshots/screenshot-cost-panel.png",
+  "https://raw.githubusercontent.com/yflmq001/dsh-cost-tracker/main/assets/screenshots/screenshot-config.png"
  ]
 }


### PR DESCRIPTION
Add 3 curated screenshots for [dsh-cost-tracker](https://github.com/yflmq001/dsh-cost-tracker) to `data/screenshots.json`, per the invite in #75.

为 dsh-cost-tracker 补充 3 张市场截图（主界面、成本面板、配置示例），对应 #75 中维护者的建议。图片已上传至插件仓库 assets/screenshots/。