### PR TITLE
Add dsh-project-memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -671,6 +671,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 
 ### Memory
 
+- [00080000/dsh-project-memory](https://github.com/00080000/dsh-project-memory) - Project memory for DeepSeek Harness: project files are indexed into searchable summaries as they are read, so after context loss the agent retrieves hits on demand instead of re-reading files, with source citations and BM25 ranking.
 - [863683348/dsh-memory-setup](https://github.com/863683348/dsh-memory-setup) - Local, auditable personal memory for DeepSeek Harness: preferences, project conventions, workflows and error lessons persisted as a changelogged JSON file in the workspace, with onboarding, auto project-convention extraction and evidence-backed lessons.
 - [863683348/dsh-plugin-focus](https://github.com/863683348/dsh-plugin-focus) - Focus board for DeepSeek Harness agents: durable, model-maintained notes in the session workspace that pin the objective, constraints, and decisions across compaction and sessions, with automatic context injection, archive on clear, and an optional web panel.
 - [aerince/dsh-active-context-pruning](https://github.com/aerince/dsh-active-context-pruning) - Model-authored context pruning for DeepSeek Harness through the official compaction API.

--- a/README.zh.md
+++ b/README.zh.md
@@ -671,6 +671,7 @@ dsh plugin --profile web add dshmarket
 
 ### 🧠 记忆
 
+- [00080000/dsh-project-memory](https://github.com/00080000/dsh-project-memory) — 为 DeepSeek Harness 提供的项目记忆插件：项目文件在读取时索引为可检索摘要，上下文失效后按需检索命中，无需重读文件，自带出处与 BM25 排序。
 - [863683348/dsh-memory-setup](https://github.com/863683348/dsh-memory-setup) — 解决 AI 金鱼脑：本地可审计的个人记忆层——偏好、项目约定、工作流与纠错教训，以带变更日志与完整性校验的 JSON 持久化在工作区，支持一次性设置、项目约定自动提取、证据化教训与快照恢复。
 - [863683348/dsh-plugin-focus](https://github.com/863683348/dsh-plugin-focus) — 为 DeepSeek Harness agent 提供持久化专注板：在会话工作区维护目标、约束与决策笔记，跨压缩与会话存活，支持自动注入上下文、清空归档与可选 Web 面板。
 - [aerince/dsh-active-context-pruning](https://github.com/aerince/dsh-active-context-pruning) — 面向 DeepSeek Harness 的模型驱动上下文裁剪插件，通过官方 compaction API 释放上下文空间。

--- a/data/plugins/00080000__dsh-project-memory.yml
+++ b/data/plugins/00080000__dsh-project-memory.yml
@@ -1,0 +1,7 @@
+url: https://github.com/00080000/dsh-project-memory
+name: 00080000/dsh-project-memory
+category: memory
+tarball: https://github.com/00080000/dsh-project-memory/releases/latest/download/dsh-project-memory-0.1.0.tgz
+description:
+  zh: "为 DeepSeek Harness 提供的项目记忆插件：项目文件在读取时索引为可检索摘要，上下文失效后按需检索命中，无需重读文件，自带出处与 BM25 排序。"
+  en: "Project memory for DeepSeek Harness: project files are indexed into searchable summaries as they are read, so after context loss the agent retrieves hits on demand instead of re-reading files, with source citations and BM25 ranking."


### PR DESCRIPTION
Persistent project memory for DeepSeek Harness.
Features: lazy file indexing, BM25 retrieval with citations, and experience notes.
Tarball available at: https://github.com/00080000/dsh-project-memory/releases/download/v0.1.0/dsh-project-memory-0.1.0.tgz