### PR TITLE
Add suanzhang-dsh to Usage & Billing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1730,4 +1730,3 @@ Listed here? Show it off:
 This is a community-maintained index. Plugins are developed and maintained by their respective authors; listing here is not an endorsement, and no guarantees are made about any plugin's safety, quality, or maintenance. Installing a plugin runs third-party code on your machine — review the source and install at your own risk. This project is not affiliated with DeepSeek.
 
 Issues here are for the list and its website only. Problems inside the plugin market UI go to [dsh-market](https://github.com/dsh-market/dsh-market/issues); problems with `dsh` itself go to [deepseek-harness](https://github.com/deepseek-ai/deepseek-harness/issues); a bug in a plugin goes to that plugin's own repository.
-

--- a/README.md
+++ b/README.md
@@ -317,6 +317,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 - [Choi-Peng/dsh-deepseek-balance](https://github.com/Choi-Peng/dsh-deepseek-balance) - DeepSeek account balance in the dsh web sidebar footer with live config hot reload and an editable Settings → Plugins card.
 - [ChrisZhangWG/dsh-codex-meter](https://github.com/ChrisZhangWG/dsh-codex-meter) - Adds a Settings Usage dashboard for DeepSeek API balance, official token and cost analysis, trends, context warnings, and live API activity.
 - [CN-Leo/dsh-deepseek-balance](https://github.com/CN-Leo/dsh-deepseek-balance) - Real-time DeepSeek account balance in the composer dock, auto-refreshing every 15 seconds with hover details.
+- [CZ1900/suanzhang-dsh](https://github.com/CZ1900/suanzhang-dsh) - Trading-terminal style cost tracker for DeepSeek Harness: sidebar balance and today spend, per-step RMB cost table, auto-synced official pricing with peak/off-peak, cross-session and per-day summaries, tool-level attribution, and cost forecast.
 - [DamonKoy/dsh-plugins#dsh-usage-cost](https://github.com/DamonKoy/dsh-plugins/tree/main/packages/dsh-usage-cost) - Token usage and cost tracking with daily/session budget alerts and a usage_report tool.
 - [DamonKoy/dsh-web-ui#dsh-live-stats](https://github.com/DamonKoy/dsh-web-ui/tree/main/packages/dsh-live-stats) - Live token estimates and generation throughput for the dsh web GUI.
 - [dk33333333/dsh-deepseek-quota-left](https://github.com/dk33333333/dsh-deepseek-quota-left) - DeepSeek API quota panel collapsed into a left-edge handle for the Web UI: click to expand balance, official today's consumption (with platform token) and live conversation cost; fork of dsh-deepseek-quota.
@@ -1729,3 +1730,4 @@ Listed here? Show it off:
 This is a community-maintained index. Plugins are developed and maintained by their respective authors; listing here is not an endorsement, and no guarantees are made about any plugin's safety, quality, or maintenance. Installing a plugin runs third-party code on your machine — review the source and install at your own risk. This project is not affiliated with DeepSeek.
 
 Issues here are for the list and its website only. Problems inside the plugin market UI go to [dsh-market](https://github.com/dsh-market/dsh-market/issues); problems with `dsh` itself go to [deepseek-harness](https://github.com/deepseek-ai/deepseek-harness/issues); a bug in a plugin goes to that plugin's own repository.
+

--- a/README.zh.md
+++ b/README.zh.md
@@ -317,6 +317,7 @@ dsh plugin --profile web add dshmarket
 - [Choi-Peng/dsh-deepseek-balance](https://github.com/Choi-Peng/dsh-deepseek-balance) — 在 DSH Web 侧边栏底部展示 DeepSeek 账户余额，支持配置热重载与可编辑的设置 → 插件卡片。
 - [ChrisZhangWG/dsh-codex-meter](https://github.com/ChrisZhangWG/dsh-codex-meter) — 在设置中添加 DeepSeek API 用量仪表板，显示余额、官方 Token 与费用分析、趋势、上下文警告及实时 API 活动。
 - [CN-Leo/dsh-deepseek-balance](https://github.com/CN-Leo/dsh-deepseek-balance) — 在 DSH Web 输入框下方实时显示 DeepSeek 账户余额，每 15 秒自动刷新，悬停查看总额、赠送与充值明细。
+- [CZ1900/suanzhang-dsh](https://github.com/CZ1900/suanzhang-dsh) — 交易终端风格的 DeepSeek Harness 计费插件：侧边栏余额与今日消费、按步骤人民币费用表、官方价自动同步（含峰谷）、跨会话与按天汇总、工具级费用归属与成本预测。
 - [DamonKoy/dsh-plugins#dsh-usage-cost](https://github.com/DamonKoy/dsh-plugins/tree/main/packages/dsh-usage-cost) — Token 用量与成本统计：日/会话预算告警 + usage_report 工具。
 - [DamonKoy/dsh-web-ui#dsh-live-stats](https://github.com/DamonKoy/dsh-web-ui/tree/main/packages/dsh-live-stats) — dsh web GUI 实时 token 估算与生成吞吐。
 - [dk33333333/dsh-deepseek-quota-left](https://github.com/dk33333333/dsh-deepseek-quota-left) — DeepSeek API 额度面板折叠为左侧边框把手：点击展开查看余额、官方精确今日已消费（配置平台 token 后）与实时对话费用；dsh-deepseek-quota 的修改版。

--- a/data/plugins/CZ1900__suanzhang-dsh.yml
+++ b/data/plugins/CZ1900__suanzhang-dsh.yml
@@ -1,0 +1,6 @@
+url: https://github.com/CZ1900/suanzhang-dsh
+name: CZ1900/suanzhang-dsh
+category: usage
+description:
+  en: 'Trading-terminal style cost tracker for DeepSeek Harness: sidebar balance and today spend, per-step RMB cost table, auto-synced official pricing with peak/off-peak, cross-session and per-day summaries, tool-level attribution, and cost forecast.'
+  zh: 交易终端风格的 DeepSeek Harness 计费插件：侧边栏余额与今日消费、按步骤人民币费用表、官方价自动同步（含峰谷）、跨会话与按天汇总、工具级费用归属与成本预测。


### PR DESCRIPTION
## 收录 suanzhang-dsh（算账）到 Usage & Billing

交易终端风格的 DeepSeek Harness 计费插件，已满足本列表收录标准：

- ✅ `package.json` 声明 `dsh.bundle.patch` manifest（可通过 `dsh plugin add` 安装）
- ✅ 携带 `dsh-plugin` topic
- ✅ commit 数 20（≥10）

**功能亮点：**
- 侧边栏常驻「当前余额 / 今日消费」，点击跳转算账页签；
- 算账页签：四格行情栏（余额/今天/累计/缓存节省）+ 按步骤人民币费用表；
- 官方价自动同步（DeepSeek 官方中文计价页，含 9:00–14:00 峰谷），失败回退内置价；
- 跨会话 / 跨天汇总、工具级费用归属、成本预测、复制明细（TSV）。

已按 Contributing 规则添加 `data/plugins/CZ1900__suanzhang-dsh.yml`。