### PR TITLE
Add zoahdev/dsh-timesheet (dev) — turn-based time tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -1478,6 +1478,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 - [ZK-Andy/dsh-continual-evolve](https://github.com/ZK-Andy/dsh-continual-evolve) - Continual self-evolution: versioned, auditable, rollback-safe harness state (prompts, memory, skills, subagent specs) refined from session trajectories, with review gates and hot-reloaded skills.
 - [zoahdev/dsh-plugin-doctor](https://github.com/zoahdev/dsh-plugin-doctor) - Health checks for DSH plugins: manifest/patch/entry/build/pack/install verification, model-callable plugin_check, profile host-shadowing + BOM detection, environment diagnostics, and poison preflight.
 - [zoahdev/dsh-rule-evolve](https://github.com/zoahdev/dsh-rule-evolve/tree/main/plugin) - Verification-driven self-evolution loop: failure logs become verified AGENTS.md rules; in-session plugin (evolve_learn / evolve_apply / evolve_touch / evolve_recall), tool-verify gate, rule lifecycle, local recall.
+- [zoahdev/dsh-timesheet](https://github.com/zoahdev/dsh-timesheet) - Turn-based time tracking from dsh session logs: totals, per-day/project/provider/source rollups, tool-call counts, failure rates, and time-to-first-token — CLI plus an agent-callable timesheet tool, dsh-timesheet/v1 reports, zero runtime deps.
 
 ### Security & Permissions
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -1478,6 +1478,7 @@ dsh plugin --profile web add dshmarket
 - [ZK-Andy/dsh-continual-evolve](https://github.com/ZK-Andy/dsh-continual-evolve) — 持续自进化：从会话轨迹沉淀版本化、可审计、可回滚的 harness 状态（提示词/记忆/技能/子代理规格），带审查门禁与技能热加载。
 - [zoahdev/dsh-plugin-doctor](https://github.com/zoahdev/dsh-plugin-doctor) — DSH 插件体检：manifest/patch/entry/build/pack/install 校验、可被模型调用的 plugin_check、profile 宿主遮蔽与 BOM 检测、环境诊断、投毒预检。
 - [zoahdev/dsh-rule-evolve](https://github.com/zoahdev/dsh-rule-evolve/tree/main/plugin) — 验证驱动的自我进化循环：失败日志自动变成经过验证的 AGENTS.md 规则；会话内插件（evolve_learn/evolve_apply/evolve_touch/evolve_recall）、工具体检、规则生命周期、本地召回。
+- [zoahdev/dsh-timesheet](https://github.com/zoahdev/dsh-timesheet) — 从 dsh 会话日志做基于 turn 的时间跟踪：总计、按天/项目/供应商/来源汇总、工具调用数、失败率与首 token 延迟——CLI + agent 可调用 timesheet 工具，dsh-timesheet/v1 报告，零运行时依赖。
 
 ### 🔒 安全与权限
 

--- a/data/plugins/zoahdev__dsh-timesheet.yml
+++ b/data/plugins/zoahdev__dsh-timesheet.yml
@@ -1,0 +1,6 @@
+url: https://github.com/zoahdev/dsh-timesheet
+name: zoahdev/dsh-timesheet
+category: dev
+description:
+  en: 'Turn-based time tracking from dsh session logs: totals, per-day/project/provider/source rollups, tool-call counts, failure rates, and time-to-first-token — CLI plus an agent-callable timesheet tool, dsh-timesheet/v1 reports, zero runtime deps.'
+  zh: '从 dsh 会话日志做基于 turn 的时间跟踪：总计、按天/项目/供应商/来源汇总、工具调用数、失败率与首 token 延迟——CLI + agent 可调用 timesheet 工具，dsh-timesheet/v1 报告，零运行时依赖。'

--- a/data/plugins/zoahdev__dsh-timesheet.yml
+++ b/data/plugins/zoahdev__dsh-timesheet.yml
@@ -4,3 +4,4 @@ category: dev
 description:
   en: 'Turn-based time tracking from dsh session logs: totals, per-day/project/provider/source rollups, tool-call counts, failure rates, and time-to-first-token — CLI plus an agent-callable timesheet tool, dsh-timesheet/v1 reports, zero runtime deps.'
   zh: '从 dsh 会话日志做基于 turn 的时间跟踪：总计、按天/项目/供应商/来源汇总、工具调用数、失败率与首 token 延迟——CLI + agent 可调用 timesheet 工具，dsh-timesheet/v1 报告，零运行时依赖。'
+# listing updated 2026-08-19 (repo hardened to 10+ commits; submission gate)


### PR DESCRIPTION
Add [zoahdev/dsh-timesheet](https://github.com/zoahdev/dsh-timesheet) to the Development & Runtime category.

**What it does:** turn-based time tracking from dsh session logs — totals, per-day/project/provider/source rollups, tool-call counts, failure rates, time-to-first-token. CLI + agent-callable \	imesheet\ tool, \dsh-timesheet/v1\ reports, zero runtime deps.

**Verification:** 7 unit tests, CI (dsh-plugin-doctor preflight + packed-artifact integration + fresh-profile dsh web boot smoke on Windows), npm \dsh-timesheet@0.1.0\ published, verified against real session logs.