### PR TITLE
docs: add dsh-high-fee-alert plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -531,6 +531,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 - [zhouchengke2046/dsh-sidebar-balance](https://github.com/zhouchengke2046/dsh-sidebar-balance) - DeepSeek Harness plugin that shows the DeepSeek API account balance and OpenCode Go plan usage (consumption ring, hover details) in the sidebar footer, with adaptive polling and zh/en locale support.
 - [zhu168/dsh-save-money#plugin](https://github.com/zhu168/dsh-save-money/tree/main/plugin) - Pause and resume tasks automatically during user-defined time windows to avoid peak-hour API costs; includes account balance display and 10-minute granularity spend bar chart.
 - [zoumutou/dsh-cost-balance](https://github.com/zoumutou/dsh-cost-balance) - Collapsible iOS-style stats pill under the composer: session cost, DeepSeek account balance, cache-hit rate, and token usage in a frosted panel.
+- [dsh-high-fee-alert](https://github.com/GuoFengyu110429/dsh-high-fee-alert) - Automatically retrieves time-of-use pricing data (with Beijing Time) and notifies users during peak periods to reduce costs.
 
 ### Themes & Appearance
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -531,6 +531,7 @@ dsh plugin --profile web add dshmarket
 - [zhouchengke2046/dsh-sidebar-balance](https://github.com/zhouchengke2046/dsh-sidebar-balance) — DSH Web 插件:在侧边栏底部显示 DeepSeek API 余额与 OpenCode Go 套餐用量(消耗圆环、悬浮详情),自适应轮询,支持中英文。
 - [zhu168/dsh-save-money#plugin](https://github.com/zhu168/dsh-save-money/tree/main/plugin) — 自定义时间窗口自动暂停/恢复任务，高峰时段节省 API 费用；含账户余额显示和 10 分钟粒度的消费柱状图。
 - [zoumutou/dsh-cost-balance](https://github.com/zoumutou/dsh-cost-balance) — 输入框下方的 iOS 风格统计条：一键展开查看会话花费、DeepSeek 账户余额、缓存命中率与 Token 用量。
+- [dsh-high-fee-alert](https://github.com/GuoFengyu110429/dsh-high-fee-alert) —— 自动获取时间与峰谷定价策略（时间为北京时间），在高峰期提示用户以节省资金。
 
 ### 🎭 主题与外观
 


### PR DESCRIPTION
<!-- Thanks for contributing! Quick checklist / 提交前快速自查 -->

- [ ] I added **one file** at `data/plugins/<owner>__<repo>.yml` — the READMEs are generated, don't edit them by hand / 我新增了一个 `data/plugins/<owner>__<repo>.yml` 文件（各语言 README 由脚本生成，不要手工编辑）
- [ ] I ran `node scripts/generate-readme.mjs` and committed the regenerated READMEs / 我已执行 `node scripts/generate-readme.mjs` 并提交了重新生成的 README
- [ ] My repo's `package.json` declares **`dsh.bundle`** (not just `dsh.client`) — [example](../blob/main/contributing.md) / 仓库 `package.json` 已声明 `dsh.bundle`（只有 `dsh.client` 无法安装）
- [ ] My repo is at least **1 day old** with **10+ commits** / 仓库创建满 1 天且提交数 ≥ 10
- [ ] `category` is one of `ui theme model session memory tools skill workflow notify dev market fun`, and themes/skins go under `theme` / `category` 取值正确，主题/皮肤类请用 `theme`
- [ ] Description states what the plugin does, no superlatives / 描述只说功能，不带营销词
- [ ] My repo has the `dsh-plugin` topic / 仓库已打 `dsh-plugin` topic

**Recommended (not required) / 推荐但不强制：**

- 📦 Publish to npm — npm installs are prebuilt and skip the `allowBuilds` approval, so users get a one-command install / 发布 npm 包：预构建产物免 `allowBuilds` 授权，用户一条命令装好
- 🔗 Declare official `@deepseek-ai/*` packages as `peerDependencies` (not `dependencies`) — avoids duplicate runtimes inside the profile / 官方 `@deepseek-ai/*` 包用 `peerDependencies` 声明（而非 `dependencies`），避免 profile 里出现重复运行时
- 🖼️ Add screenshots to [`data/screenshots.json`](../blob/main/data/screenshots.json) — they show AppStore-style in plugin markets ([how](../blob/main/contributing.md#screenshots--截图optional-recommended--可选推荐)) / 在 [`data/screenshots.json`](../blob/main/data/screenshots.json) 里附上截图——插件市场会像 App Store 一样展示（[说明](../blob/main/contributing.md#screenshots--截图optional-recommended--可选推荐)）
