### PR TITLE
Add Harzva/dsh-agent-project-sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -980,6 +980,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 - [goecho/dsh-generation](https://github.com/goecho/dsh-generation) - Adds generation_fork and generation_run to copy an agent preset and run a task on a new session.
 - [gongyijie85/dsh-repo-setup](https://github.com/gongyijie85/dsh-repo-setup) - Read-only repo bootstrap scanner (repo_setup_scan tool): detects stack/tests/docs/git/db and recommends plugins, MCP servers and hygiene files.
 - [hanyi7867069-create/dsh-content-lab](https://github.com/hanyi7867069-create/dsh-content-lab) - Content workshop tools for DSH — topic, title, post and content-calendar generation through the built-in LLM.
+- [Harzva/dsh-agent-project-sync](https://github.com/Harzva/dsh-agent-project-sync) - Discovers Codex and Claude project directories and registers them as shared DeepSeek Harness workspaces.
 - [hccccc01333/dsh-excel-chat#bundle](https://github.com/hccccc01333/dsh-excel-chat/tree/master/bundle) - Talk to Excel in DeepSeek Harness: create, edit, repair, and verify spreadsheets by conversation, with automatic formula health checks after every edit.
 - [heartleo/hn-cli#hacker-news](https://github.com/heartleo/hn-cli/tree/main/plugins/hacker-news) - Hacker News tools for feeds, discussion threads, search, and user profiles.
 - [Hefulalala/dsh-remote-workspace](https://github.com/Hefulalala/dsh-remote-workspace) - SSH/SFTP remote sites and workspaces: manage connections and remote directories like local workspaces.

--- a/README.zh.md
+++ b/README.zh.md
@@ -980,6 +980,7 @@ dsh plugin --profile web add dshmarket
 - [goecho/dsh-generation](https://github.com/goecho/dsh-generation) — 提供 generation_fork 与 generation_run，用于拷贝 Agent preset 并在新会话上跑任务。
 - [gongyijie85/dsh-repo-setup](https://github.com/gongyijie85/dsh-repo-setup) — 只读仓库体检引导工具（repo_setup_scan）：识别技术栈/测试/文档/git/数据库线索，给出插件、MCP 与卫生文件的安装建议。
 - [hanyi7867069-create/dsh-content-lab](https://github.com/hanyi7867069-create/dsh-content-lab) — 内容工坊——选题、标题、文案与排期生成工具，直接调用内置 LLM。
+- [Harzva/dsh-agent-project-sync](https://github.com/Harzva/dsh-agent-project-sync) — 发现 Codex 和 Claude 使用过的项目目录，并将其注册为共享的 DeepSeek Harness 工作区。
 - [hccccc01333/dsh-excel-chat#bundle](https://github.com/hccccc01333/dsh-excel-chat/tree/master/bundle) — 在 DeepSeek Harness 里对话完成 Excel 工作：建表、编辑、修复公式、图表校验，每次编辑后自动体检公式。
 - [heartleo/hn-cli#hacker-news](https://github.com/heartleo/hn-cli/tree/main/plugins/hacker-news) — 用于获取 Hacker News 榜单、讨论串、搜索和用户资料的工具。
 - [Hefulalala/dsh-remote-workspace](https://github.com/Hefulalala/dsh-remote-workspace) — SSH/SFTP 远程站点与远程工作区：像本地工作区一样管理远程连接与目录。

--- a/data/plugins/Harzva__dsh-agent-project-sync.yml
+++ b/data/plugins/Harzva__dsh-agent-project-sync.yml
@@ -1,0 +1,7 @@
+url: https://github.com/Harzva/dsh-agent-project-sync
+name: Harzva/dsh-agent-project-sync
+category: tools
+description:
+  en: 'Discovers Codex and Claude project directories and registers them as shared DeepSeek Harness workspaces.'
+  zh: '发现 Codex 和 Claude 使用过的项目目录，并将其注册为共享的 DeepSeek Harness 工作区。'
+tarball: https://github.com/Harzva/dsh-agent-project-sync/releases/latest/download/dsh-agent-project-sync-0.1.0.tgz


### PR DESCRIPTION
## Summary

- add Harzva/dsh-agent-project-sync to the tools category
- include factual English and Chinese descriptions
- use the uploaded GitHub Release tarball for installation

## Verification

- root package declares dsh.bundle
- repository is more than one day old with 13 commits
- dsh-plugin topic is present
- v0.1.0 tarball asset is uploaded
- generated README.md and README.zh.md from the YAML source
