### PR TITLE
docs: drop the anywhere-labs cooperation note

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,6 @@ dsh plugin --profile web add dshmarket
 
 > ℹ️ **On desktop clients.** This list is client-agnostic. A plugin is listed because it follows the official protocol — it declares a `dsh.bundle` manifest and installs with `dsh plugin add` — not because it adapts to any particular client.
 >
-> We're talking with `anywhere-labs/deepseek-harness-desktop` about working together again; we'll update this note as that progresses. Whatever comes of it, the listing rule stays as it is: adapting to any particular client is not a condition of being listed, and no plugin will be removed or demoted for not doing so.
->
 > Clients worth a look: [dsh-desktop](https://github.com/dataelement/dsh-desktop) and [deepseek-harness-desktop](https://github.com/hairyf/deepseek-harness-desktop) — both ship dsh-market built in, so everything on this list is one click away. Any other good third-party client works too.
 
 > [!WARNING]

--- a/README.zh.md
+++ b/README.zh.md
@@ -24,8 +24,6 @@ dsh plugin --profile web add dshmarket
 
 > ℹ️ **关于桌面客户端。** 本列表与客户端无关：一个插件被收录，是因为它遵守官方协议——声明 `dsh.bundle` manifest、可通过 `dsh plugin add` 安装——而不是因为它适配了某个特定客户端。
 >
-> 我们正在与 `anywhere-labs/deepseek-harness-desktop` 沟通重新合作的事，有进展会在这里同步。无论结果如何，收录标准不变：适配任何单一客户端都不是收录条件，也不会有插件因为没有适配某个客户端而被移除或降权。
->
 > 值得一试的客户端：[dsh-desktop](https://github.com/dataelement/dsh-desktop) 与 [deepseek-harness-desktop](https://github.com/hairyf/deepseek-harness-desktop)——两者均内嵌 dsh-market，本列表的插件一键即达。其他优秀的第三方客户端同样可以。
 
 > [!WARNING]


### PR DESCRIPTION
移除 README 中关于与 anywhere-labs 洽谈合作的那一段（中英各一处）。

README 不适合用来跟踪一段进行中的对话——它会悄悄过期，而且读起来像一个没人做出过的承诺。

**收录原则不会因此丢失**：上一段已经把它说全了——「一个插件被收录，是因为它遵守官方协议，而不是因为它适配了某个特定客户端」。

`node scripts/generate-readme.mjs --check` 通过，改动只在手工维护的 intro 区域，与生成的插件列表无关。