### PR TITLE
fix(catalog): prefer GitHub source for MDR-EX1000 plugins

### DIFF
--- a/data/plugins/MDR-EX1000__dsh-desktop-kit.yml
+++ b/data/plugins/MDR-EX1000__dsh-desktop-kit.yml
@@ -1,7 +1,7 @@
 url: https://github.com/MDR-EX1000/dsh-desktop-kit
 name: MDR-EX1000/dsh-desktop-kit
 category: ui
-tarball: https://github.com/MDR-EX1000/dsh-desktop-kit/releases/latest/download/dsh-desktop-kit-0.1.0.tgz
+tarball: https://github.com/MDR-EX1000/dsh-desktop-kit/releases/latest/download/dsh-desktop-kit.tgz
 description:
   en: 'macOS desktop shell for the DSH web UI: a plugin plus a small Tauri/WKWebView window over the loopback web surface — real macOS fullscreen, single instance, external links delegated to the system browser, and browser-style zoom.'
   zh: '把 DSH Web UI 装进原生 macOS 桌面窗口：插件 + 轻量 Tauri/WKWebView 外壳跑在同一个 loopback 地址上——真 macOS 全屏、单实例、外链交给系统浏览器、类浏览器页面缩放。'

--- a/data/plugins/MDR-EX1000__dsh-desktop-kit.yml
+++ b/data/plugins/MDR-EX1000__dsh-desktop-kit.yml
@@ -1,7 +1,6 @@
 url: https://github.com/MDR-EX1000/dsh-desktop-kit
 name: MDR-EX1000/dsh-desktop-kit
 category: ui
-tarball: https://github.com/MDR-EX1000/dsh-desktop-kit/releases/latest/download/dsh-desktop-kit.tgz
 description:
   en: 'macOS desktop shell for the DSH web UI: a plugin plus a small Tauri/WKWebView window over the loopback web surface — real macOS fullscreen, single instance, external links delegated to the system browser, and browser-style zoom.'
   zh: '把 DSH Web UI 装进原生 macOS 桌面窗口：插件 + 轻量 Tauri/WKWebView 外壳跑在同一个 loopback 地址上——真 macOS 全屏、单实例、外链交给系统浏览器、类浏览器页面缩放。'

--- a/data/plugins/MDR-EX1000__dsh-rw.yml
+++ b/data/plugins/MDR-EX1000__dsh-rw.yml
@@ -1,7 +1,6 @@
 url: https://github.com/MDR-EX1000/dsh-rw
 name: MDR-EX1000/dsh-rw
 category: remote
-tarball: https://github.com/MDR-EX1000/dsh-rw/releases/latest/download/dsh-rw.tgz
 description:
   en: 'Remote-SSH-style workspaces: turn an SSH host and a remote directory into a native DSH workspace; the agent operates the remote filesystem directly via 12 rw_* tools (SFTP/exec), with workspace-confined paths and known_hosts verification.'
   zh: 'Remote-SSH 风格工作区：把 SSH 主机上的远程目录变成原生 DSH 工作区，agent 通过 12 个 rw_* 工具（SFTP/exec）直接操作远程文件，路径限定在工作区内并校验 known_hosts。'


### PR DESCRIPTION
## Summary

Remove the `tarball` metadata from the MDR-EX1000 entries for `dsh-rw` and `dsh-desktop-kit`.

This makes dsh-market fall back to the shorter GitHub source targets:

- `github:MDR-EX1000/dsh-rw`
- `github:MDR-EX1000/dsh-desktop-kit`

## Why

The two repositories currently commit the compiled `lib/` output and the required desktop-kit assets, so source installation does not require rebuilding the plugins during installation. The source-install path was verified in an isolated profile by installing, removing, and reinstalling both plugins.

## Behavior change

- Confirmation UI no longer uses the long Release tarball target by default.
- New installs and updates follow the repository default branch instead of the latest formal Release tarball.
- Existing installed profiles are unchanged until reinstall/update.
