### PR TITLE
Add SLin-code/dsh-custom-skin

### DIFF
--- a/README.md
+++ b/README.md
@@ -636,6 +636,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 - [shawnlone/dsh-theme-tuner](https://github.com/shawnlone/dsh-theme-tuner) - Add a theme-adjustment panel under Appearance to customize accent, background, foreground, contrast and gradient, applied live through theme token overrides.
 - [Sim-xia/dsh-vscode-theme](https://github.com/Sim-xia/dsh-vscode-theme) - Imports .vsix theme files made for Visual Studio Code and applies them to the DSH Web UI.
 - [skymecode/dsh-deep-diving](https://github.com/skymecode/dsh-deep-diving) - Adds selectable animated skins to the "Deep diving..." status row, with configurable size and optional status-text replacement.
+- [SLin-code/dsh-custom-skin](https://github.com/SLin-code/dsh-custom-skin) - Browser-local wallpaper and translucent-panel controls for DSH Web, with multiple images, fit and position choices, shading, blur, and panel opacity.
 - [Small-tailqwq/dsh-deep-whale#maid-atelier](https://github.com/Small-tailqwq/dsh-deep-whale/tree/main/maid-atelier) - Whale-girl skin series for the DSH Web UI (maid-atelier).
 - [Smith-yue/harness-plugin](https://github.com/Smith-yue/harness-plugin) - Adds two switchable themes, built-in and local-folder background slideshows, and per-session token usage details to DeepSeek Harness Web and Desktop.
 - [starslittle/dsh-blue-whale](https://github.com/starslittle/dsh-blue-whale) - A DeepSeek Chat-style blue-whale color skin. Light and dark follow the built-in appearance.

--- a/README.zh.md
+++ b/README.zh.md
@@ -636,6 +636,7 @@ dsh plugin --profile web add dshmarket
 - [shawnlone/dsh-theme-tuner](https://github.com/shawnlone/dsh-theme-tuner) — 在「外观」下增加一个主题调节面板，可自定义强调色/背景色/前景色/对比度/渐变度，并实时生效。
 - [Sim-xia/dsh-vscode-theme](https://github.com/Sim-xia/dsh-vscode-theme) — 导入为 Visual Studio Code 设计的 .vsix 主题文件并应用到 DSH Web UI。
 - [skymecode/dsh-deep-diving](https://github.com/skymecode/dsh-deep-diving) — 为“Deep diving...”状态行添加可选动态皮肤，并支持调整尺寸和可选状态文案替换。
+- [SLin-code/dsh-custom-skin](https://github.com/SLin-code/dsh-custom-skin) — DSH Web 的浏览器本地壁纸与半透明面板插件，支持多图切换、填充与位置选择、遮罩、模糊和面板透明度调节。
 - [Small-tailqwq/dsh-deep-whale#maid-atelier](https://github.com/Small-tailqwq/dsh-deep-whale/tree/main/maid-atelier) — DSH Web 鲸鱼娘皮肤系列（深海女仆工坊 maid-atelier）。
 - [Smith-yue/harness-plugin](https://github.com/Smith-yue/harness-plugin) — 为 DeepSeek Harness Web 与桌面端提供两套可切换主题、内置及本地文件夹背景轮播和逐会话 Token 用量明细。
 - [starslittle/dsh-blue-whale](https://github.com/starslittle/dsh-blue-whale) — 复刻 DeepSeek Chat 蓝鲸配色的皮肤，亮色/深色跟随系统外观。

--- a/data/plugins/SLin-code__dsh-custom-skin.yml
+++ b/data/plugins/SLin-code__dsh-custom-skin.yml
@@ -1,0 +1,6 @@
+url: https://github.com/SLin-code/dsh-custom-skin
+name: SLin-code/dsh-custom-skin
+category: theme
+description:
+  en: Browser-local wallpaper and translucent-panel controls for DSH Web, with multiple images, fit and position choices, shading, blur, and panel opacity.
+  zh: DSH Web 的浏览器本地壁纸与半透明面板插件，支持多图切换、填充与位置选择、遮罩、模糊和面板透明度调节。


### PR DESCRIPTION
Adds SLin-code/dsh-custom-skin to the Themes & Appearance category.

The plugin provides browser-local wallpaper storage, multiple-image switching, and controls for fit, position, shading, blur, and panel opacity.

- [x] I added one file at data/plugins/<owner>__<repo>.yml; the READMEs are generated
- [x] I ran node scripts/generate-readme.mjs and committed the regenerated READMEs
- [x] My repo package.json declares dsh.bundle, not just dsh.client
- [x] My repo is at least 1 day old with 10+ commits
- [x] The plugin uses the theme category
- [x] The description states what the plugin does without superlatives
- [x] My repo has the dsh-plugin topic

Additional preparation:

- [x] Official @deepseek-ai packages are declared as peer dependencies
- [x] screenshots.json is maintained in the plugin repository
- [x] Generated READMEs, awesome-lint, and the site build pass locally