### PR TITLE
Add zhangjunjesse/dsh-claude-driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -713,6 +713,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 - [ZChenW/dsh-codex-switch](https://github.com/ZChenW/dsh-codex-switch) - Connects ChatGPT accounts through OAuth, switches among them manually or automatically, and adds Codex models with usage limits to DeepSeek Harness.
 - [ZekaiShi/evo-subagent](https://github.com/ZekaiShi/evo-subagent) - Maps a stable agent_key to an exact provider/model pair declared in role Markdown front matter, validates the pair against the live DSH model registry before spawning, and maintains per-workspace prefercmd and memory evolution files.
 - [zeng6125-rgb/dsh-llm-retry-settings](https://github.com/zeng6125-rgb/dsh-llm-retry-settings) - Settings card to tune the DSH LLM auto-retry policy (retry count, backoff, jitter) live from Settings → General.
+- [zhangjunjesse/dsh-claude-driver](https://github.com/zhangjunjesse/dsh-claude-driver) - Run the main session model on a local Claude Code subscription through the official Claude Agent SDK, taking over the llm/stream route for the claude-code provider, with token-level streaming, session resume, and DSH tools bridged in over MCP so they keep DSH sandbox and approval.
 
 ### Identity & Communication
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -713,6 +713,7 @@ dsh plugin --profile web add dshmarket
 - [ZChenW/dsh-codex-switch](https://github.com/ZChenW/dsh-codex-switch) — 通过 OAuth 连接 ChatGPT 账号，支持手动或自动切换，并为 DeepSeek Harness 添加带用量限额信息的 Codex 模型。
 - [ZekaiShi/evo-subagent](https://github.com/ZekaiShi/evo-subagent) — 将稳定的 agent_key 映射到角色 Markdown 文件 front matter 中声明的具体 provider/model 组合，spawn 前会对照 DSH 模型注册表校验该组合，并按工作区维护 prefercmd 与 memory 进化文件。
 - [zeng6125-rgb/dsh-llm-retry-settings](https://github.com/zeng6125-rgb/dsh-llm-retry-settings) — 在 DSH 设置里调整 LLM 自动重试的次数与退避时间并实时生效的设置卡片。
+- [zhangjunjesse/dsh-claude-driver](https://github.com/zhangjunjesse/dsh-claude-driver) — 让会话主模型跑在本机 Claude Code 订阅上：经官方 Claude Agent SDK 接管 claude-code provider 的 llm/stream 路由，支持 token 级流式、会话 resume 续接，并把 DSH 工具经 MCP 桥接进去以保留 DSH 的沙箱与审批。
 
 ### 🆔 身份与通信
 

--- a/data/plugins/zhangjunjesse__dsh-claude-driver.yml
+++ b/data/plugins/zhangjunjesse__dsh-claude-driver.yml
@@ -1,0 +1,6 @@
+url: https://github.com/zhangjunjesse/dsh-claude-driver
+name: zhangjunjesse/dsh-claude-driver
+category: model
+description:
+  en: 'Run the main session model on a local Claude Code subscription through the official Claude Agent SDK, taking over the llm/stream route for the claude-code provider, with token-level streaming, session resume, and DSH tools bridged in over MCP so they keep DSH sandbox and approval.'
+  zh: '让会话主模型跑在本机 Claude Code 订阅上：经官方 Claude Agent SDK 接管 claude-code provider 的 llm/stream 路由，支持 token 级流式、会话 resume 续接，并把 DSH 工具经 MCP 桥接进去以保留 DSH 的沙箱与审批。'


### PR DESCRIPTION
- [x] I added **one file** at `data/plugins/<owner>__<repo>.yml` — the READMEs are generated, don't edit them by hand
- [x] I ran `node scripts/generate-readme.mjs` and committed the regenerated READMEs
- [x] My repo's `package.json` declares **`dsh.bundle`** (not just `dsh.client`)
- [x] My repo is at least **1 day old** with **10+ commits** (created 2026-08-20, 12 commits)
- [x] `category` is one of the accepted values (`model`)
- [x] Description states what the plugin does, no superlatives
- [x] My repo has the `dsh-plugin` topic

### What it does

Takes over the official `llm/stream` seam for the `claude-code` provider, so a DSH session's **main model** runs on the local Claude Code subscription through the official `@anthropic-ai/claude-agent-sdk`. No OAuth token is extracted and no client is impersonated.

Beyond the route takeover: a model-catalog adapter (a "Claude Code" group appears in the model picker), one Claude Code session reused per DSH session so later turns skip the cold start, token-level streaming via `includePartialMessages`, and DSH tools bridged in over MCP — which is what keeps them under DSH's own sandbox and approval rather than Claude Code's.

### Relationship to my other entry

I also opened #3395 for `dsh-claude-code`. They are separate plugins with no shared surface: that one registers **tools** (`claude_code`, `claude_code_usage`) for delegating a subtask, while this one replaces the **session model** itself. Flagging it so the pair reads as two submissions rather than a resubmission.

### Validation

Run locally before opening this PR:

- `node scripts/generate-readme.mjs --check` → exit 0
- `GITHUB_TOKEN=… node scripts/check-submission.mjs --all --only-list <this entry>` → `ok  https://github.com/zhangjunjesse/dsh-claude-driver` / `all checked entries pass`