### PR TITLE
feat: add screenshots for liuwenji007/dsh-muyu

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -718,6 +718,10 @@
   "https://raw.githubusercontent.com/literaf/dsh-ai4scholar/main/docs/settings-card.png",
   "https://raw.githubusercontent.com/literaf/dsh-ai4scholar/main/docs/balance-card.png"
  ],
+ "https://github.com/liuwenji007/dsh-muyu": [
+  "https://raw.githubusercontent.com/liuwenji007/dsh-muyu/main/docs/tap.gif",
+  "https://raw.githubusercontent.com/liuwenji007/dsh-muyu/main/docs/auto-tap.gif"
+ ],
  "https://github.com/liuyuelintop/dsh-conversation-exporter": [
   "https://raw.githubusercontent.com/liuyuelintop/dsh-conversation-exporter/main/assets/select-turns.png",
   "https://raw.githubusercontent.com/liuyuelintop/dsh-conversation-exporter/main/assets/selective-export-mermaid.png",


### PR DESCRIPTION
## Summary
- Add curated screenshots for `https://github.com/liuwenji007/dsh-muyu` in `data/screenshots.json`.
- Uses existing README demo GIFs (`docs/tap.gif`, `docs/auto-tap.gif`) on GitHub raw.

## Test plan
- [ ] CI screenshots validation passes
- [ ] Key matches plugin entry URL
- [ ] Images return 200 from raw.githubusercontent.com
