### PR TITLE
docs: add screenshots for AKS1st/dsh-mermaid

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -1162,5 +1162,11 @@
   "https://raw.githubusercontent.com/wangzhishou/onebox-dsh-bridge/main/docs/images/app-connect.png",
   "https://raw.githubusercontent.com/wangzhishou/onebox-dsh-bridge/main/docs/images/app-chat.png",
   "https://raw.githubusercontent.com/wangzhishou/onebox-dsh-bridge/main/docs/images/app-feedback.png"
+ ],
+ "https://github.com/AKS1st/dsh-mermaid": [
+  "https://raw.githubusercontent.com/AKS1st/dsh-mermaid/main/assets/main-page-white.png",
+  "https://raw.githubusercontent.com/AKS1st/dsh-mermaid/main/assets/main-page-dark.png",
+  "https://raw.githubusercontent.com/AKS1st/dsh-mermaid/main/assets/fangda-white.png",
+  "https://raw.githubusercontent.com/AKS1st/dsh-mermaid/main/assets/fangda-dark.png"
  ]
 }


### PR DESCRIPTION
Add storefront screenshots for **AKS1st/dsh-mermaid** in `data/screenshots.json` (community screenshots convention, contributing.md \u00a7Screenshots).

The four images already ship in the plugin repo (`assets/main-page-white.png`, `assets/main-page-dark.png`, `assets/fangda-white.png`, `assets/fangda-dark.png`, referenced by its README) and are hosted on `raw.githubusercontent.com`; this entry lets dsh-market show them AppStore-style on the detail view.

- In-conversation rendering and zoom overlay, light/dark themes, all verified reachable (HTTP 200)
- No entry/README changes, no new plugins in this PR