### PR TITLE
Add dsh-az to plugin list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1627,6 +1627,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 - [vibeinging/dsh-trace](https://github.com/vibeinging/dsh-trace) - Telemetry backend exporting turns, model steps, and tool calls to yiTrace.
 - [william-jin-cmu/dsh-evolve](https://github.com/william-jin-cmu/dsh-evolve) - Self-evolution: the agent hot-mounts/removes persistent plugins on itself mid-session.
 - [wingsky-1/dsh-plugin-hub#packages/dsh-gzip](https://github.com/wingsky-1/dsh-plugin-hub/tree/main/packages/dsh-gzip) - Gzip compression for /api responses, fixing history-load timeouts over remote/low-bandwidth connections; skips SSE and already-encoded responses.
+- [WODE25500/dsh-az](https://github.com/WODE25500/dsh-az) - Azure resource management: query and show resources, deploy Bicep/ARM templates, and check the activity log.
 - [WODE25500/dsh-codex](https://github.com/WODE25500/dsh-codex) - OpenAI Codex CLI wrapper: one-shot exec, repo review and session resume with a default read-only sandbox.
 - [WODE25500/dsh-winget](https://github.com/WODE25500/dsh-winget) - Windows Package Manager: search, install, upgrade, uninstall, import/export and pin software through native tools.
 - [worksAssistant/dsh-quickref](https://github.com/worksAssistant/dsh-quickref) - Developer quick-reference toolbox for DSH: 12 themed categories (195 entries) plus zero-dependency tools — regex tester, JSON formatter, timestamp converter, Base64/URL codec, cron generator and line diff, in a searchable settings panel.

--- a/README.zh.md
+++ b/README.zh.md
@@ -1627,6 +1627,7 @@ dsh plugin --profile web add dshmarket
 - [vibeinging/dsh-trace](https://github.com/vibeinging/dsh-trace) — 遥测后端：把 turns、model steps、tool calls 导出到 yiTrace。
 - [william-jin-cmu/dsh-evolve](https://github.com/william-jin-cmu/dsh-evolve) — 自进化：agent 在会话内给自己热挂载/卸载持久化插件。
 - [wingsky-1/dsh-plugin-hub#packages/dsh-gzip](https://github.com/wingsky-1/dsh-plugin-hub/tree/main/packages/dsh-gzip) — /api 响应 gzip 压缩，解决远程/低带宽访问时历史加载超时；SSE 与已编码响应自动豁免。
+- [WODE25500/dsh-az](https://github.com/WODE25500/dsh-az) — Azure 资源管理：查询/展示资源、部署 Bicep/ARM 模板、查看活动日志。
 - [WODE25500/dsh-codex](https://github.com/WODE25500/dsh-codex) — OpenAI Codex CLI 封装：一次性任务、仓库审查与会话续接，默认只读沙箱。
 - [WODE25500/dsh-winget](https://github.com/WODE25500/dsh-winget) — Windows 包管理器：搜索、安装、升级、卸载、导入导出与版本固定。
 - [worksAssistant/dsh-quickref](https://github.com/worksAssistant/dsh-quickref) — 开发者速查工具箱：12 个主题 195 条速查 + 6 个零依赖工具（正则实时测试、JSON 格式化、时间戳转换、Base64/URL 编解码、Cron 生成、行 diff），设置页可搜索查阅。

--- a/data/plugins/WODE25500__dsh-az.yml
+++ b/data/plugins/WODE25500__dsh-az.yml
@@ -1,0 +1,6 @@
+url: https://github.com/WODE25500/dsh-az
+name: WODE25500/dsh-az
+category: dev
+description:
+  en: 'Azure resource management: query and show resources, deploy Bicep/ARM templates, and check the activity log.'
+  zh: 'Azure 资源管理：查询/展示资源、部署 Bicep/ARM 模板、查看活动日志。'


### PR DESCRIPTION
Adds [dsh-az](https://github.com/WODE25500/dsh-az) to the plugin list (category: $(System.Collections.Hashtable[dsh-az][0])).

> Azure resource management: query and show resources, deploy Bicep/ARM templates, and check the activity log.

Follows the contributing guide: one YAML per plugin under data/plugins/, README regenerated with node scripts/generate-readme.mjs.