### PR TITLE
Rename phone-lens subpackage path (packages/lens-mate -> packages/phone-lens)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1353,7 +1353,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 - [xing666173/dsh-vision-hub#tool-vision](https://github.com/xing666173/dsh-vision-hub/tree/main/tool-vision) - Enhanced vision toolbox: 14 pixel-level vision tools (describe, ground, detect, crop, pixel-diff, OCR, long-screenshot OCR, vectorize, colors, cutout, screenshot, present, materialize, html-screenshot) driven by one OpenAI-compatible endpoint, with clean \[图片: path] bridge markers, content-safety classification and rate-limit auto-retry.
 - [xsoc1/dsh-image-vision](https://github.com/xsoc1/dsh-image-vision) - Chat image-attachment bridge with a `view_image` tool for any OpenAI-compatible VLM (local Ollama or cloud): pasted/dropped images become `view_image` path markers before reaching text-only DeepSeek models.
 - [ysr666/dsh-vision-router](https://github.com/ysr666/dsh-vision-router) - Free vision for text-only agents: built-in keyless vision chain plus pixel tools (Q&A, grounding, crop, pixel diff, colors, OCR, SVG trace, cutout, screenshots); paste an image to use it.
-- [yxqfg/phone-lens#lens-mate](https://github.com/yxqfg/phone-lens/tree/main/packages/lens-mate) - Turn a phone camera into a live viewfinder and photo input for your dsh session, over LAN or USB.
+- [yxqfg/phone-lens#phone-lens](https://github.com/yxqfg/phone-lens/tree/main/packages/phone-lens) - Turn a phone camera into a live viewfinder and photo input for your dsh session, over LAN or USB.
 
 ### Voice & Audio
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -1353,7 +1353,7 @@ dsh plugin --profile web add dshmarket
 - [xing666173/dsh-vision-hub#tool-vision](https://github.com/xing666173/dsh-vision-hub/tree/main/tool-vision) — 增强版视觉工具箱:14 个像素级视觉工具(看图问答/定位/检测/裁剪/像素比对/OCR/长截图OCR/矢量化/取色/抠图/截图/展示/落盘/网页截图),单一 OpenAI 兼容端点驱动,桥接标记极简、规则下沉系统提示,带内容安全识别与限流自动重试。
 - [xsoc1/dsh-image-vision](https://github.com/xsoc1/dsh-image-vision) — 纯文本 DeepSeek 的聊天识图插件：view_image 工具转发任意 OpenAI 兼容 VLM（本地 Ollama 或云端），对话框粘贴/拖拽的图片自动改写为 view_image 路径标记供模型查看。
 - [ysr666/dsh-vision-router](https://github.com/ysr666/dsh-vision-router) — 为纯文本 Agent 提供视觉能力：内置免 Key 视觉链 + 像素级视觉工具（看图问答、定位、裁剪、像素对比、取色、OCR、矢量化、抠图、截图）；粘贴图片即可用。
-- [yxqfg/phone-lens#lens-mate](https://github.com/yxqfg/phone-lens/tree/main/packages/lens-mate) — 把手机相机变成 dsh 会话的实时取景与拍照输入，经局域网或 USB 直连。
+- [yxqfg/phone-lens#phone-lens](https://github.com/yxqfg/phone-lens/tree/main/packages/phone-lens) — 把手机相机变成 dsh 会话的实时取景与拍照输入，经局域网或 USB 直连。
 
 ### 🎙️ 语音与音频
 

--- a/data/plugins/yxqfg__phone-lens--packages-phone-lens.yml
+++ b/data/plugins/yxqfg__phone-lens--packages-phone-lens.yml
@@ -1,5 +1,5 @@
-url: https://github.com/yxqfg/phone-lens/tree/main/packages/lens-mate
-name: yxqfg/phone-lens#lens-mate
+url: https://github.com/yxqfg/phone-lens/tree/main/packages/phone-lens
+name: yxqfg/phone-lens#phone-lens
 category: vision
 tarball: https://github.com/yxqfg/phone-lens/releases/latest/download/phone-lens.tgz
 description:


### PR DESCRIPTION
Updates my own entry: the subpackage directory was renamed from \packages/lens-mate\ to \packages/phone-lens\ in yxqfg/phone-lens@e70da19, so the URL and name now point at the new path. Description, category, and tarball are unchanged.