### PR TITLE
Add dsh-waaagh-ork

### DIFF
--- a/README.md
+++ b/README.md
@@ -2667,6 +2667,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 - [nzl153/dsh-pet-whale](https://github.com/nzl153/dsh-pet-whale) - Desktop pet drawn from the official whale outline: pure-SVG animation follows agent state (thinking, working, celebrating, error), with poke and double-click flip interactions, cursor avoidance, 7 palettes, light/dark theme sync, and a playable web preview.
 - [omdsh-dev/dsh-auto-chess](https://github.com/omdsh-dev/dsh-auto-chess) - Auto chess: human vs AI, or AI vs AI.
 - [omdsh-dev/dsh-gomoku](https://github.com/omdsh-dev/dsh-gomoku) - Play Gomoku against the AI, or let two AIs battle it out.
+- [oopsylol/dsh-waaagh-ork](https://github.com/oopsylol/dsh-waaagh-ork) - A green pixel-Ork mascot for DSH Web that masks model thinking and output as Waaaaaaagh!!! until clicked to reveal, plus a random-length input mask.
 - [ovdoesw/dsh-xiangqi](https://github.com/ovdoesw/dsh-xiangqi) - A draggable mascot invites you to play Xiangqi (Chinese chess) while the AI thinks, with a built-in engine, move-record export, and optional multi-model commentary.
 - [PC2005-cloud/dsh-pet#dsh-pet](https://github.com/PC2005-cloud/dsh-pet/tree/main/dsh-pet) - Desktop pet for the DSH Web UI with 25 transparent animations, screen wandering, click reactions and drag, plus a reproducible asset-generation pipeline.
 - [piaobo123/dafeiyu-buchibaifan](https://github.com/piaobo123/dafeiyu-buchibaifan) - Desktop BigFish companion for DSH: real-time balance, out-of-browser desktop Q&A, 7 custom animations, 53 meme lines.

--- a/README.zh.md
+++ b/README.zh.md
@@ -2667,6 +2667,7 @@ dsh plugin --profile web add dshmarket
 - [nzl153/dsh-pet-whale](https://github.com/nzl153/dsh-pet-whale) — 官方鲸鱼轮廓的桌宠：纯 SVG 动画随 agent 状态切换（思考／工作／完成／报错），可戳可拖、双击翻滚，光标停留在身侧会自己避让，7 套色板并跟随亮暗主题，附网页预览可直接试玩。
 - [omdsh-dev/dsh-auto-chess](https://github.com/omdsh-dev/dsh-auto-chess) — 自走棋：人机对战或双 AI 对弈。
 - [omdsh-dev/dsh-gomoku](https://github.com/omdsh-dev/dsh-gomoku) — 与 AI 下五子棋，也可让 AI 对局比棋力。
+- [oopsylol/dsh-waaagh-ork](https://github.com/oopsylol/dsh-waaagh-ork) — 给 DSH Web 加一个会眨眼的像素绿皮兽人：把模型思考与输出掩码成 Waaaaaaagh!!!（点击显示原文），并支持随机长度的输入掩码。
 - [ovdoesw/dsh-xiangqi](https://github.com/ovdoesw/dsh-xiangqi) — 卡通小宠物邀请你在 AI 思考间隙下中国象棋：内置引擎、走子记谱导出、可选多模型局势点评。
 - [PC2005-cloud/dsh-pet#dsh-pet](https://github.com/PC2005-cloud/dsh-pet/tree/main/dsh-pet) — DSH Web UI 桌面宠物：25 个透明动画、屏幕漫游、点击反应与拖拽，附可复现的素材生成链。
 - [piaobo123/dafeiyu-buchibaifan](https://github.com/piaobo123/dafeiyu-buchibaifan) — 桌面大肥鱼增强版桌宠：点击实时显示 DeepSeek 余额，浏览器外桌面问答，7 套专属动作，53 条玩梗。

--- a/data/plugins/oopsylol__dsh-waaagh-ork.yml
+++ b/data/plugins/oopsylol__dsh-waaagh-ork.yml
@@ -1,0 +1,6 @@
+url: https://github.com/oopsylol/dsh-waaagh-ork
+name: oopsylol/dsh-waaagh-ork
+category: fun
+description:
+  en: "A green pixel-Ork mascot for DSH Web that masks model thinking and output as Waaaaaaagh!!! until clicked to reveal, plus a random-length input mask."
+  zh: "给 DSH Web 加一个会眨眼的像素绿皮兽人：把模型思考与输出掩码成 Waaaaaaagh!!!（点击显示原文），并支持随机长度的输入掩码。"


### PR DESCRIPTION
Add [dsh-waaagh-ork](https://github.com/oopsylol/dsh-waaagh-ork) — a green pixel-Ork mascot plugin for DSH Web (category: \un\).

- Repo declares \dsh.bundle\ in package.json (installable via \dsh plugin --profile web add dsh-waaagh-ork\).
- Published on npm: \dsh-waaagh-ork@0.1.1\.
- Has the \dsh-plugin\ topic.
- Data file: \data/plugins/oopsylol__dsh-waaagh-ork.yml\; both READMEs regenerated.