### PR TITLE
Add bainianlaoyao/easy-archive (two-step inline archive on workspace sidebar rows)

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 - [alingalingling/ui-status-label](https://github.com/alingalingling/ui-status-label) - Customize the "deep diving" thinking status label to anything you like.
 - [asukasec/dsh-message-preview](https://github.com/asukasec/dsh-message-preview) - Right-edge user-message navigator with an adaptive block layout that fits the available height, plus hover previews, keyboard controls, and click-to-jump navigation.
 - [ayahunter/dsh-trail](https://github.com/ayahunter/dsh-trail) - Replaces the Web GUI trajectory tab with a new-user-friendly round-by-round storyline, plain-language tool labels, category filters and fuzzy search.
+- [bainianlaoyao/easy-archive](https://github.com/bainianlaoyao/easy-archive) - Two-step inline archive on workspace sidebar rows — one click arms a red confirm, the second click archives; the archive entry is removed from the ⋮ menu.
 - [bill9109/dsh-drag-and-drop](https://github.com/bill9109/dsh-drag-and-drop) - Cross-platform file drag-and-drop with raw path insertion, no file copying.
 - [boogoo619/dsh-focus-overlay](https://github.com/boogoo619/dsh-focus-overlay) - Focus mode with a full-screen reading overlay that hides the header and composer and folds AI tool calls into summaries.
 - [causebefore/dsh-pomodoro](https://github.com/causebefore/dsh-pomodoro) - Pomodoro focus-and-break timer for DSH Web with configurable cycles, a draggable mini panel, and in-app, sound, and browser notifications.

--- a/README.zh.md
+++ b/README.zh.md
@@ -88,6 +88,7 @@ dsh plugin --profile web add dshmarket
 - [alingalingling/ui-status-label](https://github.com/alingalingling/ui-status-label) — 把鲸鱼娘思考时的 "deep diving" 状态文案自定义成任意你想要的样子。
 - [asukasec/dsh-message-preview](https://github.com/asukasec/dsh-message-preview) — 右侧用户消息导航条，根据消息数量与可用高度自适应排布导航块，并支持悬停预览、键盘操作与点击跳转。
 - [ayahunter/dsh-trail](https://github.com/ayahunter/dsh-trail) — 把 Web GUI 的轨迹页签替换为新手友好的回合故事线：工具名通俗中文化，支持类别筛选与模糊搜索。
+- [bainianlaoyao/easy-archive](https://github.com/bainianlaoyao/easy-archive) — 工作区侧边栏行内两击归档：点一次变红确认，再点即归档，归档项不再出现在 ⋮ 菜单里。
 - [bill9109/dsh-drag-and-drop](https://github.com/bill9109/dsh-drag-and-drop) — 跨平台文件拖拽与原始路径插入，无需复制文件。
 - [boogoo619/dsh-focus-overlay](https://github.com/boogoo619/dsh-focus-overlay) — 专注模式：全屏阅读视图，隐藏标题与输入区，把 AI 工具调用折叠成摘要。
 - [causebefore/dsh-pomodoro](https://github.com/causebefore/dsh-pomodoro) — DSH Web 番茄钟：提供可配置专注/休息循环、可拖动迷你面板，以及站内提醒、提示音和浏览器通知。

--- a/data/plugins/bainianlaoyao__easy-archive.yml
+++ b/data/plugins/bainianlaoyao__easy-archive.yml
@@ -1,0 +1,6 @@
+url: https://github.com/bainianlaoyao/easy-archive
+name: bainianlaoyao/easy-archive
+category: ui
+description:
+  en: Two-step inline archive on workspace sidebar rows — one click arms a red confirm, the second click archives; the archive entry is removed from the ⋮ menu.
+  zh: 工作区侧边栏行内两击归档：点一次变红确认，再点即归档，归档项不再出现在 ⋮ 菜单里。


### PR DESCRIPTION
## What

Add [bainianlaoyao/easy-archive](https://github.com/bainianlaoyao/easy-archive) to the UI category.

## Plugin

A DSH web plugin that moves session archiving out of the ⋮ kebab menu onto the workspace sidebar row itself:

- a hover-revealed inline archive button on every session row, right before the ⋮ menu;
- one click arms a red **确认归档 / Confirm archive** pill, a second click archives via the same wire call as the stock menu;
- the archive entry is removed from the ⋮ menu whenever it opens;
- no slot takeover — rename, fork, search, drag-reorder all stay intact;
- uses the DSH-native icon glyphs (IconArchiveOutline20 / IconCheckOutline16).

The repo declares `dsh.bundle` (cordis.patch.yml + `dsh.client` web platform), zero-build browser half, MIT-licensed, storefront screenshots in `data/screenshots.json`.

## Notes

- Supersedes #1360 (closed): that PR's GitHub Actions events stopped being delivered — pushes and a reopen produced no workflow runs — so the submission was recreated on a fresh branch.
- The repo was created on 2026-08-16 16:55Z, so the age gate (1 day / 10+ commits) flips green shortly after 2026-08-17 16:55Z; commit count is 16.