### PR TITLE
fix: update dsh-rw release tarball URL

### DIFF
--- a/data/plugins/MDR-EX1000__dsh-rw.yml
+++ b/data/plugins/MDR-EX1000__dsh-rw.yml
@@ -1,7 +1,7 @@
 url: https://github.com/MDR-EX1000/dsh-rw
 name: MDR-EX1000/dsh-rw
 category: remote
-tarball: https://github.com/MDR-EX1000/dsh-rw/releases/latest/download/dsh-rw-0.1.0.tgz
+tarball: https://github.com/MDR-EX1000/dsh-rw/releases/latest/download/dsh-rw.tgz
 description:
   en: 'Remote-SSH-style workspaces: turn an SSH host and a remote directory into a native DSH workspace; the agent operates the remote filesystem directly via 12 rw_* tools (SFTP/exec), with workspace-confined paths and known_hosts verification.'
   zh: 'Remote-SSH 风格工作区：把 SSH 主机上的远程目录变成原生 DSH 工作区，agent 通过 12 个 rw_* 工具（SFTP/exec）直接操作远程文件，路径限定在工作区内并校验 known_hosts。'


### PR DESCRIPTION
## Summary

The existing dsh-rw catalog entry points at the old `dsh-rw-0.1.0.tgz` asset, which now returns 404. The current v0.4.0 release publishes the stable asset name `dsh-rw.tgz`.

This stale URL makes the tarball probe remove the prebuilt install option and causes the storefront to fall back to the source GitHub install command.

## Change

- Update only `data/plugins/MDR-EX1000__dsh-rw.yml`
- Point `tarball` to `https://github.com/MDR-EX1000/dsh-rw/releases/latest/download/dsh-rw.tgz`

## Validation

- Stable release asset responds with HTTP 200
- Asset package version is `0.4.0`
- `npm ci`
- `node scripts/generate-readme.mjs` (both READMEs up to date)
- `SKIP_PUBLISH_CHECKS=1 node scripts/build-site.mjs`
- `git diff --check`