### PR TITLE
Fix dsh-undo-plugin display name

### DIFF
--- a/README.md
+++ b/README.md
@@ -677,7 +677,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 
 ### Sessions & Messages
 
-- [23swccp/dsh-undo#bundle-rollback](https://github.com/23swccp/dsh-undo/tree/master/packages/bundle-rollback) - Conversation undo: roll a session back to before any sent prompt via /undo, the session-header button, or the icon under the message, restoring files from a plugin-private shadow-Git snapshot and forking the conversation so the model never sees the reverted turns; includes an Archive Tasks settings page and per-tool colored tool cards.
+- [dsh-undo-plugin](https://github.com/23swccp/dsh-undo/tree/master/packages/bundle-rollback) - Conversation undo: roll a session back to before any sent prompt via /undo, the session-header button, or the icon under the message, restoring files from a plugin-private shadow-Git snapshot and forking the conversation so the model never sees the reverted turns; includes an Archive Tasks settings page and per-tool colored tool cards.
 - [3403473060/dsh-inline-images](https://github.com/3403473060/dsh-inline-images) - Render local image paths from assistant replies inline in the message body (9 formats, click-to-zoom lightbox, adjustable size).
 - [AKS1st/dsh-archived-conversations](https://github.com/AKS1st/dsh-archived-conversations) - Archived conversations list in the sidebar footer with read-only previews of the most recent messages, for sessions the product deliberately keeps hidden and unreopenable.
 - [Anionex/dsh-turn-rewind](https://github.com/Anionex/dsh-turn-rewind) - Rewind conversation and workspace state, powered by a persistent Change Ledger.

--- a/README.md
+++ b/README.md
@@ -677,7 +677,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 
 ### Sessions & Messages
 
-- [dsh-undo-plugin](https://github.com/23swccp/dsh-undo/tree/master/packages/bundle-rollback) - Conversation undo: roll a session back to before any sent prompt via /undo, the session-header button, or the icon under the message, restoring files from a plugin-private shadow-Git snapshot and forking the conversation so the model never sees the reverted turns; includes an Archive Tasks settings page and per-tool colored tool cards.
+- [dsh-undo-plugin](https://github.com/23swccp/dsh-undo/tree/master/packages/bundle-rollback) - Conversation and workspace undo: use the /undo timeline, session-header action, or message icon to roll back before any sent prompt; private Shadow Git snapshots restore files, the reverted turns stay out of model context, and Undo Rollback can recover mistakes. Includes archived-session management and per-tool colored cards.
 - [3403473060/dsh-inline-images](https://github.com/3403473060/dsh-inline-images) - Render local image paths from assistant replies inline in the message body (9 formats, click-to-zoom lightbox, adjustable size).
 - [AKS1st/dsh-archived-conversations](https://github.com/AKS1st/dsh-archived-conversations) - Archived conversations list in the sidebar footer with read-only previews of the most recent messages, for sessions the product deliberately keeps hidden and unreopenable.
 - [Anionex/dsh-turn-rewind](https://github.com/Anionex/dsh-turn-rewind) - Rewind conversation and workspace state, powered by a persistent Change Ledger.

--- a/README.zh.md
+++ b/README.zh.md
@@ -677,7 +677,7 @@ dsh plugin --profile web add dshmarket
 
 ### 💬 会话与消息
 
-- [23swccp/dsh-undo#bundle-rollback](https://github.com/23swccp/dsh-undo/tree/master/packages/bundle-rollback) — 对话撤销：通过 /undo、会话头部按钮或消息下方图标把会话回滚到任意已发送 prompt 之前，文件由插件私有 Shadow Git 快照恢复、会话 fork 成新分支，模型看不到被回滚的回合；附带归档任务设置页与工具卡片按类型着色。
+- [dsh-undo-plugin](https://github.com/23swccp/dsh-undo/tree/master/packages/bundle-rollback) — 对话撤销：通过 /undo、会话头部按钮或消息下方图标把会话回滚到任意已发送 prompt 之前，文件由插件私有 Shadow Git 快照恢复、会话 fork 成新分支，模型看不到被回滚的回合；附带归档任务设置页与工具卡片按类型着色。
 - [3403473060/dsh-inline-images](https://github.com/3403473060/dsh-inline-images) — 对话内联图片：LLM 回复中输出的本地图片路径在消息正文直接渲染为图片（9 种格式、点击放大灯箱、可调尺寸）。
 - [AKS1st/dsh-archived-conversations](https://github.com/AKS1st/dsh-archived-conversations) — 侧边栏底部的已归档对话列表，可只读预览最近消息；针对产品刻意隐藏且无法重新打开的归档会话。
 - [Anionex/dsh-turn-rewind](https://github.com/Anionex/dsh-turn-rewind) — 对话回退：基于持久 Change Ledger 回滚会话与工作区状态。

--- a/README.zh.md
+++ b/README.zh.md
@@ -677,7 +677,7 @@ dsh plugin --profile web add dshmarket
 
 ### 💬 会话与消息
 
-- [dsh-undo-plugin](https://github.com/23swccp/dsh-undo/tree/master/packages/bundle-rollback) — 对话撤销：通过 /undo、会话头部按钮或消息下方图标把会话回滚到任意已发送 prompt 之前，文件由插件私有 Shadow Git 快照恢复、会话 fork 成新分支，模型看不到被回滚的回合；附带归档任务设置页与工具卡片按类型着色。
+- [dsh-undo-plugin](https://github.com/23swccp/dsh-undo/tree/master/packages/bundle-rollback) — 对话与工作区撤销：通过 /undo 节点轴、会话头部按钮或消息下方图标回滚到任意已发送 prompt 之前；插件私有 Shadow Git 快照恢复文件，被回滚回合不会进入模型上下文，误操作还能“撤回回滚”。附带归档会话管理与工具卡片分类配色。
 - [3403473060/dsh-inline-images](https://github.com/3403473060/dsh-inline-images) — 对话内联图片：LLM 回复中输出的本地图片路径在消息正文直接渲染为图片（9 种格式、点击放大灯箱、可调尺寸）。
 - [AKS1st/dsh-archived-conversations](https://github.com/AKS1st/dsh-archived-conversations) — 侧边栏底部的已归档对话列表，可只读预览最近消息；针对产品刻意隐藏且无法重新打开的归档会话。
 - [Anionex/dsh-turn-rewind](https://github.com/Anionex/dsh-turn-rewind) — 对话回退：基于持久 Change Ledger 回滚会话与工作区状态。

--- a/data/plugins/23swccp__dsh-undo--packages-bundle-rollback.yml
+++ b/data/plugins/23swccp__dsh-undo--packages-bundle-rollback.yml
@@ -1,5 +1,5 @@
 url: https://github.com/23swccp/dsh-undo/tree/master/packages/bundle-rollback
-name: 23swccp/dsh-undo#bundle-rollback
+name: dsh-undo-plugin
 category: session
 description:
   en: 'Conversation undo: roll a session back to before any sent prompt via /undo, the session-header button, or the icon under the message, restoring files from a plugin-private shadow-Git snapshot and forking the conversation so the model never sees the reverted turns; includes an Archive Tasks settings page and per-tool colored tool cards.'

--- a/data/plugins/23swccp__dsh-undo--packages-bundle-rollback.yml
+++ b/data/plugins/23swccp__dsh-undo--packages-bundle-rollback.yml
@@ -2,5 +2,5 @@ url: https://github.com/23swccp/dsh-undo/tree/master/packages/bundle-rollback
 name: dsh-undo-plugin
 category: session
 description:
-  en: 'Conversation undo: roll a session back to before any sent prompt via /undo, the session-header button, or the icon under the message, restoring files from a plugin-private shadow-Git snapshot and forking the conversation so the model never sees the reverted turns; includes an Archive Tasks settings page and per-tool colored tool cards.'
-  zh: '对话撤销：通过 /undo、会话头部按钮或消息下方图标把会话回滚到任意已发送 prompt 之前，文件由插件私有 Shadow Git 快照恢复、会话 fork 成新分支，模型看不到被回滚的回合；附带归档任务设置页与工具卡片按类型着色。'
+  en: 'Conversation and workspace undo: use the /undo timeline, session-header action, or message icon to roll back before any sent prompt; private Shadow Git snapshots restore files, the reverted turns stay out of model context, and Undo Rollback can recover mistakes. Includes archived-session management and per-tool colored cards.'
+  zh: '对话与工作区撤销：通过 /undo 节点轴、会话头部按钮或消息下方图标回滚到任意已发送 prompt 之前；插件私有 Shadow Git 快照恢复文件，被回滚回合不会进入模型上下文，误操作还能“撤回回滚”。附带归档会话管理与工具卡片分类配色。'


### PR DESCRIPTION
Updates the existing 23swccp/dsh-undo marketplace entry display name from the monorepo subdirectory name to the published npm bundle name dsh-undo-plugin. The source URL and automatic npm mapping remain unchanged. The generated English and Chinese READMEs were refreshed with the repository generator.