### PR TITLE
Add health & decay screenshots for knowlp-rag

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -553,6 +553,8 @@
  ],
  "https://github.com/wly8691-jpg/knowlp-rag": [
   "https://raw.githubusercontent.com/wly8691-jpg/knowlp-rag/main/docs/demo.png",
+  "https://raw.githubusercontent.com/wly8691-jpg/knowlp-rag/main/docs/health.png",
+  "https://raw.githubusercontent.com/wly8691-jpg/knowlp-rag/main/docs/decay.png",
   "https://raw.githubusercontent.com/wly8691-jpg/knowlp-rag/main/docs/architecture.png"
  ],
  "https://github.com/tt-a1i/archify/tree/main/integrations/deepseek-harness": [


### PR DESCRIPTION
Extends the `knowlp-rag` screenshots entry from 2 to 4 previews, adding two new images (already committed to `wly8691-jpg/knowlp-rag` `main`):

- `docs/health.png` — `knowlp_stats` engine/graph health self-check
- `docs/decay.png` — decay forgetting-curve (1-day / 30-day / never tiers)

Order after this change: demo → health → decay → architecture.

Follow-up to #1261.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
