### PR TITLE
add dsh-goal-mode-enhance screenshots

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -1320,4 +1320,10 @@
   "https://raw.githubusercontent.com/biggerboy/dsh-conversation-anchors/master/assets/anchors-hover.png",
   "https://raw.githubusercontent.com/biggerboy/dsh-conversation-anchors/master/assets/anchors-wave.png"
  ]
+,
+ "https://github.com/KarlOfLaw/dsh-goal-mode-enhance": [
+  "https://raw.githubusercontent.com/KarlOfLaw/dsh-goal-mode-enhance/main/assets/screenshot-goal-dock.png",
+  "https://raw.githubusercontent.com/KarlOfLaw/dsh-goal-mode-enhance/main/assets/screenshot-goal-create.png",
+  "https://raw.githubusercontent.com/KarlOfLaw/dsh-goal-mode-enhance/main/assets/screenshot-goal-chip.png"
+ ]
 }


### PR DESCRIPTION
Adds an AppStore-style screenshots entry for **[KarlOfLaw/dsh-goal-mode-enhance](https://github.com/KarlOfLaw/dsh-goal-mode-enhance)** (listed in #3040), keyed by its GitHub URL:

1. Goal dock in its completed state, coexisting with the native todo strip in the shared `conversation.input.dock` slot
2. The multiline create form with the optional round cap field
3. The collapsed chip state toggled from the composer tool-row entry

All three images live in the plugin's own repo under `assets/` on `main` (raw.githubusercontent.com, per the hosting rules), so they update with the project.