### PR TITLE
Add chicheng-push: multi-channel message push plugin (notify)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1014,6 +1014,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 
 ### Notifications & Integrations
 
+- [534119219/chicheng-push](https://github.com/534119219/chicheng-push) - Multi-channel push for DeepSeek Harness: Server酱, PushPlus, Bark, DingTalk, WeCom, Telegram, Feishu, ntfy, custom webhooks and more, configurable from the settings panel and callable by other plugins via the pushNotifier service.
 - [534119219/dsh-messaging](https://github.com/534119219/dsh-messaging) - Unified messaging gateway for DeepSeek Harness: 27 IM platforms (Telegram, QQ, WeChat, Discord, WhatsApp, Feishu and more) in one plugin, with QR scan-to-authorize, per-platform workspaces, slash commands, and a web setup dialog.
 - [AbcdefgXW/dsh-msg-hub](https://github.com/AbcdefgXW/dsh-msg-hub) - IM channel bridge: WeChat (ilinkai) / QQ / Feishu with proactive push — wake the channel bot from scheduled tasks and deliver AI replies to your phone.
 - [alvinunreal/openpets#dsh](https://github.com/alvinunreal/openpets/tree/main/packages/dsh) - Bridges DeepSeek Harness lifecycle status, errors, and approval requests to a locally running OpenPets desktop companion.

--- a/README.zh.md
+++ b/README.zh.md
@@ -1014,6 +1014,7 @@ dsh plugin --profile web add dshmarket
 
 ### 🔔 通知与集成
 
+- [534119219/chicheng-push](https://github.com/534119219/chicheng-push) — DSH 多渠道消息推送插件：支持 Server酱、PushPlus、Bark、钉钉、企业微信、Telegram、飞书、ntfy、自定义 Webhook 等，可在设置面板配置多个渠道，并通过 pushNotifier 服务供其他插件调用。
 - [534119219/dsh-messaging](https://github.com/534119219/dsh-messaging) — DeepSeek Harness 的统一消息网关：一个插件接入 27 个 IM 平台（Telegram、QQ、微信、Discord、WhatsApp、飞书等），支持扫码授权、每平台独立工作区、斜杠命令与 Web 配置弹窗。
 - [AbcdefgXW/dsh-msg-hub](https://github.com/AbcdefgXW/dsh-msg-hub) — IM 渠道桥：微信（ilinkai）/ QQ / 飞书接入，支持主动推送——定时任务可唤醒渠道 bot 并把 AI 回复推送到手机。
 - [alvinunreal/openpets#dsh](https://github.com/alvinunreal/openpets/tree/main/packages/dsh) — 将 DeepSeek Harness 的生命周期状态、错误与审批请求，桥接到本地运行的 OpenPets 桌面伙伴。

--- a/data/plugins/534119219__chicheng-push.yml
+++ b/data/plugins/534119219__chicheng-push.yml
@@ -1,0 +1,6 @@
+url: https://github.com/534119219/chicheng-push
+name: 534119219/chicheng-push
+category: notify
+description:
+  en: 'Multi-channel push for DeepSeek Harness: Server酱, PushPlus, Bark, DingTalk, WeCom, Telegram, Feishu, ntfy, custom webhooks and more, configurable from the settings panel and callable by other plugins via the pushNotifier service.'
+  zh: 'DSH 多渠道消息推送插件：支持 Server酱、PushPlus、Bark、钉钉、企业微信、Telegram、飞书、ntfy、自定义 Webhook 等，可在设置面板配置多个渠道，并通过 pushNotifier 服务供其他插件调用。'

--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -2,10 +2,6 @@
  "https://github.com/030611/qiushi-dsh-evidence-audit": [
   "https://raw.githubusercontent.com/030611/qiushi-dsh-evidence-audit/main/docs/evidence-flow.svg"
  ],
- "https://github.com/7dgroup-ai/dsh-skill-7d-code-reviewer": [
-  "https://raw.githubusercontent.com/7dgroup-ai/dsh-skill-7d-code-reviewer/main/screenshots/skills.png",
-  "https://raw.githubusercontent.com/7dgroup-ai/dsh-skill-7d-code-reviewer/main/screenshots/report-preview.png"
- ],
  "https://github.com/263311487-ux/dsh-verify": [
   "https://raw.githubusercontent.com/263311487-ux/dsh-verify/main/assets/report-screenshot.png",
   "https://raw.githubusercontent.com/263311487-ux/dsh-verify/main/assets/visual-diff.png"
@@ -35,12 +31,25 @@
   "https://raw.githubusercontent.com/534119219/chicheng-gate/main/assets/mobile-ui-2.png",
   "https://raw.githubusercontent.com/534119219/chicheng-gate/main/assets/mobile-ui-3.png"
  ],
+ "https://github.com/534119219/chicheng-push": [
+  "https://raw.githubusercontent.com/534119219/chicheng-push/master/assets/screenshot-settings-entry.png",
+  "https://raw.githubusercontent.com/534119219/chicheng-push/master/assets/screenshot-channel-list.png",
+  "https://raw.githubusercontent.com/534119219/chicheng-push/master/assets/screenshot-add-channel.png"
+ ],
  "https://github.com/534119219/chicheng-stats": [
   "https://raw.githubusercontent.com/534119219/chicheng-stats/main/assets/card-mode.png",
   "https://raw.githubusercontent.com/534119219/chicheng-stats/main/assets/text-mode.png",
   "https://raw.githubusercontent.com/534119219/chicheng-stats/main/assets/usage-dialog.png",
   "https://raw.githubusercontent.com/534119219/chicheng-stats/main/assets/card-settings.png",
   "https://raw.githubusercontent.com/534119219/chicheng-stats/main/assets/text-settings.png"
+ ],
+ "https://github.com/534119219/dsh-messaging": [
+  "https://raw.githubusercontent.com/534119219/dsh-messaging/main/assets/sidebar.png",
+  "https://raw.githubusercontent.com/534119219/dsh-messaging/main/assets/dialog.png"
+ ],
+ "https://github.com/7dgroup-ai/dsh-skill-7d-code-reviewer": [
+  "https://raw.githubusercontent.com/7dgroup-ai/dsh-skill-7d-code-reviewer/main/screenshots/skills.png",
+  "https://raw.githubusercontent.com/7dgroup-ai/dsh-skill-7d-code-reviewer/main/screenshots/report-preview.png"
  ],
  "https://github.com/AI-Galaxy-GPU/dsh-sound": [
   "https://raw.githubusercontent.com/AI-Galaxy-GPU/dsh-sound/main/assets/screenshots/sound-image.png"
@@ -93,6 +102,9 @@
  ],
  "https://github.com/DocJlm/dsh-arknights/tree/main/skins/pramanix-eyjafjalla": [
   "https://raw.githubusercontent.com/DocJlm/dsh-arknights/main/skins/pramanix-eyjafjalla/preview/cover.webp"
+ ],
+ "https://github.com/Eve-146T/DSH-CODEX-SUBSCRIPTION-POOL": [
+  "https://raw.githubusercontent.com/Eve-146T/DSH-CODEX-SUBSCRIPTION-POOL/main/assets/readme/accounts-demo.png"
  ],
  "https://github.com/FengHuoLinShan/dsh-plugin-llm-balance": [
   "https://raw.githubusercontent.com/FengHuoLinShan/dsh-plugin-llm-balance/main/assets/llm-balance-preview.png"
@@ -331,6 +343,10 @@
   "https://raw.githubusercontent.com/biociao/dsh-science/main/assets/screenshots/plugin-inventory.png",
   "https://raw.githubusercontent.com/biociao/dsh-science/main/assets/screenshots/topology.png"
  ],
+ "https://github.com/chouyong/dsh-branch-review": [
+  "https://raw.githubusercontent.com/chouyong/dsh-branch-review/main/assets/branch-review-desktop.png",
+  "https://raw.githubusercontent.com/chouyong/dsh-branch-review/main/assets/branch-review-decisions.png"
+ ],
  "https://github.com/chouyong/dsh-fork-diff": [
   "https://raw.githubusercontent.com/chouyong/dsh-fork-diff/main/assets/fork-diff-desktop.png",
   "https://raw.githubusercontent.com/chouyong/dsh-fork-diff/main/assets/fork-diff-selector.png",
@@ -339,10 +355,6 @@
  "https://github.com/chouyong/dsh-fork-graph": [
   "https://raw.githubusercontent.com/chouyong/dsh-fork-graph/main/assets/screenshot-trigger.png",
   "https://raw.githubusercontent.com/chouyong/dsh-fork-graph/main/assets/screenshot-panel.png"
- ],
- "https://github.com/chouyong/dsh-branch-review": [
-  "https://raw.githubusercontent.com/chouyong/dsh-branch-review/main/assets/branch-review-desktop.png",
-  "https://raw.githubusercontent.com/chouyong/dsh-branch-review/main/assets/branch-review-decisions.png"
  ],
  "https://github.com/cirelir/dsh-change-review": [
   "https://raw.githubusercontent.com/cirelir/dsh-change-review/main/assets/screenshots/review-tab.png",
@@ -447,6 +459,9 @@
   "https://raw.githubusercontent.com/imkingjh999/dsh-shorts-wall/main/docs/screenshot-stick.png",
   "https://raw.githubusercontent.com/imkingjh999/dsh-shorts-wall/main/docs/screenshot-float.png",
   "https://raw.githubusercontent.com/imkingjh999/dsh-shorts-wall/main/docs/screenshot-minimized.png"
+ ],
+ "https://github.com/izwarm195/dsh-net-tools": [
+  "https://raw.githubusercontent.com/izwarm195/dsh-net-tools/main/assets/net_fetch-demo.png"
  ],
  "https://github.com/jiezeng2004-design/dsh-chatgpt-bridge": [
   "https://raw.githubusercontent.com/jiezeng2004-design/dsh-chatgpt-bridge/main/assets/screenshots/01-human-in-the-loop.png",
@@ -685,6 +700,11 @@
   "https://raw.githubusercontent.com/yunxiiQwQ/dsh-maid-whale-webUI/main/maid-whale-webui/preview/light.webp",
   "https://raw.githubusercontent.com/yunxiiQwQ/dsh-maid-whale-webUI/main/maid-whale-webui/preview/dark.webp"
  ],
+ "https://github.com/yyyyukari/dsh-plugin-workshop": [
+  "https://raw.githubusercontent.com/yyyyukari/dsh-plugin-workshop/master/assets/main-ui.jpg",
+  "https://raw.githubusercontent.com/yyyyukari/dsh-plugin-workshop/master/assets/installed-view.jpg",
+  "https://raw.githubusercontent.com/yyyyukari/dsh-plugin-workshop/master/assets/sidebar-entry.jpg"
+ ],
  "https://github.com/zdx8637-gitdog/dshmobile/tree/main/plugins/dshmobile-plugin": [
   "https://raw.githubusercontent.com/zdx8637-gitdog/dshmobile/main/docs/images/plugin-panel.jpg",
   "https://raw.githubusercontent.com/zdx8637-gitdog/dshmobile/main/docs/images/phone-1.jpg",
@@ -703,20 +723,5 @@
   "https://raw.githubusercontent.com/zljr/dsh-share/master/assets/share-dialog.png",
   "https://raw.githubusercontent.com/zljr/dsh-share/master/assets/share-page-light.png",
   "https://raw.githubusercontent.com/zljr/dsh-share/master/assets/share-page-dark.png"
- ],
- "https://github.com/Eve-146T/DSH-CODEX-SUBSCRIPTION-POOL": [
-  "https://raw.githubusercontent.com/Eve-146T/DSH-CODEX-SUBSCRIPTION-POOL/main/assets/readme/accounts-demo.png"
- ],
- "https://github.com/534119219/dsh-messaging": [
-  "https://raw.githubusercontent.com/534119219/dsh-messaging/main/assets/sidebar.png",
-  "https://raw.githubusercontent.com/534119219/dsh-messaging/main/assets/dialog.png"
- ],
- "https://github.com/yyyyukari/dsh-plugin-workshop": [
-  "https://raw.githubusercontent.com/yyyyukari/dsh-plugin-workshop/master/assets/main-ui.jpg",
-  "https://raw.githubusercontent.com/yyyyukari/dsh-plugin-workshop/master/assets/installed-view.jpg",
-  "https://raw.githubusercontent.com/yyyyukari/dsh-plugin-workshop/master/assets/sidebar-entry.jpg"
- ],
- "https://github.com/izwarm195/dsh-net-tools": [
-  "https://raw.githubusercontent.com/izwarm195/dsh-net-tools/main/assets/net_fetch-demo.png"
  ]
 }


### PR DESCRIPTION
### 提交内容 / What's in this PR

新增 data/plugins/534119219__chicheng-push.yml，收录 [chicheng-push](https://github.com/534119219/chicheng-push) 插件。

Adds data/plugins/534119219__chicheng-push.yml for the [chicheng-push](https://github.com/534119219/chicheng-push) plugin.

- [x] 新增一个 YAML 文件（README 由脚本生成，已重新生成并提交）
- [x] 仓库 package.json 声明 dsh.bundle（含 cordis.patch.yml）
- [x] 仓库创建满 1 天、提交数 ≥ 10（18 commits）
- [x] category: 
otify
- [x] 仓库已添加 dsh-plugin topic
- [x] 描述只说功能
- [x] data/screenshots.json 已附加 3 张截图（设置入口 / 渠道列表 / 添加渠道）