### PR TITLE
Add caisiyang123/dsh-tick-rail (ui)

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 - [bainianlaoyao/easy-archive](https://github.com/bainianlaoyao/easy-archive) - Two-step inline archive on workspace sidebar rows — one click arms a red confirm, the second click archives; the archive entry is removed from the ⋮ menu.
 - [bill9109/dsh-drag-and-drop](https://github.com/bill9109/dsh-drag-and-drop) - Cross-platform file drag-and-drop with raw path insertion, no file copying.
 - [boogoo619/dsh-focus-overlay](https://github.com/boogoo619/dsh-focus-overlay) - Focus mode with a full-screen reading overlay that hides the header and composer and folds AI tool calls into summaries.
+- [caisiyang123/dsh-tick-rail](https://github.com/caisiyang123/dsh-tick-rail) - Tick-rail conversation navigator: one tick per message you sent, a lit peak that follows the mouse with an even falloff, hover previews, click or keyboard to jump.
 - [causebefore/dsh-pomodoro](https://github.com/causebefore/dsh-pomodoro) - Pomodoro focus-and-break timer for DSH Web with configurable cycles, a draggable mini panel, and in-app, sound, and browser notifications.
 - [ccch1mneyyy/dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) - Claude Code-style full-screen terminal UI: pixel-whale header, live status line, and streaming thought expansion.
 - [ccq1/dsh-side-panel](https://github.com/ccq1/dsh-side-panel) - Side panel with file browser, terminal, and Git review for quick file previews.

--- a/README.zh.md
+++ b/README.zh.md
@@ -92,6 +92,7 @@ dsh plugin --profile web add dshmarket
 - [bainianlaoyao/easy-archive](https://github.com/bainianlaoyao/easy-archive) — 工作区侧边栏行内两击归档：点一次变红确认，再点即归档，归档项不再出现在 ⋮ 菜单里。
 - [bill9109/dsh-drag-and-drop](https://github.com/bill9109/dsh-drag-and-drop) — 跨平台文件拖拽与原始路径插入，无需复制文件。
 - [boogoo619/dsh-focus-overlay](https://github.com/boogoo619/dsh-focus-overlay) — 专注模式：全屏阅读视图，隐藏标题与输入区，把 AI 工具调用折叠成摘要。
+- [caisiyang123/dsh-tick-rail](https://github.com/caisiyang123/dsh-tick-rail) — 会话刻度线导航条：你发的每条消息一格刻度，点亮峰值随鼠标移动、两侧均匀衰减，悬停预览消息摘要，点击或键盘跳转到对应位置。
 - [causebefore/dsh-pomodoro](https://github.com/causebefore/dsh-pomodoro) — DSH Web 番茄钟：提供可配置专注/休息循环、可拖动迷你面板，以及站内提醒、提示音和浏览器通知。
 - [ccch1mneyyy/dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) — Claude Code 风格全屏终端 UI：像素鲸鱼顶栏、实时工作状态行、思考流式展开。
 - [ccq1/dsh-side-panel](https://github.com/ccq1/dsh-side-panel) — 侧边栏集成文件浏览器、终端和 Git 审查，方便预览文件。

--- a/data/plugins/caisiyang123__dsh-tick-rail.yml
+++ b/data/plugins/caisiyang123__dsh-tick-rail.yml
@@ -1,0 +1,6 @@
+url: https://github.com/caisiyang123/dsh-tick-rail
+name: caisiyang123/dsh-tick-rail
+category: ui
+description:
+  en: 'Tick-rail conversation navigator: one tick per message you sent, a lit peak that follows the mouse with an even falloff, hover previews, click or keyboard to jump.'
+  zh: '会话刻度线导航条：你发的每条消息一格刻度，点亮峰值随鼠标移动、两侧均匀衰减，悬停预览消息摘要，点击或键盘跳转到对应位置。'


### PR DESCRIPTION
## New plugin

[caisiyang123/dsh-tick-rail](https://github.com/caisiyang123/dsh-tick-rail) — Tick-rail conversation navigator for the DSH web UI.

One tick per message you sent; a lit peak follows the mouse along the rail with an even falloff, a hover card previews the message under the peak, and click or keyboard (arrows + Enter) jumps the conversation there. Mounted in the `shell.overlay` slot, anchored to the `data-chat-flow-*` markers, styled with `--dsw-alias-*` tokens only.

## Checklist

- `dsh.bundle` manifest with `cordis.patch.yml` at the repo root (plus `dsh.client` for the web UI half)
- Repo carries the `dsh-plugin` topic
- Verified end-to-end against `dsh 0.1.0-rc.6`: tarball install, module boot in `dsh web`, live interaction checks; also running in DSH Desktop
- Tests + CI in the repo (green), install docs cover the release tarball and the git `allowBuilds` path
- One YAML file added under `data/plugins/`; both READMEs regenerated with `node scripts/generate-readme.mjs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)