### PR TITLE
Update aqsk-BLG/dsh-memory tarball to v1.3.2

### DIFF
--- a/data/plugins/aqsk-BLG__dsh-memory.yml
+++ b/data/plugins/aqsk-BLG__dsh-memory.yml
@@ -4,4 +4,4 @@ category: memory
 description:
   en: 'Layered file memory for DeepSeek Harness with workspace-scoped USER/MEMORY notes, background consolidation, and hybrid session recall.'
   zh: DeepSeek Harness 分层文件记忆，提供工作区隔离的 USER/MEMORY 笔记、后台沉淀与混合会话召回。
-tarball: https://github.com/aqsk-BLG/dsh-memory/releases/download/v1.3.1/dsh-file-memory-1.3.1.tgz
+tarball: https://github.com/aqsk-BLG/dsh-memory/releases/download/v1.3.2/dsh-file-memory-1.3.2.tgz


### PR DESCRIPTION
Point the existing `aqsk-BLG/dsh-memory` listing at the v1.3.2 release tarball.

The original listing is already merged (#1951), and the v1.3.1 tarball update is merged (#1991). This only updates:

	tarball: https://github.com/aqsk-BLG/dsh-memory/releases/download/v1.3.2/dsh-file-memory-1.3.2.tgz

v1.3.2 drops the unused TOOLS settings-card tab, keeps AGENTS mapped to the DSH source-tree workspace file, and is published as `dsh-file-memory@1.3.2`.
