### PR TITLE
add zenglihunter/dsh-petdex-pet to the plugin list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1697,6 +1697,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 - [xiekai886/dsh-MusicPlayer](https://github.com/xiekai886/dsh-MusicPlayer) - A collapsible/expandable draggable floating music player with NetEase Cloud Music playlist import and song/artist search — chat and listen at the same time.
 - [yushi-xxh/dsh-homepage-skin](https://github.com/yushi-xxh/dsh-homepage-skin) - Adds the DeepSeek Harness homepage background to dsh web: WebGL fluid light, dot-line grid and a digital point-cloud whale, with dark and light palettes.
 - [yyh-001/dsh-meme](https://github.com/yyh-001/dsh-meme) - Chat meme stickers: text-only send, mood auto-send, QQ/WeChat-style picker, auto-learn, custom packs.
+- [zenglihunter/dsh-petdex-pet](https://github.com/zenglihunter/dsh-petdex-pet) - A desktop pet in the DSH web GUI: floating, draggable sprite pet that animates with agent activity (thinking, idle, error, done, awaiting approval), with a settings page for size, switching, gallery search and one-click pet install. Ships 4 bundled Hunter x Hunter starter pets.
 - [zoahdev/dsh-pet-evolve](https://github.com/zoahdev/dsh-pet-evolve) - The pet that grows with your agent: 5 evolution stages earned from real signals (verified rules, completed sessions, tool calls, compactions), agent-state mirroring, and one-click growth share cards. Zero dependencies, 100% local.
 <!-- END PLUGINS -->
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -1697,6 +1697,7 @@ dsh plugin --profile web add dshmarket
 - [xiekai886/dsh-MusicPlayer](https://github.com/xiekai886/dsh-MusicPlayer) — 可折叠/展开、自由拖动的悬浮音乐播放器，接入网易云音乐，支持歌单导入和按歌名或歌手搜索单曲导入，边对话边听歌。
 - [yushi-xxh/dsh-homepage-skin](https://github.com/yushi-xxh/dsh-homepage-skin) — 给 dsh web 铺上 DeepSeek Harness 首页同款背景：WebGL 流体光效、点线网格与数字点云鲸鱼，深色/亮色两套配色。
 - [yyh-001/dsh-meme](https://github.com/yyh-001/dsh-meme) — 聊天表情包：纯文本斗图、情绪主动发图、像 QQ/微信 一样发图、AI 自动学图、自定义表情包。
+- [zenglihunter/dsh-petdex-pet](https://github.com/zenglihunter/dsh-petdex-pet) — DSH Web 界面里的桌面宠物：右下角悬浮、可拖拽，随智能体活动切换精灵动画；设置页可管理大小、启停切换、图库搜索与一键安装宠物。内置 4 个全职猎人主角宠物包。
 - [zoahdev/dsh-pet-evolve](https://github.com/zoahdev/dsh-pet-evolve) — 会随 agent 成长的宠物：真实信号（已验证规则/会话/工具调用/压缩）驱动 5 阶段进化、镜像 agent 状态、一键导出成长分享卡。零依赖、全本地。
 <!-- END PLUGINS -->
 

--- a/data/plugins/zenglihunter__dsh-petdex-pet.yml
+++ b/data/plugins/zenglihunter__dsh-petdex-pet.yml
@@ -1,0 +1,6 @@
+url: https://github.com/zenglihunter/dsh-petdex-pet
+name: zenglihunter/dsh-petdex-pet
+category: fun
+description:
+  en: "A desktop pet in the DSH web GUI: floating, draggable sprite pet that animates with agent activity (thinking, idle, error, done, awaiting approval), with a settings page for size, switching, gallery search and one-click pet install. Ships 4 bundled Hunter x Hunter starter pets."
+  zh: "DSH Web 界面里的桌面宠物：右下角悬浮、可拖拽，随智能体活动切换精灵动画；设置页可管理大小、启停切换、图库搜索与一键安装宠物。内置 4 个全职猎人主角宠物包。"

--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -980,5 +980,10 @@
   "https://raw.githubusercontent.com/tipoLi5890/dsh-file-mention/main/assets/screenshots/file-mention-browse.png",
   "https://raw.githubusercontent.com/tipoLi5890/dsh-file-mention/main/assets/screenshots/file-mention-drag-drop.png",
   "https://raw.githubusercontent.com/tipoLi5890/dsh-file-mention/main/assets/screenshots/file-mention-upload-reference.png"
+ ],
+ "https://github.com/zenglihunter/dsh-petdex-pet": [
+  "https://raw.githubusercontent.com/zenglihunter/dsh-petdex-pet/master/img/screenshot.png",
+  "https://raw.githubusercontent.com/zenglihunter/dsh-petdex-pet/master/img/menu.png",
+  "https://raw.githubusercontent.com/zenglihunter/dsh-petdex-pet/master/img/install.png"
  ]
 }


### PR DESCRIPTION
## What's in this PR / 提交内容

Add **zenglihunter/dsh-petdex-pet** — a desktop pet plugin for the DSH web GUI: floating, draggable sprite pet animated by agent activity (thinking / idle / error / done / awaiting approval), a settings page for size, switching, gallery search and one-click pet install, plus 4 bundled Hunter x Hunter starter pets.

新增 **zenglihunter/dsh-petdex-pet** —— DSH Web GUI 桌面宠物插件：右下角悬浮、可拖拽，随智能体活动切换精灵动画；设置页支持大小调整、启停切换、图库搜索与一键安装宠物；内置 4 个全职猎人主角宠物包。

## Checklist / 自查清单

- [x] One file at `data/plugins/zenglihunter__dsh-petdex-pet.yml`; READMEs regenerated via `node scripts/generate-readme.mjs` and committed
- [x] `package.json` declares `dsh.bundle` (patch → `cordis.patch.yml`)
- [ ] Repo 1+ day old with 10+ commits — **not yet met**: repo created 2026-08-19 with 4 commits. The submission gate will flag this; everything else is ready.
- [x] `category: fun`
- [x] Description states what the plugin does (no superlatives)
- [x] Repo has the `dsh-plugin` topic

## Screenshots / 截图
- 3 screenshots registered in `data/screenshots.json` (`img/screenshot.png`, `img/menu.png`, `img/install.png`), all URLs verified reachable (HTTP 200).

## Note / 说明
The submission-gate checks (repo age ≥ 1 day, commits ≥ 10) will fail because `zenglihunter/dsh-petdex-pet` was created today with 4 commits. All other criteria pass. Happy to re-push after the repo matures, or a maintainer may review manually.

门禁中的「仓库满 1 天 / 提交数 ≥ 10」两项暂时不满足（petdex 仓库今天刚建、共 4 个提交），其余全部符合。可在仓库成熟后重新触发检查，或由维护者人工审核。
