### PR TITLE
Add curated screenshots for dsh-rewind

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -320,6 +320,12 @@
   "https://raw.githubusercontent.com/Signalight/codex-to-dsh-pet/main/assets/screenshots/screenshot-2.png",
   "https://raw.githubusercontent.com/Signalight/codex-to-dsh-pet/main/assets/screenshots/screenshot-3.png"
  ],
+ "https://github.com/SiriLee/dsh-rewind": [
+  "https://raw.githubusercontent.com/SiriLee/dsh-rewind/main/assets/screenshots/rewind-button.png",
+  "https://raw.githubusercontent.com/SiriLee/dsh-rewind/main/assets/screenshots/mode-popover.png",
+  "https://raw.githubusercontent.com/SiriLee/dsh-rewind/main/assets/screenshots/impact-list.png",
+  "https://raw.githubusercontent.com/SiriLee/dsh-rewind/main/assets/screenshots/rewind-candidates.png"
+ ],
  "https://github.com/Smalldy/godot-bridge": [
   "https://raw.githubusercontent.com/Smalldy/godot-bridge/main/assets/godot-bridge-env-check.png"
  ],


### PR DESCRIPTION
Add the AppStore-style screenshot strip for `dsh-rewind` (per the [Screenshots section of contributing.md](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/main/contributing.md#screenshots--截图optional-recommended--可选推荐)).

Adds one key to `data/screenshots.json`:

```jsonc
"https://github.com/SiriLee/dsh-rewind": [
  "https://raw.githubusercontent.com/SiriLee/dsh-rewind/main/assets/screenshots/rewind-button.png",
  "https://raw.githubusercontent.com/SiriLee/dsh-rewind/main/assets/screenshots/mode-popover.png",
  "https://raw.githubusercontent.com/SiriLee/dsh-rewind/main/assets/screenshots/impact-list.png",
  "https://raw.githubusercontent.com/SiriLee/dsh-rewind/main/assets/screenshots/rewind-candidates.png"
]
```

- Key matches the listed entry URL exactly (`https://github.com/SiriLee/dsh-rewind`).
- 4 https URLs on GitHub hosting (`raw.githubusercontent.com`), all PNG (no SVG).
- Validated locally against the same rules in `scripts/build-site.mjs` — passes.

So `dsh-rewind` shows thumbnails in storefronts' card grid / detail view instead of relying on README extraction.