### PR TITLE
docs: add dsh-diagram screenshots

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -571,5 +571,11 @@
   "https://raw.githubusercontent.com/imkingjh999/dsh-shorts-wall/main/docs/screenshot-stick.png",
   "https://raw.githubusercontent.com/imkingjh999/dsh-shorts-wall/main/docs/screenshot-float.png",
   "https://raw.githubusercontent.com/imkingjh999/dsh-shorts-wall/main/docs/screenshot-minimized.png"
+ ],
+ "https://github.com/hanzhangzzz/dsh-diagram": [
+  "https://raw.githubusercontent.com/hanzhangzzz/dsh-diagram/assets/dsh-diagram-demo.gif",
+  "https://raw.githubusercontent.com/hanzhangzzz/dsh-diagram/assets/screenshot-canvas-architecture.png",
+  "https://raw.githubusercontent.com/hanzhangzzz/dsh-diagram/assets/screenshot-canvas-flow.png",
+  "https://raw.githubusercontent.com/hanzhangzzz/dsh-diagram/assets/screenshot-chat.png"
  ]
 }


### PR DESCRIPTION
Follow-up to #385, per @fkysly's invitation.

Adds the `dsh-diagram` entry to `data/screenshots.json` — 4 images, all hosted on the plugin repo's own `assets` branch (same location as the existing README demo GIF):

1. **Demo GIF** — canvas editing flow (the one already in our README)
2. **Architecture canvas** — grouped/banded architecture diagram generated from an article in the session (v0.2.0 banded layout, export buttons, diagram list)
3. **Flow canvas** — second diagram in the same session, multi-diagram list
4. **Chat view** — natural-language request routed through the `canvas-diagram` skill to a `diagram_create` tool call

Screenshots were taken from a real install of `dsh-diagram@0.2.0` from public npm on DSH `0.1.0-rc.6`, with a generic de-privatized session.

/ 中文说明：按 @fkysly 在 #385 的邀请补提交 `dsh-diagram` 的市场截图，共 4 张（README 同款 demo GIF + 三张 v0.2.0 真实界面截图），图片都托管在插件仓库自己的 `assets` 分支。

🤖 Generated with [Claude Code](https://claude.com/claude-code)