### PR TITLE
Add chenbin-dev/dsh-auth-everying

### DIFF
--- a/README.md
+++ b/README.md
@@ -599,6 +599,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 ### Identity & Communication
 
 - [AgentConnect/dsh-awiki](https://github.com/AgentConnect/dsh-awiki) - Provides DeepSeek Harness agents with native identities based on the open Agent Network Protocol (ANP), plus identity-based direct, group, mail, and Agent-to-Agent communication.
+- [chenbin-dev/dsh-auth-everying](https://github.com/chenbin-dev/dsh-auth-everying) - Import local Claude, Codex, Grok, Gemini, Copilot, OpenCode, and CC Switch config into DeepSeek Harness with OAuth login for supported providers.
 
 ### Sessions & Messages
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -599,6 +599,7 @@ dsh plugin --profile web add dshmarket
 ### 🆔 身份与通信
 
 - [AgentConnect/dsh-awiki](https://github.com/AgentConnect/dsh-awiki) — 为 DeepSeek Harness 智能体提供基于开放协议ANP的原生身份，以及基于该身份的私聊、群聊、邮件和智能体间通信能力。
+- [chenbin-dev/dsh-auth-everying](https://github.com/chenbin-dev/dsh-auth-everying) — Import local Claude, Codex, Grok, Gemini, Copilot, OpenCode, and CC Switch config into DeepSeek Harness with OAuth login for supported providers.
 
 ### 💬 会话与消息
 

--- a/data/plugins/chenbin-dev__dsh-auth-everying.yml
+++ b/data/plugins/chenbin-dev__dsh-auth-everying.yml
@@ -1,0 +1,5 @@
+url: https://github.com/chenbin-dev/dsh-auth-everying
+name: chenbin-dev/dsh-auth-everying
+category: identity
+description:
+  en: Import local Claude, Codex, Grok, Gemini, Copilot, OpenCode, and CC Switch config into DeepSeek Harness with OAuth login for supported providers.


### PR DESCRIPTION
Import local Claude, Codex, Grok, Gemini, Copilot, OpenCode, and CC Switch config into DeepSeek Harness with OAuth login for supported providers.