### PR TITLE
Update ruisenbai/dsh-annotation tarball

### DIFF
--- a/data/plugins/ruisenbai__dsh-annotation.yml
+++ b/data/plugins/ruisenbai__dsh-annotation.yml
@@ -4,4 +4,4 @@ category: ui
 description:
   en: 'Select text in a finished assistant reply to add numbered annotations beside the quote; drafts submit with composer text and images as one user message, and the model replies to each annotation in order.'
   zh: '在已完成的助手回复中选中原文，在引文旁添加编号注解；草稿与输入框文字、图片合并为一条用户消息发送，模型按注解逐条回复。'
-tarball: https://github.com/ruisenbai/dsh-annotation/releases/download/v0.2.4/dsh-annotation-0.2.4.tgz
+tarball: https://github.com/ruisenbai/dsh-annotation/releases/latest/download/dsh-annotation.tgz


### PR DESCRIPTION
Updates the existing dsh-annotation catalog entry to the stable GitHub Releases alias:

- latest release: `v0.3.0`
- catalog target: `releases/latest/download/dsh-annotation.tgz`
- asset SHA-256: `2e79b128eca39050fc207a3d71db0ad316043fd953242c4f1d26cbd1f1eb7784`

The stable alias avoids another catalog edit for each future version. The versioned `dsh-annotation-0.3.0.tgz` asset remains available on the same release.

Validated with README generation/check, the site build, awesome-lint, and a fresh download of the stable asset.