### PR TITLE
Add amlyczz/dsh-agy-link

### DIFF
--- a/README.md
+++ b/README.md
@@ -500,6 +500,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 
 ### Models & Providers
 
+- [amlyczz/dsh-agy-link](https://github.com/amlyczz/dsh-agy-link) - Google Antigravity (agy CLI) models for DSH — streaming chat with Gemini/Claude/GPT-OSS subscriptions, native tool cards, thinking turns, and in-GUI Google OAuth login.
 - [BruceLanLan/dsh-tier-router](https://github.com/BruceLanLan/dsh-tier-router) - Two-tier model routing: a strong tier plans, advises and reviews while a cheap tier implements, with plan-mode-aware auto routing, a high-impact escalation guard, failure auto-escalation, and subagent tiering.
 - [btspoony/dsh-llm-fallbacks](https://github.com/btspoony/dsh-llm-fallbacks) - Role-based LLM retry & fallback strategies.
 - [corrinehu/dsh-workbuddy-connect](https://github.com/corrinehu/dsh-workbuddy-connect) - Brings the models in the WorkBuddy desktop app straight into DeepSeek Harness — zero configuration in the DSH chat.

--- a/README.zh.md
+++ b/README.zh.md
@@ -500,6 +500,7 @@ dsh plugin --profile web add dshmarket
 
 ### 🔌 模型与账号接入
 
+- [amlyczz/dsh-agy-link](https://github.com/amlyczz/dsh-agy-link) — 将 Google Antigravity (agy CLI) 接入 DSH：无 API Key 使用 Gemini/Claude/GPT-OSS 订阅模型，支持流式对话、原生工具卡片、思考轮次注记及 Web 界面 Google OAuth 扫码登录。
 - [BruceLanLan/dsh-tier-router](https://github.com/BruceLanLan/dsh-tier-router) — 双档模型路由：强档负责规划/咨询/评审、弱档负责实现；含计划模式自动路由、高危操作守卫、失败自动升级与子代理分层。
 - [btspoony/dsh-llm-fallbacks](https://github.com/btspoony/dsh-llm-fallbacks) — 基于角色的模型重试与备用策略。
 - [corrinehu/dsh-workbuddy-connect](https://github.com/corrinehu/dsh-workbuddy-connect) — 将 WorkBuddy 桌面 App 包含的模型自动接入 DeepSeek Harness，在 DSH 对话窗口里零配置使用。

--- a/data/plugins/amlyczz__dsh-agy-link.yml
+++ b/data/plugins/amlyczz__dsh-agy-link.yml
@@ -1,0 +1,6 @@
+url: https://github.com/amlyczz/dsh-agy-link
+name: amlyczz/dsh-agy-link
+category: model
+description:
+  en: 'Google Antigravity (agy CLI) models for DSH — streaming chat with Gemini/Claude/GPT-OSS subscriptions, native tool cards, thinking turns, and in-GUI Google OAuth login.'
+  zh: '将 Google Antigravity (agy CLI) 接入 DSH：无 API Key 使用 Gemini/Claude/GPT-OSS 订阅模型，支持流式对话、原生工具卡片、思考轮次注记及 Web 界面 Google OAuth 扫码登录。'


### PR DESCRIPTION
**Plugin**: [amlyczz/dsh-agy-link](https://github.com/amlyczz/dsh-agy-link) — category `model`
**npm**: https://www.npmjs.com/package/dsh-agy-link (0.3.5, prebuilt)

Brings Google Antigravity models (Gemini / Claude / GPT-OSS slugs exposed by the official agy CLI) into DSH as a first-class provider route:
- Full streaming responses with thinking turns and token usage.
- Native DSH tool cards (terminal, diff, view, search) mirrored via `agy_tool`.
- Multi-turn continuity with session-conversation binding and continuation spans.
- In-GUI Google OAuth login with QR code & auth helper.
- Sliding activity watchdog supporting indefinite execution for active long tasks.
- `/agy` command suite (`status`, `auth`, `doctor`, `ask`).

Checklist: `dsh.bundle` manifest declared; 41 commits; repo age >= 1 day; `dsh-plugin` topic set; published to npm; READMEs regenerated via `node scripts/generate-readme.mjs`.