### PR TITLE
Update StrataGate tarball to 0.2.26

### DIFF
--- a/data/plugins/diqierjia__StrataGate-AgentMemory--integrations-deepseek-harness.yml
+++ b/data/plugins/diqierjia__StrataGate-AgentMemory--integrations-deepseek-harness.yml
@@ -1,5 +1,5 @@
 url: https://github.com/diqierjia/StrataGate-AgentMemory/tree/main/integrations/deepseek-harness
-tarball: https://github.com/diqierjia/StrataGate-AgentMemory/releases/download/stratagate-dsh-v0.2.21/stratagate-dsh-0.2.21.tgz
+tarball: https://github.com/diqierjia/StrataGate-AgentMemory/releases/download/stratagate-dsh-v0.2.25/stratagate-dsh-0.2.25.tgz
 name: diqierjia/StrataGate-AgentMemory
 category: memory
 description:

--- a/data/plugins/diqierjia__StrataGate-AgentMemory--integrations-deepseek-harness.yml
+++ b/data/plugins/diqierjia__StrataGate-AgentMemory--integrations-deepseek-harness.yml
@@ -1,5 +1,5 @@
 url: https://github.com/diqierjia/StrataGate-AgentMemory/tree/main/integrations/deepseek-harness
-tarball: https://github.com/diqierjia/StrataGate-AgentMemory/releases/download/stratagate-dsh-v0.2.25/stratagate-dsh-0.2.25.tgz
+tarball: https://github.com/diqierjia/StrataGate-AgentMemory/releases/download/stratagate-dsh-v0.2.26/stratagate-dsh-0.2.26.tgz
 name: diqierjia/StrataGate-AgentMemory
 category: memory
 description:


### PR DESCRIPTION
## Summary
- point the existing StrataGate marketplace entry at the 0.2.26 GitHub Release tarball
- keep the existing reviewed category and descriptions unchanged

## Source release
- https://github.com/diqierjia/StrataGate-AgentMemory/releases/tag/stratagate-dsh-v0.2.26
- npm: stratagate-dsh@0.2.26

## Validation
- tarball URL returns HTTP 200
- downloaded size: 1,617,288 bytes
- source package: 92 tests passed
- package clean-install/import verification passed
- marketplace diff contains one URL-only change