### PR TITLE
Add dsh-wenan - extract short-video scripts from Douyin/Bilibili/Kuaishou/YouTube

### DIFF
--- a/README.md
+++ b/README.md
@@ -846,6 +846,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 
 ### Tools & Capabilities
 
+- [XGL2019/dsh-wenan](https://github.com/XGL2019/dsh-wenan) - Extract short-video scripts/captions from Douyin/Bilibili/Kuaishou/YouTube.
 - [1na-ko/dsh-hdc-bridge](https://github.com/1na-ko/dsh-hdc-bridge) - HarmonyOS device bridge: hdc screenshot/install/log/crash/UI automation loop with read_image, official-first versioned API knowledge (SDK .d.ts + offline bundled docs), and a DevEco CLI build/sign/lint lane.
 - [6Mikao9/dsh-wsl-workspace](https://github.com/6Mikao9/dsh-wsl-workspace) - Add a WSL workspace from the web GUI without needing to install dsh or related tools again inside WSL. Bash commands and file read/write operations run within the local WSL distribution on the host machine, while Windows files remain accessible.
 - [863683348/dsh-plugin-academic-writing](https://github.com/863683348/dsh-plugin-academic-writing) - Academic writing toolkit for DSH agents: paper outlines, title and abstract skeletons, GB/T 7714 / APA / MLA citations, phrasing QA, and a pre-submission checklist.


### PR DESCRIPTION
Add [dsh-wenan](https://github.com/XGL2019/dsh-wenan) to the Tools & Capabilities category.

A DeepSeek Harness tool plugin that extracts short-video scripts/captions (文案/标题/作者/话题/数据) from Douyin, Bilibili, Kuaishou, and YouTube via a bundled Python extractor.

- installs with `dsh plugin add dsh-wenan`
- declares a `dsh.bundle` manifest
- MIT licensed