### PR TITLE
feat: probe per-repo update notes and publish them as dsh-plugin-updates

### DIFF
--- a/.github/workflows/build-site.yml
+++ b/.github/workflows/build-site.yml
@@ -92,6 +92,15 @@ jobs:
           path: data/downloads.json
           key: downloads-v1-${{ github.run_id }}
           restore-keys: downloads-v1-
+      # data/updates.json gets its own cache entry, NOT a line in the shared
+      # list above — same reasoning as downloads below: adding a path to the
+      # shared list derives a new cache version and forces every other probe
+      # into the cold start that spent a whole quota mid-run (#1673).
+      - uses: actions/cache@v4
+        with:
+          path: data/updates.json
+          key: updates-v1-${{ github.run_id }}
+          restore-keys: updates-v1-
       - name: Build
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -121,6 +130,14 @@ jobs:
             node scripts/probe-downloads.mjs
             node scripts/probe-stars.mjs
             node scripts/probe-readmes.mjs
+            # Update notes for the market's "what changed" dialog (#294): the
+            # latest release plus a short commit tail, probed here once a day
+            # so no end-user market ever has to ask GitHub itself — anonymous
+            # REST quota is shared per egress IP and already unreliable.
+            # data/updates.json is committed AND cached above (same shape as
+            # downloads), and absence of notes is a normal state downstream,
+            # so this probe never blocks the build.
+            node scripts/probe-updates.mjs
           else
             echo "push build with cached probe data — skipping probes"
           fi
@@ -172,3 +189,14 @@ jobs:
         run: |
           npm install -g npm@latest  # trusted publishing needs npm >= 11.5
           node scripts/publish-catalog.mjs
+      # The update-notes payload, published to npm for the same reason as the
+      # catalog above — Pages IS GitHub, and the proxies that would carry it
+      # refuse non-github.com hostnames — but as its OWN package: notes are
+      # read only by a user who opened one dialog, so folding them into the
+      # catalog tarball would multiply every consumer's daily download for
+      # data most never request. See scripts/publish-updates.mjs.
+      - name: publish the update notes to npm
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+        run: |
+          npm install -g npm@latest  # trusted publishing needs npm >= 11.5
+          node scripts/publish-updates.mjs

--- a/scripts/build-site.mjs
+++ b/scripts/build-site.mjs
@@ -531,6 +531,14 @@ for (const loc of LOCALES) {
 // Plugin detail pages: /p/{owner}/{repo}[--subdir]/ per locale
 const detailMaster = fs.readFileSync('site/detail-template.html', 'utf8')
 const readmes = fs.existsSync('data/readmes.json') ? JSON.parse(fs.readFileSync('data/readmes.json', 'utf8')) : {}
+// Update notes (probe-updates.mjs): the latest release's notes and a short
+// tail of recent commits, published as docs/updates.json for market-side
+// consumers. Kept OUT of plugins.json on purpose: that file is fetched by
+// every market on every open, and 1,300 release bodies would multiply its
+// size for data only a user opening one update dialog ever reads. Absence is
+// normal — repos without releases still carry their commit tail, and an
+// entry missing here means "no notes available", never an error downstream.
+const updates = fs.existsSync('data/updates.json') ? JSON.parse(fs.readFileSync('data/updates.json', 'utf8')) : {}
 
 // render a plugin README to safe HTML: raw HTML dropped, headings demoted,
 // relative links/images resolved against the repo (probe supplies the bases)
@@ -850,6 +858,30 @@ fs.writeFileSync('docs/plugins.json', JSON.stringify(registry, null, 1) + '\n')
   }
   fs.writeFileSync('docs/readmes.json', JSON.stringify(payload) + '\n')
   console.log(`readmes.json: ${payload.count} entries, ${(fs.statSync('docs/readmes.json').size / 1048576).toFixed(1)} MB`)
+}
+
+// Public update-notes payload: /updates.json — what a consumer needs to show
+// "what changed" between an installed version and HEAD without touching the
+// GitHub API (whose anonymous budget is shared per egress IP and unusable
+// behind common proxies). One file fetched once per consumer, like readmes;
+// only listed entries, so delisting removes the notes the same build it
+// removes everything else about a plugin.
+{
+  const listed = new Set(ordered.map((e) => e.url))
+  const payload = {
+    name: 'awesome-dsh-plugin',
+    url: ORIGIN,
+    updated: registry.updated,
+    count: 0,
+    updates: {},
+  }
+  for (const [url, entry] of Object.entries(updates)) {
+    if (!listed.has(url)) continue
+    payload.updates[url] = entry
+    payload.count++
+  }
+  fs.writeFileSync('docs/updates.json', JSON.stringify(payload) + '\n')
+  console.log(`updates.json: ${payload.count} entries, ${(fs.statSync('docs/updates.json').size / 1024).toFixed(0)} KB`)
 }
 
 const lastAdded = [...ordered].map((e) => e.added).sort().pop()

--- a/scripts/probe-updates.mjs
+++ b/scripts/probe-updates.mjs
@@ -1,0 +1,199 @@
+#!/usr/bin/env node
+/**
+ * Refresh per-repo update notes into data/updates.json, published by
+ * build-site.mjs as docs/updates.json for market-side consumers (#dsh-market
+ * issue 294): what changed between a user's installed version and HEAD.
+ *
+ * Two facts shape this file:
+ *
+ * - The consumers are end users' markets, thousands of them, each holding an
+ *   installed commit sha that exists nowhere but on that machine. The catalog
+ *   cannot know where any user's installed version sits, so it publishes the
+ *   raw ingredients — the latest release's notes and a short tail of recent
+ *   commits — once a day for everyone, instead of every consumer asking
+ *   GitHub itself and burning through the anonymous 60-per-hour quota.
+ *
+ * - Anonymous REST access behind common proxies is already unreliable (the
+ *   same budget is shared per egress IP), which is why this probe runs here,
+ *   against one CI token, rather than in the market.
+ *
+ * Per repository: `/releases/latest` (a 404 is a fact — most plugins ship no
+ * releases — not a failure) and `/commits?per_page=5` (the tail the market
+ * slices at each user's installed sha; 8 covers the common case of an update
+ * being a handful of commits, and anything wider reads as "recent commits"
+ * rather than pretending to be an exact interval).
+ *
+ * Requires GITHUB_TOKEN (CI provides one; locally: GITHUB_TOKEN=$(gh auth token)).
+ * Without a token the script exits 0 without touching the file. A failed repo
+ * keeps its old entry.
+ *
+ * Usage: GITHUB_TOKEN=... node scripts/probe-updates.mjs
+ */
+import fs from 'node:fs'
+import LOCALES from '../site/locales.mjs'
+
+const OUT_FILE = 'data/updates.json'
+// Release bodies are markdown written by authors for humans reading GitHub;
+// a dialog-sized preview does not need more than this.
+const MAX_BODY_BYTES = 4 * 1024
+const COMMIT_TAIL = 5
+const MAX_MESSAGE_CHARS = 200
+// Update notes go stale fast by nature — a release published this morning is
+// exactly what a user wants to read before clicking update — so unlike the
+// readmes (7 days) this refreshes daily, matching probe-stars' cadence.
+const RECHECK_DAYS = Number(process.env.PROBE_RECHECK_DAYS ?? 1)
+const PROBE_ALL = process.env.PROBE_ALL === '1'
+const CONCURRENCY = Number(process.env.PROBE_CONCURRENCY ?? (PROBE_ALL ? 4 : 8))
+
+const token = process.env.GITHUB_TOKEN
+if (!token) {
+  console.log('no GITHUB_TOKEN — keeping committed update-notes data as-is')
+  process.exit(0)
+}
+
+const map = fs.existsSync(OUT_FILE) ? JSON.parse(fs.readFileSync(OUT_FILE, 'utf8')) : {}
+const readme = fs.readFileSync(LOCALES[0].readme, 'utf8')
+const urls = [...readme.matchAll(/^- \[.+?\]\((https:\/\/github\.com\/[^)]+)\) [—-] /gm)].map((m) => m[1])
+const today = new Date().toISOString().slice(0, 10)
+
+/** Thrown for a status the caller may want to tell apart (404 vs rate limit). */
+class HttpError extends Error {
+  constructor(status) {
+    super(`HTTP ${status}`)
+    this.status = status
+  }
+}
+
+async function gh(path) {
+  const res = await fetch(`https://api.github.com${path}`, {
+    headers: {
+      accept: 'application/vnd.github+json',
+      authorization: `Bearer ${token}`,
+      'user-agent': 'awesome-dsh-plugin-updates-probe',
+    },
+    signal: AbortSignal.timeout(15000),
+  })
+  if (res.status === 403 || res.status === 429) {
+    // Secondary limits answer with retry-after; primary exhaustion sets
+    // x-ratelimit-remaining: 0 and a reset timestamp. Sleeping is the whole
+    // remedy — retrying immediately is what earns a longer block.
+    const after = Number(res.headers.get('retry-after'))
+    const reset = Number(res.headers.get('x-ratelimit-reset'))
+    const waitMs = Number.isFinite(after) && after > 0
+      ? after * 1000
+      : (res.headers.get('x-ratelimit-remaining') === '0' && Number.isFinite(reset)
+        ? Math.max(0, reset * 1000 - Date.now()) + 1000
+        : 0)
+    if (waitMs > 0 && waitMs <= 120000) {
+      await new Promise((r) => setTimeout(r, waitMs))
+      return gh(path)
+    }
+  }
+  if (!res.ok) throw new HttpError(res.status)
+  return res.json()
+}
+
+async function probe(url) {
+  // monorepo subdir entries inherit the parent repo's history, like stars do
+  const repoPath = url.replace('https://github.com/', '').replace(/\/$/, '').split('/').slice(0, 2).join('/')
+  try {
+    let release = null
+    try {
+      const r = await gh(`/repos/${repoPath}/releases/latest`)
+      let body = typeof r.body === 'string' ? r.body : ''
+      if (body.length > MAX_BODY_BYTES) body = body.slice(0, MAX_BODY_BYTES) + '\n\n…'
+      if (r.tag_name || body) {
+        release = {
+          tag: r.tag_name ?? null,
+          name: r.name ?? null,
+          publishedAt: r.published_at ?? null,
+          url: r.html_url ?? null,
+          body,
+        }
+      }
+    } catch (e) {
+      // No releases is the ordinary case for small plugins, not a failure.
+      if (!(e instanceof HttpError && e.status === 404)) throw e
+    }
+
+    const log = await gh(`/repos/${repoPath}/commits?per_page=${COMMIT_TAIL}`)
+    const commits = (Array.isArray(log) ? log : []).map((c) => ({
+      sha: c.sha ?? null,
+      message: (c.commit?.message ?? '').split('\n')[0].slice(0, MAX_MESSAGE_CHARS),
+      date: c.commit?.author?.date ?? null,
+    })).filter((c) => c.sha !== null)
+
+    if (!release && !commits.length) throw new Error('no update data')
+    return { release, commits, checkedAt: today }
+  } catch {
+    return null // keep the previous entry
+  }
+}
+
+const fresh = (entry) =>
+  !PROBE_ALL
+  && entry !== undefined
+  && entry.checkedAt
+  && (Date.now() - new Date(entry.checkedAt).getTime()) / 86400000 <= RECHECK_DAYS
+
+const pending = urls.filter((url) => !fresh(map[url]))
+console.log(`${urls.length} listed, ${pending.length} to probe${PROBE_ALL ? ' (PROBE_ALL)' : ''}`)
+
+const failed = []
+let done = 0
+let ok = 0
+for (let i = 0; i < pending.length; i += CONCURRENCY) {
+  const batch = pending.slice(i, i + CONCURRENCY)
+  const results = await Promise.all(batch.map(async (url) => [url, await probe(url)]))
+  for (const [url, result] of results) {
+    if (result === null) failed.push(url)
+    else { map[url] = result; ok++ }
+  }
+  done += batch.length
+  if (done % 50 === 0 || done >= pending.length) console.log(`updates ${done}/${pending.length}`)
+}
+
+// Same second-pass reasoning as probe-readmes.mjs: a burst failure must not be
+// indistinguishable from "this repo has nothing", because entries added since
+// the last run have no previous data to fall back on.
+if (failed.length) {
+  console.log(`${failed.length} repo(s) failed the first pass — retrying serially`)
+  await new Promise((r) => setTimeout(r, 20000))
+  const stillFailed = []
+  for (const url of failed) {
+    const result = await probe(url)
+    if (result === null) stillFailed.push(url)
+    else { map[url] = result; ok++ }
+    await new Promise((r) => setTimeout(r, 250))
+  }
+  failed.length = 0
+  failed.push(...stillFailed)
+}
+if (failed.length) console.log(`${failed.length} repo(s) kept their previous update data`)
+
+// drop entries for URLs no longer listed
+const listed = new Set(urls)
+for (const k of Object.keys(map)) if (!listed.has(k)) delete map[k]
+
+// A run where every probe failed is almost always an exhausted quota or an API
+// outage. Unlike stars there is no publish-blocking coverage floor downstream
+// (absence of update notes is legitimate for many repos), so staleness is the
+// whole cost of writing — but an EMPTY map replacing a populated one is still
+// worth being loud about.
+const have = Object.keys(map).length
+if (pending.length && ok === 0) {
+  console.warn(`every one of the ${pending.length} probe(s) failed — nothing refreshed this run`)
+  console.warn('Usually an exhausted GitHub API quota or an API outage, not a data problem.')
+}
+if (!have && urls.length) {
+  console.error(`refusing to replace ${OUT_FILE} with an empty map over ${urls.length} listed repos`)
+  process.exit(1)
+}
+if (ok === 0 && pending.length) {
+  console.log(`${OUT_FILE} left as-is (${have} repos, nothing new to record)`)
+  process.exit(0)
+}
+
+const sorted = Object.fromEntries(Object.entries(map).sort(([a], [b]) => a.localeCompare(b)))
+fs.writeFileSync(OUT_FILE, JSON.stringify(sorted, null, 1) + '\n')
+console.log(`updates.json written: ${Object.keys(sorted).length} repos (${ok} refreshed this run)`)

--- a/scripts/publish-updates.mjs
+++ b/scripts/publish-updates.mjs
@@ -1,0 +1,134 @@
+/**
+ * Publish `updates.json` to npm as the `dsh-plugin-updates` package.
+ *
+ * The companion to publish-catalog.mjs for the update-notes data
+ * (probe-updates.mjs → data/updates.json → docs/updates.json): per-repo
+ * release notes and commit tails that a market needs to show "what changed"
+ * between an installed version and HEAD.
+ *
+ * Why its OWN package rather than a second file inside `dsh-plugin-catalog`:
+ * the catalog tarball is fetched by every market on every version bump, and
+ * update notes are read only by a user who opened one dialog. Folding them in
+ * would multiply what every consumer downloads for data most of them never
+ * request — spending on the wire exactly what splitting exists to save. The
+ * consumer pays nothing until it asks, and then rides the same mirrors.
+ *
+ * Everything is assembled in a temp directory, so this writes nothing into
+ * the repository and the invariant at the top of build-site.yml holds
+ * literally rather than approximately. Same trusted-publishing (OIDC) setup,
+ * same content-hash skip, same date-based versioning as publish-catalog.mjs.
+ */
+
+import { createHash } from 'node:crypto'
+import { execFileSync } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+const PKG = 'dsh-plugin-updates'
+const BUILT = 'docs/updates.json'
+const REGISTRY = 'https://registry.npmjs.org'
+
+/** Content hash, so unchanged notes do not earn a version of their own. */
+function sha256(buffer) {
+  return createHash('sha256').update(buffer).digest('hex')
+}
+
+/**
+ * The hash carried by the newest published version, or null.
+ *
+ * Read from the packument rather than by downloading the tarball: the field
+ * is a few bytes of metadata, and this runs on every nightly build.
+ */
+async function publishedHash() {
+  try {
+    const res = await fetch(`${REGISTRY}/${PKG}/latest`)
+    if (!res.ok) return null
+    const meta = await res.json()
+    return typeof meta.updatesSha === 'string' ? meta.updatesSha : null
+  } catch {
+    // A registry that cannot be reached has not said the data is unchanged.
+    // Publishing a duplicate version is a smaller mistake than silently
+    // skipping a real update, and npm refuses duplicates anyway.
+    return null
+  }
+}
+
+/**
+ * A date-based version, monotonic and legible — same scheme as the catalog.
+ *
+ * `YYYY.MDD.RUN` — the run number distinguishes several publishes in one day,
+ * and the date part sorts correctly within and across years.
+ */
+export function updatesVersion(now, run) {
+  const mmdd = (now.getUTCMonth() + 1) * 100 + now.getUTCDate()
+  return `${now.getUTCFullYear()}.${mmdd}.${run}`
+}
+
+/** The README the package page shows. Short, because it is shipped to readers. */
+function readme(version, entries) {
+  return `# dsh-plugin-updates
+
+Per-plugin update notes for the DeepSeek Harness plugin catalog — the latest
+release's notes and a short tail of recent commits for every listed plugin,
+probed daily and published to npm so it can be fetched from a registry mirror.
+
+It exists so a plugin market can show "what changed" between an installed
+version and HEAD without any end user touching the GitHub API, whose anonymous
+budget is shared per egress IP and unusable behind common proxies.
+
+\`\`\`js
+import updates from 'dsh-plugin-updates/updates.json' with { type: 'json' }
+\`\`\`
+
+- **Entries:** ${entries}
+- **Version:** \`${version}\` (\`YYYY.MDD.BUILD\`, published only when the data changes)
+- **Source:** <https://github.com/awesome-dsh-plugin/awesome-dsh-plugin>
+- **License:** CC0-1.0
+
+The schema is documented by its producer, \`scripts/probe-updates.mjs\`, in the
+source repository. Published automatically; do not open pull requests here.
+`
+}
+
+if (!fs.existsSync(BUILT)) {
+  console.error(`${BUILT} is missing — run scripts/build-site.mjs first`)
+  process.exit(1)
+}
+const built = fs.readFileSync(BUILT)
+const hash = sha256(built)
+if (hash === await publishedHash()) {
+  console.log(`update notes unchanged (${hash.slice(0, 12)}) — nothing to publish`)
+  process.exit(0)
+}
+
+const entries = JSON.parse(built.toString()).count ?? 0
+const version = updatesVersion(new Date(), process.env.GITHUB_RUN_NUMBER ?? '0')
+const stage = fs.mkdtempSync(path.join(os.tmpdir(), 'dsh-updates-'))
+fs.writeFileSync(path.join(stage, 'updates.json'), built)
+fs.writeFileSync(path.join(stage, 'README.md'), readme(version, entries))
+fs.copyFileSync('LICENSE', path.join(stage, 'LICENSE'))
+fs.writeFileSync(path.join(stage, 'package.json'), JSON.stringify({
+  name: PKG,
+  version,
+  description: `Per-plugin update notes for the DeepSeek Harness plugin catalog (${entries} entries) · 插件更新说明数据`,
+  homepage: 'https://awesome-dsh-plugin.com',
+  repository: {
+    type: 'git',
+    url: 'git+https://github.com/awesome-dsh-plugin/awesome-dsh-plugin.git',
+  },
+  license: 'CC0-1.0',
+  keywords: ['dsh', 'dsh-plugin', 'deepseek-harness', 'deepseek', 'changelog', 'releases'],
+  // The validator a consumer reads back on its next check, and what stops
+  // this script republishing identical notes tomorrow.
+  updatesSha: hash,
+  exports: { './updates.json': './updates.json' },
+  files: ['updates.json'],
+}, null, 2) + '\n')
+
+console.log(`publishing ${PKG}@${version} — ${entries} entries, sha ${hash.slice(0, 12)}`)
+// `DRY_RUN=1` runs everything up to and including npm's own packing checks
+// without publishing, so the whole path can be exercised by hand.
+const args = ['publish', '--access', 'public']
+if (process.env.DRY_RUN === '1') args.push('--dry-run')
+execFileSync('npm', args, { stdio: 'inherit', cwd: stage })


### PR DESCRIPTION
目录侧配套改动（[配套的市场侧 PR](https://github.com/dsh-market/dsh-market/pull/366)）：为「更新内容预览」生产数据。

## 改动
- **`scripts/probe-updates.mjs` 新增** —— 新的探测脚本，骨架与 probe-readmes 一致（token 缺失退出 0、限流 retry-after 等待、增量 RECHECK_DAYS=1 + 夜间 PROBE_ALL、失败保留旧值、二次串行重试）。每仓库两个调用：`/releases/latest`（404 是事实不是失败）+ `/commits?per_page=5`，写入 `data/updates.json`。
- **`build-site.mjs`** —— 发布公开产物 `docs/updates.json`。刻意不并入 plugins.json：那是每个市场每次打开都要拉的文件，2231 条 release 说明会成倍撑大它，而这些内容只有用户打开一个对话框时才被读到（同 readmes.json 单独成文件的先例）。
- **`scripts/publish-updates.mjs` 新增** —— 发布为独立 npm 包 `dsh-plugin-updates`（Pages 在国内不可达）。机制照抄 publish-catalog：内容 hash 跳过未变更版本、日期版本号、trusted publishing。**需要维护者一次性配置该新包的 OIDC trusted publisher。**
- **workflow** —— 新增探测调用与独立缓存步，发布挂在 nightly/dispatch。

## 备选
如果不想多维护一个包，updates.json 也可以并进 dsh-plugin-catalog 的 tarball（代价是每次目录更新约 +1MB）或者压缩后并入 plugins.json——听你的。

## 为什么在目录侧做
#294 里已对齐：匿名 REST 配额按出口 IP 共享，N 个用户 × M 个插件各打一遍 GitHub 必然触顶；目录侧一天一探、全体共享。市场侧运行时零 GitHub API 调用。

已验证：probe 对 3 个真实仓库实测通过；本地 build 全链路产出 updates.json；publish 走 DRY_RUN 打包成功（正式发布需上述权限配置）。