### PR TITLE
Add dsh-side-chat screenshots entry

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -1303,4 +1303,11 @@
   "https://raw.githubusercontent.com/PolinniZhong/dsh-personal-center/main/docs/screenshots/pet-emotions.gif",
   "https://raw.githubusercontent.com/PolinniZhong/dsh-personal-center/main/docs/screenshots/dark-model-cost.png"
  ]
+,
+ "https://github.com/KarlOfLaw/dsh-side-chat": [
+  "https://raw.githubusercontent.com/KarlOfLaw/dsh-side-chat/main/docs/assets/dsh-side-chat-hero.png",
+  "https://raw.githubusercontent.com/KarlOfLaw/dsh-side-chat/main/docs/assets/side-chat-parallel.png",
+  "https://raw.githubusercontent.com/KarlOfLaw/dsh-side-chat/main/docs/assets/side-chat-selection.png",
+  "https://raw.githubusercontent.com/KarlOfLaw/dsh-side-chat/main/docs/assets/side-chat-settings.png"
+ ]
 }


### PR DESCRIPTION
Follow-up to #2886 (KarlOfLaw/dsh-side-chat, merged): adds the screenshots entry for the storefront detail view.

- Keyed by the merged entry URL, 4 images hosted in the plugin repo own docs/assets folder (GitHub hosting, per the privacy rule).
- Screenshots were intentionally left out of #2886 to avoid repeated collisions on this shared file tail.

为已合并的 KarlOfLaw/dsh-side-chat 补充市场截图条目（4 张，均托管在插件自身仓库）。