### PR TITLE
add plugin: IT-lu/dsh-imbot (Feishu/DingTalk IM bridge)

### DIFF
--- a/data/plugins/IT-lu__dsh-imbot.yml
+++ b/data/plugins/IT-lu__dsh-imbot.yml
@@ -1,0 +1,6 @@
+url: https://github.com/IT-lu/dsh-imbot
+name: IT-lu/dsh-imbot
+category: notify
+description:
+  en: 'Two-way agent bridge for Feishu (Lark) and DingTalk groups: chat with a DeepSeek Harness agent from IM groups via long-connection / Stream Mode — no public port needed. Workspace selection/creation, session switching, archiving (synced with DSH GUI), configurable from the DSH settings page. Feishu uses interactive cards, DingTalk uses text commands.'
+  zh: 飞书 / 钉钉群双向桥接：在 IM 群里直接与 DeepSeek Harness agent 对话（飞书长连接 / 钉钉 Stream 模式，无需公网端口）。支持工作区选择/创建、会话切换、归档（与 DSH GUI 同步）、设置页图形化配置。飞书交互卡片、钉钉文本命令。


### PR DESCRIPTION
## 插件信息

- 仓库：https://github.com/IT-lu/dsh-imbot
- 功能：飞书 / 钉钉群双向桥接——在 IM 群里直接与 DeepSeek Harness agent 对话（飞书长连接 / 钉钉 Stream 模式，无需公网端口），支持工作区选择/创建、会话切换、归档（与 DSH GUI 同步）、设置页图形化配置。飞书交互卡片、钉钉文本命令。
- package.json 已声明 `dsh.bundle.patch`（可安装），README 含中英文说明。