### PR TITLE
Add screenshots for andyfan1094 plugins and bump dsh-feishu tarball to v0.2.2

### DIFF
--- a/data/plugins/andyfan1094__dsh-feishu.yml
+++ b/data/plugins/andyfan1094__dsh-feishu.yml
@@ -1,7 +1,7 @@
 url: https://github.com/andyfan1094/dsh-feishu
 name: andyfan1094/dsh-feishu
 category: notify
-tarball: https://github.com/andyfan1094/dsh-feishu/releases/download/v0.2.0/dsh-feishu-0.2.0.tgz
+tarball: https://github.com/andyfan1094/dsh-feishu/releases/download/v0.2.0/dsh-feishu-0.2.2.tgz
 description:
   en: Connects a Feishu self-built app over WebSocket, routes each chat to an independent DSH agent session, and streams replies through a Card JSON 2.0 card with plain-text fallback.
   zh: 接入飞书自建应用，把每个飞书会话映射到独立的 DSH Agent，经卡片 JSON 2.0 流式回复，不可用时回退纯文本。


### PR DESCRIPTION
Adds `data/screenshots.json` entries for the five andyfan1094 plugins (real UI screenshots, demo data only, committed to each repo under `docs/screenshots/`).

Also bumps the `dsh-feishu` tarball pin from v0.2.0 to the current v0.2.2 release (outbound upload fix).

- dsh-codebase-memory: real CLI run evidence (`get_architecture` + `search_graph`)
- dsh-feishu / dsh-github / dsh-winrm: Web panel screenshots
- dsh-minimax-usage-pro: usage panel screenshot

Entry check (`check-submission.mjs --all --only-list`) passes for the changed yml entry.