### PR TITLE
Update Jacky Creator tarball to v0.1.0-beta.4

### DIFF
--- a/data/plugins/Jackywxsz__DSH-Creator.yml
+++ b/data/plugins/Jackywxsz__DSH-Creator.yml
@@ -1,7 +1,7 @@
 url: https://github.com/Jackywxsz/DSH-Creator
 name: Jackywxsz/DSH-Creator
 category: workflow
-tarball: https://github.com/Jackywxsz/DSH-Creator/releases/download/v0.1.0-beta.3/jacky-creator-0.1.0-beta.3.tgz
+tarball: https://github.com/Jackywxsz/DSH-Creator/releases/download/v0.1.0-beta.4/jacky-creator-0.1.0-beta.4.tgz
 description:
   en: "Local-first content production and operations workspace for DSH: manage ideas, scripts, media assets, schedules, goals, publishing status, and post-publication reviews."
   zh: "面向 DSH 的本地内容生产与运营工作台：管理灵感、脚本、媒体资产、档期、目标、发布状态和发布后复盘。"


### PR DESCRIPTION
更新已收录 Jacky Creator 的预构建包地址，使市场安装指向已发布的 v0.1.0-beta.4。Release 资产 digest 与下载回读 SHA-256 均为 `28d1039b02277ee0f2c1bed4074a047cb8808698a3da9b1204b1d9073f71ce82`，`node scripts/generate-readme.mjs --check` 和 `check-submission` 已通过。