### PR TITLE
Point dsh-tradingagents tarball at v0.3.0 (structured decision records)

### DIFF
--- a/data/plugins/megatronyy__dsh-tradingagents.yml
+++ b/data/plugins/megatronyy__dsh-tradingagents.yml
@@ -4,4 +4,4 @@ category: tools
 description:
   en: A-share multi-agent analysis behind /trading-agent, ported from TradingAgents-AShare, running 14 roles (analysts, bull/bear debate, risk review, trader) through the harness LLM route.
   zh: /trading-agent 命令背后的 A 股多智能体分析，移植自 TradingAgents-AShare：14 个角色（分析师、多空辩论、风控、交易员）经 dsh 已配置的模型路由协作产出完整投研报告。
-tarball: https://github.com/megatronyy/dsh-tradingagents/releases/download/v0.2.0/dsh-tradingagents-0.2.0.tgz
+tarball: https://github.com/megatronyy/dsh-tradingagents/releases/download/v0.3.0/dsh-tradingagents-0.3.0.tgz


### PR DESCRIPTION
<!-- Thanks for contributing! Quick checklist / 提交前快速自查 -->

- [x] This PR touches **only this plugin's own entry** (`data/plugins/megatronyy__dsh-tradingagents.yml`) / 本 PR 只改了自己插件的条目
- [x] READMEs regenerate with no diff beyond the entry (`node scripts/generate-readme.mjs`) / README 重新生成无额外差异

## Summary

One-line update to the existing `megatronyy/dsh-tradingagents` entry (added via #2674): point `tarball:` at the **v0.3.0** release.

**Heads-up on the PR history:** this PR was originally opened as an "Add" while #2674 (same author, same branch, opened a day earlier) was already merging — my duplicate. Rather than closing and reopening, the branch has been rebuilt on current `main` so this PR now carries exactly the version bump. Sorry for the noise.

## What v0.3.0 adds

Structured decision records: every analysis persists a machine-readable `<id>.decision.json` next to its Markdown report (frozen quote baseline, every role's verdict, merged trade plan — action / conviction / entry / stop / targets / position — with per-field provenance and prose-fallback recovery). New `GET /tradingagents/reports/<id>/decision`; the plugin's own settings detail view renders the plan; 57 vitest specs, both typecheck configs and the build pass.

## Verification

- Tarball URL: [v0.3.0 release asset](https://github.com/megatronyy/dsh-tradingagents/releases/download/v0.3.0/dsh-tradingagents-0.3.0.tgz) (HTTP 200, 92 KB, prebuilt via `npm pack`)
- Diff is exactly one line in this plugin's own yml
