### PR TITLE
Add DIT.ai provider bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,6 +355,7 @@ dsh plugin --profile web add dshmarket
 
 - [BruceLanLan/dsh-tier-router](https://github.com/BruceLanLan/dsh-tier-router) - Two-tier model routing: a strong tier plans, advises and reviews while a cheap tier implements, with plan-mode-aware auto routing, a high-impact escalation guard, failure auto-escalation, and subagent tiering.
 - [btspoony/dsh-llm-fallbacks](https://github.com/btspoony/dsh-llm-fallbacks) - Role-based LLM retry & fallback strategies.
+- [cuboteam/Dit#dsh-plugin-dit](https://github.com/cuboteam/Dit/tree/main/packages/dsh-plugin-dit) - DIT.ai provider bundle for DeepSeek Harness: installs 29 OpenAI Chat Completions models and 10 Anthropic Messages models from one DIT_API_KEY, with protocol-specific thinking configuration.
 - [dawnliming/dsh-chinese-mode](https://github.com/dawnliming/dsh-chinese-mode) - Global Simplified-Chinese mode: a 中 switch in the input box that injects language requirements (Chinese or English per region) into every session's system prompt; anchored mode forces English thinking for anchored presets.
 - [dylan121322/llm-adaptive](https://github.com/dylan121322/llm-adaptive) - Adaptive model routing: per-request complexity classification with automatic provider routing.
 - [fieldnote-ops/keyringseam](https://github.com/fieldnote-ops/keyringseam) - macOS Keychain credential provider that replaces the local-file provider and uses a signed, notarized universal helper.

--- a/README.zh.md
+++ b/README.zh.md
@@ -355,6 +355,7 @@ dsh plugin --profile web add dshmarket
 
 - [BruceLanLan/dsh-tier-router](https://github.com/BruceLanLan/dsh-tier-router) — 双档模型路由：强档负责规划/咨询/评审、弱档负责实现；含计划模式自动路由、高危操作守卫、失败自动升级与子代理分层。
 - [btspoony/dsh-llm-fallbacks](https://github.com/btspoony/dsh-llm-fallbacks) — 基于角色的模型重试与备用策略。
+- [cuboteam/Dit#dsh-plugin-dit](https://github.com/cuboteam/Dit/tree/main/packages/dsh-plugin-dit) — DIT.ai 的 DeepSeek Harness 模型接入 bundle：使用一个 DIT_API_KEY 安装 29 个 OpenAI Chat Completions 模型和 10 个 Anthropic Messages 模型，并按协议配置 thinking。
 - [dawnliming/dsh-chinese-mode](https://github.com/dawnliming/dsh-chinese-mode) — 全局中文模式：输入框旁的「中」字开关，开启后向任意预设的系统提示注入语言要求，各区域可分别设为中文或英文；锚定模式下，锚定预设的思考强制为英文。
 - [dylan121322/llm-adaptive](https://github.com/dylan121322/llm-adaptive) — 自适应模型路由：请求级复杂度分类，按配置链自动选择后端 provider。
 - [fieldnote-ops/keyringseam](https://github.com/fieldnote-ops/keyringseam) — macOS Keychain 凭据提供器：替换本地文件提供器，并使用已签名、公证的通用二进制辅助程序。

--- a/data/plugins/cuboteam__Dit--packages-dsh-plugin-dit.yml
+++ b/data/plugins/cuboteam__Dit--packages-dsh-plugin-dit.yml
@@ -1,0 +1,6 @@
+url: https://github.com/cuboteam/Dit/tree/main/packages/dsh-plugin-dit
+name: cuboteam/Dit#dsh-plugin-dit
+category: model
+description:
+  en: 'DIT.ai provider bundle for DeepSeek Harness: installs 29 OpenAI Chat Completions models and 10 Anthropic Messages models from one DIT_API_KEY, with protocol-specific thinking configuration.'
+  zh: 'DIT.ai 的 DeepSeek Harness 模型接入 bundle：使用一个 DIT_API_KEY 安装 29 个 OpenAI Chat Completions 模型和 10 个 Anthropic Messages 模型，并按协议配置 thinking。'


### PR DESCRIPTION
## Summary

Adds the published `dsh-plugin-dit` profile bundle from the DIT monorepo to the Models & Providers category.

- npm: `dsh-plugin-dit@0.1.2`
- bundle manifest: `packages/dsh-plugin-dit/package.json`
- protocols: OpenAI Chat Completions and Anthropic Messages
- catalog: 29 Chat models and 10 Messages models
- repository topic: `dsh-plugin`

Both generated READMEs were regenerated with the repository script.