### PR TITLE
Update Jacky Creator tarball to v0.1.0-beta.6

### DIFF
--- a/data/plugins/Jackywxsz__DSH-Creator.yml
+++ b/data/plugins/Jackywxsz__DSH-Creator.yml
@@ -1,7 +1,7 @@
 url: https://github.com/Jackywxsz/DSH-Creator
 name: Jackywxsz/DSH-Creator
 category: workflow
-tarball: https://github.com/Jackywxsz/DSH-Creator/releases/download/v0.1.0-beta.5/jacky-creator-0.1.0-beta.5.tgz
+tarball: https://github.com/Jackywxsz/DSH-Creator/releases/download/v0.1.0-beta.6/jacky-creator-0.1.0-beta.6.tgz
 description:
   en: "Local-first content production and operations workspace for DSH: manage ideas, scripts, media assets, schedules, goals, publishing status, and post-publication reviews."
   zh: "面向 DSH 的本地内容生产与运营工作台：管理灵感、脚本、媒体资产、档期、目标、发布状态和发布后复盘。"


### PR DESCRIPTION
Updates the existing Jacky Creator catalog entry to the v0.1.0-beta.6 release tarball.\n\nValidation:\n- npm ci\n- node scripts/generate-readme.mjs --check\n- node scripts/check-submission.mjs --base upstream/main (1 entry checked, passed)\n- release asset SHA-256 verified against the tested package