### PR TITLE
docs: add dsh-reference-anything screenshots

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -1,4 +1,12 @@
 {
+ "https://github.com/Chael-Chael/dsh-reference-anything": [
+  "https://raw.githubusercontent.com/Chael-Chael/dsh-reference-anything/main/images/banner.png",
+  "https://raw.githubusercontent.com/Chael-Chael/dsh-reference-anything/main/images/at-external-conversations.png",
+  "https://raw.githubusercontent.com/Chael-Chael/dsh-reference-anything/main/images/at-files.png",
+  "https://raw.githubusercontent.com/Chael-Chael/dsh-reference-anything/main/images/at-sessions.png",
+  "https://raw.githubusercontent.com/Chael-Chael/dsh-reference-anything/main/images/at-commands.png",
+  "https://raw.githubusercontent.com/Chael-Chael/dsh-reference-anything/main/images/at-skills.png"
+ ],
  "https://github.com/fengb3/dsh-session-icons": [
   "https://raw.githubusercontent.com/fengb3/dsh-session-icons/master/docs/screenshot.png"
  ],


### PR DESCRIPTION
## Summary

Add five GitHub-hosted screenshots for Chael-Chael/dsh-reference-anything to data/screenshots.json so plugin storefronts can display its core reference sources in a deliberate order.

## Screenshots included

- External conversations
- Workspace files
- DSH sessions
- Commands
- Skills

## Validation

- Confirmed all five raw image URLs return HTTP 200
- Ran 
ode scripts/generate-readme.mjs`n- Ran 
ode scripts/build-site.mjs successfully