### PR TITLE
Add zhubaohi/dsh-qwen38-compaction-fix (model)

### DIFF
--- a/README.md
+++ b/README.md
@@ -803,6 +803,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 - [ZekaiShi/evo-subagent](https://github.com/ZekaiShi/evo-subagent) - Maps a stable agent_key to an exact provider/model pair declared in role Markdown front matter, validates the pair against the live DSH model registry before spawning, and maintains per-workspace prefercmd and memory evolution files.
 - [zeng6125-rgb/dsh-llm-retry-settings](https://github.com/zeng6125-rgb/dsh-llm-retry-settings) - Settings card for the DSH LLM auto-retry engine: tune retry count, backoff and jitter live from Settings -> General, with configurable retryableCodes chips - defaults add INVALID_REQUEST so OpenAI-style HTTP 400 reasoning_text errors in thinking mode get retried automatically.
 - [zhangjunjesse/dsh-claude-driver](https://github.com/zhangjunjesse/dsh-claude-driver) - Run the main session model on a local Claude Code subscription through the official Claude Agent SDK, taking over the llm/stream route for the claude-code provider, with token-level streaming, session resume, and DSH tools bridged in over MCP so they keep DSH sandbox and approval.
+- [zhubaohi/dsh-qwen38-compaction-fix](https://github.com/zhubaohi/dsh-qwen38-compaction-fix) - Compaction fix for NInfer-hosted qwen3.8-27b gateways: disables thinking on dsh context-compaction and session-title calls so xhigh reasoning stops burning the whole output budget; the same idea applies to other launch methods, this package targets NInfer only.
 
 ### Identity & Communication
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -803,6 +803,7 @@ dsh plugin --profile web add dshmarket
 - [ZekaiShi/evo-subagent](https://github.com/ZekaiShi/evo-subagent) — 将稳定的 agent_key 映射到角色 Markdown 文件 front matter 中声明的具体 provider/model 组合，spawn 前会对照 DSH 模型注册表校验该组合，并按工作区维护 prefercmd 与 memory 进化文件。
 - [zeng6125-rgb/dsh-llm-retry-settings](https://github.com/zeng6125-rgb/dsh-llm-retry-settings) — LLM 自动重试设置卡片：在设置页实时调整重试次数、退避与抖动，并可勾选额外可重试错误码（retryableCodes）—— 默认补入 INVALID_REQUEST，OpenAI thinking 模式 HTTP 400 reasoning_text 报错开箱即自动重试。
 - [zhangjunjesse/dsh-claude-driver](https://github.com/zhangjunjesse/dsh-claude-driver) — 让会话主模型跑在本机 Claude Code 订阅上：经官方 Claude Agent SDK 接管 claude-code provider 的 llm/stream 路由，支持 token 级流式、会话 resume 续接，并把 DSH 工具经 MCP 桥接进去以保留 DSH 的沙箱与审批。
+- [zhubaohi/dsh-qwen38-compaction-fix](https://github.com/zhubaohi/dsh-qwen38-compaction-fix) — 针对 NInfer 托管的 qwen3.8-27b 网关的压缩修复：在 dsh 上下文压缩与会话标题调用中关闭思考，避免 xhigh 推理耗尽全部输出预算；同一思路适用于其他启动方式，本包仅面向 NInfer。
 
 ### 🆔 身份与通信
 

--- a/data/plugins/zhubaohi__dsh-qwen38-compaction-fix.yml
+++ b/data/plugins/zhubaohi__dsh-qwen38-compaction-fix.yml
@@ -1,0 +1,7 @@
+url: https://github.com/zhubaohi/dsh-qwen38-compaction-fix
+name: zhubaohi/dsh-qwen38-compaction-fix
+category: model
+description:
+  en: 'Compaction fix for NInfer-hosted qwen3.8-27b gateways: disables thinking on dsh context-compaction and session-title calls so xhigh reasoning stops burning the whole output budget; the same idea applies to other launch methods, this package targets NInfer only.'
+  zh: '针对 NInfer 托管的 qwen3.8-27b 网关的压缩修复：在 dsh 上下文压缩与会话标题调用中关闭思考，避免 xhigh 推理耗尽全部输出预算；同一思路适用于其他启动方式，本包仅面向 NInfer。'
+tarball: https://github.com/zhubaohi/dsh-qwen38-compaction-fix/releases/download/v1.1.0/dsh-qwen38-ninfer-compaction-fix-1.1.0.tgz


### PR DESCRIPTION
Single DSH plugin **zhubaohi/dsh-qwen38-compaction-fix** (npm `dsh-qwen38-ninfer-compaction-fix`, v1.1.0): disables thinking on dsh context-compaction and session-title calls for NInfer-hosted qwen3.8-27b gateways, so xhigh reasoning stops burning the whole output budget (reasoning_effort off + sampling fields rewrites in the two internal calls). Repo: https://github.com/zhubaohi/dsh-qwen38-compaction-fix · install: `dsh plugin add dsh-qwen38-ninfer-compaction-fix`. Engine scope: NInfer only — the wire fields it rewrites are the ones the NInfer gateway interprets; the same thinking-off idea applies to other launch methods (llama.cpp, vLLM, FastMTP) as a different port. Settings namespace stays `qwen38-compaction-fix:` (existing config carries over).

- [x] I added **one file** at `data/plugins/zhubaohi__dsh-qwen38-compaction-fix.yml`; the READMEs are generated (committed the `generate-readme.mjs` output)
- [x] My repo's `package.json` declares **`dsh.bundle`**
- [x] My repo is at least **1 day old** (created 2026-08-25) with **10+ commits** (15)
- [x] `category: model`
- [x] Description states what the plugin does, no superlatives
- [x] My repo has the `dsh-plugin` topic
- [x] Published to npm (`dsh-qwen38-ninfer-compaction-fix`), tarball field points at the v1.1.0 GitHub release