### PR TITLE
Add ZSeven-W/dsh-noema

### DIFF
--- a/README.md
+++ b/README.md
@@ -669,6 +669,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 - [zhangzhenwen1/qmd-autosearch](https://github.com/zhangzhenwen1/qmd-autosearch) - Auto-supplement QMD semantic search when the model greps/globs a knowledge-base directory: zero-dependency DSH plugin, async injection via next-step, no manual invocation.
 - [zhengjy01/dsh-flomo](https://github.com/zhengjy01/dsh-flomo) - Write notes and memos to flomo (浮墨笔记) from any agent via the flomo_send tool, configured once with the flomo API URL or API Key.
 - [zhengjy01/dsh-notion-connector](https://github.com/zhengjy01/dsh-notion-connector) - Notion connector for DeepSeek Harness: search, read, query, create, update, and append Notion pages and databases via six agent tools, with a Web settings page — configured once with an Integration Token.
+- [ZSeven-W/dsh-noema](https://github.com/ZSeven-W/dsh-noema) - Long-term memory for DSH agents — durable, inspectable memories with recall, search, browse and knowledge-graph tools, import from ten other AI coding tools, and a settings page.
 
 ### Tools & Capabilities
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -669,6 +669,7 @@ dsh plugin --profile web add dshmarket
 - [zhangzhenwen1/qmd-autosearch](https://github.com/zhangzhenwen1/qmd-autosearch) — 模型在知识库目录执行 grep/glob 搜索时自动补充 QMD 语义检索：零依赖 DSH 插件，异步注入下一步上下文，无需手动调用。
 - [zhengjy01/dsh-flomo](https://github.com/zhengjy01/dsh-flomo) — 配置一次 flomo API URL / API Key，Agent 即可用 flomo_send 把笔记、摘要、待办写进 flomo（浮墨笔记）。
 - [zhengjy01/dsh-notion-connector](https://github.com/zhengjy01/dsh-notion-connector) — 配置一次 Notion Integration Token，Agent 即可搜索、读取、查询、创建、更新、追加 Notion 页面与数据库内容，并提供 Web 设置页。
+- [ZSeven-W/dsh-noema](https://github.com/ZSeven-W/dsh-noema) — 为 DSH Agent 提供长期记忆——可检索、可检视的持久记忆，带回忆、搜索、浏览与知识图谱工具，支持从十个其他 AI 编码工具导入记忆，并附设置页。
 
 ### 🛠️ 工具与能力
 

--- a/data/plugins/ZSeven-W__dsh-noema.yml
+++ b/data/plugins/ZSeven-W__dsh-noema.yml
@@ -1,0 +1,6 @@
+url: https://github.com/ZSeven-W/dsh-noema
+name: ZSeven-W/dsh-noema
+category: memory
+description:
+  en: 'Long-term memory for DSH agents — durable, inspectable memories with recall, search, browse and knowledge-graph tools, import from ten other AI coding tools, and a settings page.'
+  zh: '为 DSH Agent 提供长期记忆——可检索、可检视的持久记忆，带回忆、搜索、浏览与知识图谱工具，支持从十个其他 AI 编码工具导入记忆，并附设置页。'


### PR DESCRIPTION
Adds the dsh-noema plugin (long-term memory for DSH) to the memory category.\n\n- npm: @zseven-w/dsh-noema\n- repo: https://github.com/ZSeven-W/dsh-noema\n- declares dsh.bundle + dsh.client, 16 commits, dsh-plugin topic set