### PR TITLE
Add 534119219/chicheng-cron (Workflow & Automation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -923,6 +923,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 ### Workflow & Automation
 
 - [1052326311/dsh-plan-lattice](https://github.com/1052326311/dsh-plan-lattice) - Adds persistent execution contracts, recursive work graphs, critical clarification, and evidence gates for long or underspecified Harness tasks.
+- [534119219/chicheng-cron](https://github.com/534119219/chicheng-cron) - Cron scheduler with a sidebar UI: run shell, Python or Node scripts, skills, or agent tasks on a schedule, with push notifications and session archiving.
 - [940842546/dsh-permissions](https://github.com/940842546/dsh-permissions) - Claude Code-style permission rules engine: hard/deny/ask/allow tiers with a hard tier above full access, workspace-scoped rules, wildcard path protection, and a visual staged editor; rules persist in settings.yaml.
 - [adithya-hmt/fullstack-expert](https://github.com/adithya-hmt/fullstack-expert) - Cordis-native, evidence-driven full-stack engineering workflow: inspect-first planning, explicit verification evidence, and approval-aware gating for sensitive operations.
 - [alib8b8/dsh-plugin-aflare](https://github.com/alib8b8/dsh-plugin-aflare) - Workflow tools for the local aflare binary: generate, validate and run local-first deterministic YAML workflow DAGs (WAL crash recovery, Saga compensation) through the local aflare binary, with 300+ templates built in.

--- a/README.zh.md
+++ b/README.zh.md
@@ -923,6 +923,7 @@ dsh plugin --profile web add dshmarket
 ### 🔁 工作流与自动化
 
 - [1052326311/dsh-plan-lattice](https://github.com/1052326311/dsh-plan-lattice) — 为长期或定义不完整的 Harness 任务提供持久执行合同、递归工作图、关键澄清与证据门禁。
+- [534119219/chicheng-cron](https://github.com/534119219/chicheng-cron) — 定时任务调度器：侧栏管理界面，按 cron 表达式或间隔执行脚本、技能与 Agent 任务，支持完成后推送通知与会话归档。
 - [940842546/dsh-permissions](https://github.com/940842546/dsh-permissions) — Claude Code 风格权限规则引擎：hard/deny/ask/allow 四级规则（hard 高于全访问、不可豁免）、workspace 作用域、通配符路径保护、可视化草稿式编辑器，规则持久化于 settings.yaml。
 - [adithya-hmt/fullstack-expert](https://github.com/adithya-hmt/fullstack-expert) — 以证据驱动的全栈工程工作流：先勘察后规划、要求显式验证证据、敏感操作走审批门控。
 - [alib8b8/dsh-plugin-aflare](https://github.com/alib8b8/dsh-plugin-aflare) — aflare 工作流工具：通过本地 aflare 二进制生成、校验并执行本地优先的确定性 YAML 工作流 DAG（WAL 崩溃恢复、Saga 补偿），内置 300+ 模板。

--- a/data/plugins/534119219__chicheng-cron.yml
+++ b/data/plugins/534119219__chicheng-cron.yml
@@ -1,0 +1,6 @@
+url: https://github.com/534119219/chicheng-cron
+name: 534119219/chicheng-cron
+category: workflow
+description:
+  en: 'Cron scheduler with a sidebar UI: run shell, Python or Node scripts, skills, or agent tasks on a schedule, with push notifications and session archiving.'
+  zh: '定时任务调度器：侧栏管理界面，按 cron 表达式或间隔执行脚本、技能与 Agent 任务，支持完成后推送通知与会话归档。'

--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -9,6 +9,12 @@
   "https://raw.githubusercontent.com/2nd1st/dsh-plugin-open-app/main/docs/screenshot-app-container.jpg",
   "https://raw.githubusercontent.com/2nd1st/dsh-plugin-open-app/main/docs/screenshot-inline.jpg"
  ],
+ "https://github.com/534119219/chicheng-cron": [
+  "https://raw.githubusercontent.com/534119219/chicheng-cron/main/assets/sidebar-entry.png",
+  "https://raw.githubusercontent.com/534119219/chicheng-cron/main/assets/settings-1.png",
+  "https://raw.githubusercontent.com/534119219/chicheng-cron/main/assets/settings-2.png",
+  "https://raw.githubusercontent.com/534119219/chicheng-cron/main/assets/output-popup.png"
+ ],
  "https://github.com/534119219/chicheng-gate": [
   "https://raw.githubusercontent.com/534119219/chicheng-gate/main/assets/settings.png",
   "https://raw.githubusercontent.com/534119219/chicheng-gate/main/assets/login-gate.png",


### PR DESCRIPTION
## Plugin

**534119219/chicheng-cron** - Cron scheduler with a sidebar UI: run shell, Python or Node scripts, skills, or agent tasks on a schedule, with push notifications and session archiving. / ???????:??????,? cron ?????????????? Agent ??,???????????????

Category: `workflow`

## Checklist

- [x] `dsh.bundle` manifest declared (`dsh.bundle.patch: ./cordis.patch.yml`) - installable via `dsh plugin add`
- [x] Repo is 1+ day old and has 10+ commits (24 commits, created 2026-08-16) / ????? 1 ?,24 ???
- [x] `dsh-plugin` + `dsh` topics added / ??? topic
- [x] Real working code: cron engine + web client UI, shell/python/node scripts, skills and agent tasks, push via chicheng-push & messaging-core, run history, session archiving / ???????
- [x] READMEs regenerated with `node scripts/generate-readme.mjs` / ?? README ?????
- [x] 4 screenshots registered in `data/screenshots.json` (sidebar entry, settings x2, run-output popup) / ??? 4 ???