### PR TITLE
docs: clarify dsh-awiki ANP identity description

### DIFF
--- a/README.md
+++ b/README.md
@@ -570,7 +570,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 
 ### Identity & Communication
 
-- [AgentConnect/dsh-awiki](https://github.com/AgentConnect/dsh-awiki) - Provides DeepSeek Harness agents with native AWiki identities and identity-based direct, group, mail, and Agent-to-Agent communication.
+- [AgentConnect/dsh-awiki](https://github.com/AgentConnect/dsh-awiki) - Provides DeepSeek Harness agents with native identities based on the open Agent Network Protocol (ANP), plus identity-based direct, group, mail, and Agent-to-Agent communication.
 
 ### Sessions & Messages
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -570,7 +570,7 @@ dsh plugin --profile web add dshmarket
 
 ### 🆔 身份与通信
 
-- [AgentConnect/dsh-awiki](https://github.com/AgentConnect/dsh-awiki) — 为 DeepSeek Harness 智能体提供原生 AWiki 身份，以及基于该身份的私聊、群聊、邮件和智能体间通信能力。
+- [AgentConnect/dsh-awiki](https://github.com/AgentConnect/dsh-awiki) — 为 DeepSeek Harness 智能体提供基于开放协议ANP的原生身份，以及基于该身份的私聊、群聊、邮件和智能体间通信能力。
 
 ### 💬 会话与消息
 

--- a/data/plugins/AgentConnect__dsh-awiki.yml
+++ b/data/plugins/AgentConnect__dsh-awiki.yml
@@ -2,5 +2,5 @@ url: https://github.com/AgentConnect/dsh-awiki
 name: AgentConnect/dsh-awiki
 category: identity
 description:
-  en: Provides DeepSeek Harness agents with native AWiki identities and identity-based direct, group, mail, and Agent-to-Agent communication.
-  zh: 为 DeepSeek Harness 智能体提供原生 AWiki 身份，以及基于该身份的私聊、群聊、邮件和智能体间通信能力。
+  en: Provides DeepSeek Harness agents with native identities based on the open Agent Network Protocol (ANP), plus identity-based direct, group, mail, and Agent-to-Agent communication.
+  zh: 为 DeepSeek Harness 智能体提供基于开放协议ANP的原生身份，以及基于该身份的私聊、群聊、邮件和智能体间通信能力。


### PR DESCRIPTION
## Summary

- Make a small wording adjustment to the `AgentConnect/dsh-awiki` description.
- Clarify that its agent-native identity is based on the open Agent Network Protocol (ANP).
- Keep the existing identity-based direct, group, mail, and Agent-to-Agent communication description.
- Regenerate the English and Chinese READMEs.

## Scope

This PR changes description text only. It does not change the plugin category, installation metadata, or implementation.

## Validation

- `npm ci`
- `node scripts/generate-readme.mjs`
- `node scripts/generate-readme.mjs --check`
- `npx awesome-lint` (passes; pre-existing spelling warnings only)
- `SKIP_PUBLISH_CHECKS=1 node scripts/build-site.mjs`
- `git diff --check`
