### PR TITLE
Add ZSeven-W/dsh-ios

### DIFF
--- a/README.md
+++ b/README.md
@@ -1759,6 +1759,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 - [zoahdev/dsh-rule-evolve](https://github.com/zoahdev/dsh-rule-evolve/tree/main/plugin) - Verification-driven self-evolution loop: failure logs become verified AGENTS.md rules; in-session plugin (evolve_learn / evolve_apply / evolve_touch / evolve_recall), tool-verify gate, rule lifecycle, local recall.
 - [zoahdev/dsh-timesheet](https://github.com/zoahdev/dsh-timesheet) - Turn-based time tracking from dsh session logs: totals, per-day/project/provider/source rollups, tool-call counts, failure rates, and time-to-first-token — CLI plus an agent-callable timesheet tool, dsh-timesheet/v1 reports, zero runtime deps.
 - [zoahdev/dsh-unplug](https://github.com/zoahdev/dsh-unplug) - Plug/unplug any DeepSeek Harness plugin cleanly — list every mounted layer (bundles + patch rows), remove with full cleanup, disable/enable without deleting, and audit for orphaned/dangling state. CLI + agent-callable unplug tool. Read-only by default; destructive operations require explicit confirmation.
+- [ZSeven-W/dsh-ios](https://github.com/ZSeven-W/dsh-ios) - A live iOS Simulator — and a USB-connected iPhone — inside a DSH conversation: 21 agent tools to boot devices, build and run Xcode projects, drive the UI by accessibility identity, OCR text or list rows, read unified logs and inspect processes, backtraces and leaks, with a streaming sidebar panel you can tap, drag and rotate on.
 
 ### Security & Permissions
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -1759,6 +1759,7 @@ dsh plugin --profile web add dshmarket
 - [zoahdev/dsh-rule-evolve](https://github.com/zoahdev/dsh-rule-evolve/tree/main/plugin) — 验证驱动的自我进化循环：失败日志自动变成经过验证的 AGENTS.md 规则；会话内插件（evolve_learn/evolve_apply/evolve_touch/evolve_recall）、工具体检、规则生命周期、本地召回。
 - [zoahdev/dsh-timesheet](https://github.com/zoahdev/dsh-timesheet) — 从 dsh 会话日志做基于 turn 的时间跟踪：总计、按天/项目/供应商/来源汇总、工具调用数、失败率与首 token 延迟——CLI + agent 可调用 timesheet 工具，dsh-timesheet/v1 报告，零运行时依赖。
 - [zoahdev/dsh-unplug](https://github.com/zoahdev/dsh-unplug) — 让 DSH 插件的安装和卸载干净利落——列出所有加载层（Bundle + 补丁行）、完整卸载（清理 Bundle 列表+补丁行+依赖）、临时禁用以调试而不真正删除、以及审计残留的孤立行或悬空引用。CLI 与 agent 均可调用，默认只读，破坏性操作需二次确认。
+- [ZSeven-W/dsh-ios](https://github.com/ZSeven-W/dsh-ios) — 在 DSH 对话中运行 iOS 模拟器与 USB 连接的真机：21 个 agent 工具，可启动设备、构建运行 Xcode 工程、按无障碍标识 / OCR 文本 / 列表行驱动 UI、读取统一日志并查看进程、backtrace 与内存泄漏，并附带可点按、拖拽、旋转的实时侧边栏画面。
 
 ### 🔒 安全与权限
 

--- a/data/plugins/ZSeven-W__dsh-ios.yml
+++ b/data/plugins/ZSeven-W__dsh-ios.yml
@@ -1,0 +1,6 @@
+url: https://github.com/ZSeven-W/dsh-ios
+name: ZSeven-W/dsh-ios
+category: dev
+description:
+  en: 'A live iOS Simulator — and a USB-connected iPhone — inside a DSH conversation: 21 agent tools to boot devices, build and run Xcode projects, drive the UI by accessibility identity, OCR text or list rows, read unified logs and inspect processes, backtraces and leaks, with a streaming sidebar panel you can tap, drag and rotate on.'
+  zh: '在 DSH 对话中运行 iOS 模拟器与 USB 连接的真机：21 个 agent 工具，可启动设备、构建运行 Xcode 工程、按无障碍标识 / OCR 文本 / 列表行驱动 UI、读取统一日志并查看进程、backtrace 与内存泄漏，并附带可点按、拖拽、旋转的实时侧边栏画面。'


### PR DESCRIPTION
Adds the dsh-ios plugin (a live iOS Simulator and a USB-connected iPhone inside the conversation) to the `dev` category.

- npm: `@zseven-w/dsh-ios@0.1.0-rc.1` (published under the `next` dist-tag)
- repo: https://github.com/ZSeven-W/dsh-ios
- declares `dsh.bundle` (`{ "bundle": { "patch": "./cordis.patch.yml" }, "client": { "platform": "web" } }`) with `cordis.patch.yml` at the root
- 11 commits, repo created 2026-08-19, `dsh-plugin` topic set
- 21 registered tools, which is the number the entry claims: 9 core (`ios_sim_devices` … `ios_real_start_wda`) + 2 UI tree + 3 OCR + 2 list-row + 1 preview + 4 debug
- CI runs the fixture suites on macOS plus an experimental job that boots a real simulator

Only this plugin's entry is touched: the two README lines are the regenerated output of `node scripts/generate-readme.mjs`, one added line each, no existing entry modified.