### PR TITLE
Add dsh-character-profiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -628,6 +628,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 - [lzszq/dsh-scholar](https://github.com/lzszq/dsh-scholar) - Academic assistant plugin.
 - [mafeis/dsh-net-proxy](https://github.com/mafeis/dsh-net-proxy) - Route agent network requests through a local HTTP/CONNECT/SOCKS5 proxy.
 - [MAXeaglet/dsh-bash-terminal](https://github.com/MAXeaglet/dsh-bash-terminal) - One shell tool for PowerShell / Git Bash / WSL on Windows plus an interactive PTY terminal; the default terminal is chosen by the user in DSH settings.
+- [MlittleFriend/dsh-character-profiler](https://github.com/MlittleFriend/dsh-character-profiler) - Character consistency toolkit: personality profile cards, appearance-weight stats, and behavioral-drift detection for long-form fiction.
 - [moononnn/DeepSeek-Harness-biaoqingbao](https://github.com/moononnn/DeepSeek-Harness-biaoqingbao) - Sticker/emoji expression for assistants: emotion-driven auto-matching, library management, AI image tagging, dialects, style mimicry, and chat-based tag refinement.
 - [omdsh-dev/dsh-custom-tool](https://github.com/omdsh-dev/dsh-custom-tool) - Create and manage sandboxed JavaScript tools with a Monaco editor and model-driven tool lifecycle.
 - [omdsh-dev/dsh-data-agent](https://github.com/omdsh-dev/dsh-data-agent) - Let the AI connect to databases and write SQL for you.

--- a/README.zh.md
+++ b/README.zh.md
@@ -628,6 +628,7 @@ dsh plugin --profile web add dshmarket
 - [lzszq/dsh-scholar](https://github.com/lzszq/dsh-scholar) — 学术助手插件。
 - [mafeis/dsh-net-proxy](https://github.com/mafeis/dsh-net-proxy) — 让 agent 的网络请求走本机 HTTP/CONNECT/SOCKS5 代理。
 - [MAXeaglet/dsh-bash-terminal](https://github.com/MAXeaglet/dsh-bash-terminal) — 一个 shell 工具：Windows 上统一执行 PowerShell / Git Bash / WSL，外加交互式 PTY 终端，默认终端由用户在设置中选择。
+- [MlittleFriend/dsh-character-profiler](https://github.com/MlittleFriend/dsh-character-profiler) — 角色一致性工具包：性格侧写档案、出场权重统计与行为偏离检测。
 - [moononnn/DeepSeek-Harness-biaoqingbao](https://github.com/moononnn/DeepSeek-Harness-biaoqingbao) — 表情包表达插件：让助手用表情包表达情绪，按情绪自动配图，含图库管理、AI 识图打标、方言口音、学我说话，还能点「和助手聊聊」直接调教标签。
 - [omdsh-dev/dsh-custom-tool](https://github.com/omdsh-dev/dsh-custom-tool) — 用 Monaco 编辑器创建和管理沙箱化的自定义 JavaScript 工具。
 - [omdsh-dev/dsh-data-agent](https://github.com/omdsh-dev/dsh-data-agent) — 让 AI 帮你连数据库、写 SQL。

--- a/data/plugins/MlittleFriend__dsh-character-profiler.yml
+++ b/data/plugins/MlittleFriend__dsh-character-profiler.yml
@@ -1,0 +1,6 @@
+url: https://github.com/MlittleFriend/dsh-character-profiler
+name: MlittleFriend/dsh-character-profiler
+category: tools
+description:
+  en: 'Character consistency toolkit: personality profile cards, appearance-weight stats, and behavioral-drift detection for long-form fiction.'
+  zh: '角色一致性工具包：性格侧写档案、出场权重统计与行为偏离检测。'


### PR DESCRIPTION
## What

Adds [dsh-character-profiler](https://github.com/MlittleFriend/dsh-character-profiler) to the **Tools & Capabilities** category.

A character-consistency toolkit for long-form fiction: `novel_profile` (personality profile cards), `novel_appearance` (appearance weight & share stats), `novel_deviation` (behavioral-drift detection), and `novel_profiler_status`.

Declares a `dsh.bundle` manifest, MIT license, 11 commits, CI green.