### PR TITLE
Add screenshots for gjj-star/dsh-conversation-navigator

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -1268,4 +1268,14 @@
  "https://github.com/Whale-Zhang/dsh-complete-chime": [
   "https://raw.githubusercontent.com/Whale-Zhang/dsh-complete-chime/main/docs/settings-card.png"
  ]
+,
+ "https://github.com/gjj-star/dsh-conversation-navigator": [
+  "https://raw.githubusercontent.com/gjj-star/dsh-conversation-navigator/main/assets/screenshots/01-main.png",
+  "https://raw.githubusercontent.com/gjj-star/dsh-conversation-navigator/main/assets/screenshots/02-steps.png",
+  "https://raw.githubusercontent.com/gjj-star/dsh-conversation-navigator/main/assets/screenshots/03-minimal.png",
+  "https://raw.githubusercontent.com/gjj-star/dsh-conversation-navigator/main/assets/screenshots/04-search-n-hover.png",
+  "https://raw.githubusercontent.com/gjj-star/dsh-conversation-navigator/main/assets/screenshots/05-dark.png",
+  "https://raw.githubusercontent.com/gjj-star/dsh-conversation-navigator/main/assets/screenshots/06-theme1-preview.png",
+  "https://raw.githubusercontent.com/gjj-star/dsh-conversation-navigator/main/assets/screenshots/07-theme2-preview.png"
+ ]
 }


### PR DESCRIPTION
Add the 7 gallery screenshots for gjj-star/dsh-conversation-navigator (already listed).

- 01 main panel - 02 expanded steps - 03 minimal badge mode
- 04 search highlight + hover bubble - 05 dark theme
- 06/07 adaptation under community skins

Images are GitHub-hosted PNGs in the plugin repo (assets/screenshots/).