### PR TITLE
Add dsh-blender marketplace screenshot

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -1040,5 +1040,8 @@
   "https://raw.githubusercontent.com/lninghaha/dsh-hub-oauth-gateway/main/docs/images/usage-center-peek.png",
   "https://raw.githubusercontent.com/lninghaha/dsh-hub-oauth-gateway/main/docs/images/usage-center-dashboard.png",
   "https://raw.githubusercontent.com/lninghaha/dsh-hub-oauth-gateway/main/docs/images/usage-center-settings.png"
+ ],
+ "https://github.com/CheshireJCat/blender": [
+  "https://raw.githubusercontent.com/CheshireJCat/blender/main/assets/dsh-blender-lamp-preview.png"
  ]
 }


### PR DESCRIPTION
## Summary

- add the published `dsh-blender` smoke-test preview to `data/screenshots.json`
- key the entry by the existing plugin URL
- use a GitHub-hosted image from the plugin repository

Follow-up to the optional screenshot suggestion on #138.

## Checks

- `node -e "JSON.parse(...)"`
- `node scripts/build-site.mjs`
- `git diff --check`