### PR TITLE
fix: 更新 dsh-message-rail 截图配置

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -852,8 +852,7 @@
   "https://raw.githubusercontent.com/wuxiangru915/dsh-session-manager/main/assets/session-manager.png"
  ],
  "https://github.com/wx-yss/dsh-message-rail": [
-  "https://raw.githubusercontent.com/wx-yss/dsh-message-rail/main/assets/rail-hover-preview.png",
-  "https://raw.githubusercontent.com/wx-yss/dsh-message-rail/main/assets/rail-market-2.png"
+  "https://raw.githubusercontent.com/wx-yss/dsh-message-rail/main/assets/rail-hover-preview.png"
  ],
  "https://github.com/wz-heng/dsh-feishu-bridge": [
   "https://raw.githubusercontent.com/wz-heng/dsh-feishu-bridge/main/docs/screenshots/fail-closed-boot.png",


### PR DESCRIPTION
## 变更

- 移除已从插件仓库删除的 `rail-market-2.png`
- 保留当前用于展示插件特性的 `rail-hover-preview.png`

## 验证

- `node scripts/generate-readme.mjs --check`
- `npx awesome-lint`
- `SKIP_PUBLISH_CHECKS=1 node scripts/build-site.mjs`
- 截图配置 JSON 结构及目标条目校验通过