### PR TITLE
screenshots: add dsh-usage-billing

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -54,6 +54,16 @@
   "https://raw.githubusercontent.com/7dgroup-ai/dsh-skill-7d-code-reviewer/main/screenshots/skills.png",
   "https://raw.githubusercontent.com/7dgroup-ai/dsh-skill-7d-code-reviewer/main/screenshots/report-preview.png"
  ],
+ "https://github.com/940842546/dsh-usage-billing": [
+  "https://raw.githubusercontent.com/940842546/dsh-usage-billing/main/assets/screenshots/02-stats-dialog-overview.png",
+  "https://raw.githubusercontent.com/940842546/dsh-usage-billing/main/assets/screenshots/03-stats-dialog-charts.png",
+  "https://raw.githubusercontent.com/940842546/dsh-usage-billing/main/assets/screenshots/04-settings-usage-overview.png",
+  "https://raw.githubusercontent.com/940842546/dsh-usage-billing/main/assets/screenshots/07-stats-dialog-usd.png",
+  "https://raw.githubusercontent.com/940842546/dsh-usage-billing/main/assets/screenshots/en-02-stats-dialog-overview.png",
+  "https://raw.githubusercontent.com/940842546/dsh-usage-billing/main/assets/screenshots/en-03-stats-dialog-charts.png",
+  "https://raw.githubusercontent.com/940842546/dsh-usage-billing/main/assets/screenshots/en-04-settings-usage-overview.png",
+  "https://raw.githubusercontent.com/940842546/dsh-usage-billing/main/assets/screenshots/en-07-stats-dialog-usd.png"
+ ],
  "https://github.com/AI-Galaxy-GPU/dsh-sound": [
   "https://raw.githubusercontent.com/AI-Galaxy-GPU/dsh-sound/main/assets/screenshots/sound-image.png"
  ],


### PR DESCRIPTION
Adds 8 storefront screenshots (4 zh + 4 en, fictional demo data — no real usage or balance) for [940842546/dsh-usage-billing](https://github.com/940842546/dsh-usage-billing), hosted in the plugin repo under `assets/screenshots/`:

- stats dialog overview / charts (zh/en)
- settings overview (zh/en)
- USD currency mode (zh/en)

Follows the key convention (entry GitHub URL) and GitHub-hosted https image URLs from contributing.md.