### PR TITLE
docs: add dsh-plugin-memos-code-retrospect to Memory list

### DIFF
--- a/data/plugins/ai-fu-cn__dsh-plugin-memos-code-retrospect.yml
+++ b/data/plugins/ai-fu-cn__dsh-plugin-memos-code-retrospect.yml
@@ -1,0 +1,6 @@
+url: https://github.com/ai-fu-cn/dsh-plugin-memos-code-retrospect
+name: ai-fu-cn/dsh-plugin-memos-code-retrospect
+category: memory
+description:
+  en: 'Coding retrospect distilled memory for DSH: distills rejected solutions, pitfalls and constraints from each turn via a local LLM, tags them into MemOS (type:rejected_solution), and boosts weighted recall on coding tasks via agent/pre-step.'
+  zh: '编码任务复盘记忆：每轮对话后用本地 LLM 蒸馏被否决方案/踩坑/工程约束，按 type:rejected_solution 写入 MemOS，编码任务时对这类记忆加权召回。'


### PR DESCRIPTION
Add [dsh-plugin-memos-code-retrospect](https://github.com/ai-fu-cn/dsh-plugin-memos-code-retrospect) to the Memory section.

Coding retrospect distilled memory for DSH: distills rejected solutions / pitfalls / constraints from each turn with a local LLM, tags them into MemOS (type:rejected_solution), and boosts weighted recall on coding tasks via agent/pre-step. 14 unit tests + 4 integration tests passing. MIT license. DSH + MemOS dependency.