### PR TITLE
Add 398894496-arch/runtime36 (DSH-KRouter)

### DIFF
--- a/README.md
+++ b/README.md
@@ -726,6 +726,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 ### Memory
 
 - [00080000/dsh-project-memory](https://github.com/00080000/dsh-project-memory) - Project memory for DeepSeek Harness: project files are indexed into searchable summaries as they are read, so after context loss the agent retrieves hits on demand instead of re-reading files, with source citations and BM25 ranking.
+- [398894496-arch/runtime36](https://github.com/398894496-arch/runtime36) - Registers read-only DSH tools that route status, preference, correction, memory, project, search, and suggest against a local Obsidian vault.
 - [863683348/dsh-memory-setup](https://github.com/863683348/dsh-memory-setup) - Local, auditable personal memory for DeepSeek Harness: preferences, project conventions, workflows and error lessons persisted as a changelogged JSON file in the workspace, with onboarding, auto project-convention extraction and evidence-backed lessons.
 - [863683348/dsh-plugin-focus](https://github.com/863683348/dsh-plugin-focus) - Focus board for DeepSeek Harness agents: durable, model-maintained notes in the session workspace that pin the objective, constraints, and decisions across compaction and sessions, with automatic context injection, archive on clear, and an optional web panel.
 - [aerince/dsh-active-context-pruning](https://github.com/aerince/dsh-active-context-pruning) - Model-authored context pruning for DeepSeek Harness through the official compaction API.

--- a/README.zh.md
+++ b/README.zh.md
@@ -726,6 +726,7 @@ dsh plugin --profile web add dshmarket
 ### 🧠 记忆
 
 - [00080000/dsh-project-memory](https://github.com/00080000/dsh-project-memory) — 为 DeepSeek Harness 提供的项目记忆插件：项目文件在读取时索引为可检索摘要，上下文失效后按需检索命中，无需重读文件，自带出处与 BM25 排序。
+- [398894496-arch/runtime36](https://github.com/398894496-arch/runtime36) — 注册只读 DSH 工具，对本地 Obsidian 库做状态、偏好、纠错、记忆、项目、搜索与建议路由。
 - [863683348/dsh-memory-setup](https://github.com/863683348/dsh-memory-setup) — 解决 AI 金鱼脑：本地可审计的个人记忆层——偏好、项目约定、工作流与纠错教训，以带变更日志与完整性校验的 JSON 持久化在工作区，支持一次性设置、项目约定自动提取、证据化教训与快照恢复。
 - [863683348/dsh-plugin-focus](https://github.com/863683348/dsh-plugin-focus) — 为 DeepSeek Harness agent 提供持久化专注板：在会话工作区维护目标、约束与决策笔记，跨压缩与会话存活，支持自动注入上下文、清空归档与可选 Web 面板。
 - [aerince/dsh-active-context-pruning](https://github.com/aerince/dsh-active-context-pruning) — 面向 DeepSeek Harness 的模型驱动上下文裁剪插件，通过官方 compaction API 释放上下文空间。

--- a/data/plugins/398894496-arch__runtime36.yml
+++ b/data/plugins/398894496-arch__runtime36.yml
@@ -1,0 +1,6 @@
+url: https://github.com/398894496-arch/runtime36
+name: 398894496-arch/runtime36
+category: memory
+description:
+  en: Registers read-only DSH tools that route status, preference, correction, memory, project, search, and suggest against a local Obsidian vault.
+  zh: 注册只读 DSH 工具，对本地 Obsidian 库做状态、偏好、纠错、记忆、项目、搜索与建议路由。


### PR DESCRIPTION
<!-- Thanks for contributing! Quick checklist / 提交前快速自查 -->

- [x] I added **one file** at `data/plugins/<owner>__<repo>.yml` — the READMEs are generated, don't edit them by hand / 我新增了一个 `data/plugins/<owner>__<repo>.yml` 文件（各语言 README 由脚本生成，不要手工编辑）
- [x] I ran `node scripts/generate-readme.mjs` and committed the regenerated READMEs / 我已执行 `node scripts/generate-readme.mjs` 并提交了重新生成的 README
- [x] My repo's `package.json` declares **`dsh.bundle`** (not just `dsh.client`) — [example](../blob/main/contributing.md) / 仓库 `package.json` 已声明 `dsh.bundle`（只有 `dsh.client` 无法安装）
- [x] My repo is at least **1 day old** with **10+ commits** / 仓库创建满 1 天且提交数 ≥ 10
- [x] `category` is one of `ui theme model session memory tools skill workflow notify dev market fun`, and themes/skins go under `theme` / `category` 取值正确，主题/皮肤类请用 `theme`
- [x] Description states what the plugin does, no superlatives / 描述只说功能，不带营销词
- [x] My repo has the `dsh-plugin` topic / 仓库已打 `dsh-plugin` topic

### Plugin Submission: DSH-KRouter

- **Repository**: https://github.com/398894496-arch/runtime36
- **Category**: `memory`
- **Install**: `dsh plugin add github:398894496-arch/runtime36` (repo root; `package.json` `dsh.bundle.patch` → `extras/dsh/cordis.patch.yml`)
- **Description**: Registers read-only DSH tools that route status, preference, correction, memory, project, search, and suggest against a local Obsidian vault.

Uninstalling the DSH socket does not delete the vault. The self-evolution timer is a separate host job (`scripts/install.sh`), not this mount.

Made with [Cursor](https://cursor.com)