### PR TITLE
fix: install Deep Whale from v0.1.11 runtime tarball

### DIFF
--- a/data/plugins/GGBond2424648901__deep-whale-day-night-theme.yml
+++ b/data/plugins/GGBond2424648901__deep-whale-day-night-theme.yml
@@ -1,6 +1,7 @@
 url: https://github.com/GGBond2424648901/deep-whale-day-night-theme
 name: GGBond2424648901/deep-whale-day-night-theme
 category: theme
+tarball: https://github.com/GGBond2424648901/deep-whale-day-night-theme/releases/download/v0.1.11/deep-whale-day-night-theme-0.1.11.tgz
 description:
   en: 'Day/night whale-girl skin: a crystal workshop by day and a moon-tide observatory by night, with paired scenes, chibi companions, ornaments, and lightweight bubble and star ambience.'
   zh: 鲸鱼娘昼夜皮肤：白昼水晶工坊与夜晚月潮观测室双场景，成对角色、Q 版侧栏宠物、花边与气泡/星点轻量氛围。


### PR DESCRIPTION
## Summary

- route the existing Deep Whale day/night theme entry to its prebuilt v0.1.11 GitHub Release tarball
- keep the repository URL and complete source listing unchanged
- let dsh-market prefer the 7.53 MB immutable runtime artifact instead of downloading the 64 MB source channel

## Why

The v0.1.11 release restores official `@deepseek-ai/dsh@0.1.0-rc.7` activation and publishes a runtime-only installer. The package is not published under a verified npm scope, so the registry's supported author-declared `tarball` field is the correct install source.

## Validation

- Release URL returns the signed-in public asset and matches `SHA256SUMS.txt`
- official rc.7 install → composed-config → one active theme row → remove → no residue: passed
- `node scripts/generate-readme.mjs --check`: passed
- `SKIP_PUBLISH_CHECKS=1 node scripts/build-site.mjs`: passed (1472 rows × 2 locales)
- `node scripts/check-submission.mjs`: passed (`ok: true`, 1 entry)
- `node scripts/probe-tarballs.mjs --strict`: completed; this Windows runner could not fetch GitHub assets with Node fetch, while the same URL was independently installed successfully through DSH

Release: https://github.com/GGBond2424648901/deep-whale-day-night-theme/releases/tag/v0.1.11