### PR TITLE
Add ZJUZhiyuCai/dsh-ivory theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,6 +397,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 - [zhijun-dai/Solarized-dsh-theme](https://github.com/zhijun-dai/Solarized-dsh-theme) - Solarized and Selenized theme plugin: four faithful palettes registered with the DSH Web theme runtime.
 - [zhtx2024/dsh-skin-switcher](https://github.com/zhtx2024/dsh-skin-switcher) - A settings-panel skin manager that auto-discovers installed Web UI skins, switches between them in one click, and maintains the profile patch automatically.
 - [zhxqc/dsh-oh-my-theme](https://github.com/zhxqc/dsh-oh-my-theme) - Web theme and file workspace plugin with global typography controls, @file mentions, a project file tree, Markdown preview, and a resizable side panel.
+- [ZJUZhiyuCai/dsh-ivory](https://github.com/ZJUZhiyuCai/dsh-ivory) - Warm light and dark theme for DSH Web with responsive layout, bilingual settings, safe Markdown preview, per-block copy controls, and no telemetry.
 
 ### Models & Providers
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -397,6 +397,7 @@ dsh plugin --profile web add dshmarket
 - [zhijun-dai/Solarized-dsh-theme](https://github.com/zhijun-dai/Solarized-dsh-theme) — Solarized 与 Selenized 主题插件：向 DSH Web 主题运行时注册四套忠实色板。
 - [zhtx2024/dsh-skin-switcher](https://github.com/zhtx2024/dsh-skin-switcher) — 设置面板皮肤管理器：自动扫描已安装的 Web UI 皮肤并一键切换，profile 补丁自动维护。
 - [zhxqc/dsh-oh-my-theme](https://github.com/zhxqc/dsh-oh-my-theme) — DSH Web 主题与文件工作台：全局字体设置、@ 文件引用、项目文件树、Markdown 预览和可拖拽侧边面板。
+- [ZJUZhiyuCai/dsh-ivory](https://github.com/ZJUZhiyuCai/dsh-ivory) — DSH Web 暖中性色明暗主题，支持响应式布局、双语设置、安全 Markdown 预览、内容块复制与无遥测运行。
 
 ### 🔌 模型与账号接入
 

--- a/data/plugins/ZJUZhiyuCai__dsh-ivory.yml
+++ b/data/plugins/ZJUZhiyuCai__dsh-ivory.yml
@@ -1,0 +1,7 @@
+url: https://github.com/ZJUZhiyuCai/dsh-ivory
+name: ZJUZhiyuCai/dsh-ivory
+category: theme
+description:
+  en: Warm light and dark theme for DSH Web with responsive layout, bilingual settings, safe Markdown preview, per-block copy controls, and no telemetry.
+  zh: DSH Web 暖中性色明暗主题，支持响应式布局、双语设置、安全 Markdown 预览、内容块复制与无遥测运行。
+tarball: https://github.com/ZJUZhiyuCai/dsh-ivory/releases/latest/download/dsh-ivory.tgz

--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -258,6 +258,12 @@
   "https://raw.githubusercontent.com/YeqingTang/dsh-session-flow/main/assets/screenshots/dock-right.png",
   "https://raw.githubusercontent.com/YeqingTang/dsh-session-flow/main/assets/screenshots/folded-detail.png"
  ],
+ "https://github.com/ZJUZhiyuCai/dsh-ivory": [
+  "https://raw.githubusercontent.com/ZJUZhiyuCai/dsh-ivory/main/assets/hero-light.png",
+  "https://raw.githubusercontent.com/ZJUZhiyuCai/dsh-ivory/main/assets/hero-dark.png",
+  "https://raw.githubusercontent.com/ZJUZhiyuCai/dsh-ivory/main/assets/conversation-light.png",
+  "https://raw.githubusercontent.com/ZJUZhiyuCai/dsh-ivory/main/assets/mobile-light.png"
+ ],
  "https://github.com/a179-sanae/dsh-auto-collapse": [
   "https://raw.githubusercontent.com/a179-sanae/dsh-auto-collapse/main/assets/screenshot.png"
  ],


### PR DESCRIPTION
## Summary

Add `ZJUZhiyuCai/dsh-ivory` to **Themes & Appearance** with a published npm package, prebuilt GitHub Release tarball, and four repository-hosted screenshots.

Ivory is a warm light/dark DSH Web theme with responsive layout, English/Chinese settings, bounded DOM-based Markdown preview, per-block copy controls, and no plugin network requests or telemetry. The host entry is inert and the published package has no bundled runtime dependencies.

## Distribution

- npm: [`dsh-ivory@0.2.1`](https://www.npmjs.com/package/dsh-ivory)
- GitHub Release: [`v0.2.1`](https://github.com/ZJUZhiyuCai/dsh-ivory/releases/tag/v0.2.1)
- install: `dsh plugin --profile web add dsh-ivory`

## Verification

- `dsh.bundle` manifest present at the repository root
- npm registry signature verified with `npm audit signatures`
- npm package 0.2.1 installs into an isolated DSH 0.1.0-rc.6 web profile without peer warnings
- repository age and commit-count submission gate passes
- registry README generation and site build pass locally
- plugin gates: `npm test`; real DSH browser regression `69/69`

## Submission checklist

- [x] Added one entry at `data/plugins/ZJUZhiyuCai__dsh-ivory.yml`
- [x] Regenerated `README.md` and `README.zh.md`
- [x] Repository declares `dsh.bundle`
- [x] Repository is older than one day and has more than ten commits
- [x] Category is `theme`
- [x] Description is factual and contains no superlatives
- [x] Repository has the `dsh-plugin` topic
- [x] Screenshots use GitHub-hosted URLs
- [x] Tarball uses GitHub Release hosting
