### PR TITLE
feat: add AGI Architecture Exploration category (dsh-memory re-filed)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 
 <!-- BEGIN TOC -->
 - [Plugins](#plugins)
+  - [AGI Architecture Exploration](#agi-architecture-exploration)
   - [UI Enhancements](#ui-enhancements)
   - [Usage & Billing](#usage--billing)
   - [Themes & Appearance](#themes--appearance)
@@ -72,6 +73,10 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 ## Plugins
 
 <!-- BEGIN PLUGINS -->
+### AGI Architecture Exploration
+
+- [FuRongJun-1999/dsh-memory](https://github.com/FuRongJun-1999/dsh-memory) - White-box AGI architecture exploration: metacognition (self-cognition loop), continual learning (knowledge flywheel), world model (condition space, spatiotemporal memory graph), self-improvement (bootstrap discipline), zero-LLM white-box pipeline, and auditable trust guardrails.
+
 ### UI Enhancements
 
 - [01Virex/dsh-status-rotator](https://github.com/01Virex/dsh-status-rotator) - Replaces the "Deep diving..." turn-status label with rotating meme-worthy phrases, with typewriter and gradient effects.
@@ -878,7 +883,6 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 - [FleetingEcho/dsh-handoff](https://github.com/FleetingEcho/dsh-handoff) - Self-maintaining handoff memory per working directory and git branch: records turns, folds them into concise Markdown, and injects the result into future sessions from ~/.agent/agent-handoff, byte-compatible with pi-handoff.
 - [flymysql/dsh-memory](https://github.com/flymysql/dsh-memory) - Cross-session memory vault: remember / recall / forget tools, per-turn prompt injection, and a settings-page entry browser.
 - [freehul/sgme](https://github.com/freehul/sgme) - ShiGuang Memory Engine (SGME) bridge: multi-agent shared long-term memory via HTTP — L0/L1/L1.5/L2 distillation, scenario-based injection, unified search, and proactive care signals (memory_search / wiki_search / signal_pull / signal_claim / signal_ack), installable as `dsh-sgme`.
-- [FuRongJun-1999/dsh-memory](https://github.com/FuRongJun-1999/dsh-memory) - AGI long-term memory base: multi-agent spatiotemporal memory graph, self-evolving knowledge flywheel, self-cognition, and auditable trust guardrails.
 - [gezi-wen/sage-mem](https://github.com/gezi-wen/sage-mem) - File-based cross-session memory: plain Markdown memory files with automatic retrieval injection, format-compatible with Claude Code's CLAUDE.md and memory files, so migrating is a manual file copy.
 - [GIT121995/dsh-memory-gate](https://github.com/GIT121995/dsh-memory-gate) - Bounded local memory with CBDC authority gating: SQLite + FTS5 claims, scoped recall with explainable use/verify/ignore decisions and a full audit trail, /memory commands, ≤3-claim/1200-char injection per call, no extra model call.
 - [giter00/dsh-headroom](https://github.com/giter00/dsh-headroom) - Automatic context compression for DeepSeek Harness: compresses tool outputs before they reach the model and keeps every lossy compression reversible via CCR retrieval tools.

--- a/README.zh.md
+++ b/README.zh.md
@@ -44,6 +44,7 @@ dsh plugin --profile web add dshmarket
 
 <!-- BEGIN TOC -->
 - [插件](#插件)
+  - [🧭 AGI 架构探索](#-agi-架构探索)
   - [🎨 UI 增强](#-ui-增强)
   - [💰 用量与计费](#-用量与计费)
   - [🎭 主题与外观](#-主题与外观)
@@ -72,6 +73,10 @@ dsh plugin --profile web add dshmarket
 ## 插件
 
 <!-- BEGIN PLUGINS -->
+### 🧭 AGI 架构探索
+
+- [FuRongJun-1999/dsh-memory](https://github.com/FuRongJun-1999/dsh-memory) — 白箱AGI架构探索：元认知（自我认知循环）、持续学习（知识飞轮）、世界模型（条件空间+语义时空图）、自我改进（自举纪律）、零LLM白箱管线与可审计信任护栏。
+
 ### 🎨 UI 增强
 
 - [01Virex/dsh-status-rotator](https://github.com/01Virex/dsh-status-rotator) — 把回合状态那句 "Deep diving..." 替换成更有梗的自定义文案，按阶段轮换，支持打字机与流动渐变。
@@ -878,7 +883,6 @@ dsh plugin --profile web add dshmarket
 - [FleetingEcho/dsh-handoff](https://github.com/FleetingEcho/dsh-handoff) — 每个工作目录与 git 分支自动维护 handoff.md：记录回合、折叠为简洁 Markdown 并注入后续会话，存储于 ~/.agent/agent-handoff，与 pi-handoff 字节级兼容。
 - [flymysql/dsh-memory](https://github.com/flymysql/dsh-memory) — 跨会话记忆库：remember / recall / forget 工具、每轮提示注入与设置页条目浏览。
 - [freehul/sgme](https://github.com/freehul/sgme) — 拾光记忆引擎（SGME）桥接：多智能体共享长期记忆（HTTP）—— L0/L1/L1.5/L2 分层提炼、按场景注入、统一检索、主动关怀信号（memory_search / wiki_search / signal_pull / signal_claim / signal_ack），npm 包名 `dsh-sgme`。
-- [FuRongJun-1999/dsh-memory](https://github.com/FuRongJun-1999/dsh-memory) — AGI长期记忆基础：多智能体时空记忆图谱、自进化知识飞轮、自我认知与可审计的信任护栏。
 - [gezi-wen/sage-mem](https://github.com/gezi-wen/sage-mem) — 基于文件的跨会话记忆：纯 Markdown 记忆文件，检索结果自动注入；格式与 Claude Code 的 CLAUDE.md 及记忆文件兼容，迁移即手工复制文件。
 - [GIT121995/dsh-memory-gate](https://github.com/GIT121995/dsh-memory-gate) — 有界本地记忆 + CBDC 权威门控：SQLite + FTS5 claims，作用域召回并给出可解释的采用/核验/忽略决策与完整审计轨迹，/memory 命令，每次注入 ≤3 条/1200 字符，不增加额外模型调用。
 - [giter00/dsh-headroom](https://github.com/giter00/dsh-headroom) — 面向 DeepSeek Harness 的自动上下文压缩插件：在工具输出进入模型前压缩，并通过 CCR 检索工具保持所有有损压缩可逆。

--- a/contributing.md
+++ b/contributing.md
@@ -41,7 +41,7 @@ description:
 **Why one file per plugin / 为什么一个插件一个文件：** everyone used to append to the same spot in the same README section, so merging one PR broke the next. Separate files never collide. / 以前所有人都往同一分类的同一位置追加，合并一个 PR 就会撞掉下一个。独立文件永不冲突。
 
 Valid `category` values / 可用的 `category` 取值：
-`ui` `usage` `theme` `model` `identity` `session` `memory` `tools` `browser` `vision` `voice` `docs` `skill` `workflow` `git` `notify` `dev` `security` `remote` `market` `fun`
+`agi` `ui` `usage` `theme` `model` `identity` `session` `memory` `tools` `browser` `vision` `voice` `docs` `skill` `workflow` `git` `notify` `dev` `security` `remote` `market` `fun`
 
 This set is not fixed — see the note on categories under [how submissions are reviewed](#how-submissions-are-reviewed--收录如何评审). / 这组取值不是固定的，说明见[收录如何评审](#how-submissions-are-reviewed--收录如何评审)中关于分类的那条。
 

--- a/data/plugins/FuRongJun-1999__dsh-memory.yml
+++ b/data/plugins/FuRongJun-1999__dsh-memory.yml
@@ -1,6 +1,6 @@
 url: https://github.com/FuRongJun-1999/dsh-memory
 name: FuRongJun-1999/dsh-memory
-category: memory
+category: agi
 description:
-  en: 'AGI long-term memory base: multi-agent spatiotemporal memory graph, self-evolving knowledge flywheel, self-cognition, and auditable trust guardrails.'
-  zh: AGI长期记忆基础：多智能体时空记忆图谱、自进化知识飞轮、自我认知与可审计的信任护栏。
+  en: 'White-box AGI architecture exploration: metacognition (self-cognition loop), continual learning (knowledge flywheel), world model (condition space, spatiotemporal memory graph), self-improvement (bootstrap discipline), zero-LLM white-box pipeline, and auditable trust guardrails.'
+  zh: 白箱AGI架构探索：元认知（自我认知循环）、持续学习（知识飞轮）、世界模型（条件空间+语义时空图）、自我改进（自举纪律）、零LLM白箱管线与可审计信任护栏。

--- a/data/plugins/FuRongJun-1999__dsh-memory.yml
+++ b/data/plugins/FuRongJun-1999__dsh-memory.yml
@@ -1,6 +1,7 @@
 url: https://github.com/FuRongJun-1999/dsh-memory
 name: FuRongJun-1999/dsh-memory
 category: agi
+tarball: https://github.com/FuRongJun-1999/dsh-memory/releases/download/v0.3.0/furongjun1999-dsh-memory-0.3.0.tgz
 description:
   en: 'White-box AGI architecture exploration: metacognition (self-cognition loop), continual learning (knowledge flywheel), world model (condition space, spatiotemporal memory graph), self-improvement (bootstrap discipline), zero-LLM white-box pipeline, and auditable trust guardrails.'
   zh: 白箱AGI架构探索：元认知（自我认知循环）、持续学习（知识飞轮）、世界模型（条件空间+语义时空图）、自我改进（自举纪律）、零LLM白箱管线与可审计信任护栏。

--- a/scripts/lib/entries.mjs
+++ b/scripts/lib/entries.mjs
@@ -24,13 +24,14 @@ export const BASE_LOCALE = 'en'
 // chips and the sitemap. Kept in sync with CAT_IDS in build-site.mjs and the
 // two `categories` blocks in site/locales.mjs (reorder-categories.py rewrites
 // build-site.mjs by regex, so that array must stay on one line).
-export const CAT_IDS = ['ui', 'usage', 'theme', 'model', 'identity', 'session', 'memory', 'tools', 'browser', 'vision', 'voice', 'docs', 'skill', 'workflow', 'git', 'notify', 'dev', 'security', 'remote', 'market', 'fun']
+export const CAT_IDS = ['agi', 'ui', 'usage', 'theme', 'model', 'identity', 'session', 'memory', 'tools', 'browser', 'vision', 'voice', 'docs', 'skill', 'workflow', 'git', 'notify', 'dev', 'security', 'remote', 'market', 'fun']
 
 // Every README except the English one prefixes its headings with an emoji —
 // site/locales.mjs stores the bare names because build-site matches headings
 // by substring. A generator has to carry them, or regenerating would silently
 // strip the prefix from every translated heading.
 export const CAT_EMOJI = {
+  agi: '🧭',
   ui: '🎨',
   usage: '💰',
   theme: '🎭',

--- a/site/locales.mjs
+++ b/site/locales.mjs
@@ -57,6 +57,7 @@ export default [
     COPY_LABEL: 'Copy install command',
     COPY_TEXT: 'copy install',
     categories: {
+      agi: 'AGI Architecture Exploration',
       ui: 'UI Enhancements',
       usage: 'Usage & Billing',
       theme: 'Themes & Appearance',
@@ -166,6 +167,7 @@ export default [
     COPY_LABEL: '复制安装命令',
     COPY_TEXT: '复制安装命令',
     categories: {
+      agi: 'AGI 架构探索',
       ui: 'UI 增强',
       usage: '用量与计费',
       theme: '主题与外观',


### PR DESCRIPTION
## 变更内容 / What

新增「AGI 架构探索」（AGI Architecture Exploration）分类，并将 `FuRongJun-1999/dsh-memory` 从 `memory` 移入。

dsh-memory 不只是记忆插件——它是白箱 AGI 架构探索平台。官方 README 现有分类（memory / tools / skill / workflow / dev）都无法容纳它的横跨性：它同时实现元认知、持续学习、世界模型、自我改进与零 LLM 白箱管线。参考 contributing.md「分类体系本身也在变（usage/vision/security/browser/git/docs/remote/voice 均是从 tools/ui/dev 拆出）」，新增 `agi` 分类。

## 改动文件 / Files changed

- `scripts/lib/entries.mjs`：`CAT_IDS` 首位加 `agi`，`CAT_EMOJI` 加 `🧭`
- `site/locales.mjs`：en/zh `categories` 加 `agi`
- `contributing.md`：分类列表加 `agi`（生成器会校验同步）
- `data/plugins/FuRongJun-1999__dsh-memory.yml`：`category: memory` → `agi`，描述更新
- `README.md` / `README.zh.md`：由 `node scripts/generate-readme.mjs` 重新生成

## 描述说明 / Description note

新描述只含 dsh-memory 仓库内可核对的能力（自我认知循环 / 知识飞轮 / 条件空间+语义时空图 / 自举纪律 / 零 LLM 白箱管线 / 可审计信任护栏），未宣称已实现 AGI——「架构探索」定位，每项均有对应实现与指标。

## 分类顺序 / Category order

`agi` 置于首位，因其是最上位的架构探索类；如需调整位置维护者可自行移动（按贡献指南「分类会被维护者调整」）。