### PR TITLE
Update dsh-inline-comments tarball to v0.1.2

### DIFF
--- a/data/plugins/ruisenbai__dsh-inline-comments.yml
+++ b/data/plugins/ruisenbai__dsh-inline-comments.yml
@@ -4,4 +4,4 @@ category: ui
 description:
   en: Select text in a finished assistant reply to add numbered comments beside the quote; collect drafts and submit the batch through the official composer as one user message.
   zh: 在已完成的助手回复中选中原文，在引文旁添加编号注释；草稿攒齐后通过官方输入框一次性作为一条用户消息发送。
-tarball: https://github.com/ruisenbai/dsh-inline-comments/releases/download/v0.1.1/dsh-inline-comments-0.1.1.tgz
+tarball: https://github.com/ruisenbai/dsh-inline-comments/releases/download/v0.1.2/dsh-inline-comments-0.1.2.tgz


### PR DESCRIPTION
## Summary

Point the existing `dsh-inline-comments` catalog entry at its prebuilt v0.1.2 GitHub Release archive. This release adds DSH 0.1.0-rc.8 compatibility.

## Verification

- downloaded the release asset successfully
- `node scripts/generate-readme.mjs --check`
- `SKIP_PUBLISH_CHECKS=1 node scripts/build-site.mjs`