### PR TITLE
Update FeatherHunter/dsh-mattpocock-skills-deck: tarball for v1.6.15

### DIFF
--- a/data/plugins/FeatherHunter__dsh-mattpocock-skills-deck--package.yml
+++ b/data/plugins/FeatherHunter__dsh-mattpocock-skills-deck--package.yml
@@ -4,4 +4,4 @@ category: dev
 description:
   en: 'Right-side details panel that turns the Matt Pocock skills collection into a DSH quest board: wayfinder decision maps, per-issue triage / fix / discuss / execute actions, 9-item core-skill probe plus 20-skill radar, environment checks, and one-click handoff across sessions.'
   zh: 'Matt Pocock 技能套件的 DSH 控制面板：右侧 details 列打开；含 wayfinder 决策地图、issue 行级 triage / 修复 / 讨论 / 执行按钮、9 项核心套件探测 + 20 个技能雷达、环境检查、跨会话 handoff 交接。'
-
+tarball: https://github.com/FeatherHunter/dsh-mattpocock-skills-deck/releases/download/v1.6.15/dsh-mattpocock-skills-deck-1.6.15.tgz


### PR DESCRIPTION
﻿Update tarball for v1.6.15

- Adds tarball: https://github.com/FeatherHunter/dsh-mattpocock-skills-deck/releases/download/v1.6.15/dsh-mattpocock-skills-deck-1.6.15.tgz
- npm auto-resolved (generate-readme rejects npm field, per check)
- dsh.bundle declared, cordis.patch.yml in package/, 1.6.15 already on npm and GitHub Release v1.6.15

Related: npm publish 1.6.15 verified (npm view + install OK), GitHub Release https://github.com/FeatherHunter/dsh-mattpocock-skills-deck/releases/tag/v1.6.15
