### PR TITLE
Add ZutoMayoo/totoTheCat (desktop pet plugin)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2343,6 +2343,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 - [yyh-001/dsh-meme](https://github.com/yyh-001/dsh-meme) - Chat meme stickers: text-only send, mood auto-send, QQ/WeChat-style picker, auto-learn, custom packs.
 - [ZelinW1/dsh-cosplay](https://github.com/ZelinW1/dsh-cosplay) - Turns the DeepSeek Harness agent into any character: a global cosplay switch, SillyTavern v2 role cards with JSON import/export, a neutral/role thinking-style toggle, and natural-language card authoring via a built-in skill.
 - [zoahdev/dsh-pet-evolve](https://github.com/zoahdev/dsh-pet-evolve) - The pet that grows with your agent: 5 evolution stages earned from real signals (verified rules, completed sessions, tool calls, compactions), agent-state mirroring, and one-click growth share cards. Zero dependencies, 100% local.
+- [ZutoMayoo/totoTheCat](https://github.com/ZutoMayoo/totoTheCat) - Desktop pet for the DSH web UI: a draggable pixel-art cat with a pomodoro timer, XP levels, and 30 unlockable facts.
 <!-- END PLUGINS -->
 
 ## Contributing

--- a/README.zh.md
+++ b/README.zh.md
@@ -2343,6 +2343,7 @@ dsh plugin --profile web add dshmarket
 - [yyh-001/dsh-meme](https://github.com/yyh-001/dsh-meme) — 聊天表情包：纯文本斗图、情绪主动发图、像 QQ/微信 一样发图、AI 自动学图、自定义表情包。
 - [ZelinW1/dsh-cosplay](https://github.com/ZelinW1/dsh-cosplay) — 让 DeepSeek Harness 的 Agent 扮演任何角色：全局扮演开关、酒馆 v2 角色卡（JSON 导入导出）、中立/角色化思考切换，内置 skill 支持一句话生成角色卡。
 - [zoahdev/dsh-pet-evolve](https://github.com/zoahdev/dsh-pet-evolve) — 会随 agent 成长的宠物：真实信号（已验证规则/会话/工具调用/压缩）驱动 5 阶段进化、镜像 agent 状态、一键导出成长分享卡。零依赖、全本地。
+- [ZutoMayoo/totoTheCat](https://github.com/ZutoMayoo/totoTheCat) — DSH Web 界面的桌宠插件：可拖拽的像素猫，带番茄闹钟、经验等级与 30 条可解锁的托托事实。
 <!-- END PLUGINS -->
 
 ## 贡献

--- a/data/plugins/ZutoMayoo__totoTheCat.yml
+++ b/data/plugins/ZutoMayoo__totoTheCat.yml
@@ -1,0 +1,6 @@
+url: https://github.com/ZutoMayoo/totoTheCat
+name: ZutoMayoo/totoTheCat
+category: fun
+description:
+  en: 'Desktop pet for the DSH web UI: a draggable pixel-art cat with a pomodoro timer, XP levels, and 30 unlockable facts.'
+  zh: DSH Web 界面的桌宠插件：可拖拽的像素猫，带番茄闹钟、经验等级与 30 条可解锁的托托事实。


### PR DESCRIPTION
Adds data/plugins/ZutoMayoo__totoTheCat.yml (category: fun), plus the
screenshots.json entry and regenerated READMEs.

- dsh.bundle manifest declared in package.json
- published on npm as toto-the-cat
- repo carries the dsh-plugin topic