### PR TITLE
fix: a plugin moving inside its own repository is not a new submission

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -152,6 +152,14 @@ jobs:
           EFF=$(git log --diff-filter=A --format=%cI -1 -- .github/workflows/pr-gate.yml)
           echo "effective_from=${EFF:-1970-01-01T00:00:00Z}" >> "$GITHUB_OUTPUT"
 
+          # The checker reads the catalog AT THIS COMMIT to answer one
+          # question: is this entry's repository one we already list? A rename
+          # inside a repository we accepted long ago must not be re-judged as a
+          # new submission. It has to come from here rather than from the
+          # checkout, because the checkout is the PR — every repository the PR
+          # adds would look pre-existing.
+          echo "base=$BASE" >> "$GITHUB_OUTPUT"
+
       - name: Check submitted entries
         if: steps.pr.outputs.found == 'true' && steps.extract.outputs.none == 'false'
         id: check
@@ -164,6 +172,7 @@ jobs:
             --dir /tmp/prdata/data/plugins \
             --only-list /tmp/prdata/changed.txt \
             --pr-created "${{ steps.pr.outputs.created_at }}" \
+            --base "${{ steps.extract.outputs.base }}" \
             --json gate-result.json
 
       - name: Report result on the PR

--- a/scripts/check-submission.mjs
+++ b/scripts/check-submission.mjs
@@ -377,7 +377,30 @@ async function check(entry) {
   if (bundle.ok === false) problems.push(bundle.why)
   else if (bundle.ok === null) unverified.push(`manifest not checked — ${bundle.why}`)
 
-  if (gateApplies) {
+  // The age/commit bar filters the REPOSITORY, not the entry: it exists to
+  // keep hours-old throwaway repos out. The workflow already acts on that —
+  // it gates added and RENAMED entry files but deliberately not modified ones,
+  // because "recategorize, reword" must not re-litigate a repository that was
+  // accepted years of commits ago.
+  //
+  // Renames are in that list for a real reason (#1554): a rename is how an
+  // entry's url changes without ever looking added, and that one repointed an
+  // entry at a DIFFERENT repository, which nothing had verified. But it also
+  // catches the ordinary case — a plugin moving inside its own repository —
+  // and there the answer is already known and can now come back WORSE, since
+  // a force-push shortens history. Tlyer233/dsh-vscode-review moved a plugin
+  // up one directory and the gate rejected the move for "7 commits (needs
+  // 10)", on a repository it had already accepted.
+  //
+  // So the split is on the repository, not on the kind of change: a rename
+  // that lands on a repository the catalog already lists skips the bar; a
+  // rename that lands anywhere else still faces it, which is #1554 intact.
+  // Scoped to the BASE commit so a pull request cannot grant itself the
+  // exemption by adding a first entry for a new repository in the same push.
+  // Everything else still runs — archived, bundle manifest, the per-PR cap,
+  // and the human read of the description.
+  const alreadyListed = listedRepos !== null && listedRepos.has(repo.toLowerCase())
+  if (gateApplies && !alreadyListed) {
     const ageDays = (Date.now() - new Date(meta.body.created_at).getTime()) / 86400000
     const commits = await once(`commits:${repo}`, () => commitCount(repo))
     if (ageDays < MIN_AGE_DAYS) {
@@ -397,6 +420,38 @@ async function check(entry) {
 function changedEntryFiles(base) {
   const out = execSync(`git diff --name-only --diff-filter=d ${base}...HEAD -- ${PLUGINS_DIR}`, { encoding: 'utf8' })
   return new Set(out.split('\n').map((s) => s.trim()).filter(Boolean))
+}
+
+/**
+ * Every `owner/repo` the catalog already listed at `base`, lowercased.
+ *
+ * Read from the entry FILENAMES rather than their contents: names are
+ * `owner__repo--sub-path.yml`, and 2,500 `git show` calls to learn something
+ * the names already carry would cost more than the check it feeds. The split
+ * is exact rather than lucky — GitHub owner names are alphanumerics and
+ * hyphens only, so the first `__` is always the owner/repo boundary even when
+ * the repository name itself contains `__`.
+ * @returns the set, or null when the base cannot be read — callers must treat
+ *   null as "grant nothing", so an unreadable base fails closed.
+ */
+function listedReposAt(base) {
+  let out
+  try {
+    out = execSync(`git ls-tree -r --name-only ${base} -- ${PLUGINS_DIR}`, { encoding: 'utf8' })
+  } catch (e) {
+    console.error(`could not list entries at ${base} (${e.message}) — treating every repository as new`)
+    return null
+  }
+  const repos = new Set()
+  for (const line of out.split('\n')) {
+    const file = path.basename(line.trim())
+    if (!file.endsWith('.yml')) continue
+    const stem = file.slice(0, -'.yml'.length).split('--')[0]
+    const cut = stem.indexOf('__')
+    if (cut === -1) continue
+    repos.add(`${stem.slice(0, cut)}/${stem.slice(cut + 2)}`.toLowerCase())
+  }
+  return repos
 }
 
 // A submission whose YAML does not parse is a submission problem, and
@@ -428,6 +483,11 @@ try {
   }
   process.exit(1)
 }
+// Needs BASE: without a base commit there is no "already listed" to consult,
+// and the exemption must not fall back to the working tree — the pull request
+// IS the working tree, so every repository it adds would look pre-existing.
+const listedRepos = BASE ? listedReposAt(BASE) : null
+
 let targets = entries
 if (ONLY_LIST) {
   const want = new Set(


### PR DESCRIPTION
### What happened

The gate checks **added and renamed** entry files, not modified ones. The workflow already explains why modified entries are exempt:

> Modifying an already-listed entry (recategorize, reword) must not re-litigate repo age or commit count.

Renames are on the list because of #1554, where a rename repointed an entry at a **different** repository and the gate read "no entries changed" and passed. That reason is real — but it also catches the ordinary case: **a plugin moving inside its own repository.**

There the age/commit question was answered when the entry was first accepted, and asking it again can now answer *worse*, because a force-push shortens history. `Tlyer233/dsh-vscode-review` moved a plugin up one directory and the gate rejected the move for `7 commits (needs 10)` — on a repository it had already accepted, for a change that pointed nowhere new.

### What changed

Split on the **repository**, not on the kind of change:

- a rename landing on a repository the catalog already lists → skips the age/commit bar
- a rename landing anywhere else → still faces it, which is **#1554 intact**

Scoped to the base commit, so a PR cannot grant itself the exemption by adding a first entry for that repository in the same push. Null when the base cannot be read, so an unreadable base grants nothing. Everything else still runs: archived, bundle manifest, per-PR cap, and the human read of the description.

### Verified

End to end against the real catalog with `MIN_COMMITS` forced to 99999, so the bar rejects everything it is applied to:

```
ok    Tlyer233/dsh-vscode-review/tree/main/dsh-review   (listed   -> exempt)
ok    text2future/flowix/tree/main/dsh-flowix-memory    (listed   -> exempt)
fail  liangchen-harold/local-dsh                        (unlisted -> gated)
      "repository has 44 commit(s) (needs 99999)"
```

The listed set is read from entry **filenames** rather than 2,500 file reads. That is exact, not lucky: GitHub owner names are alphanumerics and hyphens only, so the first `__` in `owner__repo--sub.yml` is always the boundary even when the repository name itself contains `__`.