### PR TITLE
docs: sync dsh-backup zh description with en (v0.5.x feature set)

### DIFF
--- a/README.zh.md
+++ b/README.zh.md
@@ -1566,7 +1566,7 @@ dsh plugin --profile web add dshmarket
 - [worksAssistant/dsh-quickref](https://github.com/worksAssistant/dsh-quickref) — 开发者速查工具箱：12 个主题 195 条速查 + 6 个零依赖工具（正则实时测试、JSON 格式化、时间戳转换、Base64/URL 编解码、Cron 生成、行 diff），设置页可搜索查阅。
 - [x2802490130-prog/dsh-guard](https://github.com/x2802490130-prog/dsh-guard) — 开发配套守护：滚动快照、插件失败自动回退、启动失败救援、设置页管理面板。
 - [x2802490130-prog/dsh-shield](https://github.com/x2802490130-prog/dsh-shield) — 脱手模式安全网：agent 删除的目录先进回收站、链接绝不跟随，零审批。
-- [xiaoyuyu6420/dsh-backup](https://github.com/xiaoyuyu6420/dsh-backup) — 一键备份与恢复 DSH 用户数据：/backup 备份、完整性校验、恢复，定时自动备份（重启续跑），sha256 校验与自动轮换（macOS/Linux/Windows）。
+- [xiaoyuyu6420/dsh-backup](https://github.com/xiaoyuyu6420/dsh-backup) — 一键备份与恢复 DSH 用户数据：/backup 命令族与 backup_dsh 工具、可视化 Settings 面板，sha256 完整性校验与加固恢复（拒绝路径穿越/软链），定时自动备份（重启续跑、绝对节奏）、可配置轮换、归档下载路由、GitHub 私有仓库同步；macOS/Linux/Windows。
 - [xiaxingtianxia2-glitch/dsh-auto-exit](https://github.com/xiaxingtianxia2-glitch/dsh-auto-exit) — 关闭 DSH Web UI 后自动退出 CLI 进程（等效 Ctrl+C），支持可配置宽限期与试运行模式。
 - [xingyingyuzhui/dsh-updater-ui](https://github.com/xingyingyuzhui/dsh-updater-ui) — 设置页中的 DSH 自助更新器：一键检查/拉取（git pull --ff-only）、自动后台检查、版本对比与更新说明预览，带红点提醒。
 - [xxiaoxiong/dsh-prometheus](https://github.com/xxiaoxiong/dsh-prometheus) — 导出有界的 DSH Session、Agent、LLM、Tool、Approval、Subagent 与 Job Prometheus 指标，附带 Grafana 仪表盘，Endpoint 默认仅监听回环地址。

--- a/data/plugins/xiaoyuyu6420__dsh-backup.yml
+++ b/data/plugins/xiaoyuyu6420__dsh-backup.yml
@@ -3,4 +3,4 @@ name: xiaoyuyu6420/dsh-backup
 category: dev
 description:
   en: 'One-command backup & restore of DSH user data: /backup command family plus backup_dsh tool and a visual Settings panel, sha256 verify with hardened restore validation (path-traversal/symlink rejection), scheduled auto-backup that survives restarts on an absolute cadence, configurable rotation, archive download route, and GitHub sync to a private repo; macOS/Linux/Windows.'
-  zh: 一键备份与恢复 DSH 用户数据：/backup 备份、完整性校验、恢复，定时自动备份（重启续跑），sha256 校验与自动轮换（macOS/Linux/Windows）。
+  zh: 一键备份与恢复 DSH 用户数据：/backup 命令族与 backup_dsh 工具、可视化 Settings 面板，sha256 完整性校验与加固恢复（拒绝路径穿越/软链），定时自动备份（重启续跑、绝对节奏）、可配置轮换、归档下载路由、GitHub 私有仓库同步；macOS/Linux/Windows。


### PR DESCRIPTION
## What

The zh description of `data/plugins/xiaoyuyu6420__dsh-backup.yml` was still the short 0.1.0-era text, while the en side already covers the v0.5.x feature set. This PR brings zh to parity with en.

## Why now

dsh-backup v0.5.0 (2026-08-15) added the Settings panel, hardened restore (path-traversal/symlink rejection), restart-surviving scheduled auto-backup, the archive download route, and GitHub sync — and v0.5.1 (today) fixed a plugin-load failure caused by the `backupPanel/remove` remote method colliding with `RemoteNamespaceService`'s built-in `remove` (renamed to `removeEntry`). Since the entry installs from GitHub HEAD, no version field needs updating — only the zh copy was stale.

I'm the plugin author (xiaoyuyu6420/dsh-backup).