### PR TITLE
Add screenshot for creght-dev/skills

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -430,6 +430,7 @@
   "https://raw.githubusercontent.com/corrinehu/dsh-chat-imagine/main/assets/4.png"
  ],
  "https://github.com/creght-dev/skills": [
+  "https://raw.githubusercontent.com/creght-dev/skills/main/assets/screenshot-dsh.jpg",
   "https://raw.githubusercontent.com/creght-dev/skills/main/assets/screenshot-editor.jpg"
  ],
  "https://github.com/d-dev0101/open-sea-skin": [

--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -429,6 +429,9 @@
   "https://raw.githubusercontent.com/corrinehu/dsh-chat-imagine/main/assets/3.png",
   "https://raw.githubusercontent.com/corrinehu/dsh-chat-imagine/main/assets/4.png"
  ],
+ "https://github.com/creght-dev/skills": [
+  "https://raw.githubusercontent.com/creght-dev/skills/main/assets/screenshot-editor.png"
+ ],
  "https://github.com/d-dev0101/open-sea-skin": [
   "https://raw.githubusercontent.com/d-dev0101/open-sea-skin/5ae54402ec6d4c961d41aee8ed786280799712c7/docs/marketplace/open-sea-harness-cover.png",
   "https://raw.githubusercontent.com/d-dev0101/open-sea-skin/5ae54402ec6d4c961d41aee8ed786280799712c7/docs/screenshots/harness-dark-overview-40.gif",

--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -430,7 +430,7 @@
   "https://raw.githubusercontent.com/corrinehu/dsh-chat-imagine/main/assets/4.png"
  ],
  "https://github.com/creght-dev/skills": [
-  "https://raw.githubusercontent.com/creght-dev/skills/main/assets/screenshot-editor.png"
+  "https://raw.githubusercontent.com/creght-dev/skills/main/assets/screenshot-editor.jpg"
  ],
  "https://github.com/d-dev0101/open-sea-skin": [
   "https://raw.githubusercontent.com/d-dev0101/open-sea-skin/5ae54402ec6d4c961d41aee8ed786280799712c7/docs/marketplace/open-sea-harness-cover.png",


### PR DESCRIPTION
Follow-up to #90 (per @fkysly's note): adds curated screenshots for [creght-dev/skills](https://github.com/creght-dev/skills) so the storefront detail view shows them in a controlled order instead of extracting from the README.

- Key matches the README entry URL exactly: `https://github.com/creght-dev/skills`
- Images are GitHub-hosted (`raw.githubusercontent.com`) and live in the plugin's own repo under `assets/`, so they update with releases
- 2 images, inserted in the file's sorted position; the dsh session leads, the editor shot follows

Preview:
1. https://raw.githubusercontent.com/creght-dev/skills/main/assets/screenshot-dsh.jpg
2. https://raw.githubusercontent.com/creght-dev/skills/main/assets/screenshot-editor.jpg

🤖 Generated with [Claude Code](https://claude.com/claude-code)

