### PR TITLE
add zzx-dear/dsh-capybara-notify

### DIFF
--- a/README.md
+++ b/README.md
@@ -1295,6 +1295,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 - [YZz-S/dsh-notifier](https://github.com/YZz-S/dsh-notifier) - System-native notifications when a task finishes or needs your confirmation: Windows toast, macOS osascript, and Linux notify-send.
 - [zhengjy01/dsh-notify](https://github.com/zhengjy01/dsh-notify) - System-level desktop notifications: turn-completion and workflow-end banners, plus a modal alert when an approval is needed (macOS osascript / Linux notify-send).
 - [zhengjy01/dsh-ticktick](https://github.com/zhengjy01/dsh-ticktick) - Two-way TickTick/Dida365 (滴答清单) task sync via the official OAuth Open API: pull tasks across lists, create/update/complete/delete tasks, and one-shot title-deduped sync, with a web settings panel.
+- [zzx-dear/dsh-capybara-notify](https://github.com/zzx-dear/dsh-capybara-notify) - Capybara secretary for DSH: desktop pet notifications with ding sound, alert inbox API, session-aware alerts (turn done / approval needed / turn blocked), check scripts, and daily high-star plugin recommendations.
 
 ### Development & Runtime
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -1295,6 +1295,7 @@ dsh plugin --profile web add dshmarket
 - [YZz-S/dsh-notifier](https://github.com/YZz-S/dsh-notifier) — 任务完成或需要确认/输入时发送操作系统原生通知：Windows toast、macOS osascript、Linux notify-send。
 - [zhengjy01/dsh-notify](https://github.com/zhengjy01/dsh-notify) — 系统级桌面通知：回合完成 / 工作流完成横幅，需要审批时弹出模态提醒（macOS osascript / Linux notify-send）。
 - [zhengjy01/dsh-ticktick](https://github.com/zhengjy01/dsh-ticktick) — 基于官方 OAuth Open API 双向同步滴答清单（TickTick/Dida365）任务：拉取各清单任务、创建/更新/完成/删除、按标题去重的一键同步，带 Web 设置面板。
+- [zzx-dear/dsh-capybara-notify](https://github.com/zzx-dear/dsh-capybara-notify) — 水豚秘书：桌面宠物气泡+叮咚通知、告警收件箱 API、会话智能提醒（任务完成/需要确认/阻塞）、磁盘/HTTP/进程巡检脚本，以及每日高口碑插件推荐，另附 API 冒烟测试。
 
 ### 🧑‍💻 开发与运行时
 

--- a/data/plugins/zzx-dear__dsh-capybara-notify.yml
+++ b/data/plugins/zzx-dear__dsh-capybara-notify.yml
@@ -1,0 +1,9 @@
+# awesome-dsh-plugin 市场登记文件
+# 用法：fork https://github.com/awesome-dsh-plugin/awesome-dsh-plugin，
+# 把本文件以同名放进 data/plugins/，按 contributing.md 提 PR。
+url: https://github.com/zzx-dear/dsh-capybara-notify
+name: zzx-dear/dsh-capybara-notify
+category: notify
+description:
+  en: 'Capybara secretary for DSH: desktop pet notifications with ding sound, alert inbox API, session-aware alerts (turn done / approval needed / turn blocked), check scripts, and daily high-star plugin recommendations.'
+  zh: '水豚秘书：桌面宠物气泡+叮咚通知、告警收件箱 API、会话智能提醒（任务完成/需要确认/阻塞）、磁盘/HTTP/进程巡检脚本，以及每日高口碑插件推荐，另附 API 冒烟测试。'


### PR DESCRIPTION
Capybara secretary for DeepSeek Harness 🦫

- Alert inbox API: POST /api/secretary/notify, GET /api/secretary/queue, /health
- Session-aware alerts: turn done / approval asked / turn blocked (subagents silent, env-toggleable)
- Optional macOS desktop pet: transparent always-on-top window, ding sound, drag-follow, position memory, screenshot-invisible, launchd-managed (install via pet/install_pet.sh)
- Check scripts: disk/http/process templates + daily high-star plugin recommendations
- Zero credentials, zero hardcoded paths, no bundled pet assets, MIT

Repo: https://github.com/zzx-dear/dsh-capybara-notify