### PR TITLE
fix: use versionless tarball asset name for dsh-bubble-explain

### DIFF
--- a/data/plugins/Hanmiao33__dsh-bubble-explain.yml
+++ b/data/plugins/Hanmiao33__dsh-bubble-explain.yml
@@ -4,4 +4,4 @@ category: ui
 description:
   en: "Select any text in a conversation and tap the Explain button to get a streaming Markdown explanation bubble, with recursive follow-up questions."
   zh: "对话中框选任意文字后点击「解释」按钮，弹出 Markdown 实时流式解释气泡，支持递归追问。"
-tarball: "https://github.com/Hanmiao33/dsh-bubble-explain/releases/latest/download/dsh-external-bubble-explain-0.0.1.tgz"
+tarball: "https://github.com/Hanmiao33/dsh-bubble-explain/releases/latest/download/dsh-external-bubble-explain.tgz"


### PR DESCRIPTION
Addresses maintainer feedback from PR #2855 (and the known failure mode in issue #1619).

**Change:** entry's `tarball:` for `Hanmiao33/dsh-bubble-explain` now points to the versionless asset filename:

```
https://github.com/Hanmiao33/dsh-bubble-explain/releases/latest/download/dsh-external-bubble-explain.tgz
```

**Why:** the previous filename pinned the version (`...-0.0.1.tgz`). When v0.0.2 is released, `releases/latest` moves but the versioned filename disappears → the link would silently 404 (10 of 15 tarballs in issue #1619 broke exactly this way). Using a versionless asset name, `releases/latest/download/...` tracks the newest release forever with no entry edits.

Verified the new URL returns HTTP 200 (Content-Length 34883, application/octet-stream).