### PR TITLE
Add screenshots for liustack/modlens

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -1048,7 +1048,7 @@
   "https://raw.githubusercontent.com/lninghaha/dsh-hub-oauth-gateway/main/docs/images/usage-center-dashboard.png",
   "https://raw.githubusercontent.com/lninghaha/dsh-hub-oauth-gateway/main/docs/images/usage-center-settings.png"
  ],
-"https://github.com/deepseek-dsh/dsh-workspace": [
+ "https://github.com/deepseek-dsh/dsh-workspace": [
   "https://raw.githubusercontent.com/deepseek-dsh/dsh-workspace/main/assets/Screenshot-1.png",
   "https://raw.githubusercontent.com/deepseek-dsh/dsh-workspace/main/assets/Screenshot-2.png"
  ],
@@ -1070,5 +1070,11 @@
   "https://raw.githubusercontent.com/liustack/modsearch/main/assets/demo-dsh-settings-card.jpg",
   "https://raw.githubusercontent.com/liustack/modsearch/main/assets/demo-codex-search.png",
   "https://raw.githubusercontent.com/liustack/modsearch/main/assets/demo-codex-fetch.png"
+ ],
+ "https://github.com/liustack/modlens": [
+  "https://raw.githubusercontent.com/liustack/modlens/main/assets/demo-dsh-settings-card.jpg",
+  "https://raw.githubusercontent.com/liustack/modlens/main/assets/demo-dsh-paste.jpg",
+  "https://raw.githubusercontent.com/liustack/modlens/main/assets/demo-codex-chart.jpg",
+  "https://raw.githubusercontent.com/liustack/modlens/main/assets/demo-codex-app.jpg"
  ]
 }


### PR DESCRIPTION
This is a screenshots-only PR for an already-listed entry, doing the Recommended item "Add screenshots to `data/screenshots.json`". The new-entry checklist does not apply. / 本 PR 只为已收录条目补充截图（即模板推荐项里的截图一条），新增条目自查清单不适用。

liustack/modlens is already listed, but it had no key in `data/screenshots.json`, so storefronts fell back to scraping the README. This adds a curated set of 4 shots, every image hosted in the plugin's own repo.

该插件已收录，但 `data/screenshots.json` 里没有对应 key，市场只能回退到抓 README。这里为它补上挑选过的截图，图片都托管在插件自己的仓库。

**[liustack/modlens](https://github.com/liustack/modlens)** (v3.22.1), 4 shots:

1. `demo-dsh-settings-card.jpg` (new), the ModLens settings card under Settings > Plugins > Plugin config: engine picker, and which local CLIs auto mode reuses
2. `demo-dsh-paste.jpg`, an image pasted into DeepSeek Harness and read back in detail by a text-only model
3. `demo-codex-chart.jpg`, a 128-model scatter plot read in full, axes and log scale included
4. `demo-codex-app.jpg`, a screenshot transcribed down to the fine print

Notes / 说明:

- No entry file changed, so the generated READMEs are untouched and need no regeneration. `data/screenshots.json` is the only file in this PR. / 未改动任何条目文件，生成的 README 无需重新生成，本 PR 只动 `data/screenshots.json`。
- All URLs are on `raw.githubusercontent.com`, within the 1-8 limit. Validated against the `build-site.mjs` screenshot rules. / 全部为 `raw.githubusercontent.com` 链接，数量符合 1-8 张限制，已按 `build-site.mjs` 的校验规则本地验证通过。
- The key matches the entry URL in `data/plugins/liustack__modlens.yml` exactly. / key 与条目 yml 中的 url 完全一致。

A sibling PR adds screenshots for the other liustack plugin. The two are independent but append to the same spot in the file, so whichever merges second will need a trivial rebase. / 另有一个姊妹 PR 为另一个 liustack 插件补充截图。两个 PR 相互独立，但都追加在同一文件的同一位置，后合并的那个需要一次简单的 rebase。
