### PR TITLE
add 0QwQ0/dsh-discord-richpresence (notify): Discord Rich Presence for DSH interaction states

### DIFF
--- a/README.md
+++ b/README.md
@@ -1675,6 +1675,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 
 ### Notifications & Integrations
 
+- [0QwQ0/dsh-discord-richpresence](https://github.com/0QwQ0/dsh-discord-richpresence) - Push vague or rich, user-configurable DSH interaction states to the local Discord client as Rich Presence — real-time, content-free, with a user-editable status list and an optional rich-mode toggle in Settings.
 - [534119219/chicheng-push](https://github.com/534119219/chicheng-push) - Multi-channel push for DeepSeek Harness: Server酱, PushPlus, Bark, DingTalk, WeCom, Telegram, Feishu, ntfy, custom webhooks and more, configurable from the settings panel and callable by other plugins via the pushNotifier service.
 - [534119219/dsh-messaging#messaging-core](https://github.com/534119219/dsh-messaging/tree/main/packages/messaging-core) - Unified messaging gateway for DeepSeek Harness: 27 IM platforms (Telegram, QQ, WeChat, Discord, WhatsApp, Feishu and more) in one plugin, with QR scan-to-authorize, per-platform workspaces, slash commands, and a web setup dialog.
 - [988hj7tczd-oss/dsh-im-qq](https://github.com/988hj7tczd-oss/dsh-im-qq) - QQ official bot (q.qq.com) integration for DeepSeek Harness: chat with the full agent from private chats, groups and channels — WS long connection (heartbeat / reconnect / RESUME), per-chat session isolation, standard agent preset, approval inline buttons with /revoke, slash commands, whitelist fail-closed, credentials via the credentials domain.

--- a/README.zh.md
+++ b/README.zh.md
@@ -1675,6 +1675,7 @@ dsh plugin --profile web add dshmarket
 
 ### 🔔 通知与集成
 
+- [0QwQ0/dsh-discord-richpresence](https://github.com/0QwQ0/dsh-discord-richpresence) — 将模糊或丰富的 DSH 交互状态实时推送到本地 Discord 客户端作为 Rich Presence——不携带任何工作区内容，状态消息列表可自由编辑，并可在设置中切换丰富模式。
 - [534119219/chicheng-push](https://github.com/534119219/chicheng-push) — DSH 多渠道消息推送插件：支持 Server酱、PushPlus、Bark、钉钉、企业微信、Telegram、飞书、ntfy、自定义 Webhook 等，可在设置面板配置多个渠道，并通过 pushNotifier 服务供其他插件调用。
 - [534119219/dsh-messaging#messaging-core](https://github.com/534119219/dsh-messaging/tree/main/packages/messaging-core) — DeepSeek Harness 的统一消息网关：一个插件接入 27 个 IM 平台（Telegram、QQ、微信、Discord、WhatsApp、飞书等），支持扫码授权、每平台独立工作区、斜杠命令与 Web 配置弹窗。
 - [988hj7tczd-oss/dsh-im-qq](https://github.com/988hj7tczd-oss/dsh-im-qq) — 接入 QQ 官方机器人（q.qq.com）：私聊 / 群聊 / 频道 @ 与完整 agent 对话——WS 长连接（心跳 / 重连 / RESUME）、每会话隔离、标准 agent preset、审批内联按钮 + /revoke、斜杠命令、白名单 fail-closed、凭据走凭据域。

--- a/data/plugins/0QwQ0__dsh-discord-richpresence.yml
+++ b/data/plugins/0QwQ0__dsh-discord-richpresence.yml
@@ -1,0 +1,7 @@
+url: https://github.com/0QwQ0/dsh-discord-richpresence
+name: 0QwQ0/dsh-discord-richpresence
+category: notify
+description:
+  en: Push vague or rich, user-configurable DSH interaction states to the local Discord client as Rich Presence — real-time, content-free, with a user-editable status list and an optional rich-mode toggle in Settings.
+  zh: 将模糊或丰富的 DSH 交互状态实时推送到本地 Discord 客户端作为 Rich Presence——不携带任何工作区内容，状态消息列表可自由编辑，并可在设置中切换丰富模式。
+tarball: https://github.com/0QwQ0/dsh-discord-richpresence/releases/latest/download/dsh-discord-richpresence-0.2.2.tgz


### PR DESCRIPTION
Adds **one** entry: \data/plugins/0QwQ0__dsh-discord-richpresence.yml\ (category \
otify\).

**What it does** (matches the description line for line):
- Pushes the user's DSH interaction state to the **local Discord client** as Rich Presence — real-time and content-free: no session titles, message text, file paths, or tool output ever reach Discord.
- Default mode: vague, user-editable status lines (e.g. \正在指挥大肥鱼干活\) grouped by interaction phase (userInput / agentWorking / tools / forking / idle).
- Optional **rich mode** toggle in Settings → General: smarter data-driven status lines (thinking turn/step, total input tokens via \	okenMeter\, elapsed LLM thinking time, typing hints), picked intelligently and randomly, each staying on screen ≥ 8 s.
- Rich-mode data is tied to the session the user is currently interacting with (\source.kind === 'user'\); subagent and background-session events never leak in.
- Dependency-free Discord RPC client over the local IPC frame protocol (named pipe / TCP fallback, handshake, \SET_ACTIVITY\, ping/pong, reconnect).

**Rule compliance:**
- \dsh.bundle\ manifest declared in \package.json\ (\dsh.bundle.patch\ + \cordis.patch.yml\), installable via \dsh plugin add\. ✅
- \dsh-plugin\ topic added to the repo. ✅
- Repo age / commit count: repo predates this PR by 2+ days; 11 commits. ✅
- \	arball:\ points at the v0.2.2 GitHub Release asset (\dsh-discord-richpresence-0.2.2.tgz\). ✅
- \@deepseek-ai/cordis\, \@deepseek-ai/dsh-settings\ (with prerelease branch), \@deepseek-ai/schemastery\ declared as \peerDependencies\. ✅
- READMEs regenerated with \
ode scripts/generate-readme.mjs\; no other entry touched. ✅