### PR TITLE
feat: add dsh-dream-skin screenshots to screenshots.json

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -723,5 +723,9 @@
   "https://raw.githubusercontent.com/zljr/dsh-share/master/assets/share-dialog.png",
   "https://raw.githubusercontent.com/zljr/dsh-share/master/assets/share-page-light.png",
   "https://raw.githubusercontent.com/zljr/dsh-share/master/assets/share-page-dark.png"
+ ],
+ "https://github.com/RevolutionLA/dsh-dream-skin": [
+  "https://raw.githubusercontent.com/RevolutionLA/dsh-dream-skin/main/docs/screenshots/preview.png",
+  "https://raw.githubusercontent.com/RevolutionLA/dsh-dream-skin/main/docs/screenshots/settings.png"
  ]
 }


### PR DESCRIPTION
Respond to the maintainer's screenshots invite (from PR #354).

Add **dsh-dream-skin** to ["data/screenshots.json"](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/main/data/screenshots.json) so the dsh-market detail view shows AppStore-style screenshots, keyed by "https://github.com/RevolutionLA/dsh-dream-skin":

- "docs/screenshots/preview.png" — DSH interface with a skin applied
- "docs/screenshots/settings.png" — the Theme / 外观 settings section

Both are hosted in our own repo, so they update with releases.