### PR TITLE
Add store screenshots for dsh-wallpaper-engine

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -1080,5 +1080,13 @@
   "https://raw.githubusercontent.com/liustack/modlens/main/assets/demo-dsh-paste.jpg",
   "https://raw.githubusercontent.com/liustack/modlens/main/assets/demo-codex-chart.jpg",
   "https://raw.githubusercontent.com/liustack/modlens/main/assets/demo-codex-app.jpg"
+ ],
+ "https://github.com/elysia395/dsh-wallpaper-engine": [
+  "https://raw.githubusercontent.com/elysia395/dsh-wallpaper-engine/main/docs/images/showcase.png",
+  "https://raw.githubusercontent.com/elysia395/dsh-wallpaper-engine/main/docs/images/wallpaper-library.png",
+  "https://raw.githubusercontent.com/elysia395/dsh-wallpaper-engine/main/docs/images/liquid-glass-window.png",
+  "https://raw.githubusercontent.com/elysia395/dsh-wallpaper-engine/main/docs/images/features.png",
+  "https://raw.githubusercontent.com/elysia395/dsh-wallpaper-engine/main/docs/images/compact-wallpaper-library.png",
+  "https://raw.githubusercontent.com/elysia395/dsh-wallpaper-engine/main/docs/images/better-sidebar.png"
  ]
 }


### PR DESCRIPTION
Adds AppStore-style screenshots for elysia395/dsh-wallpaper-engine to \data/screenshots.json\ (6 images: showcase, wallpaper-library, liquid-glass-window, features, compact-wallpaper-library, better-sidebar — all hosted on the plugin repo under \docs/images/\, GitHub-hosted raw URLs only). Branch based on latest main; diff touches only \data/screenshots.json\.