### PR TITLE
Add 3361805598-gif/dsh-md-annotator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1142,6 +1142,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 
 ### Docs & Rendering
 
+- [3361805598-gif/dsh-md-annotator](https://github.com/3361805598-gif/dsh-md-annotator) - Markdown sidebar preview and source editor with block- and text-range annotations that can be sent to the conversation as structured revision requests.
 - [AKS1st/dsh-mermaid](https://github.com/AKS1st/dsh-mermaid) - Render Mermaid code fences in DSH Web chat messages as lazy-loaded SVG diagrams with strict sanitization and light/dark theme follow.
 - [baconbao/dsh-mermaid-image-preview](https://github.com/baconbao/dsh-mermaid-image-preview) - Preview Mermaid diagrams as images via local rendering in DSH Web when the chat message contains a Mermaid fenced code block, and also allow integration with external rendering servers.
 - [bill9109/dsh-101](https://github.com/bill9109/dsh-101) - Document reading mode for DSH.

--- a/README.md
+++ b/README.md
@@ -1142,7 +1142,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 
 ### Docs & Rendering
 
-- [3361805598-gif/dsh-md-annotator](https://github.com/3361805598-gif/dsh-md-annotator) - Markdown sidebar preview and source editor with block- and text-range annotations that can be sent to the conversation as structured revision requests.
+- [3361805598-gif/dsh-md-annotator](https://github.com/3361805598-gif/dsh-md-annotator) - Markdown sidebar preview and source editor for dsh-better-sidebar, with block- and text-range annotations that can be sent to the conversation as structured revision requests.
 - [AKS1st/dsh-mermaid](https://github.com/AKS1st/dsh-mermaid) - Render Mermaid code fences in DSH Web chat messages as lazy-loaded SVG diagrams with strict sanitization and light/dark theme follow.
 - [baconbao/dsh-mermaid-image-preview](https://github.com/baconbao/dsh-mermaid-image-preview) - Preview Mermaid diagrams as images via local rendering in DSH Web when the chat message contains a Mermaid fenced code block, and also allow integration with external rendering servers.
 - [bill9109/dsh-101](https://github.com/bill9109/dsh-101) - Document reading mode for DSH.

--- a/README.zh.md
+++ b/README.zh.md
@@ -1142,7 +1142,7 @@ dsh plugin --profile web add dshmarket
 
 ### 📄 文档与渲染
 
-- [3361805598-gif/dsh-md-annotator](https://github.com/3361805598-gif/dsh-md-annotator) — Markdown 侧边栏预览与源码编辑器，支持块级和文本选区批注，并可将批注作为结构化修改请求发送到对话框。
+- [3361805598-gif/dsh-md-annotator](https://github.com/3361805598-gif/dsh-md-annotator) — 面向 dsh-better-sidebar 扩展的 Markdown 侧边栏预览与源码编辑器，支持块级和文本选区批注，并可将批注作为结构化修改请求发送到对话框。
 - [AKS1st/dsh-mermaid](https://github.com/AKS1st/dsh-mermaid) — 把 DSH Web 会话消息中的 Mermaid 代码围栏渲染为惰性加载的 SVG 图表，严格消毒并跟随明暗主题。
 - [baconbao/dsh-mermaid-image-preview](https://github.com/baconbao/dsh-mermaid-image-preview) — 当 DSH Web 中的消息包含 Mermaid 语法时，通过本地渲染以图像形式预览 Mermaid Diagrams，并允许接入外部渲染服务器。
 - [bill9109/dsh-101](https://github.com/bill9109/dsh-101) — DSH 文档阅读模式。

--- a/README.zh.md
+++ b/README.zh.md
@@ -1142,6 +1142,7 @@ dsh plugin --profile web add dshmarket
 
 ### 📄 文档与渲染
 
+- [3361805598-gif/dsh-md-annotator](https://github.com/3361805598-gif/dsh-md-annotator) — Markdown 侧边栏预览与源码编辑器，支持块级和文本选区批注，并可将批注作为结构化修改请求发送到对话框。
 - [AKS1st/dsh-mermaid](https://github.com/AKS1st/dsh-mermaid) — 把 DSH Web 会话消息中的 Mermaid 代码围栏渲染为惰性加载的 SVG 图表，严格消毒并跟随明暗主题。
 - [baconbao/dsh-mermaid-image-preview](https://github.com/baconbao/dsh-mermaid-image-preview) — 当 DSH Web 中的消息包含 Mermaid 语法时，通过本地渲染以图像形式预览 Mermaid Diagrams，并允许接入外部渲染服务器。
 - [bill9109/dsh-101](https://github.com/bill9109/dsh-101) — DSH 文档阅读模式。

--- a/data/plugins/3361805598-gif__dsh-md-annotator.yml
+++ b/data/plugins/3361805598-gif__dsh-md-annotator.yml
@@ -2,6 +2,6 @@ url: https://github.com/3361805598-gif/dsh-md-annotator
 name: 3361805598-gif/dsh-md-annotator
 category: docs
 description:
-  en: Markdown sidebar preview and source editor with block- and text-range annotations that can be sent to the conversation as structured revision requests.
-  zh: Markdown 侧边栏预览与源码编辑器，支持块级和文本选区批注，并可将批注作为结构化修改请求发送到对话框。
+  en: Markdown sidebar preview and source editor for dsh-better-sidebar, with block- and text-range annotations that can be sent to the conversation as structured revision requests.
+  zh: 面向 dsh-better-sidebar 扩展的 Markdown 侧边栏预览与源码编辑器，支持块级和文本选区批注，并可将批注作为结构化修改请求发送到对话框。
 tarball: https://github.com/3361805598-gif/dsh-md-annotator/releases/download/v0.6.0/dsh-md-annotator-0.6.0.tgz

--- a/data/plugins/3361805598-gif__dsh-md-annotator.yml
+++ b/data/plugins/3361805598-gif__dsh-md-annotator.yml
@@ -1,0 +1,7 @@
+url: https://github.com/3361805598-gif/dsh-md-annotator
+name: 3361805598-gif/dsh-md-annotator
+category: docs
+description:
+  en: Markdown sidebar preview and source editor with block- and text-range annotations that can be sent to the conversation as structured revision requests.
+  zh: Markdown 侧边栏预览与源码编辑器，支持块级和文本选区批注，并可将批注作为结构化修改请求发送到对话框。
+tarball: https://github.com/3361805598-gif/dsh-md-annotator/releases/download/v0.6.0/dsh-md-annotator-0.6.0.tgz


### PR DESCRIPTION
- [x] I added **one file** at `data/plugins/<owner>__<repo>.yml` — the READMEs are generated, don't edit them by hand / 我新增了一个 `data/plugins/<owner>__<repo>.yml` 文件（各语言 README 由脚本生成，不要手工编辑）
- [x] I ran `node scripts/generate-readme.mjs` and committed the regenerated READMEs / 我已执行 `node scripts/generate-readme.mjs` 并提交了重新生成的 README
- [x] My repo's `package.json` declares **`dsh.bundle`** (not just `dsh.client`) / 仓库 `package.json` 已声明 `dsh.bundle`
- [x] My repo is at least **1 day old** with **10+ commits** / 仓库创建满 1 天且提交数 ≥ 10
- [x] `category` is `docs` / 分类为 `docs`
- [x] Description states what the plugin does, no superlatives / 描述只说功能，不带营销词
- [x] My repo has the `dsh-plugin` topic / 仓库已打 `dsh-plugin` topic

## Summary

Adds `dsh-md-annotator`, a Markdown sidebar preview/source editor with block- and text-range annotations that can be sent as structured revision requests. The entry includes the prebuilt v0.6.0 GitHub Release tarball.

## Validation

- `node scripts/generate-readme.mjs --check`
- `npx awesome-lint`
- `SKIP_PUBLISH_CHECKS=1 node scripts/build-site.mjs`
- `scripts/check-submission.mjs`: all checked entries pass