### PR TITLE
Add 1Mlightyears/dsh-theme-synthwave

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,6 +399,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 ### Themes & Appearance
 
 - [0nt-one/dsh-neo-skin](https://github.com/0nt-one/dsh-neo-skin) - Neo-brutalism skin with two switchable schemes (Blue Command / Aged Newspaper), hard shadows, sharp corners, and light/dark theme support.
+- [1MLightyears/dsh-theme-synthwave](https://github.com/1MLightyears/dsh-theme-synthwave) - A Synthwave theme plugin for the DSH (DeepSeek Harness) Web UI. Supports background images merrygo/video/blur.
 - [aerince/dsh-models-dev-reasoning](https://github.com/aerince/dsh-models-dev-reasoning) - Adds models.dev reasoning levels to unconfigured third-party DeepSeek Harness models.
 - [AKS1st/dsh-cyber-particle](https://github.com/AKS1st/dsh-cyber-particle) - Particle-network background overlay for the DSH Web shell: full-screen, click-through, zero runtime dependencies.
 - [AKS1st/ikun-theme-skin](https://github.com/AKS1st/ikun-theme-skin) - IKUN fandom skin for the DSH Web UI: star-blue and black-gold palettes in the system theme list, full-screen photo wallpaper rotation, a music box, and a send-button voice line.

--- a/README.zh.md
+++ b/README.zh.md
@@ -399,6 +399,7 @@ dsh plugin --profile web add dshmarket
 ### 🎭 主题与外观
 
 - [0nt-one/dsh-neo-skin](https://github.com/0nt-one/dsh-neo-skin) — 新粗野主义换肤皮肤：双方案（蓝统治 / 做旧报纸）随时切换，硬阴影 + 直角 + 2px 边框结构层，浅色/深色自适应。
+- [1MLightyears/dsh-theme-synthwave](https://github.com/1MLightyears/dsh-theme-synthwave) — 给 DSH（DeepSeek Harness）Web UI 用的合成波 / Synthwave 主题插件。支持背景图轮播/视频/模糊。
 - [aerince/dsh-models-dev-reasoning](https://github.com/aerince/dsh-models-dev-reasoning) — 为未配置的第三方 DeepSeek Harness 模型添加 models.dev 推理级别支持。
 - [AKS1st/dsh-cyber-particle](https://github.com/AKS1st/dsh-cyber-particle) — 为 DSH Web 界面提供粒子网络动态背景：全屏覆盖、点击穿透、零运行时依赖。
 - [AKS1st/ikun-theme-skin](https://github.com/AKS1st/ikun-theme-skin) — ikun 主题皮肤：星蓝昼/夜与背带裤黑金三套配色接入系统主题列表，全屏照片壁纸轮播、音乐盒与发送音效。

--- a/data/plugins/1MLightyears__dsh-theme-synthwave.yml
+++ b/data/plugins/1MLightyears__dsh-theme-synthwave.yml
@@ -1,0 +1,6 @@
+url: https://github.com/1MLightyears/dsh-theme-synthwave
+name: 1MLightyears/dsh-theme-synthwave
+category: theme
+description:
+  en: A Synthwave theme plugin for the DSH (DeepSeek Harness) Web UI. Supports background images merrygo/video/blur.
+  zh: 给 DSH（DeepSeek Harness）Web UI 用的合成波 / Synthwave 主题插件。支持背景图轮播/视频/模糊。

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
     },
     "node_modules/js-yaml": {
       "version": "5.3.0",
-      "resolved": "https://registry.npmmirror.com/js-yaml/-/js-yaml-5.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.3.0.tgz",
       "integrity": "sha512-muutsYr+e2+d3rTgUGslq5rxbBlUy3cJ61IsHag2QNDQV+7zXWjkUpmALIajhrlLlrgRUiymj6U3zUr/TMK84Q==",
       "dev": true,
       "funding": [


### PR DESCRIPTION
<!-- Thanks for contributing! Quick checklist / 提交前快速自查 -->

- [x] I added **one file** at `data/plugins/<owner>__<repo>.yml` — the READMEs are generated, don't edit them by hand / 我新增了一个 `data/plugins/<owner>__<repo>.yml` 文件（各语言 README 由脚本生成，不要手工编辑）
- [x] I ran `node scripts/generate-readme.mjs` and committed the regenerated READMEs / 我已执行 `node scripts/generate-readme.mjs` 并提交了重新生成的 README
- [x] My repo's `package.json` declares **`dsh.bundle`** (not just `dsh.client`) — [example](../blob/main/contributing.md) / 仓库 `package.json` 已声明 `dsh.bundle`（只有 `dsh.client` 无法安装）
- [ ] My repo is at least **1 day old** with **10+ commits** / 仓库创建满 1 天且提交数 ≥ 10
- [x] `category` is one of `ui theme model session memory tools skill workflow notify dev market fun`, and themes/skins go under `theme` / `category` 取值正确，主题/皮肤类请用 `theme`
- [x] Description states what the plugin does, no superlatives / 描述只说功能，不带营销词
- [x] My repo has the `dsh-plugin` topic / 仓库已打 `dsh-plugin` topic

**Recommended (not required) / 推荐但不强制：**

- 📦 Publish to npm — npm installs are prebuilt and skip the `allowBuilds` approval, so users get a one-command install / 发布 npm 包：预构建产物免 `allowBuilds` 授权，用户一条命令装好
- 🔗 Declare official `@deepseek-ai/*` packages as `peerDependencies` (not `dependencies`) — avoids duplicate runtimes inside the profile / 官方 `@deepseek-ai/*` 包用 `peerDependencies` 声明（而非 `dependencies`），避免 profile 里出现重复运行时
- 🖼️ Add screenshots to [`data/screenshots.json`](../blob/main/data/screenshots.json) — they show AppStore-style in plugin markets ([how](../blob/main/contributing.md#screenshots--截图optional-recommended--可选推荐)) / 在 [`data/screenshots.json`](../blob/main/data/screenshots.json) 里附上截图——插件市场会像 App Store 一样展示（[说明](../blob/main/contributing.md#screenshots--截图optional-recommended--可选推荐)）
