### PR TITLE
docs: add screenshots for PicGo/dsh-plugin

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -534,5 +534,9 @@
  "https://github.com/kaziii/dsh-github-connector": [
   "https://raw.githubusercontent.com/kaziii/dsh-github-connector/main/docs/assets/pr-bar.png",
   "https://raw.githubusercontent.com/kaziii/dsh-github-connector/main/docs/assets/connect-github.png"
+ ],
+ "https://github.com/PicGo/dsh-plugin": [
+  "https://raw.githubusercontent.com/PicGo/dsh-plugin/main/assets/DeepSeek-PicGo.png",
+  "https://raw.githubusercontent.com/PicGo/dsh-plugin/main/assets/dsh-plugin-picgo.png"
  ]
 }


### PR DESCRIPTION
Adds two screenshots for [`PicGo/dsh-plugin`](https://github.com/PicGo/dsh-plugin) to `data/screenshots.json`, as invited in the notice about AppStore-style screenshots in dsh-market 1.8.0+.

| Order | Image | What it shows |
|---|---|---|
| 1 | `assets/DeepSeek-PicGo.png` | Cover — DeepSeek Harness × PicGo |
| 2 | `assets/dsh-plugin-picgo.png` | The `/picgo` command and the bundled `picgo-upload` skill in the Harness palette |

Both images live in the plugin's own repo under `assets/` and are served from `raw.githubusercontent.com`, per the hosting rule in contributing.md.

`node scripts/build-site.mjs` passes locally (1081 entries, 2 locales).