### PR TITLE
Rename yyh-001/dsh-expression to dsh-meme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1403,7 +1403,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 - [xiaoshihou514/dsh-desktop-pet](https://github.com/xiaoshihou514/dsh-desktop-pet) - DSH pet, on the desktop!
 - [xiekai886/dsh-MusicPlayer](https://github.com/xiekai886/dsh-MusicPlayer) - A collapsible/expandable draggable floating music player with NetEase Cloud Music playlist import and song/artist search — chat and listen at the same time.
 - [yushi-xxh/dsh-homepage-skin](https://github.com/yushi-xxh/dsh-homepage-skin) - Adds the DeepSeek Harness homepage background to dsh web: WebGL fluid light, dot-line grid and a digital point-cloud whale, with dark and light palettes.
-- [yyh-001/dsh-expression](https://github.com/yyh-001/dsh-expression) - Meme search, the fun way: describe the vibe, and the agent finds and sends a real meme that actually fits.
+- [yyh-001/dsh-meme](https://github.com/yyh-001/dsh-meme) - Chat meme stickers: text-only send, mood auto-send, QQ/WeChat-style picker, auto-learn, custom packs.
 - [zoahdev/dsh-pet-evolve](https://github.com/zoahdev/dsh-pet-evolve) - The pet that grows with your agent: 5 evolution stages earned from real signals (verified rules, completed sessions, tool calls, compactions), agent-state mirroring, and one-click growth share cards. Zero dependencies, 100% local.
 <!-- END PLUGINS -->
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -1403,7 +1403,7 @@ dsh plugin --profile web add dshmarket
 - [xiaoshihou514/dsh-desktop-pet](https://github.com/xiaoshihou514/dsh-desktop-pet) — 鲸鱼娘桌宠，桌面端！
 - [xiekai886/dsh-MusicPlayer](https://github.com/xiekai886/dsh-MusicPlayer) — 可折叠/展开、自由拖动的悬浮音乐播放器，接入网易云音乐，支持歌单导入和按歌名或歌手搜索单曲导入，边对话边听歌。
 - [yushi-xxh/dsh-homepage-skin](https://github.com/yushi-xxh/dsh-homepage-skin) — 给 dsh web 铺上 DeepSeek Harness 首页同款背景：WebGL 流体光效、点线网格与数字点云鲸鱼，深色/亮色两套配色。
-- [yyh-001/dsh-expression](https://github.com/yyh-001/dsh-expression) — 陪 AI 斗图的搞笑插件：说个感觉，AI 帮你搜到、发出那张恰到好处的真实表情包。
+- [yyh-001/dsh-meme](https://github.com/yyh-001/dsh-meme) — 聊天表情包：纯文本斗图、情绪主动发图、像 QQ/微信 一样发图、AI 自动学图、自定义表情包。
 - [zoahdev/dsh-pet-evolve](https://github.com/zoahdev/dsh-pet-evolve) — 会随 agent 成长的宠物：真实信号（已验证规则/会话/工具调用/压缩）驱动 5 阶段进化、镜像 agent 状态、一键导出成长分享卡。零依赖、全本地。
 <!-- END PLUGINS -->
 

--- a/data/added-dates.json
+++ b/data/added-dates.json
@@ -396,7 +396,7 @@
  "https://github.com/ysr666/dsh-vision-router": "2026-08-14",
  "https://github.com/yuezengwu/dsh-explain": "2026-08-13",
  "https://github.com/yun520-1/deepseek-heartflow": "2026-08-14",
- "https://github.com/yyh-001/dsh-expression": "2026-08-14",
+ "https://github.com/yyh-001/dsh-meme": "2026-08-14",
  "https://github.com/yyyyukari/dsh-plugin-workshop": "2026-08-14",
  "https://github.com/zealot00/dsh-pet": "2026-08-14",
  "https://github.com/zhaiyateng/dsh-design-skills": "2026-08-14",

--- a/data/plugins/yyh-001__dsh-expression.yml
+++ b/data/plugins/yyh-001__dsh-expression.yml
@@ -1,6 +1,0 @@
-url: https://github.com/yyh-001/dsh-expression
-name: yyh-001/dsh-expression
-category: fun
-description:
-  en: 'Meme search, the fun way: describe the vibe, and the agent finds and sends a real meme that actually fits.'
-  zh: 陪 AI 斗图的搞笑插件：说个感觉，AI 帮你搜到、发出那张恰到好处的真实表情包。

--- a/data/plugins/yyh-001__dsh-meme.yml
+++ b/data/plugins/yyh-001__dsh-meme.yml
@@ -1,0 +1,6 @@
+url: https://github.com/yyh-001/dsh-meme
+name: yyh-001/dsh-meme
+category: fun
+description:
+  en: 'Chat meme stickers: text-only send, mood auto-send, QQ/WeChat-style picker, auto-learn, custom packs.'
+  zh: 聊天表情包：纯文本斗图、情绪主动发图、像 QQ/微信 一样发图、AI 自动学图、自定义表情包。


### PR DESCRIPTION
## Summary
- Plugin repo/package renamed from `dsh-expression` to `dsh-meme` (`https://github.com/yyh-001/dsh-meme`).
- Update the listing YAML, regenerate both READMEs, and migrate `data/added-dates.json` so the original 2026-08-14 date is kept.

## Test plan
- [ ] Confirm `dsh plugin --profile web add dsh-meme` still matches the listing URL
- [ ] Confirm only this entry changed in the generated READMEs
- [ ] Confirm CI `generate-readme --check` and submission gate pass


Made with [Cursor](https://cursor.com)