### PR TITLE
Add screenshots for hyrinx/dsh-plugin-open-with

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -1302,5 +1302,9 @@
   "https://raw.githubusercontent.com/PolinniZhong/dsh-personal-center/main/docs/screenshots/dark-pet.png",
   "https://raw.githubusercontent.com/PolinniZhong/dsh-personal-center/main/docs/screenshots/pet-emotions.gif",
   "https://raw.githubusercontent.com/PolinniZhong/dsh-personal-center/main/docs/screenshots/dark-model-cost.png"
+ ],
+ "https://github.com/hyrinx/dsh-plugin-open-with": [
+  "https://raw.githubusercontent.com/hyrinx/dsh-plugin-open-with/main/assets/screenshot-1.png",
+  "https://raw.githubusercontent.com/hyrinx/dsh-plugin-open-with/main/assets/screenshot-2.png"
  ]
 }


### PR DESCRIPTION
为已有条目 [hyrinx/dsh-plugin-open-with](https://github.com/hyrinx/dsh-plugin-open-with) 补充 App Store 风格的截图展示。

**这是对已有条目的更新**（该条目已于 #2756 合并），并非新增插件。

- 🖼️ 在 `data/screenshots.json` 中为 `https://github.com/hyrinx/dsh-plugin-open-with` 新增映射，指向
  `assets/screenshot-1.png` 与 `assets/screenshot-2.png`（均为 GitHub 托管的 `raw.githubusercontent.com` 地址，符合 contributing.md）。
- ✅ 本次**没有改动** `data/plugins/*.yml`，因此**无需重新生成 README**：README 由 YAML 文件生成，而本条目 YAML 未变
  （`node scripts/generate-readme.mjs` 校验 `README.md` 与 `README.zh.md` 均为最新，无内容差异）。
- ✅ 已有条目此前已满足：`dsh.bundle` 清单、分类 `ui`、仓库创建满 1 天且提交数 ≥ 10、已打 `dsh-plugin` topic。
- ℹ️ 分类 `ui` 与描述均保持不变，符合"只改自己那条"的规范。

<!-- 针对"仅补截图"的更新，检查项如下 -->
- [x] data/plugins/hyrinx__dsh-plugin-open-with.yml — n/a（条目已存在，未改动）
- [x] 运行 node scripts/generate-readme.mjs 并提交 README — n/a（YAML 未变，README 已核实为最新）
- [x] dsh.bundle、仓库年龄 ≥ 1 天、提交数 ≥ 10 — 已在此前收录时通过
- [x] 分类 `ui` 取值正确 — 是
- [x] 描述只说功能、无营销词 — 沿用已收录条目，未改动
- [x] 仓库已打 `dsh-plugin` topic — 已核验
- [x] 已在 data/screenshots.json 补充截图—已完成（本次 PR）