### PR TITLE
Add zeng6125-rgb/dsh-llm-retry-settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -512,6 +512,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 - [WNJXYK/dsh-codex-oauth](https://github.com/WNJXYK/dsh-codex-oauth) - Use a ChatGPT/Codex subscription in DeepSeek Harness with GPT models, image generation, web search, subscription quota reporting, model and feature controls, and browser or device-code OAuth sign-in.
 - [WSL043/dsh-codex-subscription](https://github.com/WSL043/dsh-codex-subscription) - Built-in ChatGPT OAuth provider for Codex models, selectable subscription web search, backend quota for standard Codex and Spark, and a DSH settings UI; no API key or Codex CLI required.
 - [wss534857356/dsh-plugin-codex](https://github.com/wss534857356/dsh-plugin-codex) - Codex App Server model provider using a local Codex login, with session reuse, Harness tool bridging, native action traces, and durable generated-image projection.
+- [zeng6125-rgb/dsh-llm-retry-settings](https://github.com/zeng6125-rgb/dsh-llm-retry-settings) - Settings card to tune the DSH LLM auto-retry policy (retry count, backoff, jitter) live from Settings → General.
 
 ### Sessions & Messages
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -512,6 +512,7 @@ dsh plugin --profile web add dshmarket
 - [WNJXYK/dsh-codex-oauth](https://github.com/WNJXYK/dsh-codex-oauth) — 在 DeepSeek Harness 中使用 ChatGPT/Codex 订阅接入 GPT 模型、图像生成与 Web 搜索，并支持订阅额度显示、模型与功能控制，以及浏览器或设备码 OAuth 登录。
 - [WSL043/dsh-codex-subscription](https://github.com/WSL043/dsh-codex-subscription) — 内置 ChatGPT OAuth 的 Codex 模型提供方：可切换订阅联网搜索，在设置页显示普通 Codex 与 Spark 独立额度；无需 API Key 或 Codex CLI。
 - [wss534857356/dsh-plugin-codex](https://github.com/wss534857356/dsh-plugin-codex) — 使用本地 Codex 登录的 Codex App Server 模型提供方，支持会话复用、Harness 工具桥接、原生动作轨迹和生成图片持久化。
+- [zeng6125-rgb/dsh-llm-retry-settings](https://github.com/zeng6125-rgb/dsh-llm-retry-settings) — 在 DSH 设置里调整 LLM 自动重试的次数与退避时间并实时生效的设置卡片。
 
 ### 💬 会话与消息
 

--- a/data/plugins/zeng6125-rgb__dsh-llm-retry-settings.yml
+++ b/data/plugins/zeng6125-rgb__dsh-llm-retry-settings.yml
@@ -1,0 +1,6 @@
+url: https://github.com/zeng6125-rgb/dsh-llm-retry-settings
+name: zeng6125-rgb/dsh-llm-retry-settings
+category: model
+description:
+  en: Settings card to tune the DSH LLM auto-retry policy (retry count, backoff, jitter) live from Settings → General.
+  zh: 在 DSH 设置里调整 LLM 自动重试的次数与退避时间并实时生效的设置卡片。


### PR DESCRIPTION
Add `zeng6125-rgb/dsh-llm-retry-settings` (category: model) - a settings card to tune the DSH LLM auto-retry policy (retry count, backoff, jitter) live from Settings ? General. READMEs regenerated with `node scripts/generate-readme.mjs`.