### PR TITLE
feat: publish the catalog to npm so it can be read from a mirror

### DIFF
--- a/.github/workflows/build-site.yml
+++ b/.github/workflows/build-site.yml
@@ -48,6 +48,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
+          # Needed by the catalog publish below; harmless for the site build.
+          registry-url: https://registry.npmjs.org
       - run: npm ci
       # Rolling probe cache: unique key so every run saves, restore-keys pulls
       # the most recent.
@@ -111,3 +113,21 @@ jobs:
           path: docs
       - id: deployment
         uses: actions/deploy-pages@v4
+
+      # The same plugins.json, published to npm — see
+      # scripts/publish-catalog.mjs for why it has to exist in two places.
+      #
+      # AFTER the deploy, deliberately: the site is what people look at, and
+      # a registry outage must not be able to hold it up. The script is a
+      # no-op when the catalog has not changed, so the ordinary push build
+      # publishes nothing.
+      #
+      # Still no repository write: the version and the content hash are set
+      # in the runner's working copy and never committed, so the invariant at
+      # the top of this file holds.
+      - name: publish the catalog to npm
+        # Trusted publishing (OIDC) — the id-token permission above is what
+        # authorizes it, so there is no token to leak or rotate.
+        run: |
+          npm install -g npm@latest  # trusted publishing needs npm >= 11.5
+          node scripts/publish-catalog.mjs

--- a/scripts/publish-catalog.mjs
+++ b/scripts/publish-catalog.mjs
@@ -1,0 +1,142 @@
+/**
+ * Publish `plugins.json` to npm as the `dsh-plugin-catalog` package.
+ *
+ * Why npm at all, when the catalog is already served from Pages: the market
+ * reads it from mainland China, and Pages IS GitHub — measured, the response
+ * carries `server: GitHub.com` and an edge region in Japan, which is why
+ * "the plugin list is slow to open" and "GitHub is slow" have always been
+ * the same sentence. The public GitHub proxies that make GitHub usable from
+ * there refuse any hostname that is not github.com's own (measured: this
+ * project's domain comes back 403), so the file cannot be carried through
+ * one while it lives at that address. Published to npm it rides the same
+ * mirrors every plugin already arrives on, and needs no service that did not
+ * already have to work.
+ *
+ * It also gives the catalog a version number, which it has never had: a
+ * build that ships bad data can be rolled back rather than only fixed
+ * forwards.
+ *
+ * Why its OWN package rather than adding a file to `awesome-dsh-plugin`:
+ * npm force-includes README files regardless of the `files` field, and this
+ * repo's two READMEs are generated and large (514KB + 491KB). Attaching the
+ * catalog to that package would have made every consumer download ~1MB of
+ * prose to read a list — spending on the wire exactly what this exists to
+ * save. Measured with `npm pack --dry-run`: 772KB attached, versus ~250KB
+ * standing alone.
+ *
+ * Everything is assembled in a temp directory, so this writes nothing into
+ * the repository and the invariant at the top of build-site.yml holds
+ * literally rather than approximately.
+ */
+
+import { createHash } from 'node:crypto'
+import { execFileSync } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+const PKG = 'dsh-plugin-catalog'
+const BUILT = 'docs/plugins.json'
+const REGISTRY = 'https://registry.npmjs.org'
+
+/** Content hash, so an unchanged catalog does not earn a version of its own. */
+function sha256(buffer) {
+  return createHash('sha256').update(buffer).digest('hex')
+}
+
+/**
+ * The hash carried by the newest published version, or null.
+ *
+ * Read from the packument rather than by downloading the tarball: the field
+ * is a few bytes of metadata, and this runs on every build.
+ */
+async function publishedHash() {
+  try {
+    const res = await fetch(`${REGISTRY}/${PKG}/latest`)
+    if (!res.ok) return null
+    const meta = await res.json()
+    return typeof meta.catalogSha === 'string' ? meta.catalogSha : null
+  } catch {
+    // A registry that cannot be reached has not said the catalog is
+    // unchanged. Publishing a duplicate version is a smaller mistake than
+    // silently skipping a real update, and npm refuses duplicates anyway.
+    return null
+  }
+}
+
+/**
+ * A date-based version, monotonic and legible.
+ *
+ * `YYYY.MDD.RUN` — the run number distinguishes several publishes in one
+ * day, and the date part sorts correctly within and across years (105 for
+ * Jan 5 is below 1231 for Dec 31). The month is not zero-padded because
+ * semver forbids leading zeroes in numeric identifiers.
+ */
+export function catalogVersion(now, run) {
+  const mmdd = (now.getUTCMonth() + 1) * 100 + now.getUTCDate()
+  return `${now.getUTCFullYear()}.${mmdd}.${run}`
+}
+
+/** The README the package page shows. Short, because it is shipped to readers. */
+function readme(version, entries) {
+  return `# dsh-plugin-catalog
+
+The DeepSeek Harness plugin catalog as a single JSON file — the same
+\`plugins.json\` served at <https://awesome-dsh-plugin.com/plugins.json>,
+published to npm so it can be fetched from a registry mirror.
+
+It exists because the canonical copy is served from GitHub Pages, which is
+slow to reach from some networks, and the public GitHub proxies that would
+otherwise help refuse non-github.com hostnames.
+
+\`\`\`js
+import catalog from 'dsh-plugin-catalog/plugins.json' with { type: 'json' }
+\`\`\`
+
+- **Entries:** ${entries}
+- **Version:** \`${version}\` (\`YYYY.MDD.BUILD\`, published only when the catalog changes)
+- **Source:** <https://github.com/awesome-dsh-plugin/awesome-dsh-plugin>
+- **License:** CC0-1.0
+
+The schema is documented by its producer, \`scripts/build-site.mjs\`, in the
+source repository. Published automatically; do not open pull requests here.
+`
+}
+
+const built = fs.readFileSync(BUILT)
+const hash = sha256(built)
+if (hash === await publishedHash()) {
+  console.log(`catalog unchanged (${hash.slice(0, 12)}) — nothing to publish`)
+  process.exit(0)
+}
+
+const entries = JSON.parse(built.toString()).plugins.length
+const version = catalogVersion(new Date(), process.env.GITHUB_RUN_NUMBER ?? '0')
+const stage = fs.mkdtempSync(path.join(os.tmpdir(), 'dsh-catalog-'))
+fs.writeFileSync(path.join(stage, 'plugins.json'), built)
+fs.writeFileSync(path.join(stage, 'README.md'), readme(version, entries))
+fs.copyFileSync('LICENSE', path.join(stage, 'LICENSE'))
+fs.writeFileSync(path.join(stage, 'package.json'), JSON.stringify({
+  name: PKG,
+  version,
+  description: `The DeepSeek Harness plugin catalog (${entries} entries) · DeepSeek Harness 插件目录`,
+  homepage: 'https://awesome-dsh-plugin.com',
+  repository: {
+    type: 'git',
+    url: 'git+https://github.com/awesome-dsh-plugin/awesome-dsh-plugin.git',
+  },
+  license: 'CC0-1.0',
+  keywords: ['dsh', 'dsh-plugin', 'deepseek-harness', 'deepseek', 'catalog', 'registry'],
+  // The validator a consumer reads back on its next check, and what stops
+  // this script republishing an identical catalog tomorrow.
+  catalogSha: hash,
+  exports: { './plugins.json': './plugins.json' },
+  files: ['plugins.json'],
+}, null, 2) + '\n')
+
+console.log(`publishing ${PKG}@${version} — ${entries} entries, sha ${hash.slice(0, 12)}`)
+// `DRY_RUN=1` runs everything up to and including npm's own packing checks
+// without publishing, so the whole path can be exercised by hand.
+const args = ['publish', '--access', 'public']
+if (process.env.DRY_RUN === '1') args.push('--dry-run')
+execFileSync('npm', args, { stdio: 'inherit', cwd: stage })


### PR DESCRIPTION
## 为什么

插件市场从国内读 `plugins.json` 很慢，排查下来卡点在**这个仓库**而不是市场：`awesome-dsh-plugin.com` 就是 GitHub Pages。

```
$ curl -sI https://awesome-dsh-plugin.com/plugins.json
server: GitHub.com
x-github-edge-region: japaneast
```

所以「插件列表打开慢」和「GitHub 慢」一直是同一件事。有使用者实测：国内无代理 33 秒，走代理 1.3 秒（dsh-market#188）。

国内常用的 GitHub 代理救不了它——它们**只认 github.com 系域名**，本项目的自定义域名直接 403（实测）。`raw.githubusercontent.com` 也不行：`plugins.json` 是构建产物，本仓库有意不提交它（`docs/` 在 .gitignore 里），那个路径下没有东西可代理。

npm 可以。国内各 npm 镜像本来就都在同步它，和插件本身走的是同一套基础设施，不引入任何新的、可能挂掉的服务。顺带目录第一次有了版本号：构建出坏数据可以回滚，而不是只能往前修。

## 做法

新增 `scripts/publish-catalog.mjs`，在 Pages 部署**之后**跑。

**为什么是独立的包，而不是往 `awesome-dsh-plugin` 里加个文件**：npm 无视 `files` 字段强制打包 README，而本仓库两个生成的 README 合计约 1MB。`npm pack --dry-run` 实测——挂在那个包上 772KB，独立成包 413KB。后者和 gzip 后的源站只差几 KB，也就是说使用者只为目录本身付费。

几个刻意的取舍：

- **不写仓库。** 包在临时目录里拼装，`package.json` 一个字节都不动，文件头那条 `The build never writes to the repository` 字面成立。
- **目录没变就不发。** 用内容 sha256 和已发布版本的 `catalogSha` 字段比对，普通 push 构建什么都不发，不会一天攒出几十个版本。
- **认证走 npm trusted publishing (OIDC)**，用的是这个 job 为 Pages 已经申请的 `id-token` 权限，**不需要新增任何 secret**。
- **排在 Pages 部署之后**：站点是人看的，registry 出问题不该拖住它。

版本号形如 `2026.823.42`（`YYYY.MDD.构建号`）。月份不补零是因为 semver 禁止数字段有前导零。

## 合并前需要你做一件事

在 npmjs.com 上为 **`dsh-plugin-catalog`** 配置一次可信发布（Trusted Publisher），指向本仓库的 `build-site.yml`。这个包名我确认过还没被占用。这步需要账号权限，我做不了。

配好之前合并进来，发布那一步会失败——但**只会失败在最后一步，站点部署已经完成**，不影响现有任何东西。

## 消费方

dsh-market `1.19.0-beta.1` 起，「下载区域」切到「中国大陆」时会先读这个包，读不到就回落官方 Pages 地址。所以即使这个 PR 没合、或者某次发布失败，市场也只是退回现在的速度，不会打不开。

## 试过了

```
$ DRY_RUN=1 GITHUB_RUN_NUMBER=42 node scripts/publish-catalog.mjs
publishing dsh-plugin-catalog@2026.823.42 — 1884 entries, sha 8b22fe95df82
npm notice 7.0kB   LICENSE
npm notice 871B    README.md
npm notice 659B    package.json
npm notice 1.6MB   plugins.json
npm notice package size: 413.2 kB
```
