### PR TITLE
Add zuoyunlai/lunheng-article-pipeline-dsh (skill)

### DIFF
--- a/README.md
+++ b/README.md
@@ -927,6 +927,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 - [ZihaoVistonWang/Stata-AI-Skill](https://github.com/ZihaoVistonWang/Stata-AI-Skill) - Run Stata through DeepSeek Harness: the native Stata AI Skill service auto-starts with DSH (macOS/Windows binaries bundled), so you can run regressions, do-files and econometrics workflows with no manual setup.
 - [zimai233/dsh-adhd-copilot](https://github.com/zimai233/dsh-adhd-copilot) - ADHD behavioral coaching skill: task breakdown, overwhelm management, launch rituals, and failure recovery.
 - [zjsthmjialin/commercial-ui-ux-codex-skill](https://github.com/zjsthmjialin/commercial-ui-ux-codex-skill) - Registers the commercial-ui-ux skill for DSH: task-aware commercial UI/UX/GUI design, review, repair, and implementation (SaaS, dashboards, admin panels, forms, tables, design systems) with a reference-doc system and quality gates.
+- [zuoyunlai/lunheng-article-pipeline-dsh](https://github.com/zuoyunlai/lunheng-article-pipeline-dsh) - Multi-agent deep long-form article pipeline skill for DeepSeek Harness, running 7 roles across 5 phases with parallel literature/data/case retrieval, an evidence base, independent audit and human verification gates.
 
 ### Workflow & Automation
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -927,6 +927,7 @@ dsh plugin --profile web add dshmarket
 - [ZihaoVistonWang/Stata-AI-Skill](https://github.com/ZihaoVistonWang/Stata-AI-Skill) — 在 DeepSeek Harness 中运行 Stata：Stata AI Skill 原生服务随 DSH 自动启动（内置 macOS/Windows 多平台二进制），无需手动配置即可跑回归、do 文件与计量工作流。
 - [zimai233/dsh-adhd-copilot](https://github.com/zimai233/dsh-adhd-copilot) — ADHD 行为辅导技能：任务拆解、事项过载管理、启动仪式与失败重启。
 - [zjsthmjialin/commercial-ui-ux-codex-skill](https://github.com/zjsthmjialin/commercial-ui-ux-codex-skill) — 注册 commercial-ui-ux 技能：以任务为中心的商业界面 UI/UX/GUI 设计、审查、修复与实现（SaaS、仪表盘、后台、表单、表格、设计系统），带参考文档体系与质量门禁。
+- [zuoyunlai/lunheng-article-pipeline-dsh](https://github.com/zuoyunlai/lunheng-article-pipeline-dsh) — 多 Agent 深度长文流水线技能包：7 角色 + 5 阶段，文献/数据/案例三线并行检索，产出带证据底座、反方论证、独立审计与人工核验节点的深度文章/论文。
 
 ### 🔁 工作流与自动化
 

--- a/data/plugins/zuoyunlai__lunheng-article-pipeline-dsh.yml
+++ b/data/plugins/zuoyunlai__lunheng-article-pipeline-dsh.yml
@@ -1,0 +1,6 @@
+url: https://github.com/zuoyunlai/lunheng-article-pipeline-dsh
+name: zuoyunlai/lunheng-article-pipeline-dsh
+category: skill
+description:
+  en: Multi-agent deep long-form article pipeline skill for DeepSeek Harness, running 7 roles across 5 phases with parallel literature/data/case retrieval, an evidence base, independent audit and human verification gates.
+  zh: 多 Agent 深度长文流水线技能包：7 角色 + 5 阶段，文献/数据/案例三线并行检索，产出带证据底座、反方论证、独立审计与人工核验节点的深度文章/论文。


### PR DESCRIPTION
Add `zuoyunlai/lunheng-article-pipeline-dsh` to the **skill** category.

## What it does

A multi-agent deep long-form article pipeline skill for DeepSeek Harness: **7 roles** (coordinator + literature / data / case scouts + analyst + writer + auditor) across **5 phases**, with Phase 1 running the three retrieval scouts truly in parallel. Deliverables carry an evidence base (`[L]`/`[D]`/`[C]` triple-verified), counter-argument coverage, an independent G0-G11 audit, and 4 human-in-the-loop gates. Ships as a dsh bundle plugin with an optional per-role model preset (`examples/preset/`).

## Checklist

- [x] One file at `data/plugins/zuoyunlai__lunheng-article-pipeline-dsh.yml`
- [x] Ran `node scripts/generate-readme.mjs`, regenerated READMEs committed
- [x] Repo `package.json` declares `dsh.bundle` (`{ "patch": "./cordis.patch.yml" }`)
- [x] Repo created 2026-08-17 (>1 day old), 17 commits (≥10)
- [x] `category: skill`
- [x] Description states what it does — no superlatives
- [x] `dsh-plugin` topic set

## Recommended extras

- 📦 Published to npm (`lunheng-article-pipeline`, dist-tags `latest` + `dsh`) — prebuilt install, no `allowBuilds` step
- 📄 Bilingual README + docs (installation / usage / architecture / faq)

- 新增 `zuoyunlai/lunheng-article-pipeline-dsh` 到 **skill** 分类。
- 描述只说功能：多 Agent 深度长文流水线技能包（7 角色 + 5 阶段、三线并行检索、证据底座、独立审计、人在环节点），无营销词。
