### PR TITLE
Add Aik358/dsh-anchored-monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 - [a903067276-rgb/dsh-hud](https://github.com/a903067276-rgb/dsh-hud) - HUD status panel: Git status, MCP servers, skills, model and token usage in a floating side panel.
 - [a903067276-rgb/dsh-plan-switch](https://github.com/a903067276-rgb/dsh-plan-switch) - One-click enter/exit Plan mode for the DSH web input bar, a quick-click shortcut for /plan.
 - [AcidGr/dsh-web-mobile-fix](https://github.com/AcidGr/dsh-web-mobile-fix) - Mobile layout fixes for the Web UI on narrow screens: full-screen settings panel, one-row plugin nav, full-screen sidebar, centered popups, icon-only session-log button.
+- [Aik358/dsh-anchored-monitor](https://github.com/Aik358/dsh-anchored-monitor) - A whip for DeepSeek V4 Pro: it watches the reasoning fingerprint of every thinking block and pulls the model back when it slips from focused "We will / I will" mode into scattered "let me" mode.
 - [AikenFra/dsh-alive](https://github.com/AikenFra/dsh-alive) - Zero-token online status indicator for the DeepSeek Harness web UI: an always-visible online/offline dot in the conversation header, auto-refreshed every 15 seconds with no LLM calls.
 - [AKIRACOD/dsh-drag-and-drop](https://github.com/AKIRACOD/dsh-drag-and-drop) - File-drag fork: drop documents as removable chips above the composer, send without typing.
 - [AKS1st/dsh-sysmon](https://github.com/AKS1st/dsh-sysmon) - System status floating widget: live CPU/memory/disk usage in the bottom-right corner of the DSH Web UI with threshold colour warnings.

--- a/README.zh.md
+++ b/README.zh.md
@@ -82,6 +82,7 @@ dsh plugin --profile web add dshmarket
 - [a903067276-rgb/dsh-hud](https://github.com/a903067276-rgb/dsh-hud) — HUD 状态面板：Git 状态、MCP 服务器、技能列表、模型与 token 用量，悬浮侧栏一览无余。
 - [a903067276-rgb/dsh-plan-switch](https://github.com/a903067276-rgb/dsh-plan-switch) — 输入框一键进/出 Plan 模式（/plan 的快捷点击），常驻小按钮。
 - [AcidGr/dsh-web-mobile-fix](https://github.com/AcidGr/dsh-web-mobile-fix) — Web UI 移动端布局修复：窄屏下设置面板全屏化、插件导航单行排满、侧边栏全屏、弹层居中、会话日志按钮图标化。
+- [Aik358/dsh-anchored-monitor](https://github.com/Aik358/dsh-anchored-monitor) — 给 DeepSeek V4 Pro 的鞭子：实时监听每个思维块的指纹，当模型从专注的 We will / I will 模式滑向发散的 let me 模式时把它拉回来。
 - [AikenFra/dsh-alive](https://github.com/AikenFra/dsh-alive) — 零 token 在线状态指示器：会话头部常驻显示 ● 在线 / ● 离线 状态点，每 15 秒自动检测一次，不调用任何 LLM。
 - [AKIRACOD/dsh-drag-and-drop](https://github.com/AKIRACOD/dsh-drag-and-drop) — 拖放 fork：文档以可删除「文件芯片」挂在输入框上方，不打字也能发送。
 - [AKS1st/dsh-sysmon](https://github.com/AKS1st/dsh-sysmon) — DSH Web 右下角系统状态悬浮窗：实时显示 CPU、内存、磁盘占用率，带阈值变色告警。

--- a/data/plugins/Aik358__dsh-anchored-monitor.yml
+++ b/data/plugins/Aik358__dsh-anchored-monitor.yml
@@ -1,0 +1,6 @@
+url: https://github.com/Aik358/dsh-anchored-monitor
+name: Aik358/dsh-anchored-monitor
+category: ui
+description:
+  en: 'A whip for DeepSeek V4 Pro: it watches the reasoning fingerprint of every thinking block and pulls the model back when it slips from focused "We will / I will" mode into scattered "let me" mode.'
+  zh: '给 DeepSeek V4 Pro 的鞭子：实时监听每个思维块的指纹，当模型从专注的 We will / I will 模式滑向发散的 let me 模式时把它拉回来。'


### PR DESCRIPTION
Add Aik358/dsh-anchored-monitor to the list

A real-time monitoring plugin for the DeepSeek harness: it fingerprints every reasoning/thinking block of a session, classifies the band (focused "We will / I will" vs scattered "let me" drift), and applies layered L1 → L2 → L3 interventions to pull the model back to the anchored standard — with:
- an independent monitor process (event source, window/score/baseline/state machine, JSONL logs, HTTP + SSE)
- a zero-dependency dark dashboard (band chart, intervention marks, state machine)
- a configurable persona-preset path (`preset/`) and a meme "Liang-o-meter" skin
- demo-generate / replay / calibrate tooling for verification

Published on npm: `@a9i5k4/dsh-anchored-monitor` (0.2.9)