### PR TITLE
Add screenshots for liustack/modsearch

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -1065,5 +1065,10 @@
  "https://github.com/wsz987/dsh-channels/tree/main/packages/channels": [
   "https://raw.githubusercontent.com/wsz987/dsh-channels/main/docs/ScreenShot/dsh-channels-setting.png",
   "https://raw.githubusercontent.com/wsz987/dsh-channels/main/docs/ScreenShot/telegram.png"
+ ],
+ "https://github.com/liustack/modsearch": [
+  "https://raw.githubusercontent.com/liustack/modsearch/main/assets/demo-dsh-settings-card.jpg",
+  "https://raw.githubusercontent.com/liustack/modsearch/main/assets/demo-codex-search.png",
+  "https://raw.githubusercontent.com/liustack/modsearch/main/assets/demo-codex-fetch.png"
  ]
 }


### PR DESCRIPTION
This is a screenshots-only PR for an already-listed entry, doing the Recommended item "Add screenshots to `data/screenshots.json`". The new-entry checklist does not apply. / 本 PR 只为已收录条目补充截图（即模板推荐项里的截图一条），新增条目自查清单不适用。

liustack/modsearch is already listed, but it had no key in `data/screenshots.json`, so storefronts fell back to scraping the README. This adds a curated set of 3 shots, every image hosted in the plugin's own repo.

该插件已收录，但 `data/screenshots.json` 里没有对应 key，市场只能回退到抓 README。这里为它补上挑选过的截图，图片都托管在插件自己的仓库。

**[liustack/modsearch](https://github.com/liustack/modsearch)** (v5.8.0), 3 shots:

1. `demo-dsh-settings-card.jpg` (new), the ModSearch settings card under Settings > Plugins > Plugin config: preferred engine, API key, custom base URL, and which engines join the failover chain
2. `demo-codex-search.png`, an open-ended question answered as stories with source links where cited
3. `demo-codex-fetch.png`, a single URL fetched and summarised

Notes / 说明:

- No entry file changed, so the generated READMEs are untouched and need no regeneration. `data/screenshots.json` is the only file in this PR. / 未改动任何条目文件，生成的 README 无需重新生成，本 PR 只动 `data/screenshots.json`。
- All URLs are on `raw.githubusercontent.com`, within the 1-8 limit. Validated against the `build-site.mjs` screenshot rules. / 全部为 `raw.githubusercontent.com` 链接，数量符合 1-8 张限制，已按 `build-site.mjs` 的校验规则本地验证通过。
- The key matches the entry URL in `data/plugins/liustack__modsearch.yml` exactly. / key 与条目 yml 中的 url 完全一致。

A sibling PR adds screenshots for the other liustack plugin. The two are independent but append to the same spot in the file, so whichever merges second will need a trivial rebase. / 另有一个姊妹 PR 为另一个 liustack 插件补充截图。两个 PR 相互独立，但都追加在同一文件的同一位置，后合并的那个需要一次简单的 rebase。
