### PR TITLE
Add dsh-model-memory (reasoning-effort tiers + cross-session preference memory)

### DIFF
--- a/README.md
+++ b/README.md
@@ -821,6 +821,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 - [zhujunpeng12/dsh-memory-system](https://github.com/zhujunpeng12/dsh-memory-system) - Local-first persistent memory for DeepSeek Harness: bounded pre-step hot-memory injection, exact and Chinese-bigram BM25 cold recall, six agent tools, approval-gated lease-lock writes with recovery receipts, and read-only governance and trajectory-review candidates.
 - [ZSeven-W/dsh-noema](https://github.com/ZSeven-W/dsh-noema) - Long-term memory for DSH agents — durable, inspectable memories with recall, search, browse and knowledge-graph tools, import from ten other AI coding tools, and a settings page.
 
+- [Mutx163/dsh-model-memory](https://github.com/Mutx163/dsh-model-memory) - Reasoning-effort tier manager for custom API models plus cross-session preference memory: inline low/medium/high/max toggles inside Settings -> Models, atomic settings.yaml persistence, and per-channel auto-restore of the last model and effort level in new sessions.
 ### Tools & Capabilities
 
 - [1na-ko/dsh-hdc-bridge](https://github.com/1na-ko/dsh-hdc-bridge) - HarmonyOS device bridge: hdc screenshot/install/log/crash/UI automation loop with read_image, official-first versioned API knowledge (SDK .d.ts + offline bundled docs), and a DevEco CLI build/sign/lint lane.


### PR DESCRIPTION
收录申请 / Submission: **dsh-model-memory**

- GitHub: https://github.com/Mutx163/dsh-model-memory
- npm: https://www.npmjs.com/package/dsh-model-memory
- Install: `dsh plugin --profile web add dsh-model-memory`

自定义 API 模型的思考档位（low/medium/high/max）内嵌配置 + 渠道级跨会话模型/思考强度偏好记忆，新建会话自动回填。
Inline reasoning-effort tier management for custom API models plus cross-session per-channel preference memory.