### PR TITLE
Add MengYuil/dsh-ponytail

### DIFF
--- a/README.md
+++ b/README.md
@@ -667,6 +667,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 
 - [AgentConnect/dsh-awiki](https://github.com/AgentConnect/dsh-awiki) - Provides DeepSeek Harness agents with native identities based on the open Agent Network Protocol (ANP), plus identity-based direct, group, mail, and Agent-to-Agent communication.
 - [chenbin-dev/dsh-auth-everying](https://github.com/chenbin-dev/dsh-auth-everying) - Import local Claude, Codex, Grok, Gemini, Copilot, OpenCode, and CC Switch config into DeepSeek Harness with OAuth login for supported providers.
+- [MengYuil/dsh-ponytail](https://github.com/MengYuil/dsh-ponytail) - Port of ponytail: an always-on lazy-senior-developer coding persona with intensity levels, persistence of the default level, and review, audit, debt, gain and help skills for DeepSeek Harness.
 
 ### Sessions & Messages
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -667,6 +667,7 @@ dsh plugin --profile web add dshmarket
 
 - [AgentConnect/dsh-awiki](https://github.com/AgentConnect/dsh-awiki) — 为 DeepSeek Harness 智能体提供基于开放协议ANP的原生身份，以及基于该身份的私聊、群聊、邮件和智能体间通信能力。
 - [chenbin-dev/dsh-auth-everying](https://github.com/chenbin-dev/dsh-auth-everying) — Import local Claude, Codex, Grok, Gemini, Copilot, OpenCode, and CC Switch config into DeepSeek Harness with OAuth login for supported providers.
+- [MengYuil/dsh-ponytail](https://github.com/MengYuil/dsh-ponytail) — ponytail 移植：常驻的「懒惰资深开发者」编码人设，带强度档位与 review、audit、debt、gain、help 技能，适用于 DeepSeek Harness。
 
 ### 💬 会话与消息
 

--- a/data/plugins/MengYuil__dsh-ponytail.yml
+++ b/data/plugins/MengYuil__dsh-ponytail.yml
@@ -1,0 +1,7 @@
+url: https://github.com/MengYuil/dsh-ponytail
+name: MengYuil/dsh-ponytail
+category: identity
+tarball: https://github.com/MengYuil/dsh-ponytail/releases/latest/download/mengyuly-dsh-ponytail-0.1.5.tgz
+description:
+  en: 'Port of ponytail: an always-on lazy-senior-developer coding persona with intensity levels, persistence of the default level, and review, audit, debt, gain and help skills for DeepSeek Harness.'
+  zh: 'ponytail 移植：常驻的「懒惰资深开发者」编码人设，带强度档位与 review、audit、debt、gain、help 技能，适用于 DeepSeek Harness。'


### PR DESCRIPTION
Adds `MengYuil/dsh-ponytail` (category: `identity`) — a native DeepSeek Harness port of [DietrichGebert/ponytail](https://github.com/DietrichGebert/ponytail).

**What it does**: always-on lazy-senior-developer ruleset injected as a system-prompt section, with lite/full/ultra/off intensities, a persisted default level (env var, `~/.config/ponytail/config.json` hot-reloaded, `/ponytail default`), and 6 skills + 6 slash commands (review/audit/debt/gain/help). Prebuilt `lib/` committed; `dsh.bundle.patch` declared; MIT-licensed with upstream attribution. Release tarball attached.

**Relation to gongyijie85/dsh-ponytail**: both port the same upstream. This one differs on the always-on ruleset injection (the other is skill-invocation based) and default-level persistence.

**Scope note**: the always-on section applies to the session's own agent; DSH's built-in subagent tool runs fresh, isolated children that intentionally do not inherit the parent persona (documented in the repo README).

**CI note**: the plugin repo was created today, so the `1 day old` gate will fail on this first run; it clears and I'll re-trigger CI once the repo is >24h old. All other gates (10 commits, `dsh.bundle`, README regeneration, locale parity) are already satisfied.
