### PR TITLE
Add screenshots for MrWeiCodes/dsh-permgate (6 bilingual approval/set…

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -281,6 +281,14 @@
   "https://raw.githubusercontent.com/MingoZhou/dsh-replay/main/assets/overview-light.png",
   "https://raw.githubusercontent.com/MingoZhou/dsh-replay/main/assets/timeline-light.png",
   "https://raw.githubusercontent.com/MingoZhou/dsh-replay/main/assets/audit-light.png"
+],
+ "https://github.com/MrWeiCodes/dsh-permgate": [
+  "https://raw.githubusercontent.com/MrWeiCodes/dsh-permgate/main/assets/approval-modal.png",
+  "https://raw.githubusercontent.com/MrWeiCodes/dsh-permgate/main/assets/approval-modal-en.png",
+  "https://raw.githubusercontent.com/MrWeiCodes/dsh-permgate/main/assets/reject-reason.png",
+  "https://raw.githubusercontent.com/MrWeiCodes/dsh-permgate/main/assets/reject-reason-en.png",
+  "https://raw.githubusercontent.com/MrWeiCodes/dsh-permgate/main/assets/settings-page.jpg",
+  "https://raw.githubusercontent.com/MrWeiCodes/dsh-permgate/main/assets/settings-page-en.jpg"
  ],
  "https://github.com/Mu-scorpio/token-usage-counter": [
   "https://raw.githubusercontent.com/Mu-scorpio/token-usage-counter/main/assets/usage-stats-overview.png",


### PR DESCRIPTION
This PR adds 6 screenshots for **MrWeiCodes/dsh-permgate** to `data/screenshots.json`, so the plugin shows an AppStore-style gallery on the awesome-dsh-plugin site and in dsh-market detail views.

Screenshots cover the plugin's core features in both English and Chinese:

- Approval modal with inline diff details (EN / ZH)
- Custom rejection-reason dialog (EN / ZH)
- Settings page: global & per-project category config (EN / ZH)

All image URLs point to `raw.githubusercontent.com/MrWeiCodes/dsh-permgate/main/assets/` and have been verified reachable (HTTP 200). Validated with `node scripts/build-site.mjs` (LF mode) — no errors.

本 PR 在 `data/screenshots.json` 中为 **MrWeiCodes/dsh-permgate** 注册了 6 张截图，让插件在 awesome-dsh-plugin 站点和 dsh-market 详情页显示 AppStore 风格截图画廊。

截图覆盖插件核心功能的中英文界面：

- 带内联 diff 详情的审批弹窗（中 / 英）
- 自定义拒绝原因弹窗（中 / 英）
- 设置页：全局与项目分类配置（中 / 英）

所有图片 URL 均指向 `raw.githubusercontent.com/MrWeiCodes/dsh-permgate/main/assets/`，已验证可访问（HTTP 200）。已用 `node scripts/build-site.mjs`（LF 模式）本地校验，无报错。