### PR TITLE
Add wallpap/dsh-compact-activity

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 - [vlln/dsh-navbar](https://github.com/vlln/dsh-navbar) - Conversation node navigation bar for quick jumps between user messages.
 - [vlln/dsh-task-status](https://github.com/vlln/dsh-task-status) - Background task status bar: progress plus live output tail on the chat page.
 - [vvvspec/better-reasoning-slider](https://github.com/vvvspec/better-reasoning-slider) - Official-style composer model trigger with a floating reasoning-effort slider popup.
+- [wallpap/dsh-compact-activity](https://github.com/wallpap/dsh-compact-activity) - Collapses consecutive DeepSeek Harness thinking and tool calls into a compact, expandable activity group.
 - [warmwine/dsh-ui-font](https://github.com/warmwine/dsh-ui-font) - Font engine for the Web GUI: system font enumeration, global and per-component font-size tuning with a Spy++-style picker, settings page.
 - [Waverly-W/dsh-scratchpad](https://github.com/Waverly-W/dsh-scratchpad) - Quick temporary conversation and workspace manager for DeepSeek Harness Web GUI.
 - [wefio/dsh-cache-miss](https://github.com/wefio/dsh-cache-miss) - Yellow one-line notice for a prompt cache miss after the cache was rebuilt; shows re-billed uncached input tokens, cached hit tokens, and TTFT.

--- a/README.zh.md
+++ b/README.zh.md
@@ -295,6 +295,7 @@ dsh plugin --profile web add dshmarket
 - [vlln/dsh-navbar](https://github.com/vlln/dsh-navbar) — 对话节点导航条，右缘节点串快速跳转 user 消息。
 - [vlln/dsh-task-status](https://github.com/vlln/dsh-task-status) — 后台任务状态条：对话页任务进度 + 实时输出 tail。
 - [vvvspec/better-reasoning-slider](https://github.com/vvvspec/better-reasoning-slider) — 官方风格输入框 + 浮动推理能力滑块弹窗，节点与滑块对齐，弹窗跟随 Harness 主题自适应。
+- [wallpap/dsh-compact-activity](https://github.com/wallpap/dsh-compact-activity) — 将 DeepSeek Harness 连续的思考和工具调用收进紧凑、可展开的过程项。
 - [warmwine/dsh-ui-font](https://github.com/warmwine/dsh-ui-font) — 网页界面字体引擎：系统字体枚举、准星点选的全局与逐组件字号微调、设置页。老花眼友好，自定义字体和页面部件字体和字体大小，支持SPY模式扫UI和其他插件。
 - [Waverly-W/dsh-scratchpad](https://github.com/Waverly-W/dsh-scratchpad) — DeepSeek Harness Web GUI 临时对话工作区自动化管理插件。
 - [wefio/dsh-cache-miss](https://github.com/wefio/dsh-cache-miss) — 提示缓存未命中（cache miss）时，在重建缓存的 assistant 回复下方显示一条黄色缓存提示，展示未缓存（uncached）重新计费（re-billed）的输入 token、缓存命中 token 与首字延迟（TTFT）。

--- a/data/plugins/wallpap__dsh-compact-activity.yml
+++ b/data/plugins/wallpap__dsh-compact-activity.yml
@@ -1,0 +1,6 @@
+url: https://github.com/wallpap/dsh-compact-activity
+name: wallpap/dsh-compact-activity
+category: ui
+description:
+  en: Collapses consecutive DeepSeek Harness thinking and tool calls into a compact, expandable activity group.
+  zh: 将 DeepSeek Harness 连续的思考和工具调用收进紧凑、可展开的过程项。


### PR DESCRIPTION
## Summary

- Add `wallpap/dsh-compact-activity` to the `ui` category.
- Regenerate the English and Chinese README lists.

## Verification

- `node scripts/generate-readme.mjs --check`
- `SKIP_PUBLISH_CHECKS=1 node scripts/build-site.mjs`
- `npx awesome-lint README.md` against the upstream repository metadata; 44 existing warnings remain, with no warning on the new entry.
