### PR TITLE
fix(catalog): use stable dsh-desktop-kit tarball

### DIFF
--- a/data/plugins/MDR-EX1000__dsh-desktop-kit.yml
+++ b/data/plugins/MDR-EX1000__dsh-desktop-kit.yml
@@ -1,7 +1,7 @@
 url: https://github.com/MDR-EX1000/dsh-desktop-kit
 name: MDR-EX1000/dsh-desktop-kit
 category: ui
-tarball: https://github.com/MDR-EX1000/dsh-desktop-kit/releases/latest/download/dsh-desktop-kit-0.1.0.tgz
+tarball: https://github.com/MDR-EX1000/dsh-desktop-kit/releases/latest/download/dsh-desktop-kit.tgz
 description:
   en: 'macOS desktop shell for the DSH web UI: a plugin plus a small Tauri/WKWebView window over the loopback web surface — real macOS fullscreen, single instance, external links delegated to the system browser, and browser-style zoom.'
   zh: '把 DSH Web UI 装进原生 macOS 桌面窗口：插件 + 轻量 Tauri/WKWebView 外壳跑在同一个 loopback 地址上——真 macOS 全屏、单实例、外链交给系统浏览器、类浏览器页面缩放。'


### PR DESCRIPTION
## Summary

Update the existing `MDR-EX1000/dsh-desktop-kit` catalog entry to use the stable, version-free release asset:

```text
https://github.com/MDR-EX1000/dsh-desktop-kit/releases/latest/download/dsh-desktop-kit.tgz
```

The `v0.2.1` release now contains `dsh-desktop-kit.tgz`; it is byte-for-byte identical to the versioned plugin tarball. Future releases will upload the same stable filename automatically.

The dsh-rw catalog entry already uses its stable `dsh-rw.tgz` URL and is intentionally unchanged.

## Verification

- `node scripts/generate-readme.mjs --check`
- `GITHUB_TOKEN=... node scripts/check-submission.mjs --base upstream/main`
- `npx awesome-lint` (passes; existing spelling warnings only)
- `git diff --check`
- Verified the `v0.2.1` stable asset exists and matches `dsh-desktop-kit-0.2.1.tgz` (sha256 `d679edd5c1b5ef295b6d3aceb718d932c4552a14c4c303b97882b7819e3177d8`)