### PR TITLE
add dsh-model-accordion entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 - [kongdexu/dsh-nav-pointer](https://github.com/kongdexu/dsh-nav-pointer) - Vertical message pointer rail on the left edge of the chat: one dash per user message, click to scroll to that message, hover for a preview bubble.
 - [kouyichi/dsh-tui-app](https://github.com/kouyichi/dsh-tui-app) - Interactive terminal chat app for dsh: streaming conversation, tool cards, jobs panel, full-text search, trajectory replay, multi-session tabs, and A2A dispatch (Ink-based).
 - [l541402398/dsh-file-uploads](https://github.com/l541402398/dsh-file-uploads) - Upload arbitrary local files from the Web composer, show pending cards, and manage stored files in Settings.
+- [lakabuji-arch/dsh-model-accordion](https://github.com/lakabuji-arch/dsh-model-accordion) - Provider-folded model selector for the DSH Web composer with catalog-driven reasoning effort choices.
 - [Laplace-bit/dsh-smooth-stream](https://github.com/Laplace-bit/dsh-smooth-stream) - Fluid streaming rendering and smooth scrolling for the DeepSeek Harness Web UI.
 - [lavapapa/dsh-composer-layout](https://github.com/lavapapa/dsh-composer-layout) - Web Composer placement for long prompts: keep it at the bottom or dock it in a resizable right column beside a long answer.
 - [LCQ-1024/dsh-prompt-enhancer](https://github.com/LCQ-1024/dsh-prompt-enhancer) - Adds a prompt-enhancement button to the DSH composer that rewrites drafts into agent-ready prompts.

--- a/README.zh.md
+++ b/README.zh.md
@@ -198,6 +198,7 @@ dsh plugin --profile web add dshmarket
 - [kongdexu/dsh-nav-pointer](https://github.com/kongdexu/dsh-nav-pointer) — 聊天区左侧的消息指针导轨：每条用户消息一个横条，点击滚动定位，悬停显示预览气泡。
 - [kouyichi/dsh-tui-app](https://github.com/kouyichi/dsh-tui-app) — dsh 交互式终端聊天应用：流式对话、工具卡片、任务面板、全文搜索、轨迹回放、多会话标签与 A2A 派发（Ink 实现）。
 - [l541402398/dsh-file-uploads](https://github.com/l541402398/dsh-file-uploads) — 从 Web 输入框上传任意本地文件，以待发送卡片展示，并在设置中管理已存文件。
+- [lakabuji-arch/dsh-model-accordion](https://github.com/lakabuji-arch/dsh-model-accordion) — 为 DSH Web 输入栏提供按 provider 折叠的模型选择器，并使用模型目录中的真实推理档位。
 - [Laplace-bit/dsh-smooth-stream](https://github.com/Laplace-bit/dsh-smooth-stream) — 为 DeepSeek Harness Web UI 提供流畅流式渲染和丝滑滚动。
 - [lavapapa/dsh-composer-layout](https://github.com/lavapapa/dsh-composer-layout) — 面向长提示词的 Web Composer 布局：输入框可保留在底部，也可停靠到可调宽度的右栏，与长回答并排阅读和写作。
 - [LCQ-1024/dsh-prompt-enhancer](https://github.com/LCQ-1024/dsh-prompt-enhancer) — 在 DSH 输入框添加提示词增强按钮，将草稿改写为可直接交给 Agent 执行的提示词。

--- a/data/plugins/lakabuji-arch__dsh-model-accordion.yml
+++ b/data/plugins/lakabuji-arch__dsh-model-accordion.yml
@@ -1,0 +1,6 @@
+url: https://github.com/lakabuji-arch/dsh-model-accordion
+name: lakabuji-arch/dsh-model-accordion
+category: ui
+description:
+  en: "Provider-folded model selector for the DSH Web composer with catalog-driven reasoning effort choices."
+  zh: "为 DSH Web 输入栏提供按 provider 折叠的模型选择器，并使用模型目录中的真实推理档位。"


### PR DESCRIPTION
Add dsh-model-accordion to the UI Enhancements category.

- Repository: https://github.com/lakabuji-arch/dsh-model-accordion
- Declares a \dsh.bundle\ manifest (bundle patch + web client entry).
- Provides a provider-folded model selector for the DSH Web composer with catalog-driven reasoning effort choices.
- Regenerated both READMEs via \scripts/generate-readme.mjs\ (1799 entries).

Category: ui