### PR TITLE
Add dsh-voice-call storefront screenshots

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -188,6 +188,15 @@
   "https://raw.githubusercontent.com/PC2005-cloud/dsh-pet/main/assets/screenshots/dsh-pet-running-1.png",
   "https://raw.githubusercontent.com/PC2005-cloud/dsh-pet/main/assets/screenshots/dsh-pet-running-2.png"
  ],
+ "https://github.com/PandaPolo/dsh-voice-call": [
+  "https://raw.githubusercontent.com/PandaPolo/dsh-voice-call/main/promo/screenshots/slide-1.png",
+  "https://raw.githubusercontent.com/PandaPolo/dsh-voice-call/main/promo/screenshots/slide-2.png",
+  "https://raw.githubusercontent.com/PandaPolo/dsh-voice-call/main/promo/screenshots/slide-3.png",
+  "https://raw.githubusercontent.com/PandaPolo/dsh-voice-call/main/promo/screenshots/slide-4.png",
+  "https://raw.githubusercontent.com/PandaPolo/dsh-voice-call/main/promo/screenshots/slide-5.png",
+  "https://raw.githubusercontent.com/PandaPolo/dsh-voice-call/main/promo/screenshots/slide-6.png",
+  "https://raw.githubusercontent.com/PandaPolo/dsh-voice-call/main/promo/screenshots/slide-7.png"
+ ],
  "https://github.com/PeterBon/dsh-hooks": [
   "https://raw.githubusercontent.com/PeterBon/dsh-hooks/main/assets/screenshot-1.jpg"
  ],


### PR DESCRIPTION
Adds 7 AppStore-style screenshots for [dsh-voice-call](https://github.com/PandaPolo/dsh-voice-call) to \data/screenshots.json\ (keyed by the entry URL, images hosted in our repo under \promo/screenshots/\), per the maintainer's suggestion on #750. Images are 1280x720 PNG frames from our demo recording.