### PR TITLE
Add 01men/ybkk-AIOS (enterprise AI resource platform, market)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2016,6 +2016,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 
 ### Plugin Markets & Managers
 
+- [01men/ybkk-AIOS](https://github.com/01men/ybkk-AIOS) - Enterprise AI resource platform as a 13-plugin cordis bundle: org/account/role IAM, OIDC provider, MCP server management, skill hub, agent and app registries, usage metering, wallet billing, audit with alerts, and a reviewed third-party plugin marketplace — 37 ops tools become callable by the dsh agent.
 - [1e0zj/dsh-plugin-mall](https://github.com/1e0zj/dsh-plugin-mall) - Open plugin marketplace: live GitHub dsh-plugin topic search with per-repo package.json verification (dsh.bundle/dsh.client manifest badges and a verified-only filter), npm-first installs with same-source anti-squatting checks, update detection, and five agent tools for headless use.
 - [2768651338/dsh-plugin-manager](https://github.com/2768651338/dsh-plugin-manager) - A plugin manager tab in Settings → Plugins: Chinese names and plain-language descriptions for every installed plugin, one-click enable/disable, in-UI notes editing, and search/filter over the installed catalog.
 - [863683348/dsh-feed](https://github.com/863683348/dsh-feed) - Cross-ecosystem aggregation data layer: syncs the GitHub dsh-plugin topic and the npm registry into one open JSON index, queried by model tools, a CLI, and a minimal stdio MCP server.

--- a/README.zh.md
+++ b/README.zh.md
@@ -2016,7 +2016,8 @@ dsh plugin --profile web add dshmarket
 
 ### 🛒 插件市场与管理
 
-(https://github.com/1e0zj/dsh-plugin-mall) — 开放式插件市场：GitHub dsh-plugin 话题实时搜索，逐仓库 package.json 验证（dsh.bundle/dsh.client 声明徽章与只看已验证过滤），npm 优先安装带同源防抢注校验，更新检测，并附五个可在无界面环境使用的 agent 工具。
+- [01men/ybkk-AIOS](https://github.com/01men/ybkk-AIOS) — 企业 AI 资源平台，由 13 个 cordis 插件组成：组织/账号/角色 IAM、OIDC 认证、MCP 服务管理、Skill 市场、Agent 与应用管理、计量、钱包计费、审计告警与带审核的第三方插件市场——37 个运维工具可直接被 dsh Agent 调用。
+- [1e0zj/dsh-plugin-mall](https://github.com/1e0zj/dsh-plugin-mall) — 开放式插件市场：GitHub dsh-plugin 话题实时搜索，逐仓库 package.json 验证（dsh.bundle/dsh.client 声明徽章与只看已验证过滤），npm 优先安装带同源防抢注校验，更新检测，并附五个可在无界面环境使用的 agent 工具。
 - [2768651338/dsh-plugin-manager](https://github.com/2768651338/dsh-plugin-manager) — 设置 → 插件里的插件管理页：已装插件中文名与白话描述、一键启停、界面内改备注，支持搜索与筛选。
 - [863683348/dsh-feed](https://github.com/863683348/dsh-feed) — 跨生态聚合数据层（"聚合的聚合"）：把 GitHub dsh-plugin 主题与 npm registry 归一化为开放 JSON 索引，供模型工具、CLI 与轻量 stdio MCP 服务查询。
 - [863683348/dsh-insight](https://github.com/863683348/dsh-insight) — 插件评测中心：一个答案回答"哪些值得装"——plugin_guide 按需求推荐插件、recipe 安装整套环境、plugin_rank 健康评分（0-100）、plugin_audit 静态安全扫描本地目录、plugin_verdict 给出 install / caution / research / avoid 结论。

--- a/README.zh.md
+++ b/README.zh.md
@@ -2016,7 +2016,7 @@ dsh plugin --profile web add dshmarket
 
 ### 🛒 插件市场与管理
 
-- [1e0zj/dsh-plugin-mall](https://github.com/1e0zj/dsh-plugin-mall) — 开放式插件市场：GitHub dsh-plugin 话题实时搜索，逐仓库 package.json 验证（dsh.bundle/dsh.client 声明徽章与只看已验证过滤），npm 优先安装带同源防抢注校验，更新检测，并附五个可在无界面环境使用的 agent 工具。
+(https://github.com/1e0zj/dsh-plugin-mall) — 开放式插件市场：GitHub dsh-plugin 话题实时搜索，逐仓库 package.json 验证（dsh.bundle/dsh.client 声明徽章与只看已验证过滤），npm 优先安装带同源防抢注校验，更新检测，并附五个可在无界面环境使用的 agent 工具。
 - [2768651338/dsh-plugin-manager](https://github.com/2768651338/dsh-plugin-manager) — 设置 → 插件里的插件管理页：已装插件中文名与白话描述、一键启停、界面内改备注，支持搜索与筛选。
 - [863683348/dsh-feed](https://github.com/863683348/dsh-feed) — 跨生态聚合数据层（"聚合的聚合"）：把 GitHub dsh-plugin 主题与 npm registry 归一化为开放 JSON 索引，供模型工具、CLI 与轻量 stdio MCP 服务查询。
 - [863683348/dsh-insight](https://github.com/863683348/dsh-insight) — 插件评测中心：一个答案回答"哪些值得装"——plugin_guide 按需求推荐插件、recipe 安装整套环境、plugin_rank 健康评分（0-100）、plugin_audit 静态安全扫描本地目录、plugin_verdict 给出 install / caution / research / avoid 结论。

--- a/data/plugins/01men__ybkk-AIOS.yml
+++ b/data/plugins/01men__ybkk-AIOS.yml
@@ -1,0 +1,6 @@
+url: https://github.com/01men/ybkk-AIOS
+name: 01men/ybkk-AIOS
+category: market
+description:
+  en: 'Enterprise AI resource platform as a 13-plugin cordis bundle: org/account/role IAM, OIDC provider, MCP server management, skill hub, agent and app registries, usage metering, wallet billing, audit with alerts, and a reviewed third-party plugin marketplace — 37 ops tools become callable by the dsh agent.'
+  zh: '企业 AI 资源平台，由 13 个 cordis 插件组成：组织/账号/角色 IAM、OIDC 认证、MCP 服务管理、Skill 市场、Agent 与应用管理、计量、钱包计费、审计告警与带审核的第三方插件市场——37 个运维工具可直接被 dsh Agent 调用。'


### PR DESCRIPTION
Adds one entry: `data/plugins/01men__ybkk-AIOS.yml` (category: `market`), with both READMEs regenerated via `npm ci && node scripts/generate-readme.mjs`.

- `dsh.bundle` declared in the repo root `package.json` — patch is `cordis.patch.yml`, a 13-plugin cordis bundle using relative paths so it resolves after `dsh plugin add`
- [`dsh-plugin`](https://github.com/topics/dsh-plugin) topic added to the repo
- Repo is 3 days old with 10 commits
- Description checked against the code: the bundle patch inserts 13 plugins; the platform registers 37 ops tools (asserted by `scripts/selftest.mjs`, 207/207 passing)