### PR TITLE
Add opencues/opencues#integrations-dsh

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 - [omdsh-dev/ex-setting](https://github.com/omdsh-dev/ex-setting) - Settings extensions for DSH.
 - [omdsh-dev/web-components](https://github.com/omdsh-dev/web-components) - Web Components support.
 - [openAGFS/dsh-agfs](https://github.com/openAGFS/dsh-agfs) - File-browser web app for DSH: React frontend and REST API served by the host webserver, a /dsh-agfs command that opens at the current session workspace, and a browse_files model tool.
+- [opencues/opencues#integrations-dsh](https://github.com/opencues/opencues/tree/master/integrations/dsh) - Word alternatives and underscore-gated fill-ins in the composer. End a line with _ and it is filled; misspellings are flagged as you type. Routes through the model dsh is already configured with, so it needs no API key.
 - [openma-ai/deepseek-harness-tui](https://github.com/openma-ai/deepseek-harness-tui) - A Rust/ratatui terminal client that speaks the DSH SDK JSON-RPC protocol directly and runs standalone or as a profile bundle.
 - [pc439527/dsh-side-monitor](https://github.com/pc439527/dsh-side-monitor) - Sidebar system monitor for the DSH Web UI: live host overview (CPU/memory/network/disk), process list, and Docker container status, all read-only.
 - [penguin-oo/dsh-pathlink](https://github.com/penguin-oo/dsh-pathlink) - Ctrl+click file paths and links in chat: paths open their folder in the OS file manager (with the file selected), links open in a new browser tab.

--- a/README.zh.md
+++ b/README.zh.md
@@ -165,6 +165,7 @@ dsh plugin --profile web add dshmarket
 - [omdsh-dev/ex-setting](https://github.com/omdsh-dev/ex-setting) — DSH 的设置扩展。
 - [omdsh-dev/web-components](https://github.com/omdsh-dev/web-components) — Web Components 支持。
 - [openAGFS/dsh-agfs](https://github.com/openAGFS/dsh-agfs) — 文件浏览器 Web 应用：React 前端与 REST API 由宿主 webserver 托管，/dsh-agfs 命令自动定位当前工作区，附 browse_files 模型工具。
+- [opencues/opencues#integrations-dsh](https://github.com/opencues/opencues/tree/master/integrations/dsh) — Word alternatives and underscore-gated fill-ins in the composer. End a line with _ and it is filled; misspellings are flagged as you type. Routes through the model dsh is already configured with, so it needs no API key.
 - [openma-ai/deepseek-harness-tui](https://github.com/openma-ai/deepseek-harness-tui) — Rust/ratatui 终端客户端，直接使用 DSH SDK JSON-RPC 协议，支持独立运行或作为 profile bundle 加载。
 - [pc439527/dsh-side-monitor](https://github.com/pc439527/dsh-side-monitor) — 侧边栏系统监控：实时查看宿主机概览（CPU/内存/网络/磁盘）、进程列表与 Docker 容器状态，全程只读。
 - [penguin-oo/dsh-pathlink](https://github.com/penguin-oo/dsh-pathlink) — 在对话中 Ctrl+点击文件路径与链接：路径在文件管理器中定位所在文件夹，链接在新标签页打开。

--- a/data/plugins/opencues__opencues--integrations-dsh.yml
+++ b/data/plugins/opencues__opencues--integrations-dsh.yml
@@ -1,0 +1,5 @@
+url: https://github.com/opencues/opencues/tree/master/integrations/dsh
+name: opencues/opencues#integrations-dsh
+category: ui
+description:
+  en: Word alternatives and underscore-gated fill-ins in the composer. End a line with _ and it is filled; misspellings are flagged as you type. Routes through the model dsh is already configured with, so it needs no API key.


### PR DESCRIPTION
Adds OpenCues for DeepSeek Harness.

**What it does:** word alternatives and underscore-gated fill-ins in the composer. You end a line with `_` and it gets filled; misspellings are flagged as you type. It needs no API key of its own, because it routes through `ctx.llm` — the model dsh is already configured with.

**Install:** `dsh plugin --profile web add @opencues/dsh`

Published to npm with the browser bundle prebuilt, so installs skip the `allowBuilds` build-approval step.

Against the stated requirements:

- **`dsh.bundle` declared** — the manifest declares `bundle` (the `cordis.patch.yml` layer) *and* `client`, not `client` alone.
- **Monorepo subpackage** — `url` points at the subdirectory, `name` is `owner/repo#subname`, filename is `opencues__opencues--integrations-dsh.yml`, per contributing.md.
- **Age / activity** — the repo is long-standing and actively maintained; the dsh integration itself merged today.
- **Real working code** — verified end to end against the *published* package on a clean machine state: fresh `HOME`, no `.cues` config, and every OpenCues provider key removed from the environment. `dsh plugin --profile web add @opencues/dsh` installs in seconds with no build prompt, and `the capital of iceland is _` fills to `Reykjavik` on DeepSeek's own model.
- **`zh` omitted** — happy to add a translation if you would rather I did, rather than leave it to a maintainer.

READMEs regenerated with `npm ci && node scripts/generate-readme.mjs` (1248 entries); the only diff is the one added line in each.