### PR TITLE
Add dsh-youreyes screenshots entry

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -792,5 +792,8 @@
  ],
  "https://github.com/detongz/dsh-client-ui-obsidian-memory": [
   "https://raw.githubusercontent.com/detongz/dsh-client-ui-obsidian-memory/main/assets/screenshot-panel.png"
+ ],
+ "https://github.com/54xkeee/dsh-youreyes": [
+  "https://raw.githubusercontent.com/54xkeee/dsh-youreyes/master/assets/screenshot-panel.png"
  ]
 }


### PR DESCRIPTION
Add App Store-style screenshots for [dsh-youreyes](https://github.com/54xkeee/dsh-youreyes).

The screenshot shows the bilingual vision panel (dark theme): image picker/paste, prompt input, task mode selector (glance/OCR/region/compare), detail level, and channel selection.

Keyed by the entry URL, image hosted in the plugin repo (master/assets/screenshot-panel.png).