### PR TITLE
add MoonlitDropOfBlood/dsh-archive-manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -690,6 +690,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 - [MingoZhou/dsh-replay](https://github.com/MingoZhou/dsh-replay) - Replay sessions on a playable timeline with per-step token usage, audit sensitive operations, estimate cost, view fork lineage, compare sessions, and export standalone HTML replays.
 - [Moeblack/dsh-message-edit](https://github.com/Moeblack/dsh-message-edit) - Branch-based message editing, reroll, retry, and a version timeline.
 - [Moeblack/dsh-prompt-studio](https://github.com/Moeblack/dsh-prompt-studio) - Edit user and built-in system-prompt sections with live preview.
+- [MoonlitDropOfBlood/dsh-archive-manager](https://github.com/MoonlitDropOfBlood/dsh-archive-manager) - Archived-session manager for DeepSeek Harness: grouped archive panel with restore and delete.
 - [mrzhangkris/dsh-session-pruner](https://github.com/mrzhangkris/dsh-session-pruner) - Full-type session lifecycle management: one-shot subagents archived on completion, idle continuable subagents / main sessions archived (recoverable), a capacity cap, projection-cache cleanup, and a hot-reload settings panel.
 - [MuWinds/dsh-archived-sessions](https://github.com/MuWinds/dsh-archived-sessions) - Archived-session management: browse archived sessions, unarchive them, or clear them out.
 - [Nothree-code/review-quote-sh](https://github.com/Nothree-code/review-quote-sh) - Message review and quote chips for conversations: multi-model cross review (code/reply) with severity grading and summaries, review history, and host-persisted preferences.

--- a/README.zh.md
+++ b/README.zh.md
@@ -690,6 +690,7 @@ dsh plugin --profile web add dshmarket
 - [MingoZhou/dsh-replay](https://github.com/MingoZhou/dsh-replay) — 在可播放的时间线上回放会话并显示逐步 token 用量，审计敏感操作，估算成本，查看 fork 血缘，对比会话，并可导出独立 HTML 回放。
 - [Moeblack/dsh-message-edit](https://github.com/Moeblack/dsh-message-edit) — 基于分支的消息编辑、reroll、重试与版本时间线。
 - [Moeblack/dsh-prompt-studio](https://github.com/Moeblack/dsh-prompt-studio) — 带实时预览的用户/内置 system prompt 分节编辑器。
+- [MoonlitDropOfBlood/dsh-archive-manager](https://github.com/MoonlitDropOfBlood/dsh-archive-manager) — DeepSeek Harness 会话归档管理：分组归档面板，支持恢复与删除。
 - [mrzhangkris/dsh-session-pruner](https://github.com/mrzhangkris/dsh-session-pruner) — 全类型会话生命周期管理：一次性子 agent 完成后归档，闲置的可续聊子 agent 与主会话归档（可恢复），容量上限、投影缓存清理，以及热重载设置面板。
 - [MuWinds/dsh-archived-sessions](https://github.com/MuWinds/dsh-archived-sessions) — 归档会话管理：浏览已归档会话，支持恢复（取消归档）与清空。
 - [Nothree-code/review-quote-sh](https://github.com/Nothree-code/review-quote-sh) — 对话消息审查与引用：多模型并行互审（代码/回复审查、严重度分级、综合汇总）、引用问答胶囊、评审历史与偏好记忆。

--- a/data/plugins/MoonlitDropOfBlood__dsh-archive-manager.yml
+++ b/data/plugins/MoonlitDropOfBlood__dsh-archive-manager.yml
@@ -1,0 +1,6 @@
+url: https://github.com/MoonlitDropOfBlood/dsh-archive-manager
+name: MoonlitDropOfBlood/dsh-archive-manager
+category: session
+description:
+  en: 'Archived-session manager for DeepSeek Harness: grouped archive panel with restore and delete.'
+  zh: 'DeepSeek Harness 会话归档管理：分组归档面板，支持恢复与删除。'


### PR DESCRIPTION
Add [MoonlitDropOfBlood/dsh-archive-manager](https://github.com/MoonlitDropOfBlood/dsh-archive-manager) (category: session).

Archived-session manager for DeepSeek Harness: grouped archive panel with restore and delete. Installed via dsh plugin --profile web add @duke-dsh-plugins/dsh-archive-manager (npm) or the GitHub tarball. dsh.bundle + cordis.patch.yml present; dsh-plugin topic added.