### PR TITLE
Add howmp/dsh-pentest — authorized pentest exploration mode

### DIFF
--- a/data/plugins/howmp__dsh-pentest.yml
+++ b/data/plugins/howmp__dsh-pentest.yml
@@ -1,0 +1,6 @@
+url: https://github.com/howmp/dsh-pentest
+name: howmp/dsh-pentest
+category: security
+description:
+  en: Authorized pentest mode for DeepSeek Harness — exploration chain, assets and findings with a Web view.
+  zh: 面向 DeepSeek Harness 的授权渗透模式：以探索链路记录目标、线索、资产与漏洞，并在 Web 中可视化展示。


### PR DESCRIPTION
Add [howmp/dsh-pentest](https://github.com/howmp/dsh-pentest) (`security`): authorized pentest mode for DSH — exploration chain (goal→intent→fact→finding), assets, reproducible steps, and a Web view. Uses `dsh.bundle` (patch \`cordis.patch.yml\`, storage-domain route + sqlite backend). Closes howmp/dsh-pentest#3.