### PR TITLE
data: add storefront screenshots for the dock plugin family

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -1320,4 +1320,24 @@
   "https://raw.githubusercontent.com/biggerboy/dsh-conversation-anchors/master/assets/anchors-hover.png",
   "https://raw.githubusercontent.com/biggerboy/dsh-conversation-anchors/master/assets/anchors-wave.png"
  ]
+,
+ "https://github.com/AKS1st/dock-editor": [
+  "https://raw.githubusercontent.com/AKS1st/dock-editor/main/assets/image-en.png",
+  "https://raw.githubusercontent.com/AKS1st/dock-editor/main/assets/image-zh.png"
+ ],
+ "https://github.com/AKS1st/dock-files": [
+  "https://raw.githubusercontent.com/AKS1st/dock-files/main/assets/main-gui.png",
+  "https://raw.githubusercontent.com/AKS1st/dock-files/main/assets/menu-en.png",
+  "https://raw.githubusercontent.com/AKS1st/dock-files/main/assets/menu-zh.png"
+ ],
+ "https://github.com/AKS1st/dock-git": [
+  "https://raw.githubusercontent.com/AKS1st/dock-git/main/assets/main-gui-en.png",
+  "https://raw.githubusercontent.com/AKS1st/dock-git/main/assets/main-gui-zh.png"
+ ],
+ "https://github.com/AKS1st/dock-images": [
+  "https://raw.githubusercontent.com/AKS1st/dock-images/main/assets/image.png"
+ ],
+ "https://github.com/AKS1st/dock-markdown": [
+  "https://raw.githubusercontent.com/AKS1st/dock-markdown/main/assets/image.png"
+ ]
 }


### PR DESCRIPTION
Adds storefront screenshots (data/screenshots.json) for the dock plugin family: dock-files, dock-editor, dock-image, dock-markdown, dock-git (base has no asset image; dock-media intentionally not listed).

Images live in each plugin repo under assets/ (default branch main), all raw.githubusercontent.com URLs. build-site validation passed.

Note: authored on a sandbox that cannot reach raw.githubusercontent.com for a 200 check, but all images are committed and pushed to the plugin repos.

The npm install mapping (dock-base/dock-*) is driven by probe-npm in CI (data/npm-map.json is gitignored), so those are picked up automatically.