### PR TITLE
docs: add screenshots for AKS1st/dsh-cyber-particle

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -1162,5 +1162,9 @@
   "https://raw.githubusercontent.com/wangzhishou/onebox-dsh-bridge/main/docs/images/app-connect.png",
   "https://raw.githubusercontent.com/wangzhishou/onebox-dsh-bridge/main/docs/images/app-chat.png",
   "https://raw.githubusercontent.com/wangzhishou/onebox-dsh-bridge/main/docs/images/app-feedback.png"
+ ],
+ "https://github.com/AKS1st/dsh-cyber-particle": [
+  "https://raw.githubusercontent.com/AKS1st/dsh-cyber-particle/master/assets/image_light.png",
+  "https://raw.githubusercontent.com/AKS1st/dsh-cyber-particle/master/assets/image_dark.png"
  ]
 }


### PR DESCRIPTION
Add storefront screenshots for **AKS1st/dsh-cyber-particle** in `data/screenshots.json` (community screenshots convention, contributing.md \u00a7Screenshots).

The two images already ship in the plugin repo (`assets/image_light.png`, `assets/image_dark.png`, referenced by its README) and are hosted on `raw.githubusercontent.com`; this entry lets dsh-market show them AppStore-style on the detail view.

- Light and dark theme previews, both verified reachable (HTTP 200)
- No entry/README changes, no new plugins in this PR