### PR TITLE
Add dsh-k6 to plugin list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1658,6 +1658,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 - [WM-CODER/custom-first-control-prompt](https://github.com/WM-CODER/custom-first-control-prompt) - Inject deployment-configured system-prompt sections and reference exchanges into every conversation request via stream interception, with a web settings panel.
 - [WODE25500/dsh-az](https://github.com/WODE25500/dsh-az) - Azure resource management: query and show resources, deploy Bicep/ARM templates, and check the activity log.
 - [WODE25500/dsh-codex](https://github.com/WODE25500/dsh-codex) - OpenAI Codex CLI wrapper: one-shot exec, repo review and session resume with a default read-only sandbox.
+- [WODE25500/dsh-k6](https://github.com/WODE25500/dsh-k6) - Load testing with Grafana k6: smoke-test first, then run scripts and read percentiles from the JSON summary.
 - [WODE25500/dsh-kubectl](https://github.com/WODE25500/dsh-kubectl) - Kubernetes ops for the agent: get resources with structured JSON output, describe, logs, exec, apply/delete (user-confirmed) and port-forward.
 - [WODE25500/dsh-terraform](https://github.com/WODE25500/dsh-terraform) - Infrastructure as code: gated plan/apply, state and output inspection, and configuration validation via the terraform CLI.
 - [WODE25500/dsh-winget](https://github.com/WODE25500/dsh-winget) - Windows Package Manager: search, install, upgrade, uninstall, import/export and pin software through native tools.

--- a/README.zh.md
+++ b/README.zh.md
@@ -1658,6 +1658,7 @@ dsh plugin --profile web add dshmarket
 - [WM-CODER/custom-first-control-prompt](https://github.com/WM-CODER/custom-first-control-prompt) — 通过流拦截将部署级系统提示词段落与参考对话注入每次对话请求，附带 Web 设置面板。
 - [WODE25500/dsh-az](https://github.com/WODE25500/dsh-az) — Azure 资源管理：查询/展示资源、部署 Bicep/ARM 模板、查看活动日志。
 - [WODE25500/dsh-codex](https://github.com/WODE25500/dsh-codex) — OpenAI Codex CLI 封装：一次性任务、仓库审查与会话续接，默认只读沙箱。
+- [WODE25500/dsh-k6](https://github.com/WODE25500/dsh-k6) — Grafana k6 压测：先冒烟再跑脚本，从 JSON 汇总读百分位数。
 - [WODE25500/dsh-kubectl](https://github.com/WODE25500/dsh-kubectl) — Kubernetes 运维：JSON 结构化查资源、describe、日志、exec、apply/delete（需确认）与端口转发。
 - [WODE25500/dsh-terraform](https://github.com/WODE25500/dsh-terraform) — 基础设施即代码：plan/apply 门控、state/output 检查与配置校验。
 - [WODE25500/dsh-winget](https://github.com/WODE25500/dsh-winget) — Windows 包管理器：搜索、安装、升级、卸载、导入导出与版本固定。

--- a/data/plugins/WODE25500__dsh-k6.yml
+++ b/data/plugins/WODE25500__dsh-k6.yml
@@ -1,0 +1,6 @@
+url: https://github.com/WODE25500/dsh-k6
+name: WODE25500/dsh-k6
+category: dev
+description:
+  en: 'Load testing with Grafana k6: smoke-test first, then run scripts and read percentiles from the JSON summary.'
+  zh: 'Grafana k6 压测：先冒烟再跑脚本，从 JSON 汇总读百分位数。'


### PR DESCRIPTION
Adds [dsh-k6](https://github.com/WODE25500/dsh-k6) to the plugin list (category: $(System.Collections.Hashtable[dsh-k6][0])).

> Load testing with Grafana k6: smoke-test first, then run scripts and read percentiles from the JSON summary.

Follows the contributing guide: one YAML per plugin under data/plugins/, README regenerated with node scripts/generate-readme.mjs.