### PR TITLE
Add AdonisSheldon/dsh-openai-oauth

### DIFF
--- a/README.md
+++ b/README.md
@@ -532,6 +532,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 
 ### Models & Providers
 
+- [AdonisSheldon/dsh-openai-oauth](https://github.com/AdonisSheldon/dsh-openai-oauth) - Connect a ChatGPT account to Codex models in DeepSeek Harness through browser PKCE or device-code OAuth, with automatic token refresh and Web or headless login.
 - [amlyczz/dsh-agy-link](https://github.com/amlyczz/dsh-agy-link) - Google Antigravity (agy CLI) models for DSH — streaming chat with Gemini/Claude/GPT-OSS subscriptions, native tool cards, thinking turns, and in-GUI Google OAuth login.
 - [BruceLanLan/dsh-tier-router](https://github.com/BruceLanLan/dsh-tier-router) - Two-tier model routing: a strong tier plans, advises and reviews while a cheap tier implements, with plan-mode-aware auto routing, a high-impact escalation guard, failure auto-escalation, and subagent tiering.
 - [btspoony/dsh-llm-fallbacks](https://github.com/btspoony/dsh-llm-fallbacks) - Role-based LLM retry & fallback strategies.

--- a/README.zh.md
+++ b/README.zh.md
@@ -532,6 +532,7 @@ dsh plugin --profile web add dshmarket
 
 ### 🔌 模型与账号接入
 
+- [AdonisSheldon/dsh-openai-oauth](https://github.com/AdonisSheldon/dsh-openai-oauth) — 通过浏览器 PKCE 或设备码 OAuth 将 ChatGPT 账户接入 DeepSeek Harness 的 Codex 模型，并支持自动刷新令牌以及 Web 或无头登录。
 - [amlyczz/dsh-agy-link](https://github.com/amlyczz/dsh-agy-link) — 将 Google Antigravity (agy CLI) 接入 DSH：无 API Key 使用 Gemini/Claude/GPT-OSS 订阅模型，支持流式对话、原生工具卡片、思考轮次注记及 Web 界面 Google OAuth 扫码登录。
 - [BruceLanLan/dsh-tier-router](https://github.com/BruceLanLan/dsh-tier-router) — 双档模型路由：强档负责规划/咨询/评审、弱档负责实现；含计划模式自动路由、高危操作守卫、失败自动升级与子代理分层。
 - [btspoony/dsh-llm-fallbacks](https://github.com/btspoony/dsh-llm-fallbacks) — 基于角色的模型重试与备用策略。

--- a/data/plugins/AdonisSheldon__dsh-openai-oauth.yml
+++ b/data/plugins/AdonisSheldon__dsh-openai-oauth.yml
@@ -1,0 +1,6 @@
+url: https://github.com/AdonisSheldon/dsh-openai-oauth
+name: AdonisSheldon/dsh-openai-oauth
+category: model
+description:
+  en: Connect a ChatGPT account to Codex models in DeepSeek Harness through browser PKCE or device-code OAuth, with automatic token refresh and Web or headless login.
+  zh: 通过浏览器 PKCE 或设备码 OAuth 将 ChatGPT 账户接入 DeepSeek Harness 的 Codex 模型，并支持自动刷新令牌以及 Web 或无头登录。


### PR DESCRIPTION
## Plugin

- Repository: https://github.com/AdonisSheldon/dsh-openai-oauth
- Category: Models & Providers
- Bundle: `dsh.bundle` in `package.json`

`dsh-openai-oauth` connects a ChatGPT account to Codex models in DeepSeek Harness. It supports browser PKCE and device-code OAuth, automatic token refresh, and both Web and headless login workflows.

## Validation

- repository is public, older than one day, and has more than ten commits
- repository topic includes `dsh-plugin`
- `npm ci`
- `node scripts/generate-readme.mjs --check`
- `npx awesome-lint`
- `SKIP_PUBLISH_CHECKS=1 node scripts/build-site.mjs`
