### PR TITLE
Add 452926826/dsh-ssh-logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2161,6 +2161,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 
 ### Remote & Mobile
 
+- [452926826/dsh-ssh-logs](https://github.com/452926826/dsh-ssh-logs) - Read and search bounded log output from allowlisted SSH servers and log roots without exposing arbitrary remote commands.
 - [534119219/chicheng-gate](https://github.com/534119219/chicheng-gate) - LAN / remote-access control, frpc NAT tunneling, a panel password gate, and mobile UI adaptation for the DSH Web GUI.
 - [AcidGr/dsh-web-lan-access](https://github.com/AcidGr/dsh-web-lan-access) - LAN/remote access for the Web UI: injects a crypto.randomUUID polyfill on plain-HTTP origins so the frontend survives LAN or Tailscale IP direct links.
 - [ai-eks/dsh-auth-tunnel](https://github.com/ai-eks/dsh-auth-tunnel) - Password-gated public access for the DSH Web GUI through quick or named Cloudflare Tunnels, with HTTP/WebSocket proxying and an in-app directory picker.

--- a/README.zh.md
+++ b/README.zh.md
@@ -2161,6 +2161,7 @@ dsh plugin --profile web add dshmarket
 
 ### 📱 远程与移动端
 
+- [452926826/dsh-ssh-logs](https://github.com/452926826/dsh-ssh-logs) — 从白名单 SSH 服务器和日志根目录读取或搜索有界日志内容，不开放任意远程命令。
 - [534119219/chicheng-gate](https://github.com/534119219/chicheng-gate) — DSH Web 插件：局域网/远程访问控制、frpc 内网穿透、面板密码门禁与手机端 UI 适配。
 - [AcidGr/dsh-web-lan-access](https://github.com/AcidGr/dsh-web-lan-access) — Web UI 局域网/远程访问：为纯 HTTP 非安全上下文注入 crypto.randomUUID polyfill，局域网/Tailscale IP 直连时前端不再崩溃。
 - [ai-eks/dsh-auth-tunnel](https://github.com/ai-eks/dsh-auth-tunnel) — 通过快速或命名 Cloudflare Tunnel 为 DSH Web GUI 提供密码保护的公网访问，并代理 HTTP/WebSocket 流量、改用应用内目录选择器。

--- a/data/plugins/452926826__dsh-ssh-logs.yml
+++ b/data/plugins/452926826__dsh-ssh-logs.yml
@@ -1,0 +1,6 @@
+url: https://github.com/452926826/dsh-ssh-logs
+name: 452926826/dsh-ssh-logs
+category: remote
+description:
+  en: Read and search bounded log output from allowlisted SSH servers and log roots without exposing arbitrary remote commands.
+  zh: 从白名单 SSH 服务器和日志根目录读取或搜索有界日志内容，不开放任意远程命令。


### PR DESCRIPTION
## Plugin

Adds `452926826/dsh-ssh-logs` to the `remote` category.

The plugin provides bounded, read-only log access and literal search across allowlisted SSH servers and log roots without exposing arbitrary remote commands.

## Verification

- Declares an installable `dsh.bundle` manifest
- Repository has the `dsh-plugin` topic
- Repository is more than one day old and has at least 10 commits
- Unit, marketplace manifest, and MCP smoke tests pass
- Packed tarball installation was verified in an isolated DSH Web profile
- Generated `README.md` and `README.zh.md` are in sync
