### PR TITLE
Add nxz1026/dsh-tray

### DIFF
--- a/README.md
+++ b/README.md
@@ -1659,7 +1659,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 - [moonquake2004/dsh-doctor#plugin](https://github.com/moonquake2004/dsh-doctor/tree/main/plugin) - Offline diagnostic for DSH: 19 checks across env, profile, and session state, with a settings "Doctor" panel and a read-only JSON API.
 - [MutaLucem/dsh-plugin-integration](https://github.com/MutaLucem/dsh-plugin-integration) - Discovers installed DSH plugins with tags, overlap and compatibility detection, one-click enable/disable, failure diagnosis, and update checking.
 - [NormanFxxkingRockwell/harmonyos-dev-mcp-for-dsh](https://github.com/NormanFxxkingRockwell/harmonyos-dev-mcp-for-dsh) - Bridges the harmonyos-dev-mcp Python MCP server into DSH: HarmonyOS device discovery, build/install/run/uninstall, UI automation (click/input/keys/swipe/screenshot), E2E UI-tree inspection, and log/crash analysis as 18 mcp__harmonyos__* tools.
-- [nxz1026/dsh-tray](https://github.com/nxz1026/dsh-tray) - Windows system-tray launcher for DeepSeek Harness Web: start, stop, restart, open the Web UI, and tail logs from the tray icon.
+- [nxz1026/dsh-tray](https://github.com/nxz1026/dsh-tray) - Windows system-tray launcher for DeepSeek Harness Web: start, stop, restart, open the Web UI, tail logs, live status icon, and a launch-at-login toggle.
 - [omdsh-dev/dsh-plugin-check](https://github.com/omdsh-dev/dsh-plugin-check) - Plugin health checks: manifest protocol / patch format / build traps, zero-dependency and read-only.
 - [omdsh-dev/dsh-session-health](https://github.com/omdsh-dev/dsh-session-health) - Frame-level scan diagnostics for session files (torn/corrupt/empty detection).
 - [omdsh-dev/fabric](https://github.com/omdsh-dev/fabric) - An MC-Fabric-style hook processor.

--- a/README.md
+++ b/README.md
@@ -1659,6 +1659,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 - [moonquake2004/dsh-doctor#plugin](https://github.com/moonquake2004/dsh-doctor/tree/main/plugin) - Offline diagnostic for DSH: 19 checks across env, profile, and session state, with a settings "Doctor" panel and a read-only JSON API.
 - [MutaLucem/dsh-plugin-integration](https://github.com/MutaLucem/dsh-plugin-integration) - Discovers installed DSH plugins with tags, overlap and compatibility detection, one-click enable/disable, failure diagnosis, and update checking.
 - [NormanFxxkingRockwell/harmonyos-dev-mcp-for-dsh](https://github.com/NormanFxxkingRockwell/harmonyos-dev-mcp-for-dsh) - Bridges the harmonyos-dev-mcp Python MCP server into DSH: HarmonyOS device discovery, build/install/run/uninstall, UI automation (click/input/keys/swipe/screenshot), E2E UI-tree inspection, and log/crash analysis as 18 mcp__harmonyos__* tools.
+- [nxz1026/dsh-tray](https://github.com/nxz1026/dsh-tray) - Windows system-tray launcher for DeepSeek Harness Web: start, stop, restart, open the Web UI, and tail logs from the tray icon.
 - [omdsh-dev/dsh-plugin-check](https://github.com/omdsh-dev/dsh-plugin-check) - Plugin health checks: manifest protocol / patch format / build traps, zero-dependency and read-only.
 - [omdsh-dev/dsh-session-health](https://github.com/omdsh-dev/dsh-session-health) - Frame-level scan diagnostics for session files (torn/corrupt/empty detection).
 - [omdsh-dev/fabric](https://github.com/omdsh-dev/fabric) - An MC-Fabric-style hook processor.

--- a/README.zh.md
+++ b/README.zh.md
@@ -1659,7 +1659,7 @@ dsh plugin --profile web add dshmarket
 - [moonquake2004/dsh-doctor#plugin](https://github.com/moonquake2004/dsh-doctor/tree/main/plugin) — 离线诊断工具：环境/Profile/会话共 19 项检查，带设置「诊断」面板与只读 JSON API。
 - [MutaLucem/dsh-plugin-integration](https://github.com/MutaLucem/dsh-plugin-integration) — 动态发现已装插件并打标分类，检测功能重叠与兼容冲突，一键启停切换、失效诊断与更新检测。
 - [NormanFxxkingRockwell/harmonyos-dev-mcp-for-dsh](https://github.com/NormanFxxkingRockwell/harmonyos-dev-mcp-for-dsh) — 把 harmonyos-dev-mcp Python MCP 服务桥接进 DSH：鸿蒙设备发现、构建/安装/运行/卸载、UI 自动化（点击/输入/按键/滑动/截图）、E2E 界面树检查、日志与崩溃分析，共 18 个 mcp__harmonyos__* 工具。
-- [nxz1026/dsh-tray](https://github.com/nxz1026/dsh-tray) — DeepSeek Harness Web 的 Windows 托盘启动器：托盘图标一键启动、停止、重启服务，打开 Web UI 并查看日志。
+- [nxz1026/dsh-tray](https://github.com/nxz1026/dsh-tray) — DeepSeek Harness Web 的 Windows 托盘启动器：托盘图标一键启动、停止、重启服务，打开 Web UI、查看日志，实时状态图标，并支持开机自启开关。
 - [omdsh-dev/dsh-plugin-check](https://github.com/omdsh-dev/dsh-plugin-check) — 插件健康检查：扫描清单协议/patch 格式/构建陷阱，零依赖只读。
 - [omdsh-dev/dsh-session-health](https://github.com/omdsh-dev/dsh-session-health) — 会话文件帧级扫描诊断（torn/损坏/空会话检测）。
 - [omdsh-dev/fabric](https://github.com/omdsh-dev/fabric) — 类似 MC Fabric 的 hook 处理器。

--- a/README.zh.md
+++ b/README.zh.md
@@ -1659,6 +1659,7 @@ dsh plugin --profile web add dshmarket
 - [moonquake2004/dsh-doctor#plugin](https://github.com/moonquake2004/dsh-doctor/tree/main/plugin) — 离线诊断工具：环境/Profile/会话共 19 项检查，带设置「诊断」面板与只读 JSON API。
 - [MutaLucem/dsh-plugin-integration](https://github.com/MutaLucem/dsh-plugin-integration) — 动态发现已装插件并打标分类，检测功能重叠与兼容冲突，一键启停切换、失效诊断与更新检测。
 - [NormanFxxkingRockwell/harmonyos-dev-mcp-for-dsh](https://github.com/NormanFxxkingRockwell/harmonyos-dev-mcp-for-dsh) — 把 harmonyos-dev-mcp Python MCP 服务桥接进 DSH：鸿蒙设备发现、构建/安装/运行/卸载、UI 自动化（点击/输入/按键/滑动/截图）、E2E 界面树检查、日志与崩溃分析，共 18 个 mcp__harmonyos__* 工具。
+- [nxz1026/dsh-tray](https://github.com/nxz1026/dsh-tray) — DeepSeek Harness Web 的 Windows 托盘启动器：托盘图标一键启动、停止、重启服务，打开 Web UI 并查看日志。
 - [omdsh-dev/dsh-plugin-check](https://github.com/omdsh-dev/dsh-plugin-check) — 插件健康检查：扫描清单协议/patch 格式/构建陷阱，零依赖只读。
 - [omdsh-dev/dsh-session-health](https://github.com/omdsh-dev/dsh-session-health) — 会话文件帧级扫描诊断（torn/损坏/空会话检测）。
 - [omdsh-dev/fabric](https://github.com/omdsh-dev/fabric) — 类似 MC Fabric 的 hook 处理器。

--- a/data/plugins/nxz1026__dsh-tray.yml
+++ b/data/plugins/nxz1026__dsh-tray.yml
@@ -2,5 +2,5 @@ url: https://github.com/nxz1026/dsh-tray
 name: nxz1026/dsh-tray
 category: dev
 description:
-  en: 'Windows system-tray launcher for DeepSeek Harness Web: start, stop, restart, open the Web UI, and tail logs from the tray icon.'
-  zh: 'DeepSeek Harness Web 的 Windows 托盘启动器：托盘图标一键启动、停止、重启服务，打开 Web UI 并查看日志。'
+  en: 'Windows system-tray launcher for DeepSeek Harness Web: start, stop, restart, open the Web UI, tail logs, live status icon, and a launch-at-login toggle.'
+  zh: 'DeepSeek Harness Web 的 Windows 托盘启动器：托盘图标一键启动、停止、重启服务，打开 Web UI、查看日志，实时状态图标，并支持开机自启开关。'

--- a/data/plugins/nxz1026__dsh-tray.yml
+++ b/data/plugins/nxz1026__dsh-tray.yml
@@ -1,0 +1,6 @@
+url: https://github.com/nxz1026/dsh-tray
+name: nxz1026/dsh-tray
+category: dev
+description:
+  en: 'Windows system-tray launcher for DeepSeek Harness Web: start, stop, restart, open the Web UI, and tail logs from the tray icon.'
+  zh: 'DeepSeek Harness Web 的 Windows 托盘启动器：托盘图标一键启动、停止、重启服务，打开 Web UI 并查看日志。'


### PR DESCRIPTION
## Add nxz1026/dsh-tray

Windows system-tray launcher for DeepSeek Harness Web — start / stop / restart the server, open the Web UI, tail logs, live green/red status icon, and a launch-at-login toggle.

- \package.json\ declares the \dsh.bundle\ manifest (\cordis.patch.yml\ included), installable via \dsh plugin --profile web add https://github.com/nxz1026/dsh-tray\
- Repo: 11 commits, created 2026-08-19, topic [\dsh-plugin\](https://github.com/topics/dsh-plugin) added
- Category \dev\; description states tray launcher functionality only (start/stop/restart/open UI/tail logs/status icon/launch-at-login)

Both READMEs regenerated with \
ode scripts/generate-readme.mjs\.

**Update 2026-08-23:** entry description refreshed to match v0.1.1 features — removed auto-open-browser (dsh web now opens it itself), added live status icon and launch-at-login toggle. Only this entry's YAML and its two generated README lines changed.