### PR TITLE
Add screenshots for GreenLv/dsh-session-insights

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -1,4 +1,8 @@
 {
+ "https://github.com/GreenLv/dsh-session-insights": [
+  "https://raw.githubusercontent.com/GreenLv/dsh-session-insights/main/assets/screenshots/dashboard-overview-en.png",
+  "https://raw.githubusercontent.com/GreenLv/dsh-session-insights/main/assets/screenshots/dashboard-overview-zh.png"
+ ],
  "https://github.com/LayneChai/superpowers-dsh": [
   "https://raw.githubusercontent.com/LayneChai/superpowers-dsh/main/static/home.png",
   "https://raw.githubusercontent.com/LayneChai/superpowers-dsh/main/static/install-success.png"


### PR DESCRIPTION
Register market screenshots for the existing `GreenLv/dsh-session-insights` entry.

- Two dashboard overview captures (English and Chinese), generated from the plugin's fully synthetic test fixture, hosted in the plugin repository under `assets/screenshots/`.
- No other entries are modified.