### PR TITLE
Add screenshots for dsh-plugin-terminal

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -544,6 +544,11 @@
  "https://github.com/sanqiPanax/dsh-sticker-board": [
   "https://raw.githubusercontent.com/sanqiPanax/dsh-sticker-board/master/docs/screenshot-dock.png"
  ],
+ "https://github.com/siberiah2o/dsh-plugin-terminal": [
+  "https://raw.githubusercontent.com/siberiah2o/dsh-plugin-terminal/main/docs/screenshot-collapsed.png",
+  "https://raw.githubusercontent.com/siberiah2o/dsh-plugin-terminal/main/docs/screenshot-panel.png",
+  "https://raw.githubusercontent.com/siberiah2o/dsh-plugin-terminal/main/docs/screenshot-multitab.png"
+ ],
  "https://github.com/sjh9714/dsh-movein": [
   "https://raw.githubusercontent.com/sjh9714/dsh-movein/main/docs/report.png",
   "https://raw.githubusercontent.com/sjh9714/dsh-movein/main/docs/demo.gif",


### PR DESCRIPTION
Add 3 curated screenshots (collapsed / expanded / multi-tab) for the dsh-plugin-terminal entry, keyed by its entry URL in data/screenshots.json. Images are served from the plugin repo's docs/ folder (raw.githubusercontent.com), matching the README order.

为 dsh-plugin-terminal 条目添加 3 张精选截图（收起 / 展开 / 多标签），key 与其条目 URL 完全一致；图片来自插件仓库 docs/ 目录（GitHub 托管），顺序与 README 一致。