### PR TITLE
Update KarlOfLaw/dsh-side-chat to 1.1.3

### DIFF
--- a/data/plugins/KarlOfLaw__dsh-side-chat.yml
+++ b/data/plugins/KarlOfLaw__dsh-side-chat.yml
@@ -4,4 +4,4 @@ category: ui
 description:
   en: 'Native side-by-side chat beside the main conversation: an independent archived DSH session with full native UI, on-demand parent-context retrieval, selection quoting, and a keep-or-delete lifecycle.'
   zh: 在主对话旁边打开原生并排侧聊：独立归档的真实 DSH 会话、按需读取父会话上下文、选文引用与保留或删除的生命周期。
-tarball: https://github.com/KarlOfLaw/dsh-side-chat/releases/latest/download/dsh-side-chat-1.1.2.tgz
+tarball: https://github.com/KarlOfLaw/dsh-side-chat/releases/latest/download/dsh-side-chat-1.1.3.tgz


### PR DESCRIPTION
Updates only data/plugins/KarlOfLaw__dsh-side-chat.yml to the v1.1.3 release tarball. v1.1.3 fixes a Windows cold-start race where the parallel client loader could start Side Chat before the native conversation entry registered; the plugin now follows the slot-registry lifecycle with cancellable cleanup instead of failing synchronously. Validation: 21/21 automated tests passed; DSH Desktop 2.0.3 completed 10/10 full cold starts as healthy with no Recovery Mode, no native conversation entry is unavailable error, and no new dsh-side-chat loader error; basic Side Chat UI opening was also verified. Release: https://github.com/KarlOfLaw/dsh-side-chat/releases/tag/v1.1.3