### PR TITLE
add Flonger/dsh-multi-clear (multi-select clear conversations + delete empty workspaces)

### DIFF
--- a/data/plugins/Flonger__dsh-multi-clear.yml
+++ b/data/plugins/Flonger__dsh-multi-clear.yml
@@ -1,0 +1,7 @@
+url: https://github.com/Flonger/dsh-multi-clear
+name: Flonger/dsh-multi-clear
+category: usage
+description:
+  en: Multi-select clear (archive) workspace conversations and bulk-delete empty workspaces in the DSH sidebar. Workspace-level selection (tri-state), select-all, progress and failure reporting; delete keeps folders and session logs (sessions move to Ungrouped).
+  zh: 侧边栏多选清空(归档)工作区对话，并批量删除已清空的空工作区。支持会话行/工作区头行勾选、半选态、全选、二次确认与失败保留；删除工作区保留文件夹与日志，会话移至未分组。
+tarball: https://github.com/Flonger/dsh-multi-clear/releases/latest/download/dsh-multi-clear-0.1.0.tgz


### PR DESCRIPTION
## 新增插件

- **名称**: `Flonger/dsh-multi-clear`
- **分类**: `usage`（用量与工作区管理）
- **来源**: [github.com/Flonger/dsh-multi-clear](https://github.com/Flonger/dsh-multi-clear)

### 功能

在 DSH Web 侧边栏会话列表底部新增「多选」入口，支持：

- **多选清空（归档）工作区对话**：会话行/工作区头行勾选、半选态、全选、二次确认、逐条归档、进度与失败保留；
- **批量删除空工作区**：会话已清空的工作区显示红色删除框，勾选后批量删除（文件夹与会话日志保留，会话移至未分组）；
- 分组感知行映射（基于平台公开的 sessions/workspaces 快照，不依赖内部组件）；退出时完整清理勾选框；
- 中英双语、窄侧边栏保护、`/multi-clear/status` 只读状态路由。

### 说明

- 仓库已声明 `dsh.bundle` manifest（纯 insert `cordis.patch.yml`）与 `dsh.client` bundle；
- 可通过 `dsh plugin --profile web add dsh-multi-clear`（npm 发布后）或 GitHub Release tarball 安装；
- 市场收录要求仓库创建满 1 天且 ≥10 commits（若未满足，CI 的 repo-age 检查通过后即合并）。