### PR TITLE
Update KarlOfLaw/dsh-side-chat to 1.2.0

### DIFF
--- a/data/plugins/KarlOfLaw__dsh-side-chat.yml
+++ b/data/plugins/KarlOfLaw__dsh-side-chat.yml
@@ -4,4 +4,4 @@ category: ui
 description:
   en: 'Native side-by-side chat beside the main conversation: an independent archived DSH session with full native UI, on-demand parent-context retrieval, selection quoting, and a keep-or-delete lifecycle.'
   zh: 在主对话旁边打开原生并排侧聊：独立归档的真实 DSH 会话、按需读取父会话上下文、选文引用与保留或删除的生命周期。
-tarball: https://github.com/KarlOfLaw/dsh-side-chat/releases/latest/download/dsh-side-chat-1.1.3.tgz
+tarball: https://github.com/KarlOfLaw/dsh-side-chat/releases/latest/download/dsh-side-chat-1.2.0.tgz


### PR DESCRIPTION
Updates only data/plugins/KarlOfLaw__dsh-side-chat.yml to the v1.2.0 release tarball. v1.2.0 makes Side Chat and Better Sidebar mutually exclusive, aligns the header controls while preserving the normal layout when Better Sidebar is absent, and keeps selected-text references out of the native composer draft until send time so no visible @ placeholder remains. It also adds viewport-safe selection actions, removable reference previews, remembered close behavior, and a container-responsive split layout. Validation: 24/24 automated tests passed; real DSH Desktop 2.0.3 browser acceptance confirmed mutual panel exclusion and an empty native textarea with zero native reference occurrences while the quote indicator remained visible. The marketplace README generation check and site build also passed. Release: https://github.com/KarlOfLaw/dsh-side-chat/releases/tag/v1.2.0