### PR TITLE
Add 131CDA1/dsh-scrape-webpage (browser)

### DIFF
--- a/README.md
+++ b/README.md
@@ -848,6 +848,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 
 ### Browser & Web
 
+- [131CDA1/dsh-scrape-webpage](https://github.com/131CDA1/dsh-scrape-webpage) - Fetches any http/https page and returns title, description, main text, heading outline and links, with stats (char/word counts, reading time, language) and top keywords; can download content images to the session workspace for vision analysis and dispatch them to registered analyzers via the scrape.imageAnalyzer service.
 - [1624318455/dsh-plugin-tavily](https://github.com/1624318455/dsh-plugin-tavily) - Tavily-backed web search provider for the built-in web_search tool, with a settings card for the API key, result count, and recency window.
 - [263311487-ux/dsh-verify](https://github.com/263311487-ux/dsh-verify) - Independent browser acceptance testing for agent deliverables: JSON spec in, real-Chromium verdict out.
 - [2672243194/dsh-read-url](https://github.com/2672243194/dsh-read-url) - Read any page as clean main content: charset auto-detect (GBK/GB2312/UTF-8/Big5), noise stripping, compact text/Markdown, offset continuation, optional SPA rendering, batch reads and site crawling.

--- a/README.zh.md
+++ b/README.zh.md
@@ -848,6 +848,7 @@ dsh plugin --profile web add dshmarket
 
 ### 🌐 浏览器与网页
 
+- [131CDA1/dsh-scrape-webpage](https://github.com/131CDA1/dsh-scrape-webpage) — 抓取任意 http/https 网页，提取标题、描述、正文、标题结构与链接，输出字符/词数、阅读时长、语言等统计与高频关键词；支持下载内容图片到会话工作区供视觉分析，并通过 scrape.imageAnalyzer 服务分发给已注册的识图分析器。
 - [1624318455/dsh-plugin-tavily](https://github.com/1624318455/dsh-plugin-tavily) — 基于 Tavily 的网页搜索提供方：替换内置 web_search 的后端，并提供 API Key、结果数量与时间窗口的设置卡片。
 - [263311487-ux/dsh-verify](https://github.com/263311487-ux/dsh-verify) — Agent 交付物的独立浏览器验收测试：JSON 规格进，真实 Chromium 结论出。
 - [2672243194/dsh-read-url](https://github.com/2672243194/dsh-read-url) — 读取网页返回干净正文：中文编码自动识别（GBK/GB2312/UTF-8/Big5）、噪音过滤、紧凑文本/Markdown、offset 续读、可选 SPA 渲染、批量读取与整站爬取。

--- a/data/plugins/131CDA1__dsh-scrape-webpage.yml
+++ b/data/plugins/131CDA1__dsh-scrape-webpage.yml
@@ -1,0 +1,6 @@
+url: https://github.com/131CDA1/dsh-scrape-webpage
+name: 131CDA1/dsh-scrape-webpage
+category: browser
+description:
+  en: 'Fetches any http/https page and returns title, description, main text, heading outline and links, with stats (char/word counts, reading time, language) and top keywords; can download content images to the session workspace for vision analysis and dispatch them to registered analyzers via the scrape.imageAnalyzer service.'
+  zh: '抓取任意 http/https 网页，提取标题、描述、正文、标题结构与链接，输出字符/词数、阅读时长、语言等统计与高频关键词；支持下载内容图片到会话工作区供视觉分析，并通过 scrape.imageAnalyzer 服务分发给已注册的识图分析器。'


### PR DESCRIPTION
## Summary

Adds [dsh-scrape-webpage](https://github.com/131CDA1/dsh-scrape-webpage) to the
awesome-dsh-plugin list — a zero-dependency web scraping & analysis plugin for
DeepSeek Harness, installable in one command (`dsh plugin --profile web add`).

## What it does

- **Web scraping**: fetches any http/https page (redirects, graceful non-2xx handling)
- **Content extraction**: title, meta description, main text (truncatable), H1–H6
  heading outline, link list (up to 100)
- **Built-in analysis**: char/word counts, estimated reading time, language hint
  (zh/en/mixed), top-30 keywords (CJK bigrams + English words with stop-word filtering)
- **Image support**: downloads up to 6 content images per page (relative URL
  resolution, icon/logo noise filtering) into the session workspace for
  `read_image` visual analysis
- **Extension interface**: publishes a `scrape.imageAnalyzer` service so other
  vision plugins can register an analyzer; scraped images are auto-dispatched and
  results attached to tool output

## Why it fits

- Packaged as a **bundle** (`dsh.bundle.patch` in package.json) — installs via
  `dsh plugin --profile web add dsh-scrape-webpage`, auto-registers as a
  composition layer, no manual patch editing
- Zero runtime dependencies, Host-only
- Sandbox-aware: fetches inside the session sandbox by default; HTTPS/TLS
  restrictions follow the standard escalation contract
  (`sandbox_permissions` + approval)
- README (zh) covers install, params, security model, and the image-analyzer contract

## Changes

- `data/plugins/131CDA1__dsh-scrape-webpage.yml`: new entry (category `browser`)
- `README.md` / `README.zh.md`: regenerated via `node scripts/generate-readme.mjs`

## Checklist

- [x] Read contributing.md
- [x] Only my own entry added (one YAML file + regenerated READMEs)
- [x] Category picked to match what the plugin does (`browser`)
- [x] `dsh.bundle` declared in package.json; repo has real, working code
- [x] `dsh-plugin` topic added; v1.0.0 tag + release published
