### PR TITLE
Update dsh-remote-workspace tarball to v0.1.0

### DIFF
--- a/data/plugins/Hefulalala__dsh-remote-workspace.yml
+++ b/data/plugins/Hefulalala__dsh-remote-workspace.yml
@@ -4,4 +4,4 @@ category: tools
 description:
   en: 'SSH/SFTP remote sites and workspaces: manage connections and remote directories like local workspaces.'
   zh: 'SSH/SFTP 远程站点与远程工作区：像本地工作区一样管理远程连接与目录。'
-tarball: https://github.com/Hefulalala/dsh-remote-workspace/releases/latest/download/dsh-external-dsh-remote-workspace-0.0.1.tgz
+tarball: https://github.com/Hefulalala/dsh-remote-workspace/releases/latest/download/dsh-external-dsh-remote-workspace-0.1.0.tgz


### PR DESCRIPTION
dsh-remote-workspace v0.1.0 released (stage 1: connection pooling + cache + append/offset writes). Updates the `tarball:` field to the new release asset.