### PR TITLE
Add lusblead/dsh-Kingdom (workflow)

### DIFF
--- a/README.md
+++ b/README.md
@@ -963,6 +963,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 - [Lhy723/dsh-agent-canvas](https://github.com/Lhy723/dsh-agent-canvas) - Interactive canvas for visualizing Agent, Subagent, Workflow, Phase, and tool relationships in DSH Web.
 - [ljsysfurryACE/dsh-aura-scheduler](https://github.com/ljsysfurryACE/dsh-aura-scheduler) - Proactive scheduling: an adaptive heartbeat plus a value network (urgency, relevance, interruption cost) decides when the agent should speak unprompted.
 - [lonelymoon87/dsh-specflow](https://github.com/lonelymoon87/dsh-specflow) - Adds specification artifacts, skills, commands, goal-backed implementation, and task-progress context.
+- [lusblead/dsh-Kingdom](https://github.com/lusblead/dsh-Kingdom) - Governed multi-agent kingdom in your DSH session: roles, territories, task review loop, and Claim != Fact enforced in code.
 - [lynx-gt/dsh-subagent-cwd](https://github.com/lynx-gt/dsh-subagent-cwd) - Extends dsh-subagent-tools with a per-call cwd for subagents, shipped with the two in-process provider patches it requires.
 - [lynx-gt/dsh-subagent-tools](https://github.com/lynx-gt/dsh-subagent-tools) - Per-call model, provider, persona, and toolFilter overrides for subagent delegation, with @preset: references and provider/model composite ids.
 - [MichengAI/dsh-automation](https://github.com/MichengAI/dsh-automation) - Runs scheduled coding tasks in isolated DeepSeek Harness sessions, managed from Settings or the agent.

--- a/README.zh.md
+++ b/README.zh.md
@@ -963,6 +963,7 @@ dsh plugin --profile web add dshmarket
 - [Lhy723/dsh-agent-canvas](https://github.com/Lhy723/dsh-agent-canvas) — 为 DSH Web 提供可交互画布，用于展示 Agent、Subagent、Workflow、Phase 与工具调用之间的关系。
 - [ljsysfurryACE/dsh-aura-scheduler](https://github.com/ljsysfurryACE/dsh-aura-scheduler) — 主动调度：自适应心跳 + 价值网络（紧迫度、相关性、打断代价）决定 Agent 何时主动开口。
 - [lonelymoon87/dsh-specflow](https://github.com/lonelymoon87/dsh-specflow) — 增加规格工件、技能、命令、由 goal 驱动的实施流程和任务进度上下文。
+- [lusblead/dsh-Kingdom](https://github.com/lusblead/dsh-Kingdom) — 在 DSH 会话中运行治理型多 Agent 王国：角色、领地、任务验收闭环，Claim ≠ Fact 由代码强制。
 - [lynx-gt/dsh-subagent-cwd](https://github.com/lynx-gt/dsh-subagent-cwd) — 在 dsh-subagent-tools 基础上增加子代理按调用 cwd，附带所需的两个 in-process provider 补丁。
 - [lynx-gt/dsh-subagent-tools](https://github.com/lynx-gt/dsh-subagent-tools) — 子代理委派的按调用覆盖：model/provider/persona/toolFilter、@preset: 引用与 provider/model 组合 id。
 - [MichengAI/dsh-automation](https://github.com/MichengAI/dsh-automation) — 在独立会话里按计划执行编码任务，可在设置页或对话里管理。

--- a/data/plugins/lusblead__dsh-Kingdom.yml
+++ b/data/plugins/lusblead__dsh-Kingdom.yml
@@ -1,0 +1,6 @@
+url: https://github.com/lusblead/dsh-Kingdom
+name: lusblead/dsh-Kingdom
+category: workflow
+description:
+  en: 'Governed multi-agent kingdom in your DSH session: roles, territories, task review loop, and Claim != Fact enforced in code.'
+  zh: '在 DSH 会话中运行治理型多 Agent 王国：角色、领地、任务验收闭环，Claim ≠ Fact 由代码强制。'


### PR DESCRIPTION
Add dsh-Kingdom: a governed multi-agent kingdom plugin for DeepSeek Harness.

- **What it does**: roles (Owner/Chancellor/Supervisor/Worker), territories, task review loop (plan → assign → execute → review), Claim != Fact enforced in code — a task never becomes DONE without a reviewer's approval.
- **npm**: dsh-kingdom@0.3.2 (prebuilt, no allowBuilds needed)
- **Repo**: declares \dsh.bundle\ manifest + \cordis.patch.yml\; \dsh-plugin\ topic set.
- **Category**: workflow (governance/orchestration).