### PR TITLE
Update ADWMC/helm-d description for v0.2.0 (31 tools, case workflow)

### DIFF
--- a/data/plugins/ADWMC__helm-d--packages-helmd.yml
+++ b/data/plugins/ADWMC__helm-d--packages-helmd.yml
@@ -3,5 +3,5 @@ name: ADWMC/helm-d#helmd
 category: security
 tarball: https://github.com/ADWMC/helm-d/releases/latest/download/helmd.tgz
 description:
-  en: 'Single-bundle security analysis plugin: bootstrap tool narrowing, a domain router, and 25 reverse-engineering tools covering APK, native binary, protocol, malware and LLM samples with on-demand reference docs.'
-  zh: '单包安全分析插件：引导期工具收敛、领域路由与 25 个逆向分析工具，覆盖 APK、原生二进制、协议、恶意样本与 LLM 场景，参考文档按需读取。'
+  en: 'Single-bundle security analysis plugin: bootstrap tool narrowing, a domain router, and 31 tools covering APK, native binary, protocol, malware and LLM samples, with an on-disk case workflow (auto-persisted evidence chain, E-numbered validated findings, post-compaction resume), GitHub-based external tool discovery, and on-demand reference docs.'
+  zh: '单包安全分析插件：引导期工具收敛、领域路由与 31 个工具，覆盖 APK、原生二进制、协议、恶意样本与 LLM 场景；内置磁盘案件工作区（证据链自动存证、E 编号结论校验、上下文压缩后恢复）、GitHub 工具检索与按需参考文档。'


### PR DESCRIPTION
Single-entry description update for the helmd v0.2.0 release (already live at https://github.com/ADWMC/helm-d/releases/tag/v0.2.0).

Changes vs current entry:
- tool count 25 -> 31 (verified against packages/helmd dist: 31 registered tools)
- mentions the new on-disk case workflow: auto-persisted evidence chain, E-numbered validated findings, post-compaction resume
- mentions GitHub-based external tool discovery (find_tool / save_evidence)

1 entry modified, 0 added — within the 3-entry PR limit.