### PR TITLE
Refresh humanizer-ru#dsh entry: shadow scan, 72 gates, 193 tests, bundle scope

### DIFF
--- a/data/plugins/Vladimir-Human__humanizer-ru--dsh.yml
+++ b/data/plugins/Vladimir-Human__humanizer-ru--dsh.yml
@@ -2,5 +2,5 @@ url: https://github.com/Vladimir-Human/humanizer-ru/tree/main/dsh
 name: Vladimir-Human/humanizer-ru#dsh
 category: skill
 description:
-  en: 'Cleans AI traces from Russian text: finds chatbot copy-paste artefacts (ChatGPT, Gemini, Grok, Perplexity, DeepSeek) and rewrites the text into natural prose on request; 39 regex markers with an evidence registry, offline, text-only bundle.'
-  zh: 清理俄语文本中的 AI 痕迹：识别聊天机器人复制粘贴残留（ChatGPT、Gemini、Grok、Perplexity、DeepSeek），并按需改写为自然行文；39 个正则标记配证据登记表，离线运行，纯文本 bundle。
+  en: 'Cleans AI traces from Russian text: finds chatbot copy-paste artefacts (ChatGPT, Gemini, Grok, Perplexity, DeepSeek), removes hidden marks (zero-width characters, C2PA/EXIF/XMP metadata) and rewrites the text into natural prose on request; 40 regex markers with an evidence registry, offline, text-only bundle.'
+  zh: '清理俄语文本中的 AI 痕迹：识别聊天机器人复制粘贴残留（ChatGPT、Gemini、Grok、Perplexity、DeepSeek），移除隐藏标记（零宽字符、C2PA/EXIF/XMP 元数据），并按需改写为自然行文；40 个正则标记配证据登记表，离线运行，纯文本 bundle。'

--- a/data/plugins/Vladimir-Human__humanizer-ru--dsh.yml
+++ b/data/plugins/Vladimir-Human__humanizer-ru--dsh.yml
@@ -2,5 +2,5 @@ url: https://github.com/Vladimir-Human/humanizer-ru/tree/main/dsh
 name: Vladimir-Human/humanizer-ru#dsh
 category: skill
 description:
-  en: 'Cleans AI traces from Russian text: finds chatbot copy-paste artefacts (ChatGPT, Gemini, Grok, Perplexity, DeepSeek), strips hidden text marks (zero-width characters, invisible layout) and rewrites the text into natural prose on request; 40 regex markers, 38 with full evidence-registry entries; offline, text-only.'
-  zh: '清理俄语文本中的 AI 痕迹：识别聊天机器人复制粘贴残留（ChatGPT、Gemini、Grok、Perplexity、DeepSeek），移除隐藏文本标记（零宽字符、隐形排版），并按需改写为自然行文；40 个正则标记，其中 38 个有完整证据登记；离线运行，纯文本 bundle。'
+  en: 'Cleans AI traces from Russian text: finds chatbot copy-paste artefacts (ChatGPT, Gemini, Grok, Perplexity, DeepSeek), strips hidden text marks (zero-width characters, invisible layout; shadow scan catches markers split by invisibles), and rewrites the text into natural prose on request; 40 regex markers, 38 with full evidence-registry entries; 72 gates, 193 tests; offline, text-only bundle (binary metadata removal lives in scripts/).'
+  zh: '清理俄语文本中的 AI 痕迹：识别聊天机器人复制粘贴残留（ChatGPT、Gemini、Grok、Perplexity、DeepSeek），移除隐藏文本标记（零宽字符、隐形排版；影子扫描捕获被不可见字符拆分的标记），并按需求改写为自然行文；40 个正则标记，其中 38 个有完整证据登记；72 个门控，193 个测试；离线运行，纯文本 bundle（二进制元数据移除在 scripts/ 中）。'

--- a/data/plugins/Vladimir-Human__humanizer-ru--dsh.yml
+++ b/data/plugins/Vladimir-Human__humanizer-ru--dsh.yml
@@ -2,5 +2,5 @@ url: https://github.com/Vladimir-Human/humanizer-ru/tree/main/dsh
 name: Vladimir-Human/humanizer-ru#dsh
 category: skill
 description:
-  en: 'Cleans AI traces from Russian text: finds chatbot copy-paste artefacts (ChatGPT, Gemini, Grok, Perplexity, DeepSeek), removes hidden marks (zero-width characters, C2PA/EXIF/XMP metadata) and rewrites the text into natural prose on request; 40 regex markers with an evidence registry, offline, text-only bundle.'
-  zh: '清理俄语文本中的 AI 痕迹：识别聊天机器人复制粘贴残留（ChatGPT、Gemini、Grok、Perplexity、DeepSeek），移除隐藏标记（零宽字符、C2PA/EXIF/XMP 元数据），并按需改写为自然行文；40 个正则标记配证据登记表，离线运行，纯文本 bundle。'
+  en: 'Cleans AI traces from Russian text: finds chatbot copy-paste artefacts (ChatGPT, Gemini, Grok, Perplexity, DeepSeek), strips hidden text marks (zero-width characters, invisible layout) and rewrites the text into natural prose on request; 40 regex markers, 38 with full evidence-registry entries; offline, text-only.'
+  zh: '清理俄语文本中的 AI 痕迹：识别聊天机器人复制粘贴残留（ChatGPT、Gemini、Grok、Perplexity、DeepSeek），移除隐藏文本标记（零宽字符、隐形排版），并按需改写为自然行文；40 个正则标记，其中 38 个有完整证据登记；离线运行，纯文本 bundle。'


### PR DESCRIPTION
Refresh of the record merged as #776 (16 Aug) and first refreshed in #3425 (27 Aug). Now reflects v3.16.4 (signed tag, verified):

- **shadow scan** catches markers split by invisible characters (v3.16.3 closes the `--class a` gate bypass: `turn0<U+200B>search0` no longer passes as a class-B warning);
- **72 gates, 193 tests** (was 66/193; three new gates — action.yml YAML validation, version sync, last_reviewed — close audit holes found by the five-model audit);
- **bundle scope stated accurately**: text-only bundle handles hidden TEXT marks (zero-width characters, invisible layout); binary metadata removal (C2PA/EXIF/XMP) lives in `scripts/`, outside the bundle.

40 regex markers, 38 with full evidence-registry entries — unchanged.

Touches only `data/plugins/Vladimir-Human__humanizer-ru--dsh.yml`.