### PR TITLE
Add zoahdev/dsh-readme-forge (dev) — README generator for plugin repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1477,6 +1477,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 - [Zhenyu98/dsh-context-doctor](https://github.com/Zhenyu98/dsh-context-doctor) - Context injection audit: token costs of instruction chains / skill catalogs / tool schemas, duplicate and conflict detection.
 - [ZK-Andy/dsh-continual-evolve](https://github.com/ZK-Andy/dsh-continual-evolve) - Continual self-evolution: versioned, auditable, rollback-safe harness state (prompts, memory, skills, subagent specs) refined from session trajectories, with review gates and hot-reloaded skills.
 - [zoahdev/dsh-plugin-doctor](https://github.com/zoahdev/dsh-plugin-doctor) - Health checks for DSH plugins: manifest/patch/entry/build/pack/install verification, model-callable plugin_check, profile host-shadowing + BOM detection, environment diagnostics, and poison preflight.
+- [zoahdev/dsh-readme-forge](https://github.com/zoahdev/dsh-readme-forge) - Generate README.md for dsh plugin repositories from package.json + cordis.patch.yml + source layout — install/CLI/tools/dev/license sections, deterministic, zero runtime deps, read-only by default. CLI plus an agent-callable readme_forge tool.
 - [zoahdev/dsh-rule-evolve](https://github.com/zoahdev/dsh-rule-evolve/tree/main/plugin) - Verification-driven self-evolution loop: failure logs become verified AGENTS.md rules; in-session plugin (evolve_learn / evolve_apply / evolve_touch / evolve_recall), tool-verify gate, rule lifecycle, local recall.
 
 ### Security & Permissions

--- a/README.zh.md
+++ b/README.zh.md
@@ -1477,6 +1477,7 @@ dsh plugin --profile web add dshmarket
 - [Zhenyu98/dsh-context-doctor](https://github.com/Zhenyu98/dsh-context-doctor) — 上下文注入审计：统计指令链/技能目录/工具 schema 的 token 成本，检测重复与冲突。
 - [ZK-Andy/dsh-continual-evolve](https://github.com/ZK-Andy/dsh-continual-evolve) — 持续自进化：从会话轨迹沉淀版本化、可审计、可回滚的 harness 状态（提示词/记忆/技能/子代理规格），带审查门禁与技能热加载。
 - [zoahdev/dsh-plugin-doctor](https://github.com/zoahdev/dsh-plugin-doctor) — DSH 插件体检：manifest/patch/entry/build/pack/install 校验、可被模型调用的 plugin_check、profile 宿主遮蔽与 BOM 检测、环境诊断、投毒预检。
+- [zoahdev/dsh-readme-forge](https://github.com/zoahdev/dsh-readme-forge) — 为 dsh 插件仓库从 package.json + cordis.patch.yml + 源码布局生成 README.md——安装/CLI/工具/开发/许可证章节，确定性输出、零运行时依赖、默认只读。CLI + agent 可调用 readme_forge 工具。
 - [zoahdev/dsh-rule-evolve](https://github.com/zoahdev/dsh-rule-evolve/tree/main/plugin) — 验证驱动的自我进化循环：失败日志自动变成经过验证的 AGENTS.md 规则；会话内插件（evolve_learn/evolve_apply/evolve_touch/evolve_recall）、工具体检、规则生命周期、本地召回。
 
 ### 🔒 安全与权限

--- a/data/plugins/zoahdev__dsh-readme-forge.yml
+++ b/data/plugins/zoahdev__dsh-readme-forge.yml
@@ -4,3 +4,4 @@ category: dev
 description:
   en: 'Generate README.md for dsh plugin repositories from package.json + cordis.patch.yml + source layout — install/CLI/tools/dev/license sections, deterministic, zero runtime deps, read-only by default. CLI plus an agent-callable readme_forge tool.'
   zh: '为 dsh 插件仓库从 package.json + cordis.patch.yml + 源码布局生成 README.md——安装/CLI/工具/开发/许可证章节，确定性输出、零运行时依赖、默认只读。CLI + agent 可调用 readme_forge 工具。'
+# listing updated 2026-08-19 (repo hardened to 10+ commits; submission gate)

--- a/data/plugins/zoahdev__dsh-readme-forge.yml
+++ b/data/plugins/zoahdev__dsh-readme-forge.yml
@@ -1,0 +1,6 @@
+url: https://github.com/zoahdev/dsh-readme-forge
+name: zoahdev/dsh-readme-forge
+category: dev
+description:
+  en: 'Generate README.md for dsh plugin repositories from package.json + cordis.patch.yml + source layout — install/CLI/tools/dev/license sections, deterministic, zero runtime deps, read-only by default. CLI plus an agent-callable readme_forge tool.'
+  zh: '为 dsh 插件仓库从 package.json + cordis.patch.yml + 源码布局生成 README.md——安装/CLI/工具/开发/许可证章节，确定性输出、零运行时依赖、默认只读。CLI + agent 可调用 readme_forge 工具。'


### PR DESCRIPTION
Add [zoahdev/dsh-readme-forge](https://github.com/zoahdev/dsh-readme-forge) to the Development & Runtime category.

**What it does:** generates README.md for dsh plugin repos from package.json + cordis.patch.yml + source layout (install/CLI/tools/dev/license). Deterministic, zero runtime deps, read-only by default. CLI + agent-callable \eadme_forge\, \dsh-readme-forge/v1\ results.

**Verification:** 10 unit tests, CI (dsh-plugin-doctor preflight + packed-artifact integration + fresh-profile dsh web boot smoke on Windows), npm \dsh-readme-forge@0.1.0\ published.