### PR TITLE
Update StrataGate DSH to 0.2.32

### DIFF
--- a/data/plugins/diqierjia__StrataGate-AgentMemory--integrations-deepseek-harness.yml
+++ b/data/plugins/diqierjia__StrataGate-AgentMemory--integrations-deepseek-harness.yml
@@ -1,5 +1,5 @@
 url: https://github.com/diqierjia/StrataGate-AgentMemory/tree/main/integrations/deepseek-harness
-tarball: https://github.com/diqierjia/StrataGate-AgentMemory/releases/download/stratagate-dsh-v0.2.26/stratagate-dsh-0.2.26.tgz
+tarball: https://github.com/diqierjia/StrataGate-AgentMemory/releases/download/stratagate-dsh-v0.2.32/stratagate-dsh-0.2.32.tgz
 name: diqierjia/StrataGate-AgentMemory
 category: memory
 description:


### PR DESCRIPTION
## Summary

- Update the StrataGate DSH tarball to 0.2.32.
- The release is published at https://www.npmjs.com/package/stratagate-dsh/v/0.2.32 and https://github.com/diqierjia/StrataGate-AgentMemory/releases/tag/stratagate-dsh-v0.2.32.

The source repository has the required dsh.bundle manifest, dsh-plugin topic, and passing package verification.