### PR TITLE
Add dsh-client-ui-second-brain (AI Second Brain)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1361,6 +1361,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 ### Docs & Rendering
 
 - [3361805598-gif/dsh-md-annotator](https://github.com/3361805598-gif/dsh-md-annotator) - Markdown sidebar preview and source editor for dsh-better-sidebar, with block- and text-range annotations that can be sent to the conversation as structured revision requests.
+- [aduo-111/second-brain](https://github.com/aduo-111/second-brain) - Distills daily AI conversations (Doubao, ChatGPT, DeepSeek, Kimi) into structured Markdown notes in your Obsidian vault.
 - [AKS1st/dsh-mermaid](https://github.com/AKS1st/dsh-mermaid) - Render Mermaid code fences in DSH Web chat messages as lazy-loaded SVG diagrams with strict sanitization and light/dark theme follow.
 - [baconbao/dsh-mermaid-image-preview](https://github.com/baconbao/dsh-mermaid-image-preview) - Preview Mermaid diagrams as images via local rendering in DSH Web when the chat message contains a Mermaid fenced code block, and also allow integration with external rendering servers.
 - [bill9109/dsh-101](https://github.com/bill9109/dsh-101) - Document reading mode for DSH.

--- a/README.zh.md
+++ b/README.zh.md
@@ -1361,6 +1361,7 @@ dsh plugin --profile web add dshmarket
 ### 📄 文档与渲染
 
 - [3361805598-gif/dsh-md-annotator](https://github.com/3361805598-gif/dsh-md-annotator) — 面向 dsh-better-sidebar 扩展的 Markdown 侧边栏预览与源码编辑器，支持块级和文本选区批注，并可将批注作为结构化修改请求发送到对话框。
+- [aduo-111/second-brain](https://github.com/aduo-111/second-brain) — 把每天和各种 AI 的对话提炼成结构化 Markdown 笔记，写入你的 Obsidian 库。
 - [AKS1st/dsh-mermaid](https://github.com/AKS1st/dsh-mermaid) — 把 DSH Web 会话消息中的 Mermaid 代码围栏渲染为惰性加载的 SVG 图表，严格消毒并跟随明暗主题。
 - [baconbao/dsh-mermaid-image-preview](https://github.com/baconbao/dsh-mermaid-image-preview) — 当 DSH Web 中的消息包含 Mermaid 语法时，通过本地渲染以图像形式预览 Mermaid Diagrams，并允许接入外部渲染服务器。
 - [bill9109/dsh-101](https://github.com/bill9109/dsh-101) — DSH 文档阅读模式。

--- a/data/plugins/aduo-111__second-brain.yml
+++ b/data/plugins/aduo-111__second-brain.yml
@@ -1,0 +1,6 @@
+url: https://github.com/aduo-111/second-brain
+name: aduo-111/second-brain
+category: docs
+description:
+  en: 'Distills daily AI conversations (Doubao, ChatGPT, DeepSeek, Kimi) into structured Markdown notes in your Obsidian vault.'
+  zh: '把每天和各种 AI 的对话提炼成结构化 Markdown 笔记，写入你的 Obsidian 库。'


### PR DESCRIPTION
Add [dsh-client-ui-second-brain](https://github.com/aduo-111/second-brain) — **AI 第二大脑 / AI Second Brain**: distill daily AI conversations (Doubao / ChatGPT / DeepSeek / Kimi…) into structured Markdown notes in your Obsidian vault.

- Declares a `dsh.bundle` manifest (bundle patch mounts `second-brain`), installable via `dsh plugin --profile web add dsh-client-ui-second-brain`
- npm package: `dsh-client-ui-second-brain` (1.0.2, repository points back to this repo)
- Category: docs