### PR TITLE
Add dsh-wechat-persistent to Notifications & Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1391,6 +1391,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 
 ### Notifications & Integrations
 
+- [gusu45/dsh-wechat-persistent](https://github.com/gusu45/dsh-wechat-persistent) - Real persistent WeChat bridge for DeepSeek Harness: one WeChat user = one persistent DSH session via official agents.create/resume (iLink official channel, context survives messages and restarts).
 - [534119219/chicheng-push](https://github.com/534119219/chicheng-push) - Multi-channel push for DeepSeek Harness: Server酱, PushPlus, Bark, DingTalk, WeCom, Telegram, Feishu, ntfy, custom webhooks and more, configurable from the settings panel and callable by other plugins via the pushNotifier service.
 - [534119219/dsh-messaging#messaging-core](https://github.com/534119219/dsh-messaging/tree/main/packages/messaging-core) - Unified messaging gateway for DeepSeek Harness: 27 IM platforms (Telegram, QQ, WeChat, Discord, WhatsApp, Feishu and more) in one plugin, with QR scan-to-authorize, per-platform workspaces, slash commands, and a web setup dialog.
 - [AbcdefgXW/dsh-msg-hub](https://github.com/AbcdefgXW/dsh-msg-hub) - IM channel bridge: WeChat (ilinkai) / QQ / Feishu with proactive push — wake the channel bot from scheduled tasks and deliver AI replies to your phone.


### PR DESCRIPTION
Add dsh-wechat-persistent - real persistent WeChat bridge for DeepSeek Harness.

- One WeChat user = one persistent DSH session (official agents.create/resume)
- iLink official channel (no reverse engineering)
- Context survives messages and restarts
- Installs with dsh plugin add github:gusu45/dsh-wechat-persistent