### PR TITLE
Add plugin: Akimiya-z/codex-guard#dsh

### DIFF
--- a/README.md
+++ b/README.md
@@ -1459,6 +1459,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 ### Git & Code Review
 
 - [7dgroup-ai/dsh-skill-7d-git-commit](https://github.com/7dgroup-ai/dsh-skill-7d-git-commit) - Checks git commit messages against the 7DGroup convention (Chinese type tags, length and punctuation rules) before committing, as a client-side guard before GitLab pre-receive hooks.
+- [Akimiya-z/codex-guard#dsh](https://github.com/Akimiya-z/codex-guard/tree/main/dsh) - Pre-submit pull-request hygiene checks inside DeepSeek Harness: scans the current diff for TODO leftovers, hardcoded secrets, and non-conventional commit subjects.
 - [BrambleXu/dsh-revdiff](https://github.com/BrambleXu/dsh-revdiff) - Native interactive Git diff review for DeepSeek Harness with structured annotations sent back to the current Agent session.
 - [cirelir/dsh-change-review](https://github.com/cirelir/dsh-change-review) - Session change-review plugin for DeepSeek Harness: tracks write/edit tool calls per session and renders line-level diffs with customizable colors, with session isolation, subagent aggregation, and SSE live updates.
 - [DamonKoy/dsh-web-ui#dsh-git-graph](https://github.com/DamonKoy/dsh-web-ui/tree/main/packages/dsh-git-graph) - Git branch selector and Git graph in the conversation header of the dsh web GUI.

--- a/README.zh.md
+++ b/README.zh.md
@@ -1459,6 +1459,7 @@ dsh plugin --profile web add dshmarket
 ### 🔀 Git 与代码评审
 
 - [7dgroup-ai/dsh-skill-7d-git-commit](https://github.com/7dgroup-ai/dsh-skill-7d-git-commit) — 提交前按 7DGroup 规范校验 git commit message（中文类型标签、长度与标点规则），作为 GitLab pre-receive 钩子的客户端前置校验。
+- [Akimiya-z/codex-guard#dsh](https://github.com/Akimiya-z/codex-guard/tree/main/dsh) — 在 DeepSeek Harness 内做提交前的 Pull Request 卫生检查：扫描当前改动中的 TODO 残留、硬编码密钥与非规范提交信息。
 - [BrambleXu/dsh-revdiff](https://github.com/BrambleXu/dsh-revdiff) — DeepSeek Harness 原生交互式 Git diff 审查，支持结构化批注并回传当前 Agent 会话。
 - [cirelir/dsh-change-review](https://github.com/cirelir/dsh-change-review) — 会话修改审查插件：追踪会话内 write/edit 工具调用并展示 diff 对比；会话隔离、子代理聚合、SSE 实时推送、角标与颜色自定义。
 - [DamonKoy/dsh-web-ui#dsh-git-graph](https://github.com/DamonKoy/dsh-web-ui/tree/main/packages/dsh-git-graph) — dsh web GUI 会话头部栏的 Git 分支选择器与提交图。

--- a/data/plugins/Akimiya-z__codex-guard--dsh.yml
+++ b/data/plugins/Akimiya-z__codex-guard--dsh.yml
@@ -1,0 +1,6 @@
+url: https://github.com/Akimiya-z/codex-guard/tree/main/dsh
+name: Akimiya-z/codex-guard#dsh
+category: git
+description:
+  en: 'Pre-submit pull-request hygiene checks inside DeepSeek Harness: scans the current diff for TODO leftovers, hardcoded secrets, and non-conventional commit subjects.'
+  zh: '在 DeepSeek Harness 内做提交前的 Pull Request 卫生检查：扫描当前改动中的 TODO 残留、硬编码密钥与非规范提交信息。'


### PR DESCRIPTION
Adds the codex-guard pre-submit hygiene checks as a DeepSeek Harness bundle (monorepo subpackage at dsh/).

- declares dsh.bundle + cordis.patch.yml (installs via dsh plugin add)
- registers a codex_guard tool on the official @deepseek-ai/dsh-tools API
- ran their generator: data file + both generated READMEs included

Entry: https://github.com/Akimiya-z/codex-guard/tree/main/dsh