### PR TITLE
Add optttt/dsh-auth (security login gate + LAN proxy)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1327,6 +1327,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 - [omdsh-dev/sandbox-micro](https://github.com/omdsh-dev/sandbox-micro) - Support for the microsandbox backend.
 - [omdsh-dev/sandbox-mxc](https://github.com/omdsh-dev/sandbox-mxc) - Microsoft cross-platform sandbox support.
 - [omdsh-dev/sandbox-nono](https://github.com/omdsh-dev/sandbox-nono) - Support for the nono sandbox backend.
+- [optttt/dsh-auth](https://github.com/optttt/dsh-auth) - Login gate for dsh web — username/password, idle-timeout auto logout, credentials and session expiry, single sign-on, a settings UI, and CLI to reset the password or change the username; sessions use scrypt-hashed secrets and HttpOnly cookies, with a LAN reverse proxy.
 - [PAKIKNOWLEDGE/dsh-auto-classifier](https://github.com/PAKIKNOWLEDGE/dsh-auto-classifier) - Autonomous permission classifier for the auto preset: tool-scoped allow/deny rules, an LLM semantic judge, and git checkpointing for unattended sessions.
 - [pengxuding/dsh-plugin-judge](https://github.com/pengxuding/dsh-plugin-judge) - Plugin value auditor: pre-install review (source scan + LLM judge) and post-install audit of installed bundles, with model-switch re-audit reminders.
 - [PerryLink/dsh-auto-review](https://github.com/PerryLink/dsh-auto-review) - Second-model auto-review on the approval answerer chain: a read-only reviewer subagent returns structured allow/deny verdicts with reasons, fail-closed by default.

--- a/README.zh.md
+++ b/README.zh.md
@@ -1327,6 +1327,7 @@ dsh plugin --profile web add dshmarket
 - [omdsh-dev/sandbox-micro](https://github.com/omdsh-dev/sandbox-micro) — microsandbox 沙箱支持。
 - [omdsh-dev/sandbox-mxc](https://github.com/omdsh-dev/sandbox-mxc) — 微软跨平台沙盒支持。
 - [omdsh-dev/sandbox-nono](https://github.com/omdsh-dev/sandbox-nono) — nono 沙盒支持。
+- [optttt/dsh-auth](https://github.com/optttt/dsh-auth) — dsh web 登录认证门：用户名/密码、空闲自动登出、认证有效期与单点登录，设置界面可改用户名/密码/过期时间，`dsh web p` 重置密码、`dsh web u` 改用户名；scrypt 加盐哈希 + HttpOnly Cookie，附局域网反向代理。
 - [PAKIKNOWLEDGE/dsh-auto-classifier](https://github.com/PAKIKNOWLEDGE/dsh-auto-classifier) — auto（自主模式）权限分类器：工具作用域的放行/拒绝规则、LLM 语义裁判与 git 快照，面向无人值守会话。
 - [pengxuding/dsh-plugin-judge](https://github.com/pengxuding/dsh-plugin-judge) — 插件价值裁判：装前审核（源码静态扫描 + LLM 裁判）与装后审计已装插件，模型切换时弹窗提醒复核；判断插件对当前模型是增强还是压制。
 - [PerryLink/dsh-auto-review](https://github.com/PerryLink/dsh-auto-review) — 审批链上的第二模型自动审查：只读审查子代理返回带理由的 allow/deny 结构化裁决，默认 fail-closed。

--- a/data/plugins/optttt__dsh-auth.yml
+++ b/data/plugins/optttt__dsh-auth.yml
@@ -1,0 +1,6 @@
+url: https://github.com/optttt/dsh-auth
+name: optttt/dsh-auth
+category: security
+description:
+  en: Login gate for dsh web — username/password, idle-timeout auto logout, credentials and session expiry, single sign-on, a settings UI, and CLI to reset the password or change the username; sessions use scrypt-hashed secrets and HttpOnly cookies, with a LAN reverse proxy.
+  zh: dsh web 登录认证门：用户名/密码、空闲自动登出、认证有效期与单点登录，设置界面可改用户名/密码/过期时间，`dsh web p` 重置密码、`dsh web u` 改用户名；scrypt 加盐哈希 + HttpOnly Cookie，附局域网反向代理。


### PR DESCRIPTION
### 提交内容 / What changed
- 新增收录条目：optttt/dsh-auth — DeepSeek Harness Web GUI 的登录认证门插件
- 新增 data/plugins/optttt__dsh-auth.yml（category: security）
- 执行 
ode scripts/generate-readme.mjs，重新生成 README.md / README.zh.md（条目数从 1362 → 1363）

### 插件简介 / Plugin description
**en**: Login gate for dsh web — username/password, idle-timeout auto logout, credentials and session expiry, single sign-on, a settings UI, and CLI to reset the password or change the username; sessions use scrypt-hashed secrets and HttpOnly cookies, with a LAN reverse proxy.

**zh**: dsh web 登录认证门：用户名/密码、空闲自动登出、认证有效期与单点登录，设置界面可改用户名/密码/过期时间，dsh web p 重置密码、dsh web u 改用户名；scrypt 加盐哈希 + HttpOnly Cookie，附局域网反向代理。

### 核查清单 / Checklist
- [x] 新增 data/plugins/optttt__dsh-auth.yml
- [x] 已运行 
ode scripts/generate-readme.mjs 并提交生成的 README.md / README.zh.md
- [x] 仓库 package.json 声明 dsh.bundle（patch: ./cordis.patch.yml），附 cordis.patch.yml
- [x] 仓库创建于 2026-08-17，距今 > 1 天；提交数 11（≥ 10，经 gh api /repos/optttt/dsh-auth/commits?per_page=100 实际遍历）
- [x] category = security（与列表中同类 auth-gate/web-auth/webui-auth 保持一致）
- [x] 描述为功能性陈述，无营销词；与 README 内容核对一致
- [x] 仓库已打 dsh-plugin topic（通过 gh repo edit --add-topic dsh-plugin 完成）

### 安装体验 / Install experience
- 已发布 npm：@tyler9061/dsh-auth（package.json 提供 dsh.bundle + iles 包含 cordis.patch.yml），用户可直接 dsh plugin --profile web add @tyler9061/dsh-auth，免源码构建

---

### 关于 dsh-email / About dsh-email
本次 **未** 同时提交 optttt/dsh-email：当前仓库仅 3 个提交，未达到「提交数 ≥ 10」的硬性 CI 门槛，以免被 gate 直接判拒。待作者后续把 dsh-email 补到 10+ 提交后再单独提 PR。
