### PR TITLE
Add wiyi/dsh-web-service-manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -1637,6 +1637,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 - [vibeinging/dsh-trace](https://github.com/vibeinging/dsh-trace) - Telemetry backend exporting turns, model steps, and tool calls to yiTrace.
 - [william-jin-cmu/dsh-evolve](https://github.com/william-jin-cmu/dsh-evolve) - Self-evolution: the agent hot-mounts/removes persistent plugins on itself mid-session.
 - [wingsky-1/dsh-plugin-hub#packages/dsh-gzip](https://github.com/wingsky-1/dsh-plugin-hub/tree/main/packages/dsh-gzip) - Gzip compression for /api responses, fixing history-load timeouts over remote/low-bandwidth connections; skips SSE and already-encoded responses.
+- [wiyi/dsh-web-service-manager](https://github.com/wiyi/dsh-web-service-manager) - Manage the DSH web service from a settings panel: status, version, restart, stop, and one-click updates.
 - [WM-CODER/custom-first-control-prompt](https://github.com/WM-CODER/custom-first-control-prompt) - Inject deployment-configured system-prompt sections and reference exchanges into every conversation request via stream interception, with a web settings panel.
 - [WODE25500/dsh-az](https://github.com/WODE25500/dsh-az) - Azure resource management: query and show resources, deploy Bicep/ARM templates, and check the activity log.
 - [WODE25500/dsh-codex](https://github.com/WODE25500/dsh-codex) - OpenAI Codex CLI wrapper: one-shot exec, repo review and session resume with a default read-only sandbox.

--- a/README.zh.md
+++ b/README.zh.md
@@ -1637,6 +1637,7 @@ dsh plugin --profile web add dshmarket
 - [vibeinging/dsh-trace](https://github.com/vibeinging/dsh-trace) — 遥测后端：把 turns、model steps、tool calls 导出到 yiTrace。
 - [william-jin-cmu/dsh-evolve](https://github.com/william-jin-cmu/dsh-evolve) — 自进化：agent 在会话内给自己热挂载/卸载持久化插件。
 - [wingsky-1/dsh-plugin-hub#packages/dsh-gzip](https://github.com/wingsky-1/dsh-plugin-hub/tree/main/packages/dsh-gzip) — /api 响应 gzip 压缩，解决远程/低带宽访问时历史加载超时；SSE 与已编码响应自动豁免。
+- [wiyi/dsh-web-service-manager](https://github.com/wiyi/dsh-web-service-manager) — 在设置面板中管理 DSH Web 服务:状态、版本、重启、停止与一键更新。
 - [WM-CODER/custom-first-control-prompt](https://github.com/WM-CODER/custom-first-control-prompt) — 通过流拦截将部署级系统提示词段落与参考对话注入每次对话请求，附带 Web 设置面板。
 - [WODE25500/dsh-az](https://github.com/WODE25500/dsh-az) — Azure 资源管理：查询/展示资源、部署 Bicep/ARM 模板、查看活动日志。
 - [WODE25500/dsh-codex](https://github.com/WODE25500/dsh-codex) — OpenAI Codex CLI 封装：一次性任务、仓库审查与会话续接，默认只读沙箱。

--- a/data/plugins/wiyi__dsh-web-service-manager.yml
+++ b/data/plugins/wiyi__dsh-web-service-manager.yml
@@ -1,0 +1,6 @@
+url: https://github.com/wiyi/dsh-web-service-manager
+name: wiyi/dsh-web-service-manager
+category: dev
+description:
+  en: 'Manage the DSH web service from a settings panel: status, version, restart, stop, and one-click updates.'
+  zh: 在设置面板中管理 DSH Web 服务:状态、版本、重启、停止与一键更新。


### PR DESCRIPTION
Adds [wiyi/dsh-web-service-manager](https://github.com/wiyi/dsh-web-service-manager), a settings-panel manager for the `dsh web` service.

- Status panel in Settings: running state, version, port, PID, session uptime.
- Restart via a detached-session watchdog so the replacement instance survives the harness's SIGTERM teardown.
- Stop, npm-registry version check, and one-click update-and-restart (`GET/POST /dsh-web-manager/*`).
- Declares `dsh.bundle` manifest, installs via `dsh plugin add`, bilingual README with screenshot, topics include `dsh-plugin`.