### PR TITLE
Add screenshots for jerryqx/dsh-xiaoyuzhou

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -1,4 +1,9 @@
 {
+ "https://github.com/jerryqx/dsh-xiaoyuzhou": [
+  "https://raw.githubusercontent.com/jerryqx/dsh-xiaoyuzhou/main/assets/screenshot-bar.png",
+  "https://raw.githubusercontent.com/jerryqx/dsh-xiaoyuzhou/main/assets/screenshot-mysubs.png",
+  "https://raw.githubusercontent.com/jerryqx/dsh-xiaoyuzhou/main/assets/screenshot-podcast.png"
+ ],
  "https://github.com/fengb3/dsh-session-icons": [
   "https://raw.githubusercontent.com/fengb3/dsh-session-icons/master/docs/screenshot.png"
  ],


### PR DESCRIPTION
Adds AppStore-style screenshots for the entry added in #3282 (pending its age-gate re-run).

- 3 images, hosted on `raw.githubusercontent.com` from the plugin repo `assets/` folder
- 3 images: now-playing bar, my-subscriptions list, podcast episode list
- URLs verified live (HTTP 200)
- Only touches `data/screenshots.json` (+5 lines, CRLF preserved)