### PR TITLE
Add dsh-liangxiang marketplace screenshots

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -21,6 +21,11 @@
   "https://raw.githubusercontent.com/lengzhanbao/dsh-taffy-theme/master/preview/light.webp",
   "https://raw.githubusercontent.com/lengzhanbao/dsh-taffy-theme/master/preview/dark.webp"
  ],
+ "https://github.com/liang-today/dsh-liangxiang": [
+  "https://raw.githubusercontent.com/liang-today/dsh-liangxiang/main/assets/today-card.jpg",
+  "https://raw.githubusercontent.com/liang-today/dsh-liangxiang/main/assets/plugin-panel.jpg",
+  "https://raw.githubusercontent.com/liang-today/dsh-liangxiang/main/assets/liangci.jpg"
+ ],
  "https://github.com/Little-Star888/dsh-pelican": [
   "https://raw.githubusercontent.com/Little-Star888/dsh-pelican/main/assets/screenshot-1.png"
  ],
@@ -1204,8 +1209,7 @@
   "https://raw.githubusercontent.com/ppy-web/dsh-plugin-xiaomi-mimo-tts/main/assets/menu.png",
   "https://raw.githubusercontent.com/ppy-web/dsh-plugin-xiaomi-mimo-tts/main/assets/preset.png",
   "https://raw.githubusercontent.com/ppy-web/dsh-plugin-xiaomi-mimo-tts/main/assets/image.png"
- ]
-,
+ ],
  "https://github.com/lunaship/dsh-links": [
   "https://raw.githubusercontent.com/lunaship/dsh-links/main/docs/images/phone-connection-sanitized.png",
   "https://raw.githubusercontent.com/lunaship/dsh-links/main/docs/images/android-device-list-sanitized.png",

--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -22,7 +22,7 @@
   "https://raw.githubusercontent.com/lengzhanbao/dsh-taffy-theme/master/preview/dark.webp"
  ],
  "https://github.com/liang-today/dsh-liangxiang": [
-  "https://raw.githubusercontent.com/liang-today/dsh-liangxiang/main/assets/today-card.jpg",
+  "https://raw.githubusercontent.com/liang-today/dsh-liangxiang/main/assets/main-frame.jpg",
   "https://raw.githubusercontent.com/liang-today/dsh-liangxiang/main/assets/plugin-panel.jpg",
   "https://raw.githubusercontent.com/liang-today/dsh-liangxiang/main/assets/liangci.jpg"
  ],


### PR DESCRIPTION
## Summary
- Register three GitHub-hosted screenshots for `liang-today/dsh-liangxiang` in `data/screenshots.json`.
- dsh-market search cards only render this curated list; without it the listing shows text only.

## Screenshots
- https://raw.githubusercontent.com/liang-today/dsh-liangxiang/main/assets/today-card.jpg
- https://raw.githubusercontent.com/liang-today/dsh-liangxiang/main/assets/plugin-panel.jpg
- https://raw.githubusercontent.com/liang-today/dsh-liangxiang/main/assets/liangci.jpg

Images return HTTP 200 with `image/jpeg` from GitHub raw hosting.


Made with [Cursor](https://cursor.com)