### PR TITLE
Add zoahdev/dsh-unplug (dev): plug/unplug any plugin cleanly

### DIFF
--- a/README.md
+++ b/README.md
@@ -1723,6 +1723,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 - [zoahdev/dsh-readme-forge](https://github.com/zoahdev/dsh-readme-forge) - Generate README.md for dsh plugin repositories from package.json + cordis.patch.yml + source layout — install/CLI/tools/dev/license sections, deterministic, zero runtime deps, read-only by default. CLI plus an agent-callable readme_forge tool.
 - [zoahdev/dsh-rule-evolve](https://github.com/zoahdev/dsh-rule-evolve/tree/main/plugin) - Verification-driven self-evolution loop: failure logs become verified AGENTS.md rules; in-session plugin (evolve_learn / evolve_apply / evolve_touch / evolve_recall), tool-verify gate, rule lifecycle, local recall.
 - [zoahdev/dsh-timesheet](https://github.com/zoahdev/dsh-timesheet) - Turn-based time tracking from dsh session logs: totals, per-day/project/provider/source rollups, tool-call counts, failure rates, and time-to-first-token — CLI plus an agent-callable timesheet tool, dsh-timesheet/v1 reports, zero runtime deps.
+- [zoahdev/dsh-unplug](https://github.com/zoahdev/dsh-unplug) - Plug/unplug any DeepSeek Harness plugin cleanly — list every mounted layer (bundles + patch rows), remove with full cleanup, disable/enable without deleting, and audit for orphaned/dangling state. CLI + agent-callable unplug tool. Read-only by default; destructive operations require explicit confirmation.
 
 ### Security & Permissions
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -1723,6 +1723,7 @@ dsh plugin --profile web add dshmarket
 - [zoahdev/dsh-readme-forge](https://github.com/zoahdev/dsh-readme-forge) — 为 dsh 插件仓库从 package.json + cordis.patch.yml + 源码布局生成 README.md——安装/CLI/工具/开发/许可证章节，确定性输出、零运行时依赖、默认只读。CLI + agent 可调用 readme_forge 工具。
 - [zoahdev/dsh-rule-evolve](https://github.com/zoahdev/dsh-rule-evolve/tree/main/plugin) — 验证驱动的自我进化循环：失败日志自动变成经过验证的 AGENTS.md 规则；会话内插件（evolve_learn/evolve_apply/evolve_touch/evolve_recall）、工具体检、规则生命周期、本地召回。
 - [zoahdev/dsh-timesheet](https://github.com/zoahdev/dsh-timesheet) — 从 dsh 会话日志做基于 turn 的时间跟踪：总计、按天/项目/供应商/来源汇总、工具调用数、失败率与首 token 延迟——CLI + agent 可调用 timesheet 工具，dsh-timesheet/v1 报告，零运行时依赖。
+- [zoahdev/dsh-unplug](https://github.com/zoahdev/dsh-unplug) — 让 DSH 插件的安装和卸载干净利落——列出所有加载层（Bundle + 补丁行）、完整卸载（清理 Bundle 列表+补丁行+依赖）、临时禁用以调试而不真正删除、以及审计残留的孤立行或悬空引用。CLI 与 agent 均可调用，默认只读，破坏性操作需二次确认。
 
 ### 🔒 安全与权限
 

--- a/data/plugins/zoahdev__dsh-unplug.yml
+++ b/data/plugins/zoahdev__dsh-unplug.yml
@@ -1,0 +1,6 @@
+url: https://github.com/zoahdev/dsh-unplug
+name: zoahdev/dsh-unplug
+category: dev
+description:
+  en: Plug/unplug any DeepSeek Harness plugin cleanly — list every mounted layer (bundles + patch rows), remove with full cleanup, disable/enable without deleting, and audit for orphaned/dangling state. CLI + agent-callable unplug tool. Read-only by default; destructive operations require explicit confirmation.
+  zh: 让 DSH 插件的安装和卸载干净利落——列出所有加载层（Bundle + 补丁行）、完整卸载（清理 Bundle 列表+补丁行+依赖）、临时禁用以调试而不真正删除、以及审计残留的孤立行或悬空引用。CLI 与 agent 均可调用，默认只读，破坏性操作需二次确认。


### PR DESCRIPTION
## 这是什么 / What is this

**dsh-unplug** — 让所有 DSH 插件插拔自如 / plug/unplug any plugin cleanly。

官方 `dsh plugin remove` 只处理 `dsh.profile.bundles` 列表；`cordis.patch.yml` 里的插件行会残留、没有禁用态、没有审计。本插件补齐：

- **list** — 列出所有已挂载插件（bundles + profile/home 补丁行）
- **remove** — 一次清干净：bundles + 依赖 + 补丁行，然后复检
- **disable / enable** — 不删只拔，随时恢复
- **audit** — 检测孤立补丁行、悬空 bundle、缺失 patch 文件
- **reconcile** — 一键自动修复悬空与孤立状态

## Verified

- npm: **dsh-unplug@0.2.3** published
- CI: typecheck + 15 unit tests green; GitHub Actions runs doctor + build + tests + pack
- Zero runtime dependencies; read-only by default; destructive ops require explicit --yes / force: true
- Bilingual (中文/English): CLI help, agent tool, README — Chinese users ready out of the box
