### PR TITLE
Add dsh-voice-chat plugin (voice)

### DIFF
--- a/data/plugins/maoyuching__dsh-voice-chat.yml
+++ b/data/plugins/maoyuching__dsh-voice-chat.yml
@@ -1,0 +1,6 @@
+url: https://github.com/maoyuching/dsh-voice-chat
+name: maoyuching/dsh-voice-chat
+category: voice
+description:
+  en: 'Doubao-style voice chat for DSH: press-and-hold mic in the composer converts speech to text and auto-sends, and AI replies are read aloud. Optional LLM condensing (long replies summarized into short spoken lines, following the current conversation model), TTS-friendly text cleaning, selectable Edge TTS voices, adjustable silence auto-stop, and settings embedded in DSH settings dialog.'
+  zh: '豆包式语音对话插件：聊天框麦克风按钮（按住说话）语音转文字并自动发送，AI 回复自动朗读。可选 LLM 转述精简（长回复压缩成口语再播，跟随当前对话模型）、朗读前清洗 markdown/emoji/特殊符号、Edge TTS 多种音色、静音自动结束时长可调，设置嵌入 DSH 自带设置弹窗（voice chat 类目）。'


### PR DESCRIPTION
Voice chat plugin for DSH Web: press-to-talk ASR → auto-send → spoken AI replies with optional LLM condensing (follows the current conversation model), inline edge-tts (no API key), TTS-friendly text cleaning, selectable Edge TTS voices, adjustable silence auto-stop, and a settings panel in DSH's own settings dialog.

Installs via `dsh plugin --profile web add dsh-voice-chat` (published on npm).