### PR TITLE
Add iaaiNG/quiet-light-dsh (VS Code Quiet Light theme)

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,7 @@ dsh plugin --profile web add dshmarket
 - [DocJlm/dsh-arknights#pramanix-eyjafjalla](https://github.com/DocJlm/dsh-arknights/tree/main/skins/pramanix-eyjafjalla) - Arknights-inspired fan skin for the DSH Web UI featuring Pramanix and Eyjafjalla in a day/night celestial garden.
 - [dsh-plugins/dsh-thought-buddy](https://github.com/dsh-plugins/dsh-thought-buddy) - A GrokBot-style animated avatar with a synchronized typewriter status line — right in front of the "Deep diving..." indicator.
 - [GGBond2424648901/deep-whale-day-night-theme](https://github.com/GGBond2424648901/deep-whale-day-night-theme) - Day/night whale-girl skin: a crystal workshop by day and a moon-tide observatory by night, with paired scenes, chibi companions, ornaments, and lightweight bubble and star ambience.
+- [iaaiNG/quiet-light-dsh](https://github.com/iaaiNG/quiet-light-dsh) - VS Code Quiet Light theme for the DeepSeek Harness web GUI, with a lavender sidebar and violet accent colors.
 - [Isilsolme/dsh-anthropic-fonts](https://github.com/Isilsolme/dsh-anthropic-fonts) - Anthropic Sans, Serif, and Mono fonts for the DSH Web UI, with Source Han fallback for CJK.
 - [keke050/dsh-wallpaper](https://github.com/keke050/dsh-wallpaper) - Wallpaper skin for the DSH Web UI: presets, image URL or upload, and an opacity slider that fades the interface to reveal the wallpaper.
 - [KinGao294/dsh-skin](https://github.com/KinGao294/dsh-skin) - Codex-style skin switcher plus a custom wallpaper layer with opacity and blur controls.

--- a/README.zh.md
+++ b/README.zh.md
@@ -334,6 +334,7 @@ dsh plugin --profile web add dshmarket
 - [DocJlm/dsh-arknights#pramanix-eyjafjalla](https://github.com/DocJlm/dsh-arknights/tree/main/skins/pramanix-eyjafjalla) — DSH Web 明日方舟同人皮肤“初雪和小羊”，包含昼夜星海庭园背景与双角色布局。
 - [dsh-plugins/dsh-thought-buddy](https://github.com/dsh-plugins/dsh-thought-buddy) — 在「Deep diving...」状态提示前，放一只动态小伙伴——GrokBot 风格动画头像，状态文字还会同步打字机变换。
 - [GGBond2424648901/deep-whale-day-night-theme](https://github.com/GGBond2424648901/deep-whale-day-night-theme) — 鲸鱼娘昼夜皮肤：白昼水晶工坊与夜晚月潮观测室双场景，成对角色、Q 版侧栏宠物、花边与气泡/星点轻量氛围。
+- [iaaiNG/quiet-light-dsh](https://github.com/iaaiNG/quiet-light-dsh) — DeepSeek Harness 网页端的 VS Code Quiet Light 主题，薰衣草紫侧边栏与紫罗兰强调色。
 - [Isilsolme/dsh-anthropic-fonts](https://github.com/Isilsolme/dsh-anthropic-fonts) — Anthropic Sans/Serif/Mono 字体：界面 Sans、对话 Serif、代码 Mono，中文回退思源字体。
 - [keke050/dsh-wallpaper](https://github.com/keke050/dsh-wallpaper) — DSH Web 壁纸皮肤：预设 / 图片 URL / 本地上传，透明度滑块让整面界面透出壁纸。
 - [KinGao294/dsh-skin](https://github.com/KinGao294/dsh-skin) — Codex 风格皮肤切换器 + 自定义壁纸层，可调透明度与模糊。

--- a/data/plugins/iaaiNG__quiet-light-dsh.yml
+++ b/data/plugins/iaaiNG__quiet-light-dsh.yml
@@ -1,0 +1,6 @@
+url: https://github.com/iaaiNG/quiet-light-dsh
+name: iaaiNG/quiet-light-dsh
+category: theme
+description:
+  en: 'VS Code Quiet Light theme for the DeepSeek Harness web GUI, with a lavender sidebar and violet accent colors.'
+  zh: 'DeepSeek Harness 网页端的 VS Code Quiet Light 主题，薰衣草紫侧边栏与紫罗兰强调色。'

--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -552,7 +552,7 @@
   "https://raw.githubusercontent.com/a903067276-rgb/dsh-plan-switch/main/assets/plan-button.png"
  ],
  "https://github.com/iaaiNG/quiet-light-dsh": [
-  "https://raw.githubusercontent.com/iaaiNG/quiet-light-dsh/main/assets/preview-appearance.png",
-  "https://raw.githubusercontent.com/iaaiNG/quiet-light-dsh/main/assets/palette.png"
+  "https://raw.githubusercontent.com/iaaiNG/quiet-light-dsh/main/assets/screenshot-app.png",
+  "https://raw.githubusercontent.com/iaaiNG/quiet-light-dsh/main/assets/screenshot-appearance.png"
  ]
 }

--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -550,5 +550,9 @@
  ],
  "https://github.com/a903067276-rgb/dsh-plan-switch": [
   "https://raw.githubusercontent.com/a903067276-rgb/dsh-plan-switch/main/assets/plan-button.png"
+ ],
+ "https://github.com/iaaiNG/quiet-light-dsh": [
+  "https://raw.githubusercontent.com/iaaiNG/quiet-light-dsh/main/assets/preview-appearance.png",
+  "https://raw.githubusercontent.com/iaaiNG/quiet-light-dsh/main/assets/palette.png"
  ]
 }


### PR DESCRIPTION
## What

Adds **iaaiNG/quiet-light-dsh** — a VS Code Quiet Light theme for the DeepSeek Harness web GUI, registered into the official theme system and exposed as a Quiet Light cube in the Appearance settings.

- Category: `theme`
- Repo: https://github.com/iaaiNG/quiet-light-dsh
- Declares `dsh.bundle` + `dsh.client` (installable via `dsh plugin add`)
- Screenshots added to `data/screenshots.json`

## Checklist

- [x] `data/plugins/iaaiNG__quiet-light-dsh.yml` added (one file)
- [x] README.md / README.zh.md regenerated via `node scripts/generate-readme.mjs`
- [x] `dsh-plugin` topic on the repo
- [x] Real, working code (theme registration + appearance row + persistence)