### PR TITLE
Add screenshot for Y1X1n/dsh-prompt-optimizer

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -1043,5 +1043,8 @@
  ],
  "https://github.com/CheshireJCat/blender": [
   "https://raw.githubusercontent.com/CheshireJCat/blender/main/assets/dsh-blender-lamp-preview.png"
+ ],
+ "https://github.com/Y1X1n/dsh-prompt-optimizer": [
+  "https://raw.githubusercontent.com/Y1X1n/dsh-prompt-optimizer/main/docs/screenshots/optimize-panel.png"
  ]
 }


### PR DESCRIPTION
Adds one screenshot to the entry merged in #1998: the result panel in action (five-dimension analysis + the rewritten prompt streamed live, replace/undo/copy actions, model badge with route and duration).

Image is hosted on our own repo (`raw.githubusercontent.com`), per the screenshot hosting rule. Only `data/screenshots.json` is touched.