### PR TITLE
Add sryimnoob123/dsh-global-prompt to identity category

### DIFF
--- a/data/plugins/sryimnoob123__dsh-global-prompt.yml
+++ b/data/plugins/sryimnoob123__dsh-global-prompt.yml
@@ -1,0 +1,6 @@
+url: https://github.com/sryimnoob123/dsh-global-prompt
+name: sryimnoob123/dsh-global-prompt
+category: identity
+description:
+  en: Settings panel for global and per-workspace AGENTS.md, with identity and persona injection, runtime-context toggle, and result notifications.
+  zh: 设置面板管理全局与各工作区 AGENTS.md，支持身份与人设注入、运行时上下文开关和结果通知。


### PR DESCRIPTION
Adds a settings plugin that manages global and per-workspace AGENTS.md with identity/persona injection. Verified against the code: the bundle patch re-enables agent-instructions, the server registers the two API routes, and the UI provides global/project/notification tabs.