### PR TITLE
Add dsh-maf (Microsoft Agent Framework) to plugin list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1697,6 +1697,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 - [WODE25500/dsh-codex](https://github.com/WODE25500/dsh-codex) - OpenAI Codex CLI wrapper: one-shot exec, repo review and session resume with a default read-only sandbox.
 - [WODE25500/dsh-k6](https://github.com/WODE25500/dsh-k6) - Load testing with Grafana k6: smoke-test first, then run scripts and read percentiles from the JSON summary.
 - [WODE25500/dsh-kubectl](https://github.com/WODE25500/dsh-kubectl) - Kubernetes ops for the agent: get resources with structured JSON output, describe, logs, exec, apply/delete (user-confirmed) and port-forward.
+- [WODE25500/dsh-maf](https://github.com/WODE25500/dsh-maf) - Microsoft Agent Framework (MAF) integration: validate, run and scaffold declarative agents and workflows defined in YAML.
 - [WODE25500/dsh-terraform](https://github.com/WODE25500/dsh-terraform) - Infrastructure as code: gated plan/apply, state and output inspection, and configuration validation via the terraform CLI.
 - [WODE25500/dsh-winget](https://github.com/WODE25500/dsh-winget) - Windows Package Manager: search, install, upgrade, uninstall, import/export and pin software through native tools.
 - [worksAssistant/dsh-quickref](https://github.com/worksAssistant/dsh-quickref) - Developer quick-reference toolbox for DSH: 12 themed categories (195 entries) plus zero-dependency tools — regex tester, JSON formatter, timestamp converter, Base64/URL codec, cron generator and line diff, in a searchable settings panel.

--- a/README.zh.md
+++ b/README.zh.md
@@ -1697,6 +1697,7 @@ dsh plugin --profile web add dshmarket
 - [WODE25500/dsh-codex](https://github.com/WODE25500/dsh-codex) — OpenAI Codex CLI 封装：一次性任务、仓库审查与会话续接，默认只读沙箱。
 - [WODE25500/dsh-k6](https://github.com/WODE25500/dsh-k6) — Grafana k6 压测：先冒烟再跑脚本，从 JSON 汇总读百分位数。
 - [WODE25500/dsh-kubectl](https://github.com/WODE25500/dsh-kubectl) — Kubernetes 运维：JSON 结构化查资源、describe、日志、exec、apply/delete（需确认）与端口转发。
+- [WODE25500/dsh-maf](https://github.com/WODE25500/dsh-maf) — 微软 Agent Framework (MAF) 集成：验证、运行与搭建 YAML 声明式 agents 与 workflows。
 - [WODE25500/dsh-terraform](https://github.com/WODE25500/dsh-terraform) — 基础设施即代码：plan/apply 门控、state/output 检查与配置校验。
 - [WODE25500/dsh-winget](https://github.com/WODE25500/dsh-winget) — Windows 包管理器：搜索、安装、升级、卸载、导入导出与版本固定。
 - [worksAssistant/dsh-quickref](https://github.com/worksAssistant/dsh-quickref) — 开发者速查工具箱：12 个主题 195 条速查 + 6 个零依赖工具（正则实时测试、JSON 格式化、时间戳转换、Base64/URL 编解码、Cron 生成、行 diff），设置页可搜索查阅。

--- a/data/plugins/WODE25500__dsh-maf.yml
+++ b/data/plugins/WODE25500__dsh-maf.yml
@@ -1,0 +1,6 @@
+url: https://github.com/WODE25500/dsh-maf
+name: WODE25500/dsh-maf
+category: dev
+description:
+  en: 'Microsoft Agent Framework (MAF) integration: validate, run and scaffold declarative agents and workflows defined in YAML.'
+  zh: '微软 Agent Framework (MAF) 集成：验证、运行与搭建 YAML 声明式 agents 与 workflows。'


### PR DESCRIPTION
Closing this - it duplicates #2203 (same dsh-maf entry, same 3 files). Keeping #2203 as the single canonical entry for dsh-maf.