### PR TITLE
config: turn comments on with the real Discussions IDs

### DIFF
--- a/site/comments.mjs
+++ b/site/comments.mjs
@@ -11,9 +11,9 @@
  * a broken third-party request to every visitor.
  */
 export default Object.freeze({
-  enabled: false,
+  enabled: true,
   repo: 'awesome-dsh-plugin/awesome-dsh-plugin',
-  repoId: '',
-  category: 'Plugin comments',
-  categoryId: '',
+  repoId: 'R_kgDOT3ajCQ',
+  category: 'Plugins',
+  categoryId: 'DIC_kwDOT3ajCc4DES8_',
 })


### PR DESCRIPTION
填入 #3310 等待的两个 ID 并打开开关。只改 `site/comments.mjs` 一个文件。

已在构建产物上用真实浏览器验证：点击前零第三方请求，点击后 widget 正常加载。