### PR TITLE
add zzx-dear/dsh-selection-followup

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 - [zoumutou/dsh-web-preview](https://github.com/zoumutou/dsh-web-preview) - Side web-preview panel: local static hosting, Markdown/code/image preview, one-click run of non-static projects (Cargo/npm/Go/Python) with live logs, drag files into the chat (saved to the workspace), element mark & annotate, workspace file search on 404, and link-click takeover into the side panel.
 - [ZSeven-W/dsh-openpencil](https://github.com/ZSeven-W/dsh-openpencil) - OpenPencil design preview and editing plugin.
 - [zuoguyoupan2023/adhdgofly-dsh-ext](https://github.com/zuoguyoupan2023/adhdgofly-dsh-ext) - Highlights parts of speech (nouns green, verbs red, adjectives/adverbs purple) in rendered DSH Web Markdown, with light/dark palettes, toggles, and stream-aware updates.
+- [zzx-dear/dsh-selection-followup](https://github.com/zzx-dear/dsh-selection-followup) - Select any text in a DSH chat reply to get a floating Follow-up/Copy pill: one click quotes the selection into the composer so you can type your own follow-up question, or copies it.
 
 ### Usage & Billing
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -291,6 +291,7 @@ dsh plugin --profile web add dshmarket
 - [zoumutou/dsh-web-preview](https://github.com/zoumutou/dsh-web-preview) — 侧边网页预览面板：本地静态托管、Markdown/代码/图片预览、非静态项目一键运行（Cargo/npm/Go/Python）实时日志、文件直接拖入对话（保存到工作区）、网页元素标记批注、404 时工作区文件搜索、链接点击接管到侧边预览。
 - [ZSeven-W/dsh-openpencil](https://github.com/ZSeven-W/dsh-openpencil) — OpenPencil 设计预览与编辑插件。
 - [zuoguyoupan2023/adhdgofly-dsh-ext](https://github.com/zuoguyoupan2023/adhdgofly-dsh-ext) — 在 DSH Web 已渲染的 Markdown 中做词性高亮：名词绿、动词红、形容/副词紫，支持深/浅色板、词性开关与流式防抖。
+- [zzx-dear/dsh-selection-followup](https://github.com/zzx-dear/dsh-selection-followup) — 选中聊天回复中的任意文字，浮出「追问/复制」气泡：一键把选中内容作为引用填入输入框（问题由你输入），或一键复制。另附安装与实现文档。
 
 ### 💰 用量与计费
 

--- a/data/plugins/zzx-dear__dsh-selection-followup.yml
+++ b/data/plugins/zzx-dear__dsh-selection-followup.yml
@@ -1,0 +1,6 @@
+url: https://github.com/zzx-dear/dsh-selection-followup
+name: zzx-dear/dsh-selection-followup
+category: ui
+description:
+  en: 'Select any text in a DSH chat reply to get a floating Follow-up/Copy pill: one click quotes the selection into the composer so you can type your own follow-up question, or copies it.'
+  zh: '选中聊天回复中的任意文字，浮出「追问/复制」气泡：一键把选中内容作为引用填入输入框（问题由你输入），或一键复制。另附安装与实现文档。'


### PR DESCRIPTION
Select-to-follow-up for DSH Web UI: select text in any chat reply, get a floating Follow-up / Copy pill. Follow-up quotes the selection into the composer (no canned template — the user asks their own question); Copy writes to clipboard. Pure client-side, no host logic, zero credentials.

Repo: https://github.com/zzx-dear/dsh-selection-followup