### PR TITLE
add harness-github: DSH GitHub connector (18 tools, gh-first + REST fallback, approval-gated writes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1459,6 +1459,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 ### Git & Code Review
 
 - [7dgroup-ai/dsh-skill-7d-git-commit](https://github.com/7dgroup-ai/dsh-skill-7d-git-commit) - Checks git commit messages against the 7DGroup convention (Chinese type tags, length and punctuation rules) before committing, as a client-side guard before GitLab pre-receive hooks.
+- [988hj7tczd-oss/harness-github](https://github.com/988hj7tczd-oss/harness-github) - DSH GitHub connector: review PRs, triage issues, debug CI, prepare changes (18 tools, gh-first + REST fallback, approval-gated writes).
 - [BrambleXu/dsh-revdiff](https://github.com/BrambleXu/dsh-revdiff) - Native interactive Git diff review for DeepSeek Harness with structured annotations sent back to the current Agent session.
 - [cirelir/dsh-change-review](https://github.com/cirelir/dsh-change-review) - Session change-review plugin for DeepSeek Harness: tracks write/edit tool calls per session and renders line-level diffs with customizable colors, with session isolation, subagent aggregation, and SSE live updates.
 - [DamonKoy/dsh-web-ui#dsh-git-graph](https://github.com/DamonKoy/dsh-web-ui/tree/main/packages/dsh-git-graph) - Git branch selector and Git graph in the conversation header of the dsh web GUI.

--- a/README.zh.md
+++ b/README.zh.md
@@ -1459,6 +1459,7 @@ dsh plugin --profile web add dshmarket
 ### 🔀 Git 与代码评审
 
 - [7dgroup-ai/dsh-skill-7d-git-commit](https://github.com/7dgroup-ai/dsh-skill-7d-git-commit) — 提交前按 7DGroup 规范校验 git commit message（中文类型标签、长度与标点规则），作为 GitLab pre-receive 钩子的客户端前置校验。
+- [988hj7tczd-oss/harness-github](https://github.com/988hj7tczd-oss/harness-github) — DSH GitHub 连接器:检查 PR、分诊 issue、调试 CI、准备代码变更(18 个工具,gh 优先 + REST 回退,写操作人工审批)。
 - [BrambleXu/dsh-revdiff](https://github.com/BrambleXu/dsh-revdiff) — DeepSeek Harness 原生交互式 Git diff 审查，支持结构化批注并回传当前 Agent 会话。
 - [cirelir/dsh-change-review](https://github.com/cirelir/dsh-change-review) — 会话修改审查插件：追踪会话内 write/edit 工具调用并展示 diff 对比；会话隔离、子代理聚合、SSE 实时推送、角标与颜色自定义。
 - [DamonKoy/dsh-web-ui#dsh-git-graph](https://github.com/DamonKoy/dsh-web-ui/tree/main/packages/dsh-git-graph) — dsh web GUI 会话头部栏的 Git 分支选择器与提交图。

--- a/data/plugins/988hj7tczd-oss__harness-github.yml
+++ b/data/plugins/988hj7tczd-oss__harness-github.yml
@@ -1,0 +1,6 @@
+url: https://github.com/988hj7tczd-oss/harness-github
+name: 988hj7tczd-oss/harness-github
+category: git
+description:
+  en: "DSH GitHub connector: review PRs, triage issues, debug CI, prepare changes (18 tools, gh-first + REST fallback, approval-gated writes)."
+  zh: "DSH GitHub 连接器:检查 PR、分诊 issue、调试 CI、准备代码变更(18 个工具,gh 优先 + REST 回退,写操作人工审批)。"


### PR DESCRIPTION
Adds [harness-github](https://github.com/988hj7tczd-oss/harness-github) to the **Git & Code Review** category.

- DSH GitHub connector plugin: review PRs, triage issues, debug failed Actions checks, address review feedback, prepare code changes.
- 18 github_* tools (10 read / 8 write), gh CLI first with REST fallback; no extra sign-in (reuses `gh auth login` or `GITHUB_TOKEN`).
- All write operations approval-gated via `ctx.approval` — fail-closed, zero side effects on rejection.
- Declares `dsh.bundle` manifest (cordis.patch.yml); installs with `dsh plugin add harness-github` (also on npm @0.1.0).
- 52 offline tests green; `node scripts/check.mjs` passes; CI badge shown in README.