### PR TITLE
补充工作台与 Windows 通知插件截图

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -1316,6 +1316,13 @@
   "https://raw.githubusercontent.com/KarlOfLaw/dsh-side-chat/main/docs/assets/side-chat-selection.png",
   "https://raw.githubusercontent.com/KarlOfLaw/dsh-side-chat/main/docs/assets/side-chat-settings.png"
  ],
+ "https://github.com/lsq-dsh-plugins/dsh-workbench-layout": [
+  "https://raw.githubusercontent.com/lsq-dsh-plugins/dsh-workbench-layout/main/assets/workbench-files-and-chat.png",
+  "https://raw.githubusercontent.com/lsq-dsh-plugins/dsh-workbench-layout/main/assets/workbench-git-diff.png"
+ ],
+ "https://github.com/lsq-dsh-plugins/dsh-windows-notifications": [
+  "https://raw.githubusercontent.com/lsq-dsh-plugins/dsh-windows-notifications/main/assets/notification-settings.png"
+ ],
  "https://github.com/biggerboy/dsh-conversation-anchors": [
   "https://raw.githubusercontent.com/biggerboy/dsh-conversation-anchors/master/assets/anchors-hover.png",
   "https://raw.githubusercontent.com/biggerboy/dsh-conversation-anchors/master/assets/anchors-wave.png"


### PR DESCRIPTION
## 修改内容

- 为 lsq-dsh-plugins/dsh-workbench-layout 添加 2 张市场截图
- 为 lsq-dsh-plugins/dsh-windows-notifications 添加 1 张市场截图
- 图片均托管于各自 GitHub 仓库的 assets 目录

## 验证

- screenshots.json JSON 解析通过
- README 生成一致性检查通过
- awesome-lint 通过（仅有上游既有警告）
- 站点构建通过
- 3 个图片 URL 均返回 HTTP 200