### PR TITLE
Update StrataGate 0.2.21 screenshots and tarball

### DIFF
--- a/data/plugins/diqierjia__StrataGate-AgentMemory--integrations-deepseek-harness.yml
+++ b/data/plugins/diqierjia__StrataGate-AgentMemory--integrations-deepseek-harness.yml
@@ -1,4 +1,5 @@
 url: https://github.com/diqierjia/StrataGate-AgentMemory/tree/main/integrations/deepseek-harness
+tarball: https://github.com/diqierjia/StrataGate-AgentMemory/releases/download/stratagate-dsh-v0.2.21/stratagate-dsh-0.2.21.tgz
 name: diqierjia/StrataGate-AgentMemory
 category: memory
 description:

--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -1,4 +1,8 @@
 {
+ "https://github.com/diqierjia/StrataGate-AgentMemory/tree/main/integrations/deepseek-harness": [
+  "https://raw.githubusercontent.com/diqierjia/StrataGate-AgentMemory/main/integrations/deepseek-harness/docs/assets/stratagate-short-term-memory.png",
+  "https://raw.githubusercontent.com/diqierjia/StrataGate-AgentMemory/main/integrations/deepseek-harness/docs/assets/stratagate-memory-structure.png"
+ ],
  "https://github.com/fengb3/dsh-session-icons": [
   "https://raw.githubusercontent.com/fengb3/dsh-session-icons/master/docs/screenshot.png"
  ],


### PR DESCRIPTION
## Summary
- point the existing StrataGate entry at the verified 0.2.21 GitHub Release tarball
- add two GitHub-hosted screenshots for the marketplace detail view

## Source update
- https://github.com/diqierjia/StrataGate-AgentMemory/pull/23
- https://github.com/diqierjia/StrataGate-AgentMemory/releases/tag/stratagate-dsh-v0.2.21

## Validation
- both screenshot URLs return HTTP 200
- tarball URL returns HTTP 200 and matches the uploaded 1,586,145-byte artifact
- `node scripts/generate-readme.mjs`
- `node scripts/build-site.mjs`
- `node scripts/check-bleed.mjs`
- `git diff --check`