### PR TITLE
Update Vibe Mathematics screenshots to the two framework diagrams (v1 + v2)

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -89,8 +89,8 @@
   "https://raw.githubusercontent.com/Blank-not-black/dsh-Remote/main/docs/screenshots/files.png"
  ],
  "https://github.com/ChongCyrus/Vibe-Mathematics": [
-  "https://raw.githubusercontent.com/ChongCyrus/Vibe-Mathematics/main/%E7%A4%BA%E4%BE%8B%E5%9B%BE/%E6%A1%86%E6%9E%B6%E5%9B%BE.png",
-  "https://raw.githubusercontent.com/ChongCyrus/Vibe-Mathematics/main/%E7%A4%BA%E4%BE%8B%E5%9B%BE/%E5%AE%9E%E9%99%85%E4%BD%BF%E7%94%A8%E7%A4%BA%E4%BE%8B-%E9%95%BF%E6%88%AA%E5%9B%BE.png"
+  "https://raw.githubusercontent.com/ChongCyrus/Vibe-Mathematics/main/%E7%A4%BA%E4%BE%8B%E5%9B%BE/%E6%A1%86%E6%9E%B6%E5%9B%BE-v1.png",
+  "https://raw.githubusercontent.com/ChongCyrus/Vibe-Mathematics/main/%E7%A4%BA%E4%BE%8B%E5%9B%BE/%E6%A1%86%E6%9E%B6%E5%9B%BE-v2.png"
  ],
  "https://github.com/Dely0/dsh-personal-workbench": [
   "https://raw.githubusercontent.com/Dely0/dsh-personal-workbench/main/screenshot/%E4%B8%BB%E7%95%8C%E9%9D%A2.PNG",


### PR DESCRIPTION
Updates the data/screenshots.json entry for [Vibe Mathematics](https://github.com/ChongCyrus/Vibe-Mathematics) to show the two architecture framework diagrams:

1. V1 framework diagram (??????????v1.png) ??classic pipeline architecture
2. V2 framework diagram (??????????v2.png) ??new probability-driven architecture

(Replaces the previous single v1 diagram + usage screenshot.)