### PR TITLE
Add 452926826/dsh-at-skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -1492,6 +1492,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 
 ### Skills
 
+- [452926826/dsh-at-skill](https://github.com/452926826/dsh-at-skill) - Invoke user-accessible Skills with @name tokens and show matching Skill suggestions in the conversation composer.
 - [7dgroup-ai/dsh-skill-7d-code-reviewer](https://github.com/7dgroup-ai/dsh-skill-7d-code-reviewer) - Template-driven code review skill: five-step review flow, critical/medium/minor severity grading, four-dimension scoring (quality, security, performance, maintainability), dual text and HTML report output, and an on-demand reference knowledge base.
 - [863683348/dsh-starter-zh](https://github.com/863683348/dsh-starter-zh) - Beginner starter pack for DeepSeek Harness: welcome flow, 0→1 learning path, scenario-based plugin recommendations and a self-check checklist, paired with the dsh-handbook-zh Chinese tutorial repo.
 - [akqwpeter-prog/skill-bartender](https://github.com/akqwpeter-prog/skill-bartender) - Task-to-skill pairing meta-skill with a laziness ladder for minimal loading, a user-editable routing table, and a quarantine, SkillSpector scan, human-approval install flow.

--- a/README.zh.md
+++ b/README.zh.md
@@ -1492,6 +1492,7 @@ dsh plugin --profile web add dshmarket
 
 ### 🧩 技能包
 
+- [452926826/dsh-at-skill](https://github.com/452926826/dsh-at-skill) — 通过 @名称 标记调用用户可用的 Skill，并在对话输入框中显示匹配的 Skill 候选项。
 - [7dgroup-ai/dsh-skill-7d-code-reviewer](https://github.com/7dgroup-ai/dsh-skill-7d-code-reviewer) — 模板驱动的代码审查技能：五步审查流程、严重/中等/轻微三级分级、四维评分（质量、安全、性能、可维护性），同时输出文本与 HTML 报告，内置按需加载的参考知识库。
 - [863683348/dsh-starter-zh](https://github.com/863683348/dsh-starter-zh) — DSH 新手入门包：欢迎语、从 0 到 1 学习路径、按场景推荐插件与新手自查清单，联动 dsh-handbook-zh 中文教程仓库。
 - [akqwpeter-prog/skill-bartender](https://github.com/akqwpeter-prog/skill-bartender) — 任务到技能配对元技能：懒人阶梯最小化加载、可编辑路由表、隔离-SkillSpector 扫描-人工确认的安装流程。

--- a/data/plugins/452926826__dsh-at-skill.yml
+++ b/data/plugins/452926826__dsh-at-skill.yml
@@ -1,0 +1,6 @@
+url: https://github.com/452926826/dsh-at-skill
+name: 452926826/dsh-at-skill
+category: skill
+description:
+  en: Invoke user-accessible Skills with @name tokens and show matching Skill suggestions in the conversation composer.
+  zh: 通过 @名称 标记调用用户可用的 Skill，并在对话输入框中显示匹配的 Skill 候选项。


### PR DESCRIPTION
## Plugin

Adds `452926826/dsh-at-skill` to the `skill` category.

The plugin invokes user-accessible Skills through `@name` tokens and provides matching Skill suggestions in the conversation composer.

## Verification

- Declares an installable `dsh.bundle` manifest and Web client entry
- Repository has the `dsh-plugin` topic
- Repository is more than one day old and has at least 10 commits
- Package and marketplace manifest checks pass
- Packed tarball installation was verified in an isolated DSH Web profile
- Generated `README.md` and `README.zh.md` are in sync
