### PR TITLE
Add alpacachen/dsh-worktree

### DIFF
--- a/README.md
+++ b/README.md
@@ -1644,6 +1644,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 ### Git & Code Review
 
 - [7dgroup-ai/dsh-skill-7d-git-commit](https://github.com/7dgroup-ai/dsh-skill-7d-git-commit) - Checks git commit messages against the 7DGroup convention (Chinese type tags, length and punctuation rules) before committing, as a client-side guard before GitLab pre-receive hooks.
+- [alpacachen/dsh-worktree](https://github.com/alpacachen/dsh-worktree) - Creates task-branch Git worktrees and opens them as DSH Workspaces from the web GUI.
 - [andyfan1094/dsh-github](https://github.com/andyfan1094/dsh-github) - GitHub account management plus a local Git workflow for the web GUI with clone, fast-forward pull, status, commit, push, and host-side push guards.
 - [BrambleXu/dsh-revdiff](https://github.com/BrambleXu/dsh-revdiff) - Native interactive Git diff review for DeepSeek Harness with structured annotations sent back to the current Agent session.
 - [Cerbur/clutch-dsh#clutch-dsh-worktree](https://github.com/Cerbur/clutch-dsh/tree/main/packages/clutch-dsh-worktree) - Adds a Worktree view to DSH Web UI that groups Sessions by Git worktree while keeping DSH as the source of truth.

--- a/README.md
+++ b/README.md
@@ -1644,7 +1644,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 ### Git & Code Review
 
 - [7dgroup-ai/dsh-skill-7d-git-commit](https://github.com/7dgroup-ai/dsh-skill-7d-git-commit) - Checks git commit messages against the 7DGroup convention (Chinese type tags, length and punctuation rules) before committing, as a client-side guard before GitLab pre-receive hooks.
-- [alpacachen/dsh-worktree](https://github.com/alpacachen/dsh-worktree) - Creates task-branch Git worktrees and opens them as DSH Workspaces from the web GUI.
+- [alpacachen/dsh-worktree](https://github.com/alpacachen/dsh-worktree) - A minimal worktree management solution with only one button and one dialog.
 - [andyfan1094/dsh-github](https://github.com/andyfan1094/dsh-github) - GitHub account management plus a local Git workflow for the web GUI with clone, fast-forward pull, status, commit, push, and host-side push guards.
 - [BrambleXu/dsh-revdiff](https://github.com/BrambleXu/dsh-revdiff) - Native interactive Git diff review for DeepSeek Harness with structured annotations sent back to the current Agent session.
 - [Cerbur/clutch-dsh#clutch-dsh-worktree](https://github.com/Cerbur/clutch-dsh/tree/main/packages/clutch-dsh-worktree) - Adds a Worktree view to DSH Web UI that groups Sessions by Git worktree while keeping DSH as the source of truth.

--- a/README.zh.md
+++ b/README.zh.md
@@ -1644,6 +1644,7 @@ dsh plugin --profile web add dshmarket
 ### 🔀 Git 与代码评审
 
 - [7dgroup-ai/dsh-skill-7d-git-commit](https://github.com/7dgroup-ai/dsh-skill-7d-git-commit) — 提交前按 7DGroup 规范校验 git commit message（中文类型标签、长度与标点规则），作为 GitLab pre-receive 钩子的客户端前置校验。
+- [alpacachen/dsh-worktree](https://github.com/alpacachen/dsh-worktree) — 从 Web GUI 创建任务分支 Git worktree，并将其作为 DSH Workspace 打开。
 - [andyfan1094/dsh-github](https://github.com/andyfan1094/dsh-github) — Web GUI 的 GitHub 账号与本地 Git 工作流插件，支持 clone、快进 pull、status、commit、push，推送默认关闭并有宿主侧开关保护。
 - [BrambleXu/dsh-revdiff](https://github.com/BrambleXu/dsh-revdiff) — DeepSeek Harness 原生交互式 Git diff 审查，支持结构化批注并回传当前 Agent 会话。
 - [Cerbur/clutch-dsh#clutch-dsh-worktree](https://github.com/Cerbur/clutch-dsh/tree/main/packages/clutch-dsh-worktree) — 为 DSH Web UI 增加按 Git Worktree 组织 Session 的视角，同时继续由 DSH 管理原始 Project 和 Session 数据。

--- a/README.zh.md
+++ b/README.zh.md
@@ -1644,7 +1644,7 @@ dsh plugin --profile web add dshmarket
 ### 🔀 Git 与代码评审
 
 - [7dgroup-ai/dsh-skill-7d-git-commit](https://github.com/7dgroup-ai/dsh-skill-7d-git-commit) — 提交前按 7DGroup 规范校验 git commit message（中文类型标签、长度与标点规则），作为 GitLab pre-receive 钩子的客户端前置校验。
-- [alpacachen/dsh-worktree](https://github.com/alpacachen/dsh-worktree) — 从 Web GUI 创建任务分支 Git worktree，并将其作为 DSH Workspace 打开。
+- [alpacachen/dsh-worktree](https://github.com/alpacachen/dsh-worktree) — 极简 worktree 管理方案，只有一个按钮和一个弹窗。
 - [andyfan1094/dsh-github](https://github.com/andyfan1094/dsh-github) — Web GUI 的 GitHub 账号与本地 Git 工作流插件，支持 clone、快进 pull、status、commit、push，推送默认关闭并有宿主侧开关保护。
 - [BrambleXu/dsh-revdiff](https://github.com/BrambleXu/dsh-revdiff) — DeepSeek Harness 原生交互式 Git diff 审查，支持结构化批注并回传当前 Agent 会话。
 - [Cerbur/clutch-dsh#clutch-dsh-worktree](https://github.com/Cerbur/clutch-dsh/tree/main/packages/clutch-dsh-worktree) — 为 DSH Web UI 增加按 Git Worktree 组织 Session 的视角，同时继续由 DSH 管理原始 Project 和 Session 数据。

--- a/data/plugins/alpacachen__dsh-worktree.yml
+++ b/data/plugins/alpacachen__dsh-worktree.yml
@@ -3,5 +3,5 @@ name: alpacachen/dsh-worktree
 category: git
 tarball: https://github.com/alpacachen/dsh-worktree/releases/download/v1.0.1/dsh-simple-worktree-1.0.1.tgz
 description:
-  en: Creates task-branch Git worktrees and opens them as DSH Workspaces from the web GUI.
-  zh: 从 Web GUI 创建任务分支 Git worktree，并将其作为 DSH Workspace 打开。
+  en: A minimal worktree management solution with only one button and one dialog.
+  zh: 极简 worktree 管理方案，只有一个按钮和一个弹窗。

--- a/data/plugins/alpacachen__dsh-worktree.yml
+++ b/data/plugins/alpacachen__dsh-worktree.yml
@@ -1,0 +1,7 @@
+url: https://github.com/alpacachen/dsh-worktree
+name: alpacachen/dsh-worktree
+category: git
+tarball: https://github.com/alpacachen/dsh-worktree/releases/download/v1.0.1/dsh-simple-worktree-1.0.1.tgz
+description:
+  en: Creates task-branch Git worktrees and opens them as DSH Workspaces from the web GUI.
+  zh: 从 Web GUI 创建任务分支 Git worktree，并将其作为 DSH Workspace 打开。

--- a/data/plugins/alpacachen__dsh-worktree.yml
+++ b/data/plugins/alpacachen__dsh-worktree.yml
@@ -1,7 +1,7 @@
 url: https://github.com/alpacachen/dsh-worktree
 name: alpacachen/dsh-worktree
 category: git
-tarball: https://github.com/alpacachen/dsh-worktree/releases/download/v1.0.1/dsh-simple-worktree-1.0.1.tgz
+tarball: https://github.com/alpacachen/dsh-worktree/releases/download/v1.0.2/alpacachen-dsh-simple-worktree-1.0.2.tgz
 description:
   en: A minimal worktree management solution with only one button and one dialog.
   zh: 极简 worktree 管理方案，只有一个按钮和一个弹窗。

--- a/data/plugins/alpacachen__dsh-worktree.yml
+++ b/data/plugins/alpacachen__dsh-worktree.yml
@@ -1,7 +1,6 @@
 url: https://github.com/alpacachen/dsh-worktree
 name: alpacachen/dsh-worktree
 category: git
-tarball: https://github.com/alpacachen/dsh-worktree/releases/download/v1.0.2/alpacachen-dsh-simple-worktree-1.0.2.tgz
 description:
   en: A minimal worktree management solution with only one button and one dialog.
   zh: 极简 worktree 管理方案，只有一个按钮和一个弹窗。


### PR DESCRIPTION
## Summary

Adds `alpacachen/dsh-worktree`, a web GUI plugin for creating task-branch Git worktrees and opening them as DSH Workspaces.

## Submission checks

- Public repository with the `dsh-plugin` topic
- Declares `dsh.bundle.patch` and includes working host/client code
- Repository is older than one day and has more than ten commits
- Full plugin validation passes (build, typecheck, 10 unit tests, bundle and package checks)
- Published as `@alpacachen/dsh-simple-worktree@1.0.2` on npm for the preferred prebuilt installation path
- Regenerated both catalog READMEs with `node scripts/generate-readme.mjs`
