### PR TITLE
Add sryimnoob123/dsh-tool-pwsh-safe to tools category

### DIFF
--- a/data/plugins/sryimnoob123__dsh-tool-pwsh-safe.yml
+++ b/data/plugins/sryimnoob123__dsh-tool-pwsh-safe.yml
@@ -1,0 +1,6 @@
+url: https://github.com/sryimnoob123/dsh-tool-pwsh-safe
+name: sryimnoob123/dsh-tool-pwsh-safe
+category: tools
+description:
+  en: Runs PowerShell scripts through base64 encoding, so quotes, $, backslashes and CJK survive as written. Same sandbox channel as the built-in pwsh tool.
+  zh: 把 PowerShell 脚本 base64 编码后执行，引号、$、反斜杠、中文全部原样传递，免去转义地狱。走与内置 pwsh 工具相同的沙箱通道。


### PR DESCRIPTION
Adds a PowerShell tool plugin that base64-encodes scripts and runs them through the sandboxed pwsh executor, so quotes, dollar signs, backslashes and CJK survive as written. Verified against the code: registers tool 'pwsh_safe' on ctx.tools, calls ctx.shell with the same channel as the built-in pwsh tool.