### PR TITLE
feat: DeepTrial/dsh-bash-rtk — add prebuilt tarball

### DIFF
--- a/data/plugins/DeepTrial__dsh-bash-rtk.yml
+++ b/data/plugins/DeepTrial__dsh-bash-rtk.yml
@@ -1,7 +1,7 @@
 url: https://github.com/DeepTrial/dsh-bash-rtk
 name: DeepTrial/dsh-bash-rtk
 category: tools
-tarball: https://github.com/DeepTrial/dsh-bash-rtk/releases/latest/download/deeptrial-dsh-bash-rtk-0.1.1.tgz
+tarball: https://github.com/DeepTrial/dsh-bash-rtk/releases/latest/download/dsh-bash-rtk-latest.tgz
 description:
   en: Route eligible shell commands through rtk to compress tool output and save tokens.
   zh: 将符合条件的 shell 命令路由给 rtk，压缩工具输出并节省 token。

--- a/data/plugins/DeepTrial__dsh-bash-rtk.yml
+++ b/data/plugins/DeepTrial__dsh-bash-rtk.yml
@@ -1,7 +1,7 @@
 url: https://github.com/DeepTrial/dsh-bash-rtk
 name: DeepTrial/dsh-bash-rtk
 category: tools
-tarball: https://github.com/DeepTrial/dsh-bash-rtk/releases/latest/download/dsh-bash-rtk-0.1.1.tgz
+tarball: https://github.com/DeepTrial/dsh-bash-rtk/releases/latest/download/deeptrial-dsh-bash-rtk-0.1.1.tgz
 description:
   en: Route eligible shell commands through rtk to compress tool output and save tokens.
   zh: 将符合条件的 shell 命令路由给 rtk，压缩工具输出并节省 token。

--- a/data/plugins/DeepTrial__dsh-bash-rtk.yml
+++ b/data/plugins/DeepTrial__dsh-bash-rtk.yml
@@ -1,6 +1,7 @@
 url: https://github.com/DeepTrial/dsh-bash-rtk
 name: DeepTrial/dsh-bash-rtk
 category: tools
+tarball: https://github.com/DeepTrial/dsh-bash-rtk/releases/latest/download/dsh-bash-rtk-0.1.1.tgz
 description:
   en: Route eligible shell commands through rtk to compress tool output and save tokens.
   zh: 将符合条件的 shell 命令路由给 rtk，压缩工具输出并节省 token。


### PR DESCRIPTION
Add tarball: field pointing at the GitHub Release prebuilt tarball for DeepTrial/dsh-bash-rtk.

The plugin's lib/ is build output (not committed to the repo), so build-from-source installs failed dsh-market's loadable-entry check. The tarball carries the compiled lib/ + manifests, so the market now offers a prebuilt install instead.

Verified: tarball downloads (HTTP 200) and contains lib/index.js, dsh.plugin.json, cordis.patch.yml.