### PR TITLE
Add young-tim/dsh-llm-governor

### DIFF
--- a/README.md
+++ b/README.md
@@ -594,6 +594,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 - [WSL043/dsh-codex-subscription](https://github.com/WSL043/dsh-codex-subscription) - Built-in ChatGPT OAuth provider for Codex models, selectable subscription web search, backend quota for standard Codex and Spark, and a DSH settings UI; no API key or separate Codex installation required.
 - [wss534857356/dsh-plugin-codex](https://github.com/wss534857356/dsh-plugin-codex) - Codex App Server model provider using a local Codex login, with session reuse, Harness tool bridging, native action traces, and durable generated-image projection.
 - [xiaozhe7772222/dsh-opencode-zen](https://github.com/xiaozhe7772222/dsh-opencode-zen) - Zero-cost access to 6 free large models. No registration, no recharge, 6 free models built-in, multi-key rotation and rate-limit backoff.
+- [young-tim/dsh-llm-governor](https://github.com/young-tim/dsh-llm-governor) - Governs multi-model access, monthly credits, manual/quality/credit/auto routing, failure rerouting, and usage auditing for DSH.
 - [zeng6125-rgb/dsh-llm-retry-settings](https://github.com/zeng6125-rgb/dsh-llm-retry-settings) - Settings card to tune the DSH LLM auto-retry policy (retry count, backoff, jitter) live from Settings → General.
 
 ### Identity & Communication

--- a/README.zh.md
+++ b/README.zh.md
@@ -594,6 +594,7 @@ dsh plugin --profile web add dshmarket
 - [WSL043/dsh-codex-subscription](https://github.com/WSL043/dsh-codex-subscription) — 内置 ChatGPT OAuth 的 Codex 模型提供方：可切换订阅联网搜索，在设置页显示普通 Codex 与 Spark 独立额度；无需 API Key，也不需要另装 Codex。
 - [wss534857356/dsh-plugin-codex](https://github.com/wss534857356/dsh-plugin-codex) — 使用本地 Codex 登录的 Codex App Server 模型提供方，支持会话复用、Harness 工具桥接、原生动作轨迹和生成图片持久化。
 - [xiaozhe7772222/dsh-opencode-zen](https://github.com/xiaozhe7772222/dsh-opencode-zen) — 0元接入6个免费大模型，免注册免充值，内置6个免费模型，多Key轮换与限流退避。
+- [young-tim/dsh-llm-governor](https://github.com/young-tim/dsh-llm-governor) — 为 DSH 提供多模型访问控制、月度 Credits、手动/质量优先/额度优先/自动路由、失败重路由与 Usage 审计。
 - [zeng6125-rgb/dsh-llm-retry-settings](https://github.com/zeng6125-rgb/dsh-llm-retry-settings) — 在 DSH 设置里调整 LLM 自动重试的次数与退避时间并实时生效的设置卡片。
 
 ### 🆔 身份与通信

--- a/data/plugins/young-tim__dsh-llm-governor.yml
+++ b/data/plugins/young-tim__dsh-llm-governor.yml
@@ -1,0 +1,6 @@
+url: https://github.com/young-tim/dsh-llm-governor
+name: young-tim/dsh-llm-governor
+category: model
+description:
+  en: Governs multi-model access, monthly credits, manual/quality/credit/auto routing, failure rerouting, and usage auditing for DSH.
+  zh: 为 DSH 提供多模型访问控制、月度 Credits、手动/质量优先/额度优先/自动路由、失败重路由与 Usage 审计。


### PR DESCRIPTION
## Summary

Add young-tim/dsh-llm-governor to the Models & Providers category. The plugin provides multi-model access control, monthly credits, manual/quality/credit/auto routing, failure rerouting, and usage auditing for DSH.

## Checklist

- [x] Added one plugin entry under data/plugins/
- [x] Regenerated README.md and README.zh.md
- [x] Ran node scripts/generate-readme.mjs --check
- [x] Ran node scripts/build-site.mjs
- [x] Ran the local submission gate with a complete pass
- [x] Repository is public, older than one day, has at least ten commits, and carries the dsh-plugin topic