### PR TITLE
screenshots: add dsh-subagent-vision storefront screenshots

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -457,6 +457,10 @@
  "https://github.com/moguiyu/dsh-tavily/tree/main/packages/dsh-tool-tavily-search": [
   "https://raw.githubusercontent.com/moguiyu/dsh-tavily/main/assets/tavily-search.png"
  ],
+ "https://github.com/niuniuaba/dsh-subagent-vision": [
+  "https://raw.githubusercontent.com/niuniuaba/dsh-subagent-vision/main/assets/screenshot-models.png",
+  "https://raw.githubusercontent.com/niuniuaba/dsh-subagent-vision/main/assets/screenshot-vision-route.png"
+ ],
  "https://github.com/nonewind/dsh-spend": [
   "https://raw.githubusercontent.com/nonewind/dsh-spend/main/docs/screenshots/dashboard.png",
   "https://raw.githubusercontent.com/nonewind/dsh-spend/main/docs/screenshots/details-window.png"


### PR DESCRIPTION
Follow-up to the dsh-market screenshot support (PR #800): adds the [dsh-subagent-vision](https://github.com/niuniuaba/dsh-subagent-vision) entry to `data/screenshots.json`, per the [contributing guide](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/main/contributing.md#screenshots--截图optional-recommended--可选推荐).

Two dark-theme screenshots, hosted in the plugin's own `assets/` so they track releases:

1. **Settings > 模型** — the `qwen` custom provider (DashScope Anthropic-compatible endpoint) with the `qwen3.8-max` model catalog.
   https://raw.githubusercontent.com/niuniuaba/dsh-subagent-vision/main/assets/screenshot-models.png
2. **Settings > 视觉处理模型** — the vision-route picker with `qwen: qwen3.8-max` selected.
   https://raw.githubusercontent.com/niuniuaba/dsh-subagent-vision/main/assets/screenshot-vision-route.png