### PR TITLE
Add sryimnoob123/dsh-web-search-ollama to web category

### DIFF
--- a/data/plugins/sryimnoob123__dsh-web-search-ollama.yml
+++ b/data/plugins/sryimnoob123__dsh-web-search-ollama.yml
@@ -1,0 +1,6 @@
+url: https://github.com/sryimnoob123/dsh-web-search-ollama
+name: sryimnoob123/dsh-web-search-ollama
+category: web
+description:
+  en: Routes the DSH web_search tool through Ollama's web search API, reusing OLLAMA_API_KEY. No DeepSeek official key needed.
+  zh: 让 DSH 的 web_search 工具走 Ollama 联网搜索 API，复用 OLLAMA_API_KEY，无需 DeepSeek 官方 Key。


### PR DESCRIPTION
Adds a search provider plugin that routes DSH's web_search tool through Ollama's web search API using OLLAMA_API_KEY. Verified against the code: registers provider id 'ollama' on the ctx.web seam, maps Ollama {title,url,content} to WebSource {url,title,snippet}.