### PR TITLE
Add WM-CODER/custom-first-control-prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -1635,6 +1635,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 - [vibeinging/dsh-trace](https://github.com/vibeinging/dsh-trace) - Telemetry backend exporting turns, model steps, and tool calls to yiTrace.
 - [william-jin-cmu/dsh-evolve](https://github.com/william-jin-cmu/dsh-evolve) - Self-evolution: the agent hot-mounts/removes persistent plugins on itself mid-session.
 - [wingsky-1/dsh-plugin-hub#packages/dsh-gzip](https://github.com/wingsky-1/dsh-plugin-hub/tree/main/packages/dsh-gzip) - Gzip compression for /api responses, fixing history-load timeouts over remote/low-bandwidth connections; skips SSE and already-encoded responses.
+- [WM-CODER/custom-first-control-prompt](https://github.com/WM-CODER/custom-first-control-prompt) - Inject deployment-configured system-prompt sections and reference exchanges into every conversation request via stream interception, with a web settings panel.
 - [WODE25500/dsh-az](https://github.com/WODE25500/dsh-az) - Azure resource management: query and show resources, deploy Bicep/ARM templates, and check the activity log.
 - [WODE25500/dsh-codex](https://github.com/WODE25500/dsh-codex) - OpenAI Codex CLI wrapper: one-shot exec, repo review and session resume with a default read-only sandbox.
 - [WODE25500/dsh-terraform](https://github.com/WODE25500/dsh-terraform) - Infrastructure as code: gated plan/apply, state and output inspection, and configuration validation via the terraform CLI.

--- a/README.zh.md
+++ b/README.zh.md
@@ -1635,6 +1635,7 @@ dsh plugin --profile web add dshmarket
 - [vibeinging/dsh-trace](https://github.com/vibeinging/dsh-trace) — 遥测后端：把 turns、model steps、tool calls 导出到 yiTrace。
 - [william-jin-cmu/dsh-evolve](https://github.com/william-jin-cmu/dsh-evolve) — 自进化：agent 在会话内给自己热挂载/卸载持久化插件。
 - [wingsky-1/dsh-plugin-hub#packages/dsh-gzip](https://github.com/wingsky-1/dsh-plugin-hub/tree/main/packages/dsh-gzip) — /api 响应 gzip 压缩，解决远程/低带宽访问时历史加载超时；SSE 与已编码响应自动豁免。
+- [WM-CODER/custom-first-control-prompt](https://github.com/WM-CODER/custom-first-control-prompt) — 通过流拦截将部署级系统提示词段落与参考对话注入每次对话请求，附带 Web 设置面板。
 - [WODE25500/dsh-az](https://github.com/WODE25500/dsh-az) — Azure 资源管理：查询/展示资源、部署 Bicep/ARM 模板、查看活动日志。
 - [WODE25500/dsh-codex](https://github.com/WODE25500/dsh-codex) — OpenAI Codex CLI 封装：一次性任务、仓库审查与会话续接，默认只读沙箱。
 - [WODE25500/dsh-terraform](https://github.com/WODE25500/dsh-terraform) — 基础设施即代码：plan/apply 门控、state/output 检查与配置校验。

--- a/data/plugins/WM-CODER__custom-first-control-prompt.yml
+++ b/data/plugins/WM-CODER__custom-first-control-prompt.yml
@@ -1,0 +1,6 @@
+url: https://github.com/WM-CODER/custom-first-control-prompt
+name: WM-CODER/custom-first-control-prompt
+category: dev
+description:
+  en: Inject deployment-configured system-prompt sections and reference exchanges into every conversation request via stream interception, with a web settings panel.
+  zh: 通过流拦截将部署级系统提示词段落与参考对话注入每次对话请求，附带 Web 设置面板。


### PR DESCRIPTION
## 插件
- **仓库**：https://github.com/WM-CODER/custom-first-control-prompt
- **npm**：@wm-coders/dsh-custom-first-control-prompt@0.2.1
- **分类**：dev

## 功能

通过 llm/stream waterfall 拦截，将部署级系统提示词段落与user/assist参考对话注入每次对话请求，零会话日志写入。附带 Web 设置面板，可编辑配置并预览注入内容。

## 检查清单

- 仓库 package.json 声明了 dsh.bundle manifest
- 仓库包含真实可用代码
- 仓库创建满 1 天，提交数 ≥ 10
- 已添加 dsh-plugin topic
- 描述属实，无营销词
- pm 包已发布（repository 字段指回 GitHub 仓库）
- 本 PR 仅含 1 条条目
