### PR TITLE
Add screenshot for Gastronomicluna/Matrix-code

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -1291,5 +1291,8 @@
  "https://github.com/BananaSoldier01/dsh-tidychat": [
   "https://raw.githubusercontent.com/BananaSoldier01/dsh-tidychat/main/assets/navigator.png",
   "https://raw.githubusercontent.com/BananaSoldier01/dsh-tidychat/main/assets/settings.png"
+ ],
+ "https://github.com/Gastronomicluna/Matrix-code": [
+  "https://raw.githubusercontent.com/Gastronomicluna/Matrix-code/main/assets/demo.png"
  ]
 }


### PR DESCRIPTION
Follow-up to #2547: registers the demo screenshot for the just-merged \Gastronomicluna/Matrix-code\ entry in \data/screenshots.json\ (hosted in the plugin repo at \ssets/demo.png\). One file changed.