### PR TITLE
Add miiaowuwu/dsh-event-sounds to Sessions & Messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,6 +456,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 - [Max-Null/dsh-chinese-thinking](https://github.com/Max-Null/dsh-chinese-thinking) - Injects one fixed system-prompt section so the agent thinks and replies in Chinese, regardless of the user's language.
 - [mayf3/dsh-session-doctor](https://github.com/mayf3/dsh-session-doctor) - Diagnose, unstick, and read DSH sessions: list sessions with agent status, read conversations, diagnose stuck agents, recover them with cancel+keepInbox, and send messages to other sessions.
 - [MichengAI/dsh-archive-manager](https://github.com/MichengAI/dsh-archive-manager) - Adds an archived-sessions page in Settings to search, restore, and delete archived DeepSeek Harness sessions by workspace.
+- [miiaowuwu/dsh-event-sounds](https://github.com/miiaowuwu/dsh-event-sounds) - Plays your chosen sound effects when a session ends, options pop up, permission is requested, or generation stops.
 - [Moeblack/dsh-message-edit](https://github.com/Moeblack/dsh-message-edit) - Branch-based message editing, reroll, retry, and a version timeline.
 - [Moeblack/dsh-prompt-studio](https://github.com/Moeblack/dsh-prompt-studio) - Edit user and built-in system-prompt sections with live preview.
 - [MuWinds/dsh-archived-sessions](https://github.com/MuWinds/dsh-archived-sessions) - Archived-session management: browse archived sessions, unarchive them, or clear them out.

--- a/README.zh.md
+++ b/README.zh.md
@@ -456,6 +456,7 @@ dsh plugin --profile web add dshmarket
 - [Max-Null/dsh-chinese-thinking](https://github.com/Max-Null/dsh-chinese-thinking) — 注入一条固定 system-prompt 段落，让 Agent 无论用户使用什么语言都始终用中文思考和回复。
 - [mayf3/dsh-session-doctor](https://github.com/mayf3/dsh-session-doctor) — 会话医生：列出会话（含 agent 运行状态）、读取会话记录、诊断卡死的 agent、解卡（cancel + keepInbox 保留排队消息）、向其他会话发送消息。
 - [MichengAI/dsh-archive-manager](https://github.com/MichengAI/dsh-archive-manager) — 在设置里增加已归档会话页，可按工作区搜索、恢复和删除已归档会话。
+- [miiaowuwu/dsh-event-sounds](https://github.com/miiaowuwu/dsh-event-sounds) — 语音控制插件：在会话结束、弹出选项、请求许可或停止生成时播放指定音效。
 - [Moeblack/dsh-message-edit](https://github.com/Moeblack/dsh-message-edit) — 基于分支的消息编辑、reroll、重试与版本时间线。
 - [Moeblack/dsh-prompt-studio](https://github.com/Moeblack/dsh-prompt-studio) — 带实时预览的用户/内置 system prompt 分节编辑器。
 - [MuWinds/dsh-archived-sessions](https://github.com/MuWinds/dsh-archived-sessions) — 归档会话管理：浏览已归档会话，支持恢复（取消归档）与清空。

--- a/data/plugins/miiaowuwu__dsh-event-sounds.yml
+++ b/data/plugins/miiaowuwu__dsh-event-sounds.yml
@@ -1,0 +1,6 @@
+url: https://github.com/miiaowuwu/dsh-event-sounds
+name: miiaowuwu/dsh-event-sounds
+category: session
+description:
+  en: 'Plays your chosen sound effects when a session ends, options pop up, permission is requested, or generation stops.'
+  zh: 语音控制插件：在会话结束、弹出选项、请求许可或停止生成时播放指定音效。


### PR DESCRIPTION
Plays your chosen sound effects when a session ends, options pop up, permission is requested, or generation stops.

- Declares a \dsh.bundle\ manifest (cordis.patch.yml) and is installable via \dsh plugin add\
- Published on npm as \dsh-client-ui-event-sounds\
- Repo tagged with the \dsh-plugin\ topic