### PR TITLE
Add dsh-focus-overlay plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 - [asukasec/dsh-message-preview](https://github.com/asukasec/dsh-message-preview) - Right-edge user-message navigator with an adaptive block layout that fits the available height, plus hover previews, keyboard controls, and click-to-jump navigation.
 - [ayahunter/dsh-trail](https://github.com/ayahunter/dsh-trail) - Replaces the Web GUI trajectory tab with a new-user-friendly round-by-round storyline, plain-language tool labels, category filters and fuzzy search.
 - [bill9109/dsh-drag-and-drop](https://github.com/bill9109/dsh-drag-and-drop) - Cross-platform file drag-and-drop with raw path insertion, no file copying.
+- [boogoo619/dsh-focus-overlay](https://github.com/boogoo619/dsh-focus-overlay) - Focus mode with a full-screen reading overlay that hides the header and composer and folds AI tool calls into summaries.
 - [causebefore/dsh-pomodoro](https://github.com/causebefore/dsh-pomodoro) - Pomodoro focus-and-break timer for DSH Web with configurable cycles, a draggable mini panel, and in-app, sound, and browser notifications.
 - [ccch1mneyyy/dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) - Claude Code-style full-screen terminal UI: pixel-whale header, live status line, and streaming thought expansion.
 - [ccq1/dsh-side-panel](https://github.com/ccq1/dsh-side-panel) - Side panel with file browser, terminal, and Git review for quick file previews.

--- a/README.zh.md
+++ b/README.zh.md
@@ -89,6 +89,7 @@ dsh plugin --profile web add dshmarket
 - [asukasec/dsh-message-preview](https://github.com/asukasec/dsh-message-preview) — 右侧用户消息导航条，根据消息数量与可用高度自适应排布导航块，并支持悬停预览、键盘操作与点击跳转。
 - [ayahunter/dsh-trail](https://github.com/ayahunter/dsh-trail) — 把 Web GUI 的轨迹页签替换为新手友好的回合故事线：工具名通俗中文化，支持类别筛选与模糊搜索。
 - [bill9109/dsh-drag-and-drop](https://github.com/bill9109/dsh-drag-and-drop) — 跨平台文件拖拽与原始路径插入，无需复制文件。
+- [boogoo619/dsh-focus-overlay](https://github.com/boogoo619/dsh-focus-overlay) — 专注模式：全屏阅读视图，隐藏标题与输入区，把 AI 工具调用折叠成摘要。
 - [causebefore/dsh-pomodoro](https://github.com/causebefore/dsh-pomodoro) — DSH Web 番茄钟：提供可配置专注/休息循环、可拖动迷你面板，以及站内提醒、提示音和浏览器通知。
 - [ccch1mneyyy/dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) — Claude Code 风格全屏终端 UI：像素鲸鱼顶栏、实时工作状态行、思考流式展开。
 - [ccq1/dsh-side-panel](https://github.com/ccq1/dsh-side-panel) — 侧边栏集成文件浏览器、终端和 Git 审查，方便预览文件。

--- a/data/plugins/boogoo619__dsh-focus-overlay.yml
+++ b/data/plugins/boogoo619__dsh-focus-overlay.yml
@@ -1,0 +1,6 @@
+url: https://github.com/boogoo619/dsh-focus-overlay
+name: boogoo619/dsh-focus-overlay
+category: ui
+description:
+  en: Focus mode with a full-screen reading overlay that hides the header and composer and folds AI tool calls into summaries.
+  zh: 专注模式：全屏阅读视图，隐藏标题与输入区，把 AI 工具调用折叠成摘要。


### PR DESCRIPTION
Adds **dsh-focus-overlay** — a focus mode for the DeepSeek Harness web GUI: a full-screen reading overlay that hides the header/composer and folds the AI tool-call flow into summaries.

- Category: `ui`
- Repo: https://github.com/boogoo619/dsh-focus-overlay
- Declares a `dsh.bundle` manifest (installable via `dsh plugin add dsh-focus-overlay`)
- Has the `dsh-plugin` topic

Both READMEs were regenerated with `npm ci && node scripts/generate-readme.mjs`.
