### PR TITLE
feat: add 5 DSH plugins from xchannel1987

### DIFF
--- a/data/plugins/xchannel1987__dsh-mobile-xc.yml
+++ b/data/plugins/xchannel1987__dsh-mobile-xc.yml
@@ -1,0 +1,6 @@
+url: https://github.com/xchannel1987/dsh-mobile-xc
+name: xchannel1987/dsh-mobile-xc
+category: remote
+description:
+  en: "Mobile access for DeepSeek Harness - access from Android app or mobile browser with secure LAN/remote connections and persistent device pairing."
+  zh: "DeepSeek Harness 移动端访问 - 通过 Android App 或手机浏览器访问，支持安全局域网/远程连接和持久设备配对。"

--- a/data/plugins/xchannel1987__dsh-power-xc.yml
+++ b/data/plugins/xchannel1987__dsh-power-xc.yml
@@ -1,0 +1,6 @@
+url: https://github.com/xchannel1987/dsh-power-xc
+name: xchannel1987/dsh-power-xc
+category: tools
+description:
+  en: "Power management for DeepSeek Harness - restart/shutdown functionality via Web UI button, with graceful session flush and process management."
+  zh: "DeepSeek Harness 电源管理 - 通过 Web UI 按钮实现重启/关机功能，支持优雅会话刷新和进程管理。"

--- a/data/plugins/xchannel1987__dsh-reverse-proxy-xc.yml
+++ b/data/plugins/xchannel1987__dsh-reverse-proxy-xc.yml
@@ -1,0 +1,6 @@
+url: https://github.com/xchannel1987/dsh-reverse-proxy-xc
+name: xchannel1987/dsh-reverse-proxy-xc
+category: remote
+description:
+  en: "Reverse proxy for DeepSeek Harness - expose local DSH instance to the internet with ngrok or similar tunneling services."
+  zh: "DeepSeek Harness 反向代理 - 使用 ngrok 或类似隧道服务将本地 DSH 实例暴露到互联网。"

--- a/data/plugins/xchannel1987__dsh-session-xc.yml
+++ b/data/plugins/xchannel1987__dsh-session-xc.yml
@@ -1,0 +1,6 @@
+url: https://github.com/xchannel1987/dsh-session-xc
+name: xchannel1987/dsh-session-xc
+category: session
+description:
+  en: "Session management for DeepSeek Harness - enhanced session operations including session archiving, exporting, and advanced session controls."
+  zh: "DeepSeek Harness 会话管理 - 增强的会话操作，包括会话归档、导出和高级会话控制。"

--- a/data/plugins/xchannel1987__dsh-token-usage-xc.yml
+++ b/data/plugins/xchannel1987__dsh-token-usage-xc.yml
@@ -1,0 +1,6 @@
+url: https://github.com/xchannel1987/dsh-token-usage-xc
+name: xchannel1987/dsh-token-usage-xc
+category: usage
+description:
+  en: "Token usage tracking for DeepSeek Harness - monitor and display token consumption per session and conversation with detailed statistics."
+  zh: "DeepSeek Harness Token 使用追踪 - 监控和显示每个会话和对话的 Token 消耗，提供详细统计信息。"


### PR DESCRIPTION
## 新增插件

### 1. dsh-mobile-xc
移动端 UI 完美适配插件。
- 📱 移动端抽屉导航
- 🎨 玻璃卡片设计
- 📐 Safe Area 全覆盖
- 📲 PWA 支持

https://github.com/xchannel1987/dsh-mobile-xc

### 2. dsh-power-xc
电源管理插件。
- 🔘 侧边栏电源按钮
- 🔄 平滑重启过渡
- 🛠️ 自包含重启引擎

https://github.com/xchannel1987/dsh-power-xc

### 3. dsh-reverse-proxy-xc
局域网反向代理插件。
- 🌐 完整功能访问
- 🔧 修复反代问题

https://github.com/xchannel1987/dsh-reverse-proxy-xc

### 4. dsh-session-xc
会话管理增强插件。
- 📊 会话数统计
- 📁 归档管理
- 🔀 跨工作区移动

https://github.com/xchannel1987/dsh-session-xc

### 5. dsh-token-usage-xc
Token 用量统计插件。
- 📊 今日用量（按模型）
- 📈 7 日趋势图
- 💾 数据持久化

https://github.com/xchannel1987/dsh-token-usage-xc