### PR TITLE
Fix GBK mojibake in dsh-version-update zh description

### DIFF
--- a/README.zh.md
+++ b/README.zh.md
@@ -1726,7 +1726,7 @@ dsh plugin --profile web add dshmarket
 - [Starfie1d1272/dsh-builtin-toggles](https://github.com/Starfie1d1272/dsh-builtin-toggles) — DSH Web 内置 capability 的 evidence-backed 检查器：展示运行/配置溯源、兼容性与漂移诊断，并仅为 9 个经过审阅的 UI leaf 提供 fail-closed 控制。
 - [strukto-ai/mirage#dsh](https://github.com/strukto-ai/mirage/tree/main/typescript/packages/dsh) — 把文件系统与 bash 提供者换成 mirage 虚拟工作区：文件工具与 shell 命令作用于挂载的资源（RAM、S3、Redis、Slack、Gmail、Notion、Postgres）而非宿主磁盘，支持按挂载点设置读/写/执行模式、按命令选择沙箱（进程内 monty、pyodide、quickjs；远程 docker、e2b、daytona），并可在虚拟终端中安装 CLI（git、gh、slack、linear、ntn、gws，或自行注册的程序树）作为命令头词。
 - [stuarthu/dsh-hot-reload](https://github.com/stuarthu/dsh-hot-reload) — 插件升级后在运行中的 dsh 内直接重载，无需重启；重载失败时回滚到旧版本并提示手动重启。
-- [SuCriss/dsh-version-update](https://github.com/SuCriss/dsh-version-update) — DeepSeek Harness �汾���²������ʾ��ǰ�汾��������°汾��һ�����²�����������
+- [SuCriss/dsh-version-update](https://github.com/SuCriss/dsh-version-update) — DeepSeek Harness 版本更新插件：显示当前版本，检查最新版本，一键更新并重启宿主。
 - [swaylq/dsh-genie](https://github.com/swaylq/dsh-genie) — 把 agent 现场造出来的插件留下来：将 `cordis_define` 的动态包固化成能跨重启存活的正式插件，写包并注册 profile 层的全过程不用 pnpm、不联网、不需要构建授权。
 - [tancheng33/dsh-spill-s3](https://github.com/tancheng33/dsh-spill-s3) — spill seam 的 S3 兼容后端：超长工具输出写入对象存储（S3、MinIO、R2），会话前缀经哈希、键不可猜测，而不是落在 agent 的本地磁盘上。
 - [Tang-mm95/dsh-single-instance-guard](https://github.com/Tang-mm95/dsh-single-instance-guard) — 检测到其他存活的 dsh 实例占用同一 DSH_HOME 数据目录时中止启动，防止并发写会话日志导致的历史损坏。

--- a/data/plugins/SuCriss__dsh-version-update.yml
+++ b/data/plugins/SuCriss__dsh-version-update.yml
@@ -3,5 +3,5 @@ name: SuCriss/dsh-version-update
 category: dev
 tarball: https://github.com/SuCriss/dsh-version-update/releases/download/v0.3.0/dsh-version-update-0.3.0.tgz
 description:
-  zh: "DeepSeek Harness °æ±¾¸üĞÂ²å¼ş£ºÏÔÊ¾µ±Ç°°æ±¾£¬¼ì²é×îĞÂ°æ±¾£¬Ò»¼ü¸üĞÂ²¢ÖØÆôËŞÖ÷¡£"
+  zh: "DeepSeek Harness ç‰ˆæœ¬æ›´æ–°æ’ä»¶ï¼šæ˜¾ç¤ºå½“å‰ç‰ˆæœ¬ï¼Œæ£€æŸ¥æœ€æ–°ç‰ˆæœ¬ï¼Œä¸€é”®æ›´æ–°å¹¶é‡å¯å®¿ä¸»ã€‚"
   en: "Version update plugin for DeepSeek Harness: display current version, check latest, one-click update and restart host."


### PR DESCRIPTION
## Problem

The zh description of `SuCriss/dsh-version-update` renders as replacement characters everywhere:

> DeepSeek Harness �汾���²������ʾ��ǰ�汾...

Live impact: `docs/plugins.json` on the deployed site carries the mojibake string, so every consumer of `/plugins.json` (including the dsh GUI plugin market) shows garbage.

## Root cause

`data/plugins/SuCriss__dsh-version-update.yml` was saved with **GBK** (Windows ANSI) bytes for its Chinese text while the rest of the file — and the whole repo — is UTF-8. Any UTF-8 decode turns each GBK pair into U+FFFD junk, and `generate-readme.mjs` then baked that junk into `README.zh.md`, which is what `build-site.mjs` parses for descriptions.

Proof: the file's zh value is byte sequence `B0 E6 B1 BE ...`, which decodes as GBK to 「DeepSeek Harness 版本更新插件：显示当前版本，检查最新版本，一键更新并重启宿主。」 and as UTF-8 to the garbled string above.

## Fix

- Re-encode `data/plugins/SuCriss__dsh-version-update.yml` as UTF-8 (content otherwise unchanged).
- Regenerate `README.zh.md` from the clean entry (`node scripts/generate-readme.mjs`) — removes all 39 U+FFFD characters.

After merge, the next `build-site` run republishes `plugins.json` with the correct zh text.