### PR TITLE
Add dsh-mobile-gui-agent marketplace screenshots

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -178,6 +178,11 @@
   "https://raw.githubusercontent.com/KLRSL/dsh-biomemory/main/assets/screenshot-settings.png",
   "https://raw.githubusercontent.com/KLRSL/dsh-biomemory/main/assets/screenshot-memory-settings.png"
  ],
+ "https://github.com/kunjinkao-os/dsh-mobile-gui-agent": [
+  "https://raw.githubusercontent.com/kunjinkao-os/dsh-mobile-gui-agent/main/docs/images/open-settings-wifi-demo.png",
+  "https://raw.githubusercontent.com/kunjinkao-os/dsh-mobile-gui-agent/main/docs/images/open-taobao-demo.png",
+  "https://raw.githubusercontent.com/kunjinkao-os/dsh-mobile-gui-agent/main/docs/images/mobile-gui-agent-alarm-task.png"
+ ],
  "https://github.com/LKMeng2001/dsh-mcp-market": [
   "https://raw.githubusercontent.com/LKMeng2001/dsh-mcp-market/main/assets/market-discover.png"
  ],


### PR DESCRIPTION
Adds the three existing product demo screenshots for `dsh-mobile-gui-agent` to the marketplace gallery.

- Uses only screenshots already hosted in the plugin repository
- Excludes the generated marketplace cover image
- Ordered as: Settings navigation, Taobao launch, alarm task