### PR TITLE
Add 863683348/dsh-starter-zh (beginner starter pack: welcome + 0→1 path + plugin picks + checklist)

### DIFF
--- a/README.md
+++ b/README.md
@@ -812,6 +812,7 @@ dsh plugin --profile web add dshmarket
 
 ### Skills
 
+- [863683348/dsh-starter-zh](https://github.com/863683348/dsh-starter-zh) - Beginner starter pack for DeepSeek Harness: welcome flow, 0→1 learning path, scenario-based plugin recommendations and a self-check checklist, paired with the dsh-handbook-zh Chinese tutorial repo.
 - [AKS1st/dsh-skill-manager](https://github.com/AKS1st/dsh-skill-manager) - Skill Manager page in the DSH settings panel: browse system / user / workspace / preset skills, expand a skill to its file tree, view and edit files, import skills from a zip, and export or delete them (system skills read-only).
 - [Cavan-Ou/hermes-dsh-collab](https://github.com/Cavan-Ou/hermes-dsh-collab) - Hook DeepSeek Harness into a Hermes pipeline: dispatch-spec template, model-tier routing, orchestrator-run quality gates, git single-writer rule, as a SKILL.md pack (bundle installable).
 - [Chu-Xin-r/wanjiqi-meme](https://github.com/Chu-Xin-r/wanjiqi-meme) - Barrage-meme skill distilled from 22,771 real messages in the 6657 live room: wanjiqi-style banter, CS and DOTA cross-memes, player roasting and casting commentary.

--- a/README.zh.md
+++ b/README.zh.md
@@ -812,6 +812,7 @@ dsh plugin --profile web add dshmarket
 
 ### 🧩 技能包
 
+- [863683348/dsh-starter-zh](https://github.com/863683348/dsh-starter-zh) — DSH 新手入门包：欢迎语、从 0 到 1 学习路径、按场景推荐插件与新手自查清单，联动 dsh-handbook-zh 中文教程仓库。
 - [AKS1st/dsh-skill-manager](https://github.com/AKS1st/dsh-skill-manager) — DSH 设置面板内的「技能管理」页面：按系统 / 用户 / 工作区 / 预设浏览技能，展开技能查看文件树、查看和编辑文件，支持从 zip 导入技能，以及导出、删除（系统技能只读）。
 - [Cavan-Ou/hermes-dsh-collab](https://github.com/Cavan-Ou/hermes-dsh-collab) — 把 DeepSeek Harness 接进 Hermes 管线：派单 spec 模板、模型档位路由、质量门、git 唯一写者约定，SKILL.md 技能包（bundle 可安装）。
 - [Chu-Xin-r/wanjiqi-meme](https://github.com/Chu-Xin-r/wanjiqi-meme) — 玩机器（6657 直播间）烂梗技能包：22771 条真实弹幕蒸馏而成，涵盖玩机器式弹幕烂梗、CS×DOTA 双料梗、选手锐评与解说吐槽。

--- a/data/plugins/863683348__dsh-starter-zh.yml
+++ b/data/plugins/863683348__dsh-starter-zh.yml
@@ -1,0 +1,6 @@
+url: https://github.com/863683348/dsh-starter-zh
+name: 863683348/dsh-starter-zh
+category: skill
+description:
+  en: 'Beginner starter pack for DeepSeek Harness: welcome flow, 0→1 learning path, scenario-based plugin recommendations and a self-check checklist, paired with the dsh-handbook-zh Chinese tutorial repo.'
+  zh: 'DSH 新手入门包：欢迎语、从 0 到 1 学习路径、按场景推荐插件与新手自查清单，联动 dsh-handbook-zh 中文教程仓库。'


### PR DESCRIPTION
Add [863683348/dsh-starter-zh](https://github.com/863683348/dsh-starter-zh) — beginner starter pack for DeepSeek Harness (中文新手入门包).

- welcome flow + 0→1 learning path (run → profile → install → write → publish)
- scenario-based plugin recommendations (start here / focus & memory / security / productivity)
- 10-item self-check checklist
- systemPrompt guidance so the model walks new users through the pack
- paired with the [dsh-handbook-zh](https://github.com/863683348/dsh-handbook-zh) Chinese tutorial repo (from-0-to-1 handbook)

npm: `dsh-starter-zh` · topics: dsh-plugin / deepseek-harness / cordis / starter / onboarding