### PR TITLE
Add dsh-zcode-sync: sync ZCode custom model providers into DSH

### DIFF
--- a/README.md
+++ b/README.md
@@ -651,6 +651,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 - [xiaozhe7772222/dsh-opencode-zen](https://github.com/xiaozhe7772222/dsh-opencode-zen) - Zero-cost access to 6 free large models. No registration, no recharge, 6 free models built-in, multi-key rotation and rate-limit backoff.
 - [ZChenW/dsh-codex-switch](https://github.com/ZChenW/dsh-codex-switch) - Connects ChatGPT accounts through OAuth, switches among them manually or automatically, and adds Codex models with usage limits to DeepSeek Harness.
 - [zeng6125-rgb/dsh-llm-retry-settings](https://github.com/zeng6125-rgb/dsh-llm-retry-settings) - Settings card to tune the DSH LLM auto-retry policy (retry count, backoff, jitter) live from Settings → General.
+- [zzy1601/dsh-zcode-sync](https://github.com/zzy1601/dsh-zcode-sync) - Syncs ZCode custom model providers into DeepSeek Harness - merges providers and API keys from ZCode's config into the llm-pi-ai namespace via in-process settings/credentials services, gated by llm-pi-ai's own validation; idempotent startup/interval sync, zero hardcoded paths.
 
 ### Identity & Communication
 

--- a/README.md
+++ b/README.md
@@ -651,7 +651,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 - [xiaozhe7772222/dsh-opencode-zen](https://github.com/xiaozhe7772222/dsh-opencode-zen) - Zero-cost access to 6 free large models. No registration, no recharge, 6 free models built-in, multi-key rotation and rate-limit backoff.
 - [ZChenW/dsh-codex-switch](https://github.com/ZChenW/dsh-codex-switch) - Connects ChatGPT accounts through OAuth, switches among them manually or automatically, and adds Codex models with usage limits to DeepSeek Harness.
 - [zeng6125-rgb/dsh-llm-retry-settings](https://github.com/zeng6125-rgb/dsh-llm-retry-settings) - Settings card to tune the DSH LLM auto-retry policy (retry count, backoff, jitter) live from Settings → General.
-- [zzy1601/dsh-zcode-sync](https://github.com/zzy1601/dsh-zcode-sync) - Syncs ZCode custom model providers into DeepSeek Harness - merges providers and API keys from ZCode's config into the llm-pi-ai namespace via in-process settings/credentials services, gated by llm-pi-ai's own validation; idempotent startup/interval sync, zero hardcoded paths.
+- [zzy1601/dsh-zcode-sync](https://github.com/zzy1601/dsh-zcode-sync) - Syncs ZCode custom model providers into DeepSeek Harness: merges providers and API keys from ZCode's config into the llm-pi-ai namespace via in-process settings/credentials services, gated by llm-pi-ai's own validation; idempotent startup/interval sync, zero hardcoded paths.
 
 ### Identity & Communication
 

--- a/README.md
+++ b/README.md
@@ -2014,6 +2014,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 - [zhaenggg/dsh-ssh-remote](https://github.com/zhaenggg/dsh-ssh-remote) - SSH remote execution set: give a session an ssh:// workspace and every file, command, and shell operation runs on the remote host.
 - [zhu1090093659/dsh-web-ui#packages/dsh-remote-web-ui](https://github.com/zhu1090093659/dsh-web-ui/tree/main/packages/dsh-remote-web-ui) - Remote control of a dsh web workspace from phone or PC: QR-code pairing through a token-gated channel, SSE real-time sync, and separate mobile and full desktop GUI modes.
 - [zylzyqzz/dsh-mobile-pwa](https://github.com/zylzyqzz/dsh-mobile-pwa) - Complete mobile PWA for DSH, built on dsh-mobile-gate: secure remote-access gateway plus install-to-homescreen (manifest + service worker), offline capability, touch gestures (pull-to-refresh, edge-swipe back, pinch-zoom font), agent-done push notifications, and touch-first layout — desktop unaffected.
+- [zzy1601/dsh-weixin-bot](https://github.com/zzy1601/dsh-weixin-bot) - Drive a native DSH agent from WeChat ClawBot: multi-turn context per chat, joins the default agent preset so the full toolset executes real tasks, and pushes live progress mid-run (thinking acks, tool-call counters, heartbeats).
 
 ### Plugin Markets & Managers
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -651,6 +651,7 @@ dsh plugin --profile web add dshmarket
 - [xiaozhe7772222/dsh-opencode-zen](https://github.com/xiaozhe7772222/dsh-opencode-zen) — 0元接入6个免费大模型，免注册免充值，内置6个免费模型，多Key轮换与限流退避。
 - [ZChenW/dsh-codex-switch](https://github.com/ZChenW/dsh-codex-switch) — 通过 OAuth 连接 ChatGPT 账号，支持手动或自动切换，并为 DeepSeek Harness 添加带用量限额信息的 Codex 模型。
 - [zeng6125-rgb/dsh-llm-retry-settings](https://github.com/zeng6125-rgb/dsh-llm-retry-settings) — 在 DSH 设置里调整 LLM 自动重试的次数与退避时间并实时生效的设置卡片。
+- [zzy1601/dsh-zcode-sync](https://github.com/zzy1601/dsh-zcode-sync) — 把 ZCode 的自定义模型提供商自动同步进 DeepSeek Harness——通过进程内 settings/credentials 服务把 config.json 里的 provider 与 API Key 合并进 llm-pi-ai 命名空间，写入受其自带校验把关；启动/周期/配置变更时幂等同步，零硬编码路径。
 
 ### 🆔 身份与通信
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -2014,6 +2014,7 @@ dsh plugin --profile web add dshmarket
 - [zhaenggg/dsh-ssh-remote](https://github.com/zhaenggg/dsh-ssh-remote) — SSH 远程执行插件集：把会话工作区指向 ssh:// 目录，文件读写、命令与 shell 全部在远程主机上执行。
 - [zhu1090093659/dsh-web-ui#packages/dsh-remote-web-ui](https://github.com/zhu1090093659/dsh-web-ui/tree/main/packages/dsh-remote-web-ui) — 手机/PC 远程操控 dsh web 工作区：扫码配对、令牌门控通道、SSE 实时同步，提供移动端与完整桌面 GUI 两种远程形态。
 - [zylzyqzz/dsh-mobile-pwa](https://github.com/zylzyqzz/dsh-mobile-pwa) — 基于 dsh-mobile-gate 的完整移动端 PWA：安全远程访问网关 + 可安装到主屏（manifest + service worker）+ 离线可用 + 触屏手势（下拉刷新/边缘返弹/捏合缩放字体）+ agent 完成推送 + 触屏优先布局，桌面零影响。
+- [zzy1601/dsh-weixin-bot](https://github.com/zzy1601/dsh-weixin-bot) — 在微信里通过 ClawBot 驱动本机 DSH 原生 Agent：同一会话多轮上下文；创建时加入默认 agent preset，工具全量可用、任务真执行；执行中实时推送思考确认、工具调用计数与心跳，不再发出去就没音讯。
 
 ### 🛒 插件市场与管理
 

--- a/data/plugins/zzy1601__dsh-weixin-bot.yml
+++ b/data/plugins/zzy1601__dsh-weixin-bot.yml
@@ -1,0 +1,6 @@
+url: https://github.com/zzy1601/dsh-weixin-bot
+name: zzy1601/dsh-weixin-bot
+category: remote
+description:
+  en: 'Drive a native DSH agent from WeChat ClawBot: multi-turn context per chat, joins the default agent preset so the full toolset executes real tasks, and pushes live progress mid-run (thinking acks, tool-call counters, heartbeats).'
+  zh: '在微信里通过 ClawBot 驱动本机 DSH 原生 Agent：同一会话多轮上下文；创建时加入默认 agent preset，工具全量可用、任务真执行；执行中实时推送思考确认、工具调用计数与心跳，不再发出去就没音讯。'

--- a/data/plugins/zzy1601__dsh-zcode-sync.yml
+++ b/data/plugins/zzy1601__dsh-zcode-sync.yml
@@ -1,0 +1,6 @@
+url: https://github.com/zzy1601/dsh-zcode-sync
+name: zzy1601/dsh-zcode-sync
+category: model
+description:
+  en: 'Syncs ZCode custom model providers into DeepSeek Harness: merges providers and API keys from ZCode''s config into the llm-pi-ai namespace via in-process settings/credentials services, gated by llm-pi-ai''s own validation; idempotent startup/interval sync, zero hardcoded paths.'
+  zh: '把 ZCode 的自定义模型提供商自动同步进 DeepSeek Harness——通过进程内 settings/credentials 服务把 config.json 里的 provider 与 API Key 合并进 llm-pi-ai 命名空间，写入受其自带校验把关；启动/周期/配置变更时幂等同步，零硬编码路径。'


### PR DESCRIPTION
## What

[zzy1601/dsh-zcode-sync](https://github.com/zzy1601/dsh-zcode-sync) keeps every custom model provider configured in [ZCode](https://zcode.ai) available inside DeepSeek Harness's model picker.

- Reads `~/.zcode/v2/config.json` and **merges** providers + API keys into the `llm-pi-ai` settings namespace through DSH's in-process settings & credentials services
- Writes are gated by `llm-pi-ai`'s own validator (duplicate model IDs / invalid reasoning efforts are rejected at write time instead of corrupting the namespace registration)
- Idempotent: runs once after startup, optionally on an interval, and on settings changes; zero writes when state matches
- Zero hardcoded machine paths; category suggestion: **model** (Models & Providers)

## Verification

- Tested against a live setup: 27 providers / 84 models synced, second pass reported zero changes (idempotent), daemon-managed instance loads the plugin cleanly

## Install

```bash
dsh plugin --profile web add github:zzy1601/dsh-zcode-sync
```