### PR TITLE
Update StrataGate DSH to 0.2.36

### DIFF
--- a/data/plugins/diqierjia__StrataGate-AgentMemory--integrations-deepseek-harness.yml
+++ b/data/plugins/diqierjia__StrataGate-AgentMemory--integrations-deepseek-harness.yml
@@ -1,5 +1,5 @@
 url: https://github.com/diqierjia/StrataGate-AgentMemory/tree/main/integrations/deepseek-harness
-tarball: https://github.com/diqierjia/StrataGate-AgentMemory/releases/download/stratagate-dsh-v0.2.35/stratagate-dsh-0.2.35.tgz
+tarball: https://github.com/diqierjia/StrataGate-AgentMemory/releases/download/stratagate-dsh-v0.2.36/stratagate-dsh-0.2.36.tgz
 name: diqierjia/StrataGate-AgentMemory
 category: memory
 description:


### PR DESCRIPTION
Updates the StrataGate DSH marketplace tarball from 0.2.35 to the verified 0.2.36 GitHub Release asset.