### PR TITLE
screenshots: add hero shot for dsh-feishu

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -825,5 +825,8 @@
  ],
  "https://github.com/54xkeee/dsh-youreyes": [
   "https://raw.githubusercontent.com/54xkeee/dsh-youreyes/master/assets/screenshot-panel.png"
+ ],
+ "https://github.com/itr-del/dsh-feishu": [
+  "https://raw.githubusercontent.com/itr-del/dsh-feishu/master/assets/hero.png"
  ]
 }


### PR DESCRIPTION
Add the dsh-feishu entry to `data/screenshots.json` so dsh-market (1.8.0+) can display an App Store-style hero card.

**Entry:**
- Key: `https://github.com/itr-del/dsh-feishu`
- Image: `https://raw.githubusercontent.com/itr-del/dsh-feishu/master/assets/hero.png`
  - 1600×900 hero shot showing local dsh process logs (terminal mock) on the left, Feishu IM mock on the right, and a WebSocket bridge arrow in the middle.

**Why:**
Per @fkysly's invitation on PR #127 — makes the entry self-explanatory in dsh-market without readers needing to open the README. The hero shot emphasises the product positioning ("DSH × Feishu — bidirectional WS bridge for a local DeepSeek agent"), which a README text alone can't convey as efficiently.

**Verified:**
- ✅ Image hosted on `raw.githubusercontent.com` (matches the contribution policy in contributing.md).
- ✅ Image stored in our own repo (`assets/hero.png`) so it ships with releases.
- ✅ Same `master` branch the README links to.

Thanks for the storefront feature! 🙏

---

## Branch note
This is the clean replacement for the stale-branch PR. It is based on the current `main` tree and uses the fresh `feishu-hero` branch. The fork token only has `repo` scope, so the five existing workflow-file differences remain visible in the PR; the only content change is the `data/screenshots.json` entry for `https://github.com/itr-del/dsh-feishu`.