### PR TITLE
Add dsh-passwords screenshots for the marketplace gallery

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -584,5 +584,14 @@
  "https://github.com/Gin-7/dsh-pet-remielle": [
   "https://raw.githubusercontent.com/Gin-7/dsh-pet-remielle/main/assets/screenshot-waiting.png",
   "https://raw.githubusercontent.com/Gin-7/dsh-pet-remielle/main/assets/screenshot-priding.png"
+ ],
+ "https://github.com/slywalker2006/dsh-passwords": [
+  "https://raw.githubusercontent.com/slywalker2006/dsh-passwords/main/docs/screenshots/white-login.png",
+  "https://raw.githubusercontent.com/slywalker2006/dsh-passwords/main/docs/screenshots/black-login.png",
+  "https://raw.githubusercontent.com/slywalker2006/dsh-passwords/main/docs/screenshots/white-login-en.png",
+  "https://raw.githubusercontent.com/slywalker2006/dsh-passwords/main/docs/screenshots/main-ui.png",
+  "https://raw.githubusercontent.com/slywalker2006/dsh-passwords/main/docs/screenshots/chat.png",
+  "https://raw.githubusercontent.com/slywalker2006/dsh-passwords/main/docs/screenshots/card-front.png",
+  "https://raw.githubusercontent.com/slywalker2006/dsh-passwords/main/docs/screenshots/card-back.png"
  ]
 }


### PR DESCRIPTION
Thanks for the marketplace screenshots feature (comment on #84) — adding a curated set of 7 screenshots for dsh-passwords.

Images are hosted in the plugin's own repo under `docs/screenshots/` (raw.githubusercontent.com URLs):

1. Light login page
2. Dark login page
3. English login page
4. Main DSH web UI behind the gateway
5. In-app chat panel
6. Settings card (front)
7. Settings card (back / permissions)
