### PR TITLE
Add 1070296335-create/dph-taskboard (UI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 
 - [01Virex/dsh-status-rotator](https://github.com/01Virex/dsh-status-rotator) - Replaces the "Deep diving..." turn-status label with rotating meme-worthy phrases, with typewriter and gradient effects.
 - [0xsline/dsh-spotlight](https://github.com/0xsline/dsh-spotlight) - Keyboard-first command palette for the DSH Web UI.
+- [1070296335-create/dph-taskboard](https://github.com/1070296335-create/dph-taskboard) - Session-based task board in the sidebar: drag sessions into todo/doing/review/done columns, create sessions with model and reasoning-effort selection, trash with restore, notes, export/import.
 - [13071301808/dsh-composer-expand](https://github.com/13071301808/dsh-composer-expand) - Composer expand/collapse toggle for the Web UI: a ⬆/⬇ button in the composer tool row grows the input to a tall 70vh writing view for long drafts.
 - [2768651338/dsh-effort-slider](https://github.com/2768651338/dsh-effort-slider) - A Claude Code-style reasoning-effort slider for the DSH Web UI: stepless drag, snap-on-release, a WebGL fire trail, and real, working thinking-effort control for any custom third-party model or provider.
 - [2nd1st/dsh-plugin-open-app](https://github.com/2nd1st/dsh-plugin-open-app) - Runs open-mcp-apps inside DSH: every MCP app gets its own sidebar container with a separate workspace, session, and App mode, an agent status strip under the app, and inline app rendering in ordinary chats.

--- a/README.zh.md
+++ b/README.zh.md
@@ -77,6 +77,7 @@ dsh plugin --profile web add dshmarket
 
 - [01Virex/dsh-status-rotator](https://github.com/01Virex/dsh-status-rotator) — 把回合状态那句 "Deep diving..." 替换成更有梗的自定义文案，按阶段轮换，支持打字机与流动渐变。
 - [0xsline/dsh-spotlight](https://github.com/0xsline/dsh-spotlight) — 键盘优先的命令面板（command palette）。
+- [1070296335-create/dph-taskboard](https://github.com/1070296335-create/dph-taskboard) — 侧边栏会话化任务看板：拖拽会话到待办/进行中/评审中/已完成四列，新建会话可选模型与推理强度，回收站可恢复，支持备注与导出导入。
 - [13071301808/dsh-composer-expand](https://github.com/13071301808/dsh-composer-expand) — Web UI 输入框展开/收起：composer 工具行新增 ⬆/⬇ 按钮，一键把输入框扩大到 70vh 高度，方便写长 prompt。
 - [2768651338/dsh-effort-slider](https://github.com/2768651338/dsh-effort-slider) — 仿 Claude Code 的推理等级滑块：无极拖动、松手吸附、WebGL 火焰跟随，任何自定义第三方模型/提供商都能获得真实生效的思考强度调节。
 - [2nd1st/dsh-plugin-open-app](https://github.com/2nd1st/dsh-plugin-open-app) — 把 open-mcp-apps 接进 DSH：每个 MCP app 都是侧边栏里自己的容器，带独立 workspace、会话与 App mode，应用下方是 agent 状态条，普通聊天里也能行内渲染 app。

--- a/data/plugins/1070296335-create__dph-taskboard.yml
+++ b/data/plugins/1070296335-create__dph-taskboard.yml
@@ -1,0 +1,6 @@
+url: https://github.com/1070296335-create/dph-taskboard
+name: 1070296335-create/dph-taskboard
+category: ui
+description:
+  en: Session-based task board in the sidebar: drag sessions into todo/doing/review/done columns, create sessions with model and reasoning-effort selection, trash with restore, notes, export/import.
+  zh: 侧边栏会话化任务看板：拖拽会话到待办/进行中/评审中/已完成四列，新建会话可选模型与推理强度，回收站可恢复，支持备注与导出导入。

--- a/data/plugins/1070296335-create__dph-taskboard.yml
+++ b/data/plugins/1070296335-create__dph-taskboard.yml
@@ -2,5 +2,5 @@ url: https://github.com/1070296335-create/dph-taskboard
 name: 1070296335-create/dph-taskboard
 category: ui
 description:
-  en: Session-based task board in the sidebar: drag sessions into todo/doing/review/done columns, create sessions with model and reasoning-effort selection, trash with restore, notes, export/import.
+  en: 'Session-based task board in the sidebar: drag sessions into todo/doing/review/done columns, create sessions with model and reasoning-effort selection, trash with restore, notes, export/import.'
   zh: 侧边栏会话化任务看板：拖拽会话到待办/进行中/评审中/已完成四列，新建会话可选模型与推理强度，回收站可恢复，支持备注与导出导入。


### PR DESCRIPTION
Adds the session-based task board plugin to the UI category.

- **Repo**: https://github.com/1070296335-create/dph-taskboard
- **Category**: `ui`
- **dsh.bundle**: declared (`dsh.bundle.patch` → `./cordis.patch.yml`), installable via `dsh plugin add`
- **What it does**: a task board entry next to the workspace search icon in the sidebar; four status columns (todo / doing / review / done) with drag-and-drop; sessions are first-class cards (create sessions with name / model / reasoning effort / opening message / group placement); trash with restore; notes (description / priority / labels); export/import; running-status dot; host-side snapshot for agents to read.