### PR TITLE
Add ZSeven-W/dsh-crew

### DIFF
--- a/README.md
+++ b/README.md
@@ -1203,6 +1203,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 - [zclDragon/dsh-tool-generate-image](https://github.com/zclDragon/dsh-tool-generate-image) - Model-facing `generate_image` tool for text-only models: the model asks for a picture in natural language, Gemini draws it via the Antigravity CLI, the image is saved to a configurable output directory, and the tool returns the file paths for the model to use in its work.
 - [ZEM17/dsh-subagent-agy](https://github.com/ZEM17/dsh-subagent-agy) - Google Antigravity CLI (agy) as a DSH product subagent: delegate tasks to a Gemini coding agent with your Antigravity login (no API key), with conversation follow-ups, background streaming progress, image analysis by path, and a pop-up login window.
 - [ZhenHuangLab/dsh-sync](https://github.com/ZhenHuangLab/dsh-sync) - Policy-driven Git sync for DSH settings and profile configuration, with secret-aware projections, conflict review, and per-line apply controls.
+- [ZSeven-W/dsh-crew](https://github.com/ZSeven-W/dsh-crew) - Dispatch work to DSH agents from Claude Code or Codex: native subagent progress, in-host worker sessions with per-tier presets, and a multimodal bridge for vision and image generation.
 - [ztl34245881-commits/dsh-task-planner](https://github.com/ztl34245881-commits/dsh-task-planner) - Task planning with experience muscle-memory: condition-reflex recall of past solutions, LLM capability matching, and auto-persisted lessons.
 
 ### Git & Code Review

--- a/README.zh.md
+++ b/README.zh.md
@@ -1203,6 +1203,7 @@ dsh plugin --profile web add dshmarket
 - [zclDragon/dsh-tool-generate-image](https://github.com/zclDragon/dsh-tool-generate-image) — 给纯文本模型的 `generate_image` 工具：模型用自然语言要一张图，经 Antigravity CLI 让 Gemini 画出，保存到可配置输出目录并返回文件路径，供模型在任务中使用。
 - [ZEM17/dsh-subagent-agy](https://github.com/ZEM17/dsh-subagent-agy) — 把 Google Antigravity CLI（agy）接入 DSH 作为产品子代理：用 Antigravity 登录态（无需 API key）委托 Gemini 编程智能体干活，支持对话续聊、后台流式进度、按路径识图与自动弹出登录窗口。
 - [ZhenHuangLab/dsh-sync](https://github.com/ZhenHuangLab/dsh-sync) — 面向 DSH 设置与 Profile 配置的策略化 Git 同步，支持敏感信息隔离、冲突审阅与按行选择应用。
+- [ZSeven-W/dsh-crew](https://github.com/ZSeven-W/dsh-crew) — 从 Claude Code / Codex 派发任务给 DSH Agent：原生子代理进度、按能力分层预设的宿主内工作会话，以及为纯文本 Harness 提供视觉与图像生成的多模态桥。
 - [ztl34245881-commits/dsh-task-planner](https://github.com/ztl34245881-commits/dsh-task-planner) — 带经验肌肉记忆的任务规划：条件反射检索历史方案 + LLM 能力匹配 + 经验自动沉淀。
 
 ### 🔀 Git 与代码评审

--- a/data/plugins/ZSeven-W__dsh-crew.yml
+++ b/data/plugins/ZSeven-W__dsh-crew.yml
@@ -1,0 +1,6 @@
+url: https://github.com/ZSeven-W/dsh-crew
+name: ZSeven-W/dsh-crew
+category: workflow
+description:
+  en: 'Dispatch work to DSH agents from Claude Code or Codex: native subagent progress, in-host worker sessions with per-tier presets, and a multimodal bridge for vision and image generation.'
+  zh: '从 Claude Code / Codex 派发任务给 DSH Agent：原生子代理进度、按能力分层预设的宿主内工作会话，以及为纯文本 Harness 提供视觉与图像生成的多模态桥。'


### PR DESCRIPTION
Adds the dsh-crew plugin (dispatch work to DSH agents from Claude Code / Codex) to the workflow category.\n\n- npm: @zseven-w/dsh-crew\n- repo: https://github.com/ZSeven-W/dsh-crew\n- declares dsh.bundle + dsh.client, 16 commits, dsh-plugin topic set