### PR TITLE
Refuse DeepSeek Harness itself as a submission

### DIFF
--- a/scripts/check-submission.mjs
+++ b/scripts/check-submission.mjs
@@ -5,6 +5,7 @@
 //      whole tree is enumerated rather than a guessed list of directories)
 //   2. the repo is at least MIN_AGE_DAYS old and has >= MIN_COMMITS commits
 //   3. the repo exists and isn't archived
+//   4. the repo is not DSH itself (it declares `dsh.bundle` and would pass 1-3)
 //
 // Needs GITHUB_TOKEN: the git-tree enumeration and the commit count are API
 // calls, and unauthenticated (60/hr per IP) is nowhere near enough. That is
@@ -21,6 +22,15 @@ const MIN_AGE_DAYS = 1
 const MIN_COMMITS = 10
 const CONCURRENCY = 6
 const MAX_TREE_PKGS = 40
+
+// DSH itself declares `dsh.bundle`: packages/bundle/base/package.json is
+// @deepseek-ai/dsh-base, and it is the 19th of 248 manifests in that tree, so
+// the enumeration reaches it well inside MAX_TREE_PKGS and the age and commit
+// thresholds are met by years. The harness would therefore pass the gate as a
+// plugin for itself. Listing the product in a list of plugins for the product
+// is the one wrong entry every visitor would recognise, so it is refused by
+// identity rather than by contract.
+const FIRST_PARTY_REPOS = new Set(['deepseek-ai/deepseek-harness'])
 
 // Entries submitted before the gate existed are judged by the old rules; only
 // the manifest check applies to them. Set to when the rule change landed.
@@ -131,6 +141,9 @@ async function commitCount(repo) {
 
 async function check(entry) {
   const { repo, sub } = decompose(entry.url)
+  if (FIRST_PARTY_REPOS.has(repo.toLowerCase())) {
+    return ['this is DeepSeek Harness itself, not a plugin for it']
+  }
   const meta = await api(`repos/${repo}`)
   if (meta.status === 404) return [`repository not found: https://github.com/${repo}`]
   if (meta.status !== 200) {


### PR DESCRIPTION
## What

`check-submission.mjs` refuses `deepseek-ai/deepseek-harness` by identity, before the manifest and threshold checks run.

## Why

The harness satisfies every current rule, so the gate would accept the product as a plugin for the product:

- `packages/bundle/base/package.json` is `@deepseek-ai/dsh-base` and declares `dsh.bundle`
- it is the **19th** of **248** `package.json` files in the tree, so the enumeration reaches it well inside `MAX_TREE_PKGS = 40`
- `truncated` is `false`, so the tree is fully readable and no "unknown" path is taken
- age and commit thresholds pass by years

The contract checks are correct here — the harness genuinely declares a bundle. What makes it wrong as an entry is identity, not conformance, so that is where the check goes.

It is not currently listed; this closes the path before someone submits it.

## How to verify

Reproduce the accept-path facts:

```sh
gh api "repos/deepseek-ai/deepseek-harness/git/trees/HEAD?recursive=1" \
  --jq '{truncated, manifests: [.tree[]|select(.path|endswith("package.json"))]|length}'
# => {"truncated": false, "manifests": 248}

gh api repos/deepseek-ai/deepseek-harness/contents/packages/bundle/base/package.json \
  --jq '.content' | base64 -d | jq -c '{name, dsh}'
# => {"name":"@deepseek-ai/dsh-base","dsh":{"bundle":{"patch":"./cordis.patch.yml"}}}
```

Then confirm the guard rejects the harness while still accepting plugins, including a monorepo one and another repo in the same org:

| URL | Expected |
| --- | --- |
| `deepseek-ai/deepseek-harness` | refused |
| `deepseek-ai/deepseek-harness/tree/main/packages/bundle/base` | refused |
| `DeepSeek-AI/DeepSeek-Harness` | refused (case) |
| `Chinesezjc/dsh-interconnect` | accepted |
| `zhu1090093659/dsh-web-ui` | accepted (monorepo) |
| `deepseek-ai/some-other-repo` | accepted (same org) |

I checked this both ways: with the guard all six behave as above; with `FIRST_PARTY_REPOS` emptied, the three refusals turn into acceptances. Happy to add that as a committed test if you have a preferred location — `scripts/` has no test convention today, so I left it out rather than introduce one.
