### PR TITLE
docs: add screenshots for AKS1st/model-usage-plugin

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -1162,5 +1162,8 @@
   "https://raw.githubusercontent.com/wangzhishou/onebox-dsh-bridge/main/docs/images/app-connect.png",
   "https://raw.githubusercontent.com/wangzhishou/onebox-dsh-bridge/main/docs/images/app-chat.png",
   "https://raw.githubusercontent.com/wangzhishou/onebox-dsh-bridge/main/docs/images/app-feedback.png"
+ ],
+ "https://github.com/AKS1st/model-usage-plugin": [
+  "https://raw.githubusercontent.com/AKS1st/model-usage-plugin/main/image.png"
  ]
 }


### PR DESCRIPTION
Add storefront screenshot for **AKS1st/model-usage-plugin** in `data/screenshots.json` (community screenshots convention, contributing.md \u00a7Screenshots).

The screenshot already ships in the plugin repo (`image.png`, referenced by its README) and is hosted on `raw.githubusercontent.com`; this entry lets dsh-market show it AppStore-style on the detail view.

- Settings \"model usage\" tab preview, verified reachable (HTTP 200)
- No entry/README changes, no new plugins in this PR