### PR TITLE
Add screenshots for falser101/dsh-mascot

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -1009,5 +1009,10 @@
  "https://github.com/lemonorangeapple/dsh-effort-switcher": [
   "https://raw.githubusercontent.com/lemonorangeapple/dsh-effort-switcher/master/screenshots/1.png",
   "https://raw.githubusercontent.com/lemonorangeapple/dsh-effort-switcher/master/screenshots/2.png"
+ ],
+ "https://github.com/falser101/dsh-mascot": [
+  "https://raw.githubusercontent.com/falser101/dsh-mascot/main/assets/cover.jpg",
+  "https://raw.githubusercontent.com/falser101/dsh-mascot/main/assets/faces.jpg",
+  "https://raw.githubusercontent.com/falser101/dsh-mascot/main/assets/skins.jpg"
  ]
 }


### PR DESCRIPTION
Storefronts were picking the first README thumbnail (a breed face). This registers three GitHub-hosted shots for [falser101/dsh-mascot](https://github.com/falser101/dsh-mascot):

1. Product cover (pet in the GUI, first-run hint)
2. Working vs writing expressions
3. All ten cat/dog skins

Install (npm, once published): `dsh plugin --profile web add @falser101/mascot`