### PR TITLE
Add screenshots for knowlp-rag

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -550,5 +550,9 @@
  ],
  "https://github.com/a903067276-rgb/dsh-plan-switch": [
   "https://raw.githubusercontent.com/a903067276-rgb/dsh-plan-switch/main/assets/plan-button.png"
- ]
+ ],
+  "https://github.com/wly8691-jpg/knowlp-rag": [
+   "https://raw.githubusercontent.com/wly8691-jpg/knowlp-rag/main/docs/demo.png",
+   "https://raw.githubusercontent.com/wly8691-jpg/knowlp-rag/main/docs/architecture.png"
+  ]
 }


### PR DESCRIPTION
Adds a curated screenshot entry for the `knowlp-rag` plugin, keyed by its entry URL.

Two images (already committed in the plugin repo on `main`):
- `docs/demo.png` — search-results demo
- `docs/architecture.png` — architecture diagram

The plugin README currently has no embedded images, so this gives dsh-market 1.8.0+ real AppStore-style previews instead of an empty fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
