### PR TITLE
Add changmodel catalog entry

### DIFF
--- a/data/plugins/qq928820655__changmodel.yml
+++ b/data/plugins/qq928820655__changmodel.yml
@@ -1,0 +1,6 @@
+url: https://github.com/qq928820655/changmodel
+name: changmodel
+category: model
+description:
+  zh: "模型切换、模型能力配置、固定摘要模型、子 agent 角色路由与输入历史增强。"
+  en: "Model switching, model capability configuration, fixed compaction models, subagent routing, and input history enhancement."


### PR DESCRIPTION
## Summary
- Add changmodel to the plugin catalog.
- Provide Chinese and English descriptions so the installed card renders a summary instead of the install URL.

## Test plan
- [x] Validate the catalog entry fields and GitHub source URL.