### PR TITLE
feat: add dsh-computer-use-vision plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1167,6 +1167,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 - [xiaozhe7772222/dsh-draw-router](https://github.com/xiaozhe7772222/dsh-draw-router) - Unified image generation router for DeepSeek Harness (DSH): auto-discovers image models from any OpenAI-compatible endpoint, provides draw_image and draw_list_sources tools, supports SenseNova, StepFun, Agnes, Qwen, Flux, SD, Imagen and more.
 - [ximengxiaolan/dsh-vision-bridge](https://github.com/ximengxiaolan/dsh-vision-bridge) - Composer-attached images are transcribed to text by an OpenAI-compatible vision model before reaching text-only DeepSeek models.
 - [xsoc1/dsh-image-vision](https://github.com/xsoc1/dsh-image-vision) - Chat image-attachment bridge with a `view_image` tool for any OpenAI-compatible VLM (local Ollama or cloud): pasted/dropped images become `view_image` path markers before reaching text-only DeepSeek models.
+- [xuanyuanluoxue/computer-use-vision](https://github.com/xuanyuanluoxue/computer-use-vision) - Windows computer-use capability for DSH: screenshot → vision model → simulated mouse/keyboard with self-evolving knowledge base. Dual-mode plugin tools + skill-only pwsh fallback.
 - [ysr666/dsh-vision-router](https://github.com/ysr666/dsh-vision-router) - Free vision for text-only agents: built-in keyless vision chain plus pixel tools (Q&A, grounding, crop, pixel diff, colors, OCR, SVG trace, cutout, screenshots); paste an image to use it.
 
 ### Voice & Audio

--- a/README.zh.md
+++ b/README.zh.md
@@ -1167,6 +1167,7 @@ dsh plugin --profile web add dshmarket
 - [xiaozhe7772222/dsh-draw-router](https://github.com/xiaozhe7772222/dsh-draw-router) — DeepSeek Harness 统一绘图路由器：自动识别任意 OpenAI 兼容接口的绘图模型，提供 draw_image 和 draw_list_sources 工具，支持商汤、阶跃、Agnes、千问、Flux、SD、Imagen 等。
 - [ximengxiaolan/dsh-vision-bridge](https://github.com/ximengxiaolan/dsh-vision-bridge) — 输入框贴图自动识别：由 OpenAI 兼容视觉模型转成文字描述后，再交给纯文本 DeepSeek 模型处理。
 - [xsoc1/dsh-image-vision](https://github.com/xsoc1/dsh-image-vision) — 纯文本 DeepSeek 的聊天识图插件：view_image 工具转发任意 OpenAI 兼容 VLM（本地 Ollama 或云端），对话框粘贴/拖拽的图片自动改写为 view_image 路径标记供模型查看。
+- [xuanyuanluoxue/computer-use-vision](https://github.com/xuanyuanluoxue/computer-use-vision) — Windows 桌面识图+模拟操作能力：截图→vision模型→模拟鼠标键盘，内置自进化应用技巧库。支持插件工具模式和纯skill模式双形态。
 - [ysr666/dsh-vision-router](https://github.com/ysr666/dsh-vision-router) — 为纯文本 Agent 提供视觉能力：内置免 Key 视觉链 + 像素级视觉工具（看图问答、定位、裁剪、像素对比、取色、OCR、矢量化、抠图、截图）；粘贴图片即可用。
 
 ### 🎙️ 语音与音频

--- a/data/plugins/xuanyuanluoxue__computer-use-vision.yml
+++ b/data/plugins/xuanyuanluoxue__computer-use-vision.yml
@@ -1,0 +1,6 @@
+url: https://github.com/xuanyuanluoxue/computer-use-vision
+name: xuanyuanluoxue/computer-use-vision
+category: vision
+description:
+  en: "Windows computer-use capability for DSH: screenshot → vision model → simulated mouse/keyboard with self-evolving knowledge base. Dual-mode plugin tools + skill-only pwsh fallback."
+  zh: Windows 桌面识图+模拟操作能力：截图→vision模型→模拟鼠标键盘，内置自进化应用技巧库。支持插件工具模式和纯skill模式双形态。


### PR DESCRIPTION
## 插件信息

- **名称**: dsh-computer-use-vision
- **仓库**: https://github.com/xuanyuanluoxue/computer-use-vision
- **分类**: vision
- **安装**: dsh plugin add dsh-computer-use-vision

## 描述

Windows 桌面识图+模拟操作能力：截图→vision模型→模拟鼠标键盘，内置自进化应用技巧库。

- 8 个模型工具（computer-see/click/rightclick/drag/type/key/scroll/knowledge）
- 双形态：插件模式（defineTool 注册）+ 纯 skill 模式（pwsh 回退）
- 自进化知识库（knowledge/）：操作前查技巧，用后沉淀经验
- DSH bundle manifest（dsh.bundle + cordis.patch.yml）

## 验证

- [x] package.json 声明 dsh.bundle
- [x] GitHub 仓库创建满 1 天 ✅
- [x] 提交数 ≥ 10 ✅
- [x] 已添加 dsh-plugin topic