### PR TITLE
docs: add Sttrevens/dsh-linked-folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,6 +404,7 @@ dsh plugin --profile web add dshmarket
 
 ### Sessions & Messages
 
+- [Sttrevens/dsh-linked-folders](https://github.com/Sttrevens/dsh-linked-folders) - Multi-folder workspace: a durable global linked-folders list plus per-session on-the-fly linking (link_folder/unlink_folder), managed from the Web sidebar.
 - [3274375092/dsh-voice](https://github.com/3274375092/dsh-voice) - Voice input for DeepSeek Harness: speak into the microphone and the recognized text is submitted as a normal chat message, via local or browser speech recognition.
 - [3403473060/dsh-inline-images](https://github.com/3403473060/dsh-inline-images) - Render local image paths from assistant replies inline in the message body (9 formats, click-to-zoom lightbox, adjustable size).
 - [Anionex/dsh-turn-rewind](https://github.com/Anionex/dsh-turn-rewind) - Rewind conversation and workspace state, powered by a persistent Change Ledger.

--- a/README.zh.md
+++ b/README.zh.md
@@ -404,6 +404,7 @@ dsh plugin --profile web add dshmarket
 
 ### 💬 会话与消息
 
+- [Sttrevens/dsh-linked-folders](https://github.com/Sttrevens/dsh-linked-folders) — 多文件夹工作区：全局链接文件夹列表 + 会话内临时挂载（link_folder/unlink_folder），侧边栏管理。
 - [3274375092/dsh-voice](https://github.com/3274375092/dsh-voice) — 语音输入插件：对着麦克风说话，识别后的文字作为普通聊天消息发送（本地模型或浏览器语音识别）。
 - [3403473060/dsh-inline-images](https://github.com/3403473060/dsh-inline-images) — 对话内联图片：LLM 回复中输出的本地图片路径在消息正文直接渲染为图片（9 种格式、点击放大灯箱、可调尺寸）。
 - [Anionex/dsh-turn-rewind](https://github.com/Anionex/dsh-turn-rewind) — 对话回退：基于持久 Change Ledger 回滚会话与工作区状态。


### PR DESCRIPTION
Adds **Sttrevens/dsh-linked-folders** under Sessions & Messages (both README.md and README.zh.md).

Multi-folder workspace for dsh: a durable global linked-folders list (cross-session) plus per-session on-the-fly linking via `link_folder`/`unlink_folder`, with a Web sidebar manager and a native folder-picker button. Declares `dsh.bundle` + `dsh.client`.

- Repo: https://github.com/Sttrevens/dsh-linked-folders
- npm: https://www.npmjs.com/package/@steven-wu/dsh-linked-folders
- Install: `dsh plugin --profile web add @steven-wu/dsh-linked-folders`