### PR TITLE
docs: add dsh-plugin-workshop screenshots

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -683,5 +683,10 @@
  "https://github.com/534119219/dsh-messaging": [
   "https://raw.githubusercontent.com/534119219/dsh-messaging/main/assets/sidebar.png",
   "https://raw.githubusercontent.com/534119219/dsh-messaging/main/assets/dialog.png"
+ ],
+ "https://github.com/yyyyukari/dsh-plugin-workshop": [
+  "https://raw.githubusercontent.com/yyyyukari/dsh-plugin-workshop/master/assets/main-ui.jpg",
+  "https://raw.githubusercontent.com/yyyyukari/dsh-plugin-workshop/master/assets/installed-view.jpg",
+  "https://raw.githubusercontent.com/yyyyukari/dsh-plugin-workshop/master/assets/sidebar-entry.jpg"
  ]
 }


### PR DESCRIPTION
Add 3 AppStore-style screenshots for dsh-plugin-workshop (sidebar entry, main browse UI, installed-plugins manager), keyed by its entry URL. Images are hosted in the plugin repo under `assets/`.