### PR TITLE
feat: list Bob-Bo1 Obsidian workbench plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1042,6 +1042,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 - [AKS1st/dsh-mermaid](https://github.com/AKS1st/dsh-mermaid) - Render Mermaid code fences in DSH Web chat messages as lazy-loaded SVG diagrams with strict sanitization and light/dark theme follow.
 - [baconbao/dsh-mermaid-image-preview](https://github.com/baconbao/dsh-mermaid-image-preview) - Preview Mermaid diagrams as images via local rendering in DSH Web when the chat message contains a Mermaid fenced code block, and also allow integration with external rendering servers.
 - [bill9109/dsh-101](https://github.com/bill9109/dsh-101) - Document reading mode for DSH.
+- [Bob-Bo1/obsidian-workbench](https://github.com/Bob-Bo1/obsidian-workbench) - Obsidian-style Markdown workbench for DSH: browse, edit, preview, create, move, and delete notes inside the selected local vault.
 - [didclawapp-ai/DSH-Office](https://github.com/didclawapp-ai/DSH-Office) - Create, read, and edit PPTX, DOCX, XLSX, and PDF via the local zagens-office CLI as office_schema / office_write / office_edit / office_read tools.
 - [dream-num/dsh-univer-office](https://github.com/dream-num/dsh-univer-office) - Create, edit, inspect, and deliver spreadsheets, documents, presentations, databases, and canvases in DeepSeek Harness, with live preview and worktree review.
 - [duyanta123/arch-doc](https://github.com/duyanta123/arch-doc) - Analyze a codebase and generate architecture documentation: module responsibilities, dependencies, entry points and run methods.

--- a/README.zh.md
+++ b/README.zh.md
@@ -1042,6 +1042,7 @@ dsh plugin --profile web add dshmarket
 - [AKS1st/dsh-mermaid](https://github.com/AKS1st/dsh-mermaid) — 把 DSH Web 会话消息中的 Mermaid 代码围栏渲染为惰性加载的 SVG 图表，严格消毒并跟随明暗主题。
 - [baconbao/dsh-mermaid-image-preview](https://github.com/baconbao/dsh-mermaid-image-preview) — 当 DSH Web 中的消息包含 Mermaid 语法时，通过本地渲染以图像形式预览 Mermaid Diagrams，并允许接入外部渲染服务器。
 - [bill9109/dsh-101](https://github.com/bill9109/dsh-101) — DSH 文档阅读模式。
+- [Bob-Bo1/obsidian-workbench](https://github.com/Bob-Bo1/obsidian-workbench) — DSH 内的 Obsidian 风格 Markdown 工作台：浏览、编辑、预览、创建、移动和删除所选本地仓库中的笔记。
 - [didclawapp-ai/DSH-Office](https://github.com/didclawapp-ai/DSH-Office) — 通过本机 zagens-office CLI 读写编辑 PPTX / DOCX / XLSX / PDF，注册为 office_schema / office_write / office_edit / office_read。
 - [dream-num/dsh-univer-office](https://github.com/dream-num/dsh-univer-office) — 在 DeepSeek Harness 中创建、编辑、检查和交付表格、文档、演示文稿、多维表格和画布，支持实时预览与 worktree 审阅。
 - [duyanta123/arch-doc](https://github.com/duyanta123/arch-doc) — 分析代码库并生成架构文档：模块职责、依赖关系、入口点与运行方式。

--- a/data/plugins/Bob-Bo1__obsidian-workbench.yml
+++ b/data/plugins/Bob-Bo1__obsidian-workbench.yml
@@ -1,0 +1,6 @@
+url: https://github.com/Bob-Bo1/obsidian-workbench
+name: Bob-Bo1/obsidian-workbench
+category: docs
+description:
+  en: 'Obsidian-style Markdown workbench for DSH: browse, edit, preview, create, move, and delete notes inside the selected local vault.'
+  zh: 'DSH 内的 Obsidian 风格 Markdown 工作台：浏览、编辑、预览、创建、移动和删除所选本地仓库中的笔记。'


### PR DESCRIPTION
## Plugin

- Repository: https://github.com/Bob-Bo1/obsidian-workbench
- Category: docs
- Description: Obsidian-style Markdown workbench for DSH: browse, edit, preview, create, move, and delete notes inside the selected local vault.

## Checks

- Added the required `dsh.bundle` manifest and `dsh-plugin` topic in the plugin repository.
- Added one plugin YAML entry under `data/plugins/`.
- Regenerated `README.md` and `README.zh.md` with `node scripts/generate-readme.mjs`.
- Verified the generator check and `git diff --check` locally.
