### PR TITLE
Switch dsh-cache-miss to npm install path and strengthen search keywords

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 - [vlln/dsh-task-status](https://github.com/vlln/dsh-task-status) - Background task status bar: progress plus live output tail on the chat page.
 - [vvvspec/better-reasoning-slider](https://github.com/vvvspec/better-reasoning-slider) - Official-style composer model trigger with a floating reasoning-effort slider popup.
 - [warmwine/dsh-ui-font](https://github.com/warmwine/dsh-ui-font) - Font engine for the Web GUI: system font enumeration, global and per-component font-size tuning with a Spy++-style picker, settings page.
-- [wefio/dsh-cache-miss](https://github.com/wefio/dsh-cache-miss) - Yellow one-line prompt-cache-miss notice under assistant replies that rebuilt the prompt cache.
+- [wefio/dsh-cache-miss](https://github.com/wefio/dsh-cache-miss) - Yellow one-line notice for a prompt cache miss after the cache was rebuilt; shows re-billed uncached input tokens, cached hit tokens, and TTFT.
 - [weshopai/weshop-dsh-plugin](https://github.com/weshopai/weshop-dsh-plugin) - Infinite-canvas e-commerce visual workspace for product photography, virtual try-on, background edits, and video, synced live with the Harness conversation.
 - [whiteguo233/dsh-openbiliclaw](https://github.com/whiteguo233/dsh-openbiliclaw) - OpenBiliClaw consumer panel for DSH: recommendations, saved lists, Socratic dialogue, profile views, and Agent Bridge tools.
 - [WhitePlusMS/dsh-git-graph](https://github.com/WhitePlusMS/dsh-git-graph) - Dedicated read-only Git Graph view beside Chat and Trajectory: commit topology, local/remote/tag refs, HEAD and working-tree status, search, filtering, first-parent mode, refresh, and load more.

--- a/README.zh.md
+++ b/README.zh.md
@@ -240,7 +240,7 @@ dsh plugin --profile web add dshmarket
 - [vlln/dsh-task-status](https://github.com/vlln/dsh-task-status) — 后台任务状态条：对话页任务进度 + 实时输出 tail。
 - [vvvspec/better-reasoning-slider](https://github.com/vvvspec/better-reasoning-slider) — 官方风格输入框 + 浮动推理能力滑块弹窗，节点与滑块对齐，弹窗跟随 Harness 主题自适应。
 - [warmwine/dsh-ui-font](https://github.com/warmwine/dsh-ui-font) — 网页界面字体引擎：系统字体枚举、准星点选的全局与逐组件字号微调、设置页。老花眼友好，自定义字体和页面部件字体和字体大小，支持SPY模式扫UI和其他插件。
-- [wefio/dsh-cache-miss](https://github.com/wefio/dsh-cache-miss) — 在重建了提示缓存的 assistant 回复下方显示一条黄色的缓存未命中提示。
+- [wefio/dsh-cache-miss](https://github.com/wefio/dsh-cache-miss) — 提示缓存未命中（cache miss）时，在重建缓存的 assistant 回复下方显示一条黄色缓存提示，展示未缓存（uncached）重新计费（re-billed）的输入 token、缓存命中 token 与首字延迟（TTFT）。
 - [weshopai/weshop-dsh-plugin](https://github.com/weshopai/weshop-dsh-plugin) — 电商可视化工作区：在无限画布上完成产品图、虚拟试穿、背景处理与视频生成，并与 Harness 对话实时同步。
 - [whiteguo233/dsh-openbiliclaw](https://github.com/whiteguo233/dsh-openbiliclaw) — OpenBiliClaw 的 DSH 消费侧插件：提供推荐、收藏列表、苏格拉底式对话、画像面板和 Agent Bridge 工具。
 - [WhitePlusMS/dsh-git-graph](https://github.com/WhitePlusMS/dsh-git-graph) — Chat 和 Trajectory 旁的独立 Git Graph 视图：提交拓扑、本地/远程/tag 引用、HEAD 与工作区状态、搜索、筛选、首父模式、刷新和加载更多。

--- a/data/plugins/wefio__dsh-cache-miss.yml
+++ b/data/plugins/wefio__dsh-cache-miss.yml
@@ -2,6 +2,6 @@ url: https://github.com/wefio/dsh-cache-miss
 name: wefio/dsh-cache-miss
 category: ui
 description:
-  en: Yellow one-line prompt-cache-miss notice under assistant replies that rebuilt the prompt cache.
-  zh: 在重建了提示缓存的 assistant 回复下方显示一条黄色的缓存未命中提示。
+  en: Yellow one-line notice for a prompt cache miss after the cache was rebuilt; shows re-billed uncached input tokens, cached hit tokens, and TTFT.
+  zh: 提示缓存未命中（cache miss）时，在重建缓存的 assistant 回复下方显示一条黄色缓存提示，展示未缓存（uncached）重新计费（re-billed）的输入 token、缓存命中 token 与首字延迟（TTFT）。
 tarball: https://github.com/wefio/dsh-cache-miss/releases/latest/download/dsh-cache-miss.tgz

--- a/data/plugins/wefio__dsh-cache-miss.yml
+++ b/data/plugins/wefio__dsh-cache-miss.yml
@@ -4,4 +4,4 @@ category: ui
 description:
   en: Yellow one-line notice for a prompt cache miss after the cache was rebuilt; shows re-billed uncached input tokens, cached hit tokens, and TTFT.
   zh: 提示缓存未命中（cache miss）时，在重建缓存的 assistant 回复下方显示一条黄色缓存提示，展示未缓存（uncached）重新计费（re-billed）的输入 token、缓存命中 token 与首字延迟（TTFT）。
-tarball: https://github.com/wefio/dsh-cache-miss/releases/latest/download/dsh-cache-miss.tgz
+

--- a/data/plugins/wefio__dsh-cache-miss.yml
+++ b/data/plugins/wefio__dsh-cache-miss.yml
@@ -4,4 +4,4 @@ category: ui
 description:
   en: Yellow one-line prompt-cache-miss notice under assistant replies that rebuilt the prompt cache.
   zh: 在重建了提示缓存的 assistant 回复下方显示一条黄色的缓存未命中提示。
-tarball: https://github.com/wefio/dsh-cache-miss/releases/latest/download/dsh-cache-miss-0.1.0.tgz
+tarball: https://github.com/wefio/dsh-cache-miss/releases/latest/download/dsh-cache-miss.tgz


### PR DESCRIPTION
Updates the dsh-cache-miss registry entry:

- Drop the GitHub release tarball fallback; the package is published on npm, so the registry install command becomes \dsh plugin --profile web add dsh-cache-miss\.
- Expand the bilingual description to cover cache-miss search terms: cache miss, rebuilt cache, uncached, re-billed, cached tokens, and TTFT.