### PR TITLE
Add 452926826/dsh-feishu-bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -2389,6 +2389,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 
 ### Remote & Mobile
 
+- [452926826/dsh-feishu-bot](https://github.com/452926826/dsh-feishu-bot) - Connect Feishu chats to DeepSeek Harness projects, conversations, replies, and scoped tool approvals over WebSocket.
 - [452926826/dsh-ssh-logs](https://github.com/452926826/dsh-ssh-logs) - Read and search bounded log output from allowlisted SSH servers and log roots without exposing arbitrary remote commands.
 - [534119219/chicheng-gate](https://github.com/534119219/chicheng-gate) - LAN / remote-access control, frpc NAT tunneling, a panel password gate, and mobile UI adaptation for the DSH Web GUI.
 - [AcidGr/dsh-web-lan-access](https://github.com/AcidGr/dsh-web-lan-access) - LAN/remote access for the Web UI: injects a crypto.randomUUID polyfill on plain-HTTP origins so the frontend survives LAN or Tailscale IP direct links.

--- a/README.zh.md
+++ b/README.zh.md
@@ -2389,6 +2389,7 @@ dsh plugin --profile web add dshmarket
 
 ### 📱 远程与移动端
 
+- [452926826/dsh-feishu-bot](https://github.com/452926826/dsh-feishu-bot) — 通过 WebSocket 将飞书聊天连接到 DeepSeek Harness 的项目、对话、回复和限定范围的工具审批。
 - [452926826/dsh-ssh-logs](https://github.com/452926826/dsh-ssh-logs) — 从白名单 SSH 服务器和日志根目录读取或搜索有界日志内容，不开放任意远程命令。
 - [534119219/chicheng-gate](https://github.com/534119219/chicheng-gate) — DSH Web 插件：局域网/远程访问控制、frpc 内网穿透、面板密码门禁与手机端 UI 适配。
 - [AcidGr/dsh-web-lan-access](https://github.com/AcidGr/dsh-web-lan-access) — Web UI 局域网/远程访问：为纯 HTTP 非安全上下文注入 crypto.randomUUID polyfill，局域网/Tailscale IP 直连时前端不再崩溃。

--- a/data/plugins/452926826__dsh-feishu-bot.yml
+++ b/data/plugins/452926826__dsh-feishu-bot.yml
@@ -1,0 +1,6 @@
+url: https://github.com/452926826/dsh-feishu-bot
+name: 452926826/dsh-feishu-bot
+category: remote
+description:
+  en: Connect Feishu chats to DeepSeek Harness projects, conversations, replies, and scoped tool approvals over WebSocket.
+  zh: 通过 WebSocket 将飞书聊天连接到 DeepSeek Harness 的项目、对话、回复和限定范围的工具审批。


### PR DESCRIPTION
## Plugin

Adds `452926826/dsh-feishu-bot` to the `remote` category.

The plugin connects Feishu chats to DeepSeek Harness projects, conversations, responses, and chat-scoped tool approvals over WebSocket.

## Verification

- Declares an installable `dsh.bundle` manifest and Web settings client
- Repository has the `dsh-plugin` topic
- Repository is more than one day old and has at least 10 commits
- Build, 33 tests, marketplace manifest checks, and package checks pass
- Packed tarball installation was verified in an isolated DSH Web profile
- Generated `README.md` and `README.zh.md` are in sync

The Feishu SDK depends on `protobufjs`. Under pnpm's build-script policy, installation may generate an `allowBuilds.protobufjs` prompt; the plugin README documents setting it to `true` and rerunning installation.
