### PR TITLE
feat: add dsh-docking-layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 - [a903067276-rgb/dsh-hud](https://github.com/a903067276-rgb/dsh-hud) - HUD status panel: Git status, MCP servers, skills, model and token usage in a floating side panel.
 - [a903067276-rgb/dsh-plan-switch](https://github.com/a903067276-rgb/dsh-plan-switch) - One-click enter/exit Plan mode for the DSH web input bar, a quick-click shortcut for /plan.
 - [AcidGr/dsh-web-mobile-fix](https://github.com/AcidGr/dsh-web-mobile-fix) - Mobile layout fixes for the Web UI on narrow screens: full-screen settings panel, one-row plugin nav, full-screen sidebar, centered popups, icon-only session-log button.
+- [ai-eks/dsh-docking-layout](https://github.com/ai-eks/dsh-docking-layout) - Dockable DSH Web UI layout that organizes conversations as tabs across draggable split groups.
 - [Aik358/dsh-anchored-monitor](https://github.com/Aik358/dsh-anchored-monitor) - A whip for DeepSeek V4 Pro: it watches the reasoning fingerprint of every thinking block and pulls the model back when it slips from focused "We will / I will" mode into scattered "let me" mode.
 - [AikenFra/dsh-alive](https://github.com/AikenFra/dsh-alive) - Zero-token online status indicator for the DeepSeek Harness web UI: an always-visible online/offline dot in the conversation header, auto-refreshed every 15 seconds with no LLM calls.
 - [AKIRACOD/dsh-drag-and-drop](https://github.com/AKIRACOD/dsh-drag-and-drop) - File-drag fork: drop documents as removable chips above the composer, send without typing.

--- a/README.zh.md
+++ b/README.zh.md
@@ -89,6 +89,7 @@ dsh plugin --profile web add dshmarket
 - [a903067276-rgb/dsh-hud](https://github.com/a903067276-rgb/dsh-hud) — HUD 状态面板：Git 状态、MCP 服务器、技能列表、模型与 token 用量，悬浮侧栏一览无余。
 - [a903067276-rgb/dsh-plan-switch](https://github.com/a903067276-rgb/dsh-plan-switch) — 输入框一键进/出 Plan 模式（/plan 的快捷点击），常驻小按钮。
 - [AcidGr/dsh-web-mobile-fix](https://github.com/AcidGr/dsh-web-mobile-fix) — Web UI 移动端布局修复：窄屏下设置面板全屏化、插件导航单行排满、侧边栏全屏、弹层居中、会话日志按钮图标化。
+- [ai-eks/dsh-docking-layout](https://github.com/ai-eks/dsh-docking-layout) — 可停靠的 DSH Web UI 布局插件，将对话组织为标签页，并支持拖拽拆分对话分组。
 - [Aik358/dsh-anchored-monitor](https://github.com/Aik358/dsh-anchored-monitor) — 给 DeepSeek V4 Pro 的鞭子：实时监听每个思维块的指纹，当模型从专注的 We will / I will 模式滑向发散的 let me 模式时把它拉回来。
 - [AikenFra/dsh-alive](https://github.com/AikenFra/dsh-alive) — 零 token 在线状态指示器：会话头部常驻显示 ● 在线 / ● 离线 状态点，每 15 秒自动检测一次，不调用任何 LLM。
 - [AKIRACOD/dsh-drag-and-drop](https://github.com/AKIRACOD/dsh-drag-and-drop) — 拖放 fork：文档以可删除「文件芯片」挂在输入框上方，不打字也能发送。

--- a/data/plugins/ai-eks__dsh-docking-layout.yml
+++ b/data/plugins/ai-eks__dsh-docking-layout.yml
@@ -1,0 +1,6 @@
+url: https://github.com/ai-eks/dsh-docking-layout
+name: ai-eks/dsh-docking-layout
+category: ui
+description:
+  en: Dockable DSH Web UI layout that organizes conversations as tabs across draggable split groups.
+  zh: 可停靠的 DSH Web UI 布局插件，将对话组织为标签页，并支持拖拽拆分对话分组。


### PR DESCRIPTION
## Summary

- add `ai-eks/dsh-docking-layout` to the UI category
- provide concise English and Chinese descriptions
- regenerate both README files from the plugin data

## Validation

- [x] I added **one file** at `data/plugins/<owner>__<repo>.yml` — the READMEs are generated, don't edit them by hand / 我新增了一个 `data/plugins/<owner>__<repo>.yml` 文件（各语言 README 由脚本生成，不要手工编辑）
- [x] I ran `node scripts/generate-readme.mjs` and committed the regenerated READMEs / 我已执行 `node scripts/generate-readme.mjs` 并提交了重新生成的 README
- [x] My repo's `package.json` declares **`dsh.bundle`** (not just `dsh.client`) / 仓库 `package.json` 已声明 `dsh.bundle`
- [x] My repo is at least **1 day old with 10+ commits** / 仓库创建满 1 天且提交数不少于 10
- [x] `category` is `ui` / 分类使用 `ui`
- [x] Description states what the plugin does, with no superlatives / 描述只陈述插件功能
- [x] My repo has the `dsh-plugin` topic / 仓库已添加 `dsh-plugin` topic

Local checks passed: submission gate, generated README check, `awesome-lint`, site build, and `git diff --check`.
