### PR TITLE
Carry stars/downloads probe data for the moguiyu/dsh-tavily root relist

### DIFF
--- a/data/downloads.json
+++ b/data/downloads.json
@@ -1227,10 +1227,6 @@
   "downloads": 1250,
   "checkedAt": "2026-08-19"
  },
- "https://github.com/moguiyu/dsh-tavily/tree/main/packages/dsh-tool-tavily-search": {
-  "downloads": 1865,
-  "checkedAt": "2026-08-19"
- },
  "https://github.com/Mombrane/dsh-subagent-monitor": {
   "downloads": 246,
   "checkedAt": "2026-08-19"
@@ -2493,6 +2489,10 @@
  },
  "https://github.com/zylzyqzz/dsh-mobile-pwa": {
   "downloads": 220,
+  "checkedAt": "2026-08-19"
+ },
+ "https://github.com/moguiyu/dsh-tavily": {
+  "downloads": 1865,
   "checkedAt": "2026-08-19"
  }
 }

--- a/data/stars.json
+++ b/data/stars.json
@@ -3307,10 +3307,6 @@
   "stars": 3,
   "checkedAt": "2026-08-19"
  },
- "https://github.com/moguiyu/dsh-tavily/tree/main/packages/dsh-tool-tavily-search": {
-  "stars": 3,
-  "checkedAt": "2026-08-19"
- },
  "https://github.com/Mombrane/dsh-subagent-monitor": {
   "stars": 16,
   "checkedAt": "2026-08-19"
@@ -5973,6 +5969,10 @@
  },
  "https://github.com/zylzyqzz/dsh-mobile-pwa": {
   "stars": 0,
+  "checkedAt": "2026-08-19"
+ },
+ "https://github.com/moguiyu/dsh-tavily": {
+  "stars": 3,
   "checkedAt": "2026-08-19"
  }
 }


### PR DESCRIPTION
## Why

[#2194](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/pull/2194) re-pointed `moguiyu/dsh-tavily` from the monorepo subpackage (`packages/dsh-tool-tavily-search`) to the repo root. `data/stars.json` and `data/downloads.json` are **keyed by entry URL**, so the new root URL had no probe entry — the browser view showed empty stars/downloads for the plugin until the next daily probe refresh.

## Change

Carry the last-known-good probe values from the old subpackage URL to the new root URL, the same repoint convention `data/added-dates.json` documents:

| file | carried value |
|---|---|
| `data/stars.json` | `{ "stars": 3, "checkedAt": "2026-08-19" }` (the subdir probe already inherits the parent repo's stars) |
| `data/downloads.json` | `{ "downloads": 1865, "checkedAt": "2026-08-19" }` |

Only the two keys move; nothing else changes (4-line block swap per file).

## Notes

- No `data/plugins` entries are added or changed — the submission gate reports "nothing to verify" by design.
- The next daily probe will re-derive both values for the root URL and overwrite/confirm them, so this is a stop-gap migration, not a permanent override.
