### PR TITLE
Update dsh-codex-workflow to 1.0.6

### DIFF
--- a/data/plugins/kui123456789__dsh-codex-workflow.yml
+++ b/data/plugins/kui123456789__dsh-codex-workflow.yml
@@ -4,4 +4,4 @@ category: workflow
 description:
   en: Coordinates Codex planning and independent review while the original DSH session implements and tests changes.
   zh: 协调 Codex 制定计划和独立审查，由 DSH 原会话完成代码修改与测试。
-tarball: https://github.com/kui123456789/dsh-codex-workflow/releases/latest/download/dsh-codex-workflow-1.0.5.tgz
+tarball: https://github.com/kui123456789/dsh-codex-workflow/releases/latest/download/dsh-codex-workflow-1.0.6.tgz


### PR DESCRIPTION
## Summary

- update `dsh-codex-workflow` release tarball from `1.0.5` to `1.0.6`
- keep the existing repository metadata and descriptions unchanged

## Verification

- `node scripts/generate-readme.mjs`
- `node scripts/generate-readme.mjs --check`
- `npx awesome-lint README.md` (passes with existing repository warnings only)
- `SKIP_PUBLISH_CHECKS=1 node scripts/build-site.mjs`
- GitHub Release `v1.0.6` contains `dsh-codex-workflow-1.0.6.tgz`