### PR TITLE
Add MichengAI/dsh-archive-manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,6 +443,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 - [lsz-asd/dsh-plugin-session-delete](https://github.com/lsz-asd/dsh-plugin-session-delete) - Delete DSH sessions from the web UI and desktop client: header danger button and session-row menu item with a risk-consent dialog; host endpoint and agent tool remove the session log, projection cache, and workspace accounting.
 - [Max-Null/dsh-chinese-thinking](https://github.com/Max-Null/dsh-chinese-thinking) - Injects one fixed system-prompt section so the agent thinks and replies in Chinese, regardless of the user's language.
 - [mayf3/dsh-session-doctor](https://github.com/mayf3/dsh-session-doctor) - Diagnose, unstick, and read DSH sessions: list sessions with agent status, read conversations, diagnose stuck agents, recover them with cancel+keepInbox, and send messages to other sessions.
+- [MichengAI/dsh-archive-manager](https://github.com/MichengAI/dsh-archive-manager) - Adds an archived-sessions page in Settings to search, restore, and delete archived DeepSeek Harness sessions by workspace.
 - [Moeblack/dsh-message-edit](https://github.com/Moeblack/dsh-message-edit) - Branch-based message editing, reroll, retry, and a version timeline.
 - [Moeblack/dsh-prompt-studio](https://github.com/Moeblack/dsh-prompt-studio) - Edit user and built-in system-prompt sections with live preview.
 - [MuWinds/dsh-archived-sessions](https://github.com/MuWinds/dsh-archived-sessions) - Archived-session management: browse archived sessions, unarchive them, or clear them out.

--- a/README.zh.md
+++ b/README.zh.md
@@ -443,6 +443,7 @@ dsh plugin --profile web add dshmarket
 - [lsz-asd/dsh-plugin-session-delete](https://github.com/lsz-asd/dsh-plugin-session-delete) — 在 Web UI 与桌面客户端中删除 DSH 会话：头部危险按钮 + 会话行菜单项，风险确认弹窗，宿主端点与 agent 工具同步清理会话日志、投影缓存与工作区记账。
 - [Max-Null/dsh-chinese-thinking](https://github.com/Max-Null/dsh-chinese-thinking) — 注入一条固定 system-prompt 段落，让 Agent 无论用户使用什么语言都始终用中文思考和回复。
 - [mayf3/dsh-session-doctor](https://github.com/mayf3/dsh-session-doctor) — 会话医生：列出会话（含 agent 运行状态）、读取会话记录、诊断卡死的 agent、解卡（cancel + keepInbox 保留排队消息）、向其他会话发送消息。
+- [MichengAI/dsh-archive-manager](https://github.com/MichengAI/dsh-archive-manager) — 在设置里增加已归档会话页，可按工作区搜索、恢复和删除已归档会话。
 - [Moeblack/dsh-message-edit](https://github.com/Moeblack/dsh-message-edit) — 基于分支的消息编辑、reroll、重试与版本时间线。
 - [Moeblack/dsh-prompt-studio](https://github.com/Moeblack/dsh-prompt-studio) — 带实时预览的用户/内置 system prompt 分节编辑器。
 - [MuWinds/dsh-archived-sessions](https://github.com/MuWinds/dsh-archived-sessions) — 归档会话管理：浏览已归档会话，支持恢复（取消归档）与清空。

--- a/data/plugins/MichengAI__dsh-archive-manager.yml
+++ b/data/plugins/MichengAI__dsh-archive-manager.yml
@@ -1,0 +1,6 @@
+url: https://github.com/MichengAI/dsh-archive-manager
+name: MichengAI/dsh-archive-manager
+category: session
+description:
+  en: Adds an archived-sessions page in Settings to search, restore, and delete archived DeepSeek Harness sessions by workspace.
+  zh: 在设置里增加已归档会话页，可按工作区搜索、恢复和删除已归档会话。


### PR DESCRIPTION
Adds [MichengAI/dsh-archive-manager](https://github.com/MichengAI/dsh-archive-manager) under Sessions & Messages.

Eligibility: dsh.bundle, cordis.patch.yml, 1+ day, 41+ commits, dsh-plugin topic, official packages as peerDependencies.

Validation: node scripts/generate-readme.mjs