### PR TITLE
docs: add screenshots for AKS1st/dsh-skill-manager

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -1162,5 +1162,11 @@
   "https://raw.githubusercontent.com/wangzhishou/onebox-dsh-bridge/main/docs/images/app-connect.png",
   "https://raw.githubusercontent.com/wangzhishou/onebox-dsh-bridge/main/docs/images/app-chat.png",
   "https://raw.githubusercontent.com/wangzhishou/onebox-dsh-bridge/main/docs/images/app-feedback.png"
+ ],
+ "https://github.com/AKS1st/dsh-skill-manager": [
+  "https://raw.githubusercontent.com/AKS1st/dsh-skill-manager/main/assets/screenshot-en.png",
+  "https://raw.githubusercontent.com/AKS1st/dsh-skill-manager/main/assets/editor-en.png",
+  "https://raw.githubusercontent.com/AKS1st/dsh-skill-manager/main/assets/screenshot-zh.png",
+  "https://raw.githubusercontent.com/AKS1st/dsh-skill-manager/main/assets/editor-zh.png"
  ]
 }


### PR DESCRIPTION
Add storefront screenshots for **AKS1st/dsh-skill-manager** in `data/screenshots.json` (community screenshots convention, contributing.md \u00a7Screenshots).

Four screenshots already ship in the plugin repo (`assets/screenshot-en.png`, `assets/editor-en.png`, `assets/screenshot-zh.png`, `assets/editor-zh.png`, referenced by its README) and are hosted on `raw.githubusercontent.com`; this entry lets dsh-market show them AppStore-style on the detail view.

- Skills page and file editor, EN and ZH variants, all verified reachable (HTTP 200)
- No entry/README changes, no new plugins in this PR