### PR TITLE
Add chenbin-dev/dsh-auth-everying

### DIFF
--- a/README.md
+++ b/README.md
@@ -599,6 +599,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 ### Identity & Communication
 
 - [AgentConnect/dsh-awiki](https://github.com/AgentConnect/dsh-awiki) - Provides DeepSeek Harness agents with native identities based on the open Agent Network Protocol (ANP), plus identity-based direct, group, mail, and Agent-to-Agent communication.
+- [chenbin-dev/dsh-auth-everying](https://github.com/chenbin-dev/dsh-auth-everying) - Import local Claude, Codex, Grok, Gemini, Copilot, OpenCode, and CC Switch config into DeepSeek Harness with OAuth login for supported providers.
 
 ### Sessions & Messages
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -599,6 +599,7 @@ dsh plugin --profile web add dshmarket
 ### 🆔 身份与通信
 
 - [AgentConnect/dsh-awiki](https://github.com/AgentConnect/dsh-awiki) — 为 DeepSeek Harness 智能体提供基于开放协议ANP的原生身份，以及基于该身份的私聊、群聊、邮件和智能体间通信能力。
+- [chenbin-dev/dsh-auth-everying](https://github.com/chenbin-dev/dsh-auth-everying) — 导入本地 Claude、Codex、Grok、Gemini、Copilot、OpenCode 与 CC Switch 配置到 DeepSeek Harness，为支持的官方供应商提供 OAuth 登录。
 
 ### 💬 会话与消息
 

--- a/data/plugins/chenbin-dev__dsh-auth-everying.yml
+++ b/data/plugins/chenbin-dev__dsh-auth-everying.yml
@@ -1,0 +1,6 @@
+url: https://github.com/chenbin-dev/dsh-auth-everying
+name: chenbin-dev/dsh-auth-everying
+category: identity
+description:
+  en: Import local Claude, Codex, Grok, Gemini, Copilot, OpenCode, and CC Switch config into DeepSeek Harness with OAuth login for supported providers.
+  zh: 瀵煎叆鏈湴 Claude銆丆odex銆丟rok銆丟emini銆丆opilot銆丱penCode 涓?CC Switch 閰嶇疆鍒?DeepSeek Harness锛屼负鏀寔鐨勫畼鏂逛緵搴斿晢鎻愪緵 OAuth 鐧诲綍銆


### PR DESCRIPTION
Import local Claude, Codex, Grok, Gemini, Copilot, OpenCode, and CC Switch config into DeepSeek Harness with OAuth login for supported providers.