### PR TITLE
Add dsh-think-bounce-pet plugin to fun category

### DIFF
--- a/README.md
+++ b/README.md
@@ -2192,6 +2192,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 ### Just for Fun
 
 - [609476965/dsh-LorebookMD](https://github.com/609476965/dsh-LorebookMD) - Import SillyTavern/TavernAI character cards and world books, save them as local Markdown lore documents, and generate novel prose from your prompts with the world settings as reference.
+- [9livewolf/dsh-think-bounce-pet](https://github.com/9livewolf/dsh-think-bounce-pet) - This plugin lets two deepseek bounce around the interface—it has no real purpose.
 - [Aik358/dsh-draw-gacha](https://github.com/Aik358/dsh-draw-gacha) - Pull a 3D lever next to the send button and turn the model's reasoning signals into a pixel-art gacha reveal.
 - [AmeKrance/anan-thermal-monitor](https://github.com/AmeKrance/anan-thermal-monitor) - Purple-white desktop pet that docks to the screen edge and shows real-time CPU, RAM, GPU and NVMe temperatures with hardware info.
 - [AnacondaKC/dsh-douyin](https://github.com/AnacondaKC/dsh-douyin) - Short-video sidebar: native player, series navigation, precise history replay.

--- a/README.zh.md
+++ b/README.zh.md
@@ -2192,6 +2192,7 @@ dsh plugin --profile web add dshmarket
 ### 🎮 娱乐
 
 - [609476965/dsh-LorebookMD](https://github.com/609476965/dsh-LorebookMD) — 导入酒馆（SillyTavern/TavernAI）角色卡与世界书，落地为本地 Markdown 设定文档，激活创作模式后根据用户输入、参考世界书创作小说。
+- [9livewolf/dsh-think-bounce-pet](https://github.com/9livewolf/dsh-think-bounce-pet) — 这个插件的功能就是让两只大肥鱼在界面弹来弹去，无实意
 - [Aik358/dsh-draw-gacha](https://github.com/Aik358/dsh-draw-gacha) — 在发送按钮旁拉动 3D 拉杆，把模型思维链的文本信号变成一场像素风抽卡演出。
 - [AmeKrance/anan-thermal-monitor](https://github.com/AmeKrance/anan-thermal-monitor) — 紫白桌宠悬浮球，贴边停靠实时显示 CPU/内存/GPU/NVMe 温度与硬件信息。
 - [AnacondaKC/dsh-douyin](https://github.com/AnacondaKC/dsh-douyin) — 侧栏短视频：原生播放器、系列导航、精确历史回放。

--- a/data/plugins/9livewolf__dsh-think-bounce-pet.yml
+++ b/data/plugins/9livewolf__dsh-think-bounce-pet.yml
@@ -1,0 +1,6 @@
+url: https://github.com/9livewolf/dsh-think-bounce-pet
+name: 9livewolf/dsh-think-bounce-pet
+category: fun
+description:
+  en: 'This plugin lets two deepseek bounce around the interface—it has no real purpose.'
+  zh: '这个插件的功能就是让两只大肥鱼在界面弹来弹去，无实意'


### PR DESCRIPTION
Adds `dsh-think-bounce-pet` to the `fun` category.

The plugin lets two deepseek bounce around the interface - it has no real purpose.