### PR TITLE
Add MingoZhou/dsh-replay (session)

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,6 +489,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 - [Max-Null/dsh-chinese-thinking](https://github.com/Max-Null/dsh-chinese-thinking) - Injects one fixed system-prompt section so the agent thinks and replies in Chinese, regardless of the user's language.
 - [mayf3/dsh-session-doctor](https://github.com/mayf3/dsh-session-doctor) - Diagnose, unstick, and read DSH sessions: list sessions with agent status, read conversations, diagnose stuck agents, recover them with cancel+keepInbox, and send messages to other sessions.
 - [MichengAI/dsh-archive-manager](https://github.com/MichengAI/dsh-archive-manager) - Adds an archived-sessions page in Settings to search, restore, and delete archived DeepSeek Harness sessions by workspace.
+- [MingoZhou/dsh-replay](https://github.com/MingoZhou/dsh-replay) - Replay sessions on a playable timeline with per-step token usage, audit sensitive operations, estimate cost, view fork lineage, compare sessions, and export standalone HTML replays.
 - [Moeblack/dsh-message-edit](https://github.com/Moeblack/dsh-message-edit) - Branch-based message editing, reroll, retry, and a version timeline.
 - [Moeblack/dsh-prompt-studio](https://github.com/Moeblack/dsh-prompt-studio) - Edit user and built-in system-prompt sections with live preview.
 - [MuWinds/dsh-archived-sessions](https://github.com/MuWinds/dsh-archived-sessions) - Archived-session management: browse archived sessions, unarchive them, or clear them out.

--- a/README.zh.md
+++ b/README.zh.md
@@ -489,6 +489,7 @@ dsh plugin --profile web add dshmarket
 - [Max-Null/dsh-chinese-thinking](https://github.com/Max-Null/dsh-chinese-thinking) — 注入一条固定 system-prompt 段落，让 Agent 无论用户使用什么语言都始终用中文思考和回复。
 - [mayf3/dsh-session-doctor](https://github.com/mayf3/dsh-session-doctor) — 会话医生：列出会话（含 agent 运行状态）、读取会话记录、诊断卡死的 agent、解卡（cancel + keepInbox 保留排队消息）、向其他会话发送消息。
 - [MichengAI/dsh-archive-manager](https://github.com/MichengAI/dsh-archive-manager) — 在设置里增加已归档会话页，可按工作区搜索、恢复和删除已归档会话。
+- [MingoZhou/dsh-replay](https://github.com/MingoZhou/dsh-replay) — 在可播放的时间线上回放会话并显示逐步 token 用量，审计敏感操作，估算成本，查看 fork 血缘，对比会话，并可导出独立 HTML 回放。
 - [Moeblack/dsh-message-edit](https://github.com/Moeblack/dsh-message-edit) — 基于分支的消息编辑、reroll、重试与版本时间线。
 - [Moeblack/dsh-prompt-studio](https://github.com/Moeblack/dsh-prompt-studio) — 带实时预览的用户/内置 system prompt 分节编辑器。
 - [MuWinds/dsh-archived-sessions](https://github.com/MuWinds/dsh-archived-sessions) — 归档会话管理：浏览已归档会话，支持恢复（取消归档）与清空。

--- a/data/plugins/MingoZhou__dsh-replay.yml
+++ b/data/plugins/MingoZhou__dsh-replay.yml
@@ -1,0 +1,6 @@
+url: https://github.com/MingoZhou/dsh-replay
+name: MingoZhou/dsh-replay
+category: session
+description:
+  en: Replay sessions on a playable timeline with per-step token usage, audit sensitive operations, estimate cost, view fork lineage, compare sessions, and export standalone HTML replays.
+  zh: 在可播放的时间线上回放会话并显示逐步 token 用量，审计敏感操作，估算成本，查看 fork 血缘，对比会话，并可导出独立 HTML 回放。

--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -850,5 +850,10 @@
  "https://github.com/hyzyn/dsh-plugin-kit/tree/main/packages/rss": [
   "https://raw.githubusercontent.com/hyzyn/dsh-plugin-kit/main/docs/dsh-plugin-kit-rss-setting.png",
   "https://raw.githubusercontent.com/hyzyn/dsh-plugin-kit/main/docs/dsh-plugin-kit-rss-view.png"
+ ],
+ "https://github.com/MingoZhou/dsh-replay": [
+  "https://raw.githubusercontent.com/MingoZhou/dsh-replay/main/assets/overview-light.png",
+  "https://raw.githubusercontent.com/MingoZhou/dsh-replay/main/assets/timeline-light.png",
+  "https://raw.githubusercontent.com/MingoZhou/dsh-replay/main/assets/audit-light.png"
  ]
 }


### PR DESCRIPTION
<!-- Thanks for contributing! Quick checklist / 提交前快速自查 -->
- [x] I added **one file** at `data/plugins/<owner>__<repo>.yml` — the READMEs are generated, don't edit them by hand / 我新增了一个 `data/plugins/<owner>__<repo>.yml` 文件（各语言 README 由脚本生成，不要手工编辑）
- [x] I ran `node scripts/generate-readme.mjs` and committed the regenerated READMEs / 我已执行 `node scripts/generate-readme.mjs` 并提交了重新生成的 README
- [x] My repo's `package.json` declares **`dsh.bundle`** (not just `dsh.client`) / 仓库 `package.json` 已声明 `dsh.bundle`
- [x] My repo is at least **1 day old** with **10+ commits** / 仓库创建满 1 天且提交数 ≥ 10
- [x] `category` is one of `ui theme model session memory tools skill workflow notify dev market fun` / `category` 取值正确（session）
- [x] Description states what the plugin does, no superlatives / 描述只说功能，不带营销词
- [x] My repo has the `dsh-plugin` topic / 仓库已打 `dsh-plugin` topic

**Recommended items — all done / 推荐项也都已完成：**
- 📦 Published to npm as [`@mingozhou/dsh-replay`](https://www.npmjs.com/package/@mingozhou/dsh-replay) (prebuilt, one-command install)
- 🔗 All official `@deepseek-ai/*` packages are optional `peerDependencies`
- 🖼️ Screenshots added to `data/screenshots.json`

---

**dsh-replay** — replay any session on a playable timeline (per-step token usage), audit sensitive operations, estimate cost, view fork lineage, compare sessions, and export standalone HTML replays.

🎮 Live demo (no install): https://mingozhou.github.io/dsh-replay/