### PR TITLE
Refuse repositories that vendor DSH's own bundle packages

### DIFF
--- a/scripts/check-submission.mjs
+++ b/scripts/check-submission.mjs
@@ -32,6 +32,19 @@ const MAX_TREE_PKGS = 40
 // identity rather than by contract.
 const FIRST_PARTY_REPOS = new Set(['deepseek-ai/deepseek-harness'])
 
+// Packages published only by the DSH project. A repository containing one of
+// these under `dsh.bundle` is shipping a copy of the harness: measured on the
+// live topic, five repositories carry `packages/bundle/base/package.json` naming
+// `@deepseek-ai/dsh-base` verbatim, reached about 21 manifests into a ~250
+// manifest tree, so this check finds it inside MAX_TREE_PKGS and accepts them.
+// `fork` is false for all five, so they are source copies that neither an owner
+// check nor a fork check detects.
+const FIRST_PARTY_PACKAGES = new Set([
+  '@deepseek-ai/dsh-base',
+  '@deepseek-ai/dsh-web-app',
+  '@deepseek-ai/dsh-headless',
+])
+
 // Entries submitted before the gate existed are judged by the old rules; only
 // the manifest check applies to them. Set to when the rule change landed.
 const GATE_EFFECTIVE_FROM = process.env.GATE_EFFECTIVE_FROM ?? '2026-08-16T00:00:00Z'
@@ -111,14 +124,32 @@ async function hasBundle(repo, sub) {
   const pkgs = found.slice(0, MAX_TREE_PKGS)
 
   let sawClient = false
+  let vendored = null
   for (const p of pkgs) {
     const f = await api(`repos/${repo}/contents/${p}`)
     if (f.status !== 200 || !f.body?.content) continue
     const pkg = parsePkg(f.body.content)
     if (!pkg) continue
     const dsh = pkg.dsh ?? {}
-    if (dsh.bundle) return { ok: true, at: p }
+    if (dsh.bundle) {
+      // A repository that vendors DSH's own bundle packages satisfies this
+      // check by containing the harness, not by offering a plugin. Recorded
+      // rather than accepted, and only reported if no genuine bundle turns up
+      // later in the tree — a plugin repository may legitimately keep a copy
+      // of the harness for testing.
+      if (FIRST_PARTY_PACKAGES.has(pkg.name)) {
+        vendored ??= { at: p, name: pkg.name }
+        continue
+      }
+      return { ok: true, at: p }
+    }
     if (dsh.client) sawClient = true
+  }
+  if (vendored) {
+    return {
+      ok: false,
+      why: `\`${vendored.at}\` is DSH's own \`${vendored.name}\`, so this repository contains the harness rather than a plugin for it`,
+    }
   }
   if (sawClient) return { ok: false, why: 'declares only `dsh.client` — that alone is not installable' }
   // Same reasoning as a truncated tree: with more manifests than the cap, the


### PR DESCRIPTION
## What

`check-submission.mjs` refuses a repository whose `dsh.bundle` manifest is one of DSH's own bundle packages, unless a genuine bundle appears elsewhere in the tree.

## Why

Five repositories on the topic ship `packages/bundle/base/package.json` naming `@deepseek-ai/dsh-base` verbatim. They contain the harness rather than a plugin for it, and they pass the current gate:

| Repository | Stars | Created | `dsh.bundle` found at |
| --- | --- | --- | --- |
| `fufankeji/deepseek-harness-studio` | 208 | 2026-08-15 | manifest #21 of 255 |
| `KeepLost/harniverse` | 0 | 2026-08-14 | manifest #21 of 253 |

Both are inside `MAX_TREE_PKGS = 40`, both have `truncated: false`, and both clear the age and commit thresholds. `soolaugust/deepseek-harness-cli`, `my-dsh/oh-my-dsh` and `BenHuHuan/dhs-tuicode` carry the same package.

`fork` is **false** for all five — these are source copies, not GitHub forks, so an owner check or a fork check does not see them. The name is not the author's mistake; it is the harness's own name, which is why this is decided by package identity rather than by contract.

None is currently listed. This closes the path rather than correcting an entry.

## How to verify

```sh
gh api "repos/fufankeji/deepseek-harness-studio/git/trees/HEAD?recursive=1" \
  --jq '{truncated, manifests: [.tree[]|select(.path|endswith("package.json"))]|length}'
# => {"truncated": false, "manifests": 255}

gh api repos/fufankeji/deepseek-harness-studio/contents/packages/bundle/base/package.json \
  --jq '.content' | base64 -d | jq -c '{name, dsh}'
# => {"name":"@deepseek-ai/dsh-base","dsh":{"bundle":{"patch":"./cordis.patch.yml"}}}

gh api repos/fufankeji/deepseek-harness-studio --jq '.fork'
# => false
```

Behaviour, checked in both directions against the scan loop:

| Tree | Expected |
| --- | --- |
| only `@deepseek-ai/dsh-base` declares a bundle | refused |
| a third-party bundle at the root | accepted |
| `@deepseek-ai/dsh-base` **and** a real plugin bundle | accepted |
| plugin bundle in a subpackage | accepted |
| no bundle anywhere | refused, unchanged message |

Removing `@deepseek-ai/dsh-base` from the set flips the first row to accepted, so the guard is doing the work. The third row is the case that made this a record-then-report rather than a return: a plugin repository may legitimately keep a copy of the harness for testing.

Independent of #1339, which refuses the harness repository by name; this refuses copies of it by package name. Either can land without the other.
