### PR TITLE
Add dsh-plugin-nlbi (Text2SQL + BI reports)

### DIFF
--- a/README.md
+++ b/README.md
@@ -972,6 +972,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 ### Tools & Capabilities
 
 - [0xRabit/dsh-crypto-portfolio](https://github.com/0xRabit/dsh-crypto-portfolio) - Crypto portfolio tracker for DSH: BTC / EVM (DeBank free+paid) / Solana / Hyperliquid L1 / CEX balances with multi-provider API failover, per-profile configs, scheduled daily refresh and trend charts (self-contained web dashboard).
+- [1byteone/dsh-plugin-nlbi](https://github.com/1byteone/dsh-plugin-nlbi) - Natural-language data queries + BI reports: Text2SQL, charts, report saving, schema/data grid panel, and a sidebar workbench — all behind DSH's MySQL connection layer.
 - [1na-ko/dsh-hdc-bridge](https://github.com/1na-ko/dsh-hdc-bridge) - HarmonyOS device bridge: hdc screenshot/install/log/crash/UI automation loop with read_image, official-first versioned API knowledge (SDK .d.ts + offline bundled docs), and a DevEco CLI build/sign/lint lane.
 - [6Mikao9/dsh-wsl-workspace](https://github.com/6Mikao9/dsh-wsl-workspace) - Add a WSL workspace from the web GUI without needing to install dsh or related tools again inside WSL. Bash commands and file read/write operations run within the local WSL distribution on the host machine, while Windows files remain accessible.
 - [863683348/dsh-plugin-academic-writing](https://github.com/863683348/dsh-plugin-academic-writing) - Academic writing toolkit for DSH agents: paper outlines, title and abstract skeletons, GB/T 7714 / APA / MLA citations, phrasing QA, and a pre-submission checklist.

--- a/README.zh.md
+++ b/README.zh.md
@@ -972,6 +972,7 @@ dsh plugin --profile web add dshmarket
 ### 🛠️ 工具与能力
 
 - [0xRabit/dsh-crypto-portfolio](https://github.com/0xRabit/dsh-crypto-portfolio) — 加密货币组合追踪器：BTC / EVM（DeBank 免费+付费双源）/ Solana / Hyperliquid L1 / CEX 余额，多 API 源自动切换、多 Profile 配置、每日定时刷新与趋势图（自带 Web 仪表盘）。
+- [1byteone/dsh-plugin-nlbi](https://github.com/1byteone/dsh-plugin-nlbi) — 自然语言查询 + 商业智能报表：Text2SQL、图表、报表收藏、Schema/数据面板与侧栏工作台，基于 DSH 的 MySQL 连接层。
 - [1na-ko/dsh-hdc-bridge](https://github.com/1na-ko/dsh-hdc-bridge) — 鸿蒙设备桥：hdc 截图/装包/日志/崩溃/UI 自动化闭环（配 read_image 看图），官方优先版本化 API 知识层（SDK .d.ts + 离线随包文档），以及 DevEco CLI 构建/签名/lint 通道。
 - [6Mikao9/dsh-wsl-workspace](https://github.com/6Mikao9/dsh-wsl-workspace) — 从 Web GUI 添加 WSL 工作区，无需在 WSL 之中再次安装 dsh 以及相关工具，bash 命令与文件读写运行在本机 WSL 发行版内，Windows 文件仍可访问。
 - [863683348/dsh-plugin-academic-writing](https://github.com/863683348/dsh-plugin-academic-writing) — 为 DSH agent 提供学术写作工具包：论文大纲、标题与摘要骨架、GB/T 7714 / APA / MLA 引文格式化、措辞质检与投稿前清单。

--- a/data/plugins/1byteone__dsh-plugin-nlbi.yml
+++ b/data/plugins/1byteone__dsh-plugin-nlbi.yml
@@ -1,0 +1,6 @@
+url: https://github.com/1byteone/dsh-plugin-nlbi
+name: 1byteone/dsh-plugin-nlbi
+category: tools
+description:
+  en: "Natural-language data queries + BI reports: Text2SQL, charts, report saving, schema/data grid panel, and a sidebar workbench — all behind DSH's MySQL connection layer."
+  zh: "自然语言查询 + 商业智能报表：Text2SQL、图表、报表收藏、Schema/数据面板与侧栏工作台，基于 DSH 的 MySQL 连接层。"


### PR DESCRIPTION
Add [dsh-plugin-nlbi](https://github.com/1byteone/dsh-plugin-nlbi) — Natural-language data queries + BI reports for DeepSeek Harness.

## Features
- `nl_query`: Text2SQL natural-language query with AST-level SQL safety validation
- `sql_to_chart`: automatic BI chart generation (bar/line/pie/stat)
- Report saving & re-run (`save_report` / `list_reports` / `delete_report` / `rerun_report`)
- Sidebar data workbench: schema tree + data grid preview (IDEA Database-style)
- Inherits dsh-mysql connection layer: table allowlist, read-only mode, per-session selection

## Install
```sh
dsh plugin --profile web add github:1byteone/dsh-plugin-nlbi
```

Declares a `dsh.bundle` manifest, installable via `dsh plugin add`.