### PR TITLE
screenshots: add real settings-card screenshot for Frog755/dsh-client-auto-retry

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -1063,7 +1063,8 @@
   "https://raw.githubusercontent.com/winditer/dsh-elf/main/assets/screenshot-chat.png"
  ],
  "https://github.com/Frog755/dsh-client-auto-retry": [
-  "https://raw.githubusercontent.com/Frog755/dsh-client-auto-retry/main/assets/demo.svg"
+  "https://raw.githubusercontent.com/Frog755/dsh-client-auto-retry/main/assets/demo.svg",
+  "https://raw.githubusercontent.com/Frog755/dsh-client-auto-retry/main/assets/screenshot-settings-card.png"
  ],
  "https://github.com/lemonorangeapple/dsh-effort-switcher": [
   "https://raw.githubusercontent.com/lemonorangeapple/dsh-effort-switcher/master/screenshots/1.png",


### PR DESCRIPTION
Adds a real settings-card screenshot for Frog755/dsh-client-auto-retry to data/screenshots.json, complementing the existing workflow diagram. The screenshot was captured from the DSH web UI settings panel. No YAML or description changes; existing entry untouched. Screenshot hosted at https://raw.githubusercontent.com/Frog755/dsh-client-auto-retry/main/assets/screenshot-settings-card.png