### PR TITLE
Add dsh-musage

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,6 +479,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 - [Starlight-bananice/dsh-status-bar](https://github.com/Starlight-bananice/dsh-status-bar) - A configurable 17-segment session status bar for the dsh composer dock with live TPS, per-model cost estimation, and a usage & cost dialog.
 - [stevenx65/dsh-balance-plugin](https://github.com/stevenx65/dsh-balance-plugin) - DeepSeek balance and token usage in the web sidebar, with a today/all-time toggle and provider filtering.
 - [Sttrevens/dsh-cost-meter](https://github.com/Sttrevens/dsh-cost-meter) - Per-turn USD cost badge in the Web UI: session total in the header and per-turn cost in each message footer, with a hover breakdown.
+- [Thedeergod666/dsh-musage](https://github.com/Thedeergod666/dsh-musage) - Shows coding-plan usage and balance for 5 AI providers (MiniMax, DeepSeek, Kimi, OpenRouter, Zhipu) beside the composer input, switching with the selected model and reusing API keys configured in DSH model settings.
 - [V-dev-388/dsh-usage-meter](https://github.com/V-dev-388/dsh-usage-meter) - Settings-page usage dashboard: per-provider/model token summary across all sessions, with today/7-day/30-day CSS-bar trends and a cache-hit rate.
 - [v587d/dsh-opencode-go-usage](https://github.com/v587d/dsh-opencode-go-usage) - OpenCode Go subscription usage (rolling/weekly/monthly windows with reset countdowns) in the composer dock, with a built-in credential editor.
 - [vibeinging/dsh-agent-budget](https://github.com/vibeinging/dsh-agent-budget) - Agent-tree token budget management.

--- a/README.zh.md
+++ b/README.zh.md
@@ -479,6 +479,7 @@ dsh plugin --profile web add dshmarket
 - [Starlight-bananice/dsh-status-bar](https://github.com/Starlight-bananice/dsh-status-bar) — 输入栏下可配置的 17 段会话状态栏，提供实时 TPS、按模型分别计价的费用估算，以及用量与费用弹窗。
 - [stevenx65/dsh-balance-plugin](https://github.com/stevenx65/dsh-balance-plugin) — dsh 网页侧边栏的 DeepSeek 余额与 token 用量监控：今日/累计切换，并按 provider 过滤其他厂商。
 - [Sttrevens/dsh-cost-meter](https://github.com/Sttrevens/dsh-cost-meter) — Web UI 美元成本徽标：头部显示会话总成本、每条回复结尾显示该轮成本，悬停看分项。
+- [Thedeergod666/dsh-musage](https://github.com/Thedeergod666/dsh-musage) — 在 composer 输入框旁显示 5 家 AI 套餐用量与余额（MiniMax、DeepSeek、Kimi、OpenRouter、智谱），跟随当前模型自动切换，复用 DSH 模型设置里已配的 API Key。
 - [V-dev-388/dsh-usage-meter](https://github.com/V-dev-388/dsh-usage-meter) — 设置页用量仪表盘：按服务商/模型汇总全部会话 token 用量，含今日/近 7 天/近 30 天趋势柱状图与缓存命中率。
 - [v587d/dsh-opencode-go-usage](https://github.com/v587d/dsh-opencode-go-usage) — 在输入框上方 dock 显示 OpenCode Go 订阅用量（5h 滚动/每周/每月窗口与重置倒计时），内置凭据编辑器。
 - [vibeinging/dsh-agent-budget](https://github.com/vibeinging/dsh-agent-budget) — agent 树 token 预算管理。

--- a/data/plugins/Thedeergod666__dsh-musage.yml
+++ b/data/plugins/Thedeergod666__dsh-musage.yml
@@ -1,0 +1,6 @@
+url: https://github.com/Thedeergod666/dsh-musage
+name: Thedeergod666/dsh-musage
+category: usage
+description:
+  en: Shows coding-plan usage and balance for 5 AI providers (MiniMax, DeepSeek, Kimi, OpenRouter, Zhipu) beside the composer input, switching with the selected model and reusing API keys configured in DSH model settings.
+  zh: 在 composer 输入框旁显示 5 家 AI 套餐用量与余额（MiniMax、DeepSeek、Kimi、OpenRouter、智谱），跟随当前模型自动切换，复用 DSH 模型设置里已配的 API Key。


### PR DESCRIPTION
**What**
Adds `dsh-musage` to the `usage` category.

**What it does**
Shows coding-plan usage and balance for 5 AI providers (MiniMax, DeepSeek, Kimi, OpenRouter, Zhipu) beside the DSH composer input. Follows the currently selected model (switching to a MiniMax route shows the 5h/7d windows; switching to DeepSeek shows the CNY balance; switching to OpenRouter shows the USD balance). Reuses API keys already configured in DSH model settings — no extra credentials to manage.

**Manifest**
`dsh.bundle` declared in `package.json` (host half via `cordis.patch.yml`; client half via `./client` export). Zero npm dependencies.

**Screenshots**
Three PNGs in `docs/assets/screenshots/` showing the widget in three provider contexts.