### PR TITLE
Add 7dgroup-ai/dsh-skill-7d-git-commit (git)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1101,6 +1101,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 
 ### Git & Code Review
 
+- [7dgroup-ai/dsh-skill-7d-git-commit](https://github.com/7dgroup-ai/dsh-skill-7d-git-commit) - Checks git commit messages against the 7DGroup convention (Chinese type tags, length and punctuation rules) before committing, as a client-side guard before GitLab pre-receive hooks.
 - [BrambleXu/dsh-revdiff](https://github.com/BrambleXu/dsh-revdiff) - Native interactive Git diff review for DeepSeek Harness with structured annotations sent back to the current Agent session.
 - [cirelir/dsh-change-review](https://github.com/cirelir/dsh-change-review) - Session change-review plugin for DeepSeek Harness: tracks write/edit tool calls per session and renders line-level diffs with customizable colors, with session isolation, subagent aggregation, and SSE live updates.
 - [DamonKoy/dsh-web-ui#dsh-git-graph](https://github.com/DamonKoy/dsh-web-ui/tree/main/packages/dsh-git-graph) - Git branch selector and Git graph in the conversation header of the dsh web GUI.

--- a/README.zh.md
+++ b/README.zh.md
@@ -1101,6 +1101,7 @@ dsh plugin --profile web add dshmarket
 
 ### 🔀 Git 与代码评审
 
+- [7dgroup-ai/dsh-skill-7d-git-commit](https://github.com/7dgroup-ai/dsh-skill-7d-git-commit) — 提交前按 7DGroup 规范校验 git commit message（中文类型标签、长度与标点规则），作为 GitLab pre-receive 钩子的客户端前置校验。
 - [BrambleXu/dsh-revdiff](https://github.com/BrambleXu/dsh-revdiff) — DeepSeek Harness 原生交互式 Git diff 审查，支持结构化批注并回传当前 Agent 会话。
 - [cirelir/dsh-change-review](https://github.com/cirelir/dsh-change-review) — 会话修改审查插件：追踪会话内 write/edit 工具调用并展示 diff 对比；会话隔离、子代理聚合、SSE 实时推送、角标与颜色自定义。
 - [DamonKoy/dsh-web-ui#dsh-git-graph](https://github.com/DamonKoy/dsh-web-ui/tree/main/packages/dsh-git-graph) — dsh web GUI 会话头部栏的 Git 分支选择器与提交图。

--- a/data/plugins/7dgroup-ai__dsh-skill-7d-git-commit.yml
+++ b/data/plugins/7dgroup-ai__dsh-skill-7d-git-commit.yml
@@ -1,0 +1,6 @@
+url: https://github.com/7dgroup-ai/dsh-skill-7d-git-commit
+name: 7dgroup-ai/dsh-skill-7d-git-commit
+category: git
+description:
+  en: 'Checks git commit messages against the 7DGroup convention (Chinese type tags, length and punctuation rules) before committing, as a client-side guard before GitLab pre-receive hooks.'
+  zh: '提交前按 7DGroup 规范校验 git commit message（中文类型标签、长度与标点规则），作为 GitLab pre-receive 钩子的客户端前置校验。'


### PR DESCRIPTION
<!-- Thanks for contributing! Quick checklist / 提交前快速自查 -->

- [x] I added **one file** at `data/plugins/7dgroup-ai__dsh-skill-7d-git-commit.yml` — the READMEs are generated, don't edit them by hand / 我新增了一个 `data/plugins/<owner>__<repo>.yml` 文件（各语言 README 由脚本生成，不要手工编辑）
- [x] I ran `node scripts/generate-readme.mjs` and committed the regenerated READMEs / 我已执行 `node scripts/generate-readme.mjs` 并提交了重新生成的 README
- [x] My repo's `package.json` declares **`dsh.bundle`** (not just `dsh.client`) — [example](../blob/main/contributing.md) / 仓库 `package.json` 已声明 `dsh.bundle`（只有 `dsh.client` 无法安装）
- [x] My repo is at least **1 day old** with **10+ commits** — 16 commits now; repo created 2026-08-17 21:35 CST (13:35 UTC), crosses 1 day later today. If the submission gate fails on age, regate re-runs it automatically / 仓库创建满 1 天且提交数 ≥ 10（现有 16 个提交；仓库于北京时间昨晚创建，今晚满 1 天，门禁若因年龄失败 regate 会自动重跑）
- [x] `category` is valid (`git`) / `category` 取值正确，主题/皮肤类请用 `theme`
- [x] Description states what the plugin does, no superlatives / 描述只说功能，不带营销词
- [x] My repo has the `dsh-plugin` topic / 仓库已打 `dsh-plugin` topic

**Recommended (done) / 推荐项（已做）:**

- 📦 Published to npm: `@7dgroup/dsh-skill-7d-git-commit`
- 🔗 Official `@deepseek-ai/*` packages declared as `peerDependencies`