### PR TITLE
Add alaxrpg/dsh-adaptive-model-router to the Model category

### DIFF
--- a/README.md
+++ b/README.md
@@ -614,6 +614,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 ### Models & Providers
 
 - [AdonisSheldon/dsh-openai-oauth](https://github.com/AdonisSheldon/dsh-openai-oauth) - Connect a ChatGPT account to Codex models in DeepSeek Harness through browser PKCE or device-code OAuth, with automatic token refresh and Web or headless login.
+- [alaxrpg/dsh-adaptive-model-router](https://github.com/alaxrpg/dsh-adaptive-model-router) - Adaptive model discovery, evaluation, tiering, and subagent routing for DeepSeek Harness.
 - [amlyczz/dsh-agy-link](https://github.com/amlyczz/dsh-agy-link) - Google Antigravity (agy CLI) models for DSH — streaming chat with Gemini/Claude/GPT-OSS subscriptions, native tool cards, thinking turns, and in-GUI Google OAuth login.
 - [beijingwahw/dsh-proactive](https://github.com/beijingwahw/dsh-proactive) - Proactive multi-model scheduling plugin: multi-source signal intake with dedup and urgency ranking, a four-way execute/defer/dismiss/ask-user decision engine, DAG plan generation with parallel model execution, quality reflection with automatic retry and model switch, long-term memory for task patterns and lessons, and strategy evolution via genetic algorithms with sandboxed evaluation and canary rollout.
 - [BruceLanLan/dsh-tier-router](https://github.com/BruceLanLan/dsh-tier-router) - Two-tier model routing: a strong tier plans, advises and reviews while a cheap tier implements, with plan-mode-aware auto routing, a high-impact escalation guard, failure auto-escalation, and subagent tiering.

--- a/README.zh.md
+++ b/README.zh.md
@@ -614,6 +614,7 @@ dsh plugin --profile web add dshmarket
 ### 🔌 模型与账号接入
 
 - [AdonisSheldon/dsh-openai-oauth](https://github.com/AdonisSheldon/dsh-openai-oauth) — 通过浏览器 PKCE 或设备码 OAuth 将 ChatGPT 账户接入 DeepSeek Harness 的 Codex 模型，并支持自动刷新令牌以及 Web 或无头登录。
+- [alaxrpg/dsh-adaptive-model-router](https://github.com/alaxrpg/dsh-adaptive-model-router) — 面向 DeepSeek Harness 的自适应模型发现、评估、定级与子代理路由插件。
 - [amlyczz/dsh-agy-link](https://github.com/amlyczz/dsh-agy-link) — 将 Google Antigravity (agy CLI) 接入 DSH：无 API Key 使用 Gemini/Claude/GPT-OSS 订阅模型，支持流式对话、原生工具卡片、思考轮次注记及 Web 界面 Google OAuth 扫码登录。
 - [beijingwahw/dsh-proactive](https://github.com/beijingwahw/dsh-proactive) — 主动式多模型协同调度插件：多源信号接入（去重与紧急度排序），execute/defer/dismiss/ask-user 四级决策引擎，DAG 计划生成与多模型并行执行，质量反思自动重试与切换模型，任务模式与经验教训长期记忆，以及遗传算法策略进化（沙盒评估、金丝雀发布）。
 - [BruceLanLan/dsh-tier-router](https://github.com/BruceLanLan/dsh-tier-router) — 双档模型路由：强档负责规划/咨询/评审、弱档负责实现；含计划模式自动路由、高危操作守卫、失败自动升级与子代理分层。

--- a/data/plugins/alaxrpg__dsh-adaptive-model-router.yml
+++ b/data/plugins/alaxrpg__dsh-adaptive-model-router.yml
@@ -1,0 +1,6 @@
+url: https://github.com/alaxrpg/dsh-adaptive-model-router
+name: alaxrpg/dsh-adaptive-model-router
+category: model
+description:
+  en: "Adaptive model discovery, evaluation, tiering, and subagent routing for DeepSeek Harness."
+  zh: "面向 DeepSeek Harness 的自适应模型发现、评估、定级与子代理路由插件。"


### PR DESCRIPTION
Add [alaxrpg/dsh-adaptive-model-router](https://github.com/alaxrpg/dsh-adaptive-model-router) to the **Model** category.

- url: https://github.com/alaxrpg/dsh-adaptive-model-router
- category: `model`
- description.en + description.zh included
- READMEs regenerated (2136 entries)
- Repo declares `dsh.bundle` manifest, installable via `dsh plugin add github:alaxrpg/dsh-adaptive-model-router`
- `dsh-plugin` topic on repo — verified
- Repo is > 1 day old with 11 commits — verified
- 78/78 tests passing in the worktree