### PR TITLE
fix: point DIT plugin entry to public repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,6 +453,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 
 - [BruceLanLan/dsh-tier-router](https://github.com/BruceLanLan/dsh-tier-router) - Two-tier model routing: a strong tier plans, advises and reviews while a cheap tier implements, with plan-mode-aware auto routing, a high-impact escalation guard, failure auto-escalation, and subagent tiering.
 - [btspoony/dsh-llm-fallbacks](https://github.com/btspoony/dsh-llm-fallbacks) - Role-based LLM retry & fallback strategies.
+- [cuboteam/dsh-plugin-dit](https://github.com/cuboteam/dsh-plugin-dit) - DIT.ai provider bundle for DeepSeek Harness: installs 29 OpenAI Chat Completions models and 10 Anthropic Messages models from one DIT_API_KEY, with protocol-specific thinking configuration.
 - [dawnliming/dsh-chinese-mode](https://github.com/dawnliming/dsh-chinese-mode) - Global Chinese mode: a compact pill switch beside the composer that injects a language requirement into any preset's system prompt (complete personas excepted); reply, thinking and tool output each toggle between Chinese and English, and anchored presets are supported.
 - [dingminhua/dsh-subagent-default-model#plugin](https://github.com/dingminhua/dsh-subagent-default-model/tree/main/plugin) - Configurable default model for subagent delegations via settings.yaml, with single-model and multi-model round-robin or random strategies.
 - [dylan121322/llm-adaptive](https://github.com/dylan121322/llm-adaptive) - Adaptive model routing: per-request complexity classification with automatic provider routing.

--- a/README.zh.md
+++ b/README.zh.md
@@ -453,6 +453,7 @@ dsh plugin --profile web add dshmarket
 
 - [BruceLanLan/dsh-tier-router](https://github.com/BruceLanLan/dsh-tier-router) — 双档模型路由：强档负责规划/咨询/评审、弱档负责实现；含计划模式自动路由、高危操作守卫、失败自动升级与子代理分层。
 - [btspoony/dsh-llm-fallbacks](https://github.com/btspoony/dsh-llm-fallbacks) — 基于角色的模型重试与备用策略。
+- [cuboteam/dsh-plugin-dit](https://github.com/cuboteam/dsh-plugin-dit) — DIT.ai 的 DeepSeek Harness 模型接入 bundle：使用一个 DIT_API_KEY 安装 29 个 OpenAI Chat Completions 模型和 10 个 Anthropic Messages 模型，并按协议配置 thinking。
 - [dawnliming/dsh-chinese-mode](https://github.com/dawnliming/dsh-chinese-mode) — 全局中文模式：输入框旁的紧凑胶囊开关，开启后向任意预设（完整 persona 除外）的系统提示注入语言要求；回复、思考、工具区域可分别切换中英文，并兼容锚定预设。
 - [dingminhua/dsh-subagent-default-model#plugin](https://github.com/dingminhua/dsh-subagent-default-model/tree/main/plugin) — 通过 settings.yaml 为子代理派发配置默认模型，支持单模型与多模型轮换/随机分配策略。
 - [dylan121322/llm-adaptive](https://github.com/dylan121322/llm-adaptive) — 自适应模型路由：请求级复杂度分类，按配置链自动选择后端 provider。

--- a/data/plugins/cuboteam__dsh-plugin-dit.yml
+++ b/data/plugins/cuboteam__dsh-plugin-dit.yml
@@ -1,0 +1,6 @@
+url: https://github.com/cuboteam/dsh-plugin-dit
+name: cuboteam/dsh-plugin-dit
+category: model
+description:
+  en: 'DIT.ai provider bundle for DeepSeek Harness: installs 29 OpenAI Chat Completions models and 10 Anthropic Messages models from one DIT_API_KEY, with protocol-specific thinking configuration.'
+  zh: 'DIT.ai 的 DeepSeek Harness 模型接入 bundle：使用一个 DIT_API_KEY 安装 29 个 OpenAI Chat Completions 模型和 10 个 Anthropic Messages 模型，并按协议配置 thinking。'


### PR DESCRIPTION
## Summary

Update the existing `dsh-plugin-dit` directory entry to its new standalone public source repository: https://github.com/cuboteam/dsh-plugin-dit.

The previous URL pointed to a package directory inside the private `cuboteam/Dit` monorepo and returned 404 for community users. The npm package name, feature set, and ownership are unchanged. This is a source-location migration of the already-listed entry, not a new plugin submission.

## Validation

- Regenerated both READMEs from `data/plugins`
- `node scripts/generate-readme.mjs --check`
- `npx awesome-lint`
- `node scripts/build-site.mjs`
- Standalone repository CI covers bundle tests, both Harness transports, and `npm pack --dry-run`

Note: renaming the data file is required by the repository filename validator. If the submission gate treats it as newly added because of the filename change, please review it as a migration of the existing accepted entry.