### PR TITLE
feat: add totoro-pet desktop pet plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 <!-- BEGIN PLUGINS -->
 ### UI Enhancements
 
+- [Lucasli2018/totoro-pet](https://github.com/Lucasli2018/totoro-pet) - DSH Web GUI Desktop Pet Plugin – Floating chibi Totoro with feeding, petting, playing, and sleeping interactions.
 - [01Virex/dsh-status-rotator](https://github.com/01Virex/dsh-status-rotator) - Replaces the "Deep diving..." turn-status label with rotating meme-worthy phrases, with typewriter and gradient effects.
 - [0xsline/dsh-spotlight](https://github.com/0xsline/dsh-spotlight) - Keyboard-first command palette for the DSH Web UI.
 - [1070296335-create/dph-taskboard](https://github.com/1070296335-create/dph-taskboard) - Session-based task board in the sidebar: drag sessions into todo/doing/review/done columns, create sessions with model and reasoning-effort selection, trash with restore, notes, export/import.

--- a/data/plugins/Lucasli2018__totoro-pet.yml
+++ b/data/plugins/Lucasli2018__totoro-pet.yml
@@ -1,0 +1,6 @@
+url: https://github.com/Lucasli2018/totoro-pet
+name: Lucasli2018/totoro-pet
+category: fun
+description:
+  en: A desktop pet that lives in a floating overlay; click it to interact and switch between idle, sleeping, happy, and eating states.
+  zh: '桌面宠物插件，常驻悬浮层养一只龙猫，点击互动并可在待机、睡觉、开心、进食等状态间切换。'

--- a/data/plugins/Lucasli2018_totoro-pet.yml
+++ b/data/plugins/Lucasli2018_totoro-pet.yml
@@ -1,0 +1,6 @@
+url: https://github.com/Lucasli2018/totoro-pet  # 必须与仓库地址完全一致
+name: Lucasli2018/totoro-pet                   # 列表中将显示的链接文字
+category: ui                             # 插件分类，可选值见下方说明
+description:
+  en: 'DSH Web GUI desktop pet plugin – floating chibi Totoro with interactive feeding, petting, playing, and sleeping mechanics.' # 英文描述，必填
+  zh: 'DSH Web GUI 桌宠插件（悬浮 Q 版龙猫 · 喂食/抚摸/玩耍/睡觉互动养成）' # 中文描述，可选


### PR DESCRIPTION
Add totoro-pet, a DSH Web GUI desktop pet plugin.

- Repo: https://github.com/Lucasli2018/totoro-pet
- Category: fun
- Published to npm as totoro-pet
- dsh.bundle present; repo age > 1 day; 12 commits; dsh-plugin topic set.