### PR TITLE
Add Aik358/dsh-draw-gacha

### DIFF
--- a/README.md
+++ b/README.md
@@ -1417,6 +1417,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 ### Just for Fun
 
 - [609476965/dsh-LorebookMD](https://github.com/609476965/dsh-LorebookMD) - Import SillyTavern/TavernAI character cards and world books, save them as local Markdown lore documents, and generate novel prose from your prompts with the world settings as reference.
+- [Aik358/dsh-draw-gacha](https://github.com/Aik358/dsh-draw-gacha) - Pull a 3D lever next to the send button and turn the model's reasoning signals into a pixel-art gacha reveal.
 - [AmeKrance/anan-thermal-monitor](https://github.com/AmeKrance/anan-thermal-monitor) - Purple-white desktop pet that docks to the screen edge and shows real-time CPU, RAM, GPU and NVMe temperatures with hardware info.
 - [AnacondaKC/dsh-douyin](https://github.com/AnacondaKC/dsh-douyin) - Short-video sidebar: native player, series navigation, precise history replay.
 - [AnacondaKC/dsh-stock-market](https://github.com/AnacondaKC/dsh-stock-market) - Fixes the bug where your account can't lose money while you code.

--- a/README.zh.md
+++ b/README.zh.md
@@ -1417,6 +1417,7 @@ dsh plugin --profile web add dshmarket
 ### 🎮 娱乐
 
 - [609476965/dsh-LorebookMD](https://github.com/609476965/dsh-LorebookMD) — 导入酒馆（SillyTavern/TavernAI）角色卡与世界书，落地为本地 Markdown 设定文档，激活创作模式后根据用户输入、参考世界书创作小说。
+- [Aik358/dsh-draw-gacha](https://github.com/Aik358/dsh-draw-gacha) — 在发送按钮旁拉动 3D 拉杆，把模型思维链的文本信号变成一场像素风抽卡演出。
 - [AmeKrance/anan-thermal-monitor](https://github.com/AmeKrance/anan-thermal-monitor) — 紫白桌宠悬浮球，贴边停靠实时显示 CPU/内存/GPU/NVMe 温度与硬件信息。
 - [AnacondaKC/dsh-douyin](https://github.com/AnacondaKC/dsh-douyin) — 侧栏短视频：原生播放器、系列导航、精确历史回放。
 - [AnacondaKC/dsh-stock-market](https://github.com/AnacondaKC/dsh-stock-market) — 有效解决了写代码的时候账户不能同时亏钱的 BUG。

--- a/data/plugins/Aik358__dsh-draw-gacha.yml
+++ b/data/plugins/Aik358__dsh-draw-gacha.yml
@@ -1,0 +1,6 @@
+url: https://github.com/Aik358/dsh-draw-gacha
+name: Aik358/dsh-draw-gacha
+category: fun
+description:
+  en: "Pull a 3D lever next to the send button and turn the model's reasoning signals into a pixel-art gacha reveal."
+  zh: '在发送按钮旁拉动 3D 拉杆，把模型思维链的文本信号变成一场像素风抽卡演出。'


### PR DESCRIPTION
Add Aik358/dsh-draw-gacha — pull a 3D lever next to the send button and turn the model's chain-of-thought signals into a pixel-art gacha reveal. URL: https://github.com/Aik358/dsh-draw-gacha · npm: `@a9i5k4/dsh-draw-gacha` v0.1.6