### PR TITLE
Update StrataGate DSH to 0.2.34

### DIFF
--- a/data/plugins/diqierjia__StrataGate-AgentMemory--integrations-deepseek-harness.yml
+++ b/data/plugins/diqierjia__StrataGate-AgentMemory--integrations-deepseek-harness.yml
@@ -1,5 +1,5 @@
 url: https://github.com/diqierjia/StrataGate-AgentMemory/tree/main/integrations/deepseek-harness
-tarball: https://github.com/diqierjia/StrataGate-AgentMemory/releases/download/stratagate-dsh-v0.2.32/stratagate-dsh-0.2.32.tgz
+tarball: https://github.com/diqierjia/StrataGate-AgentMemory/releases/download/stratagate-dsh-v0.2.34/stratagate-dsh-0.2.34.tgz
 name: diqierjia/StrataGate-AgentMemory
 category: memory
 description:

--- a/data/plugins/diqierjia__StrataGate-AgentMemory--integrations-deepseek-harness.yml
+++ b/data/plugins/diqierjia__StrataGate-AgentMemory--integrations-deepseek-harness.yml
@@ -1,5 +1,5 @@
 url: https://github.com/diqierjia/StrataGate-AgentMemory/tree/main/integrations/deepseek-harness
-tarball: https://github.com/diqierjia/StrataGate-AgentMemory/releases/download/stratagate-dsh-v0.2.34/stratagate-dsh-0.2.34.tgz
+tarball: https://github.com/diqierjia/StrataGate-AgentMemory/releases/download/stratagate-dsh-v0.2.35/stratagate-dsh-0.2.35.tgz
 name: diqierjia/StrataGate-AgentMemory
 category: memory
 description:


### PR DESCRIPTION
## Summary

- Update the StrataGate DSH tarball to 0.2.34.
- The release is published at https://www.npmjs.com/package/stratagate-dsh/v/0.2.34 and https://github.com/diqierjia/StrataGate-AgentMemory/releases/tag/stratagate-dsh-v0.2.34.

The package artifact was SHA-256 verified before trusted publishing and passed a clean installation/import check.