### PR TITLE
chore(dsh-dual-auto): tarball -> v0.1.2 (fix: cordis.patch.yml in files)

### DIFF
--- a/data/plugins/lengquan88__dsh-dual-auto.yml
+++ b/data/plugins/lengquan88__dsh-dual-auto.yml
@@ -1,7 +1,7 @@
 url: https://github.com/lengquan88/dsh-dual-auto
 name: lengquan88/dsh-dual-auto
 category: tools
-tarball: https://github.com/lengquan88/dsh-dual-auto/releases/latest/download/lengquan88-dsh-dual-auto-0.1.1.tgz
+tarball: https://github.com/lengquan88/dsh-dual-auto/releases/latest/download/lengquan88-dsh-dual-auto-0.1.2.tgz
 description:
   zh: "双模型 Auto 路由插件：低成本模型直返 / 高成本模型升级 + 逃逸学习闭环（直返答错自动学习指纹，同指纹下次强制升级），状态持久化并与 Python ModelRouter 互通。"
   en: "Dual-model auto-routing plugin: low-cost direct / high-cost upgrade with an escape-learning closed loop (wrong direct answers auto-learn fingerprints, force-upgrading the same fingerprint next time), persisted and interoperable with the Python ModelRouter."


### PR DESCRIPTION
v0.1.1 旧资产缺 cordis.patch.yml (package files 白名单不含), dsh plugin add 时 ENOENT 安装失败 — 已实测确认。
v0.1.2 files 已含 patch, 端到端安装 + patch 注入验证通过 (dsh plugin add + --dump-config)。
本 PR 仅把 tarball 指针移到 0.1.2(修复版)。