### PR TITLE
docs: update dsh-token-usage-sidebar listing for v1.1.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -625,7 +625,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 - [xobexo/dsh-smart-scenario-router](https://github.com/xobexo/dsh-smart-scenario-router) - Routes dsh requests by conversation scenario and retries with fallback models when requests fail.
 - [xohmai/dsh-cpa-status](https://github.com/xohmai/dsh-cpa-status) - CPA account-pool status panel: sidebar health light, quota bars, success-rate ticks, and gateway key endings.
 - [xxvk/dsh-cost-crystal](https://github.com/xxvk/dsh-cost-crystal) - Floating cost crystal for the Web UI: balance card, real-time tok/s, peak/off-peak billing countdown, last-24h spend, and a 🔮 next-message cost forecast, all timezone-aware.
-- [y2zyyr/dsh-token-usage-sidebar](https://github.com/y2zyyr/dsh-token-usage-sidebar) - Persistent provider-reported token usage for DSH Web, with a sidebar summary and settings-page breakdowns by range, token type, provider, and model.
+- [y2zyyr/dsh-token-usage-sidebar](https://github.com/y2zyyr/dsh-token-usage-sidebar) - Persistent local token-usage accounting for DSH Web with automatic history discovery and compact provider/model details.
 - [yangyongzhen/dsh-session-report](https://github.com/yangyongzhen/dsh-session-report) - Per-session cost & usage report cards: tokens, cache hits, duration.
 - [Ychris12138/dsh-usage-stats](https://github.com/Ychris12138/dsh-usage-stats) - Multi-provider usage dashboard with provider/model token breakdowns, calendar drill-downs, account balances, and OpenCode Go / Z.ai subscription quota tracking.
 - [yflmq001/dsh-cost-tracker](https://github.com/yflmq001/dsh-cost-tracker) - Per-model token cost tracking with configurable cache-hit/miss, output and peak-window pricing, a live session cost bar, and unconfigured-model flags.

--- a/README.zh.md
+++ b/README.zh.md
@@ -625,7 +625,7 @@ dsh plugin --profile web add dshmarket
 - [xobexo/dsh-smart-scenario-router](https://github.com/xobexo/dsh-smart-scenario-router) — 根据对话场景选择模型，并在请求失败时按候选链进行回退。
 - [xohmai/dsh-cpa-status](https://github.com/xohmai/dsh-cpa-status) — CPA 账号池状态面板：侧栏健康灯、配额进度、成功率刻度与网关密钥末四位一览。
 - [xxvk/dsh-cost-crystal](https://github.com/xxvk/dsh-cost-crystal) — Web UI 成本水晶球:余额卡片、实时 tok/s 速率、波峰/低峰计费倒计时、近 24h 消耗,以及 🔮 下一条消息消耗预测,全部时区感知。
-- [y2zyyr/dsh-token-usage-sidebar](https://github.com/y2zyyr/dsh-token-usage-sidebar) — 为 DSH Web 持久保存 provider 上报的 Token 用量，提供侧边栏摘要，以及按范围、Token 类别、供应商和模型查看的设置页明细。
+- [y2zyyr/dsh-token-usage-sidebar](https://github.com/y2zyyr/dsh-token-usage-sidebar) — 为 DSH Web 提供自动发现历史记录的本地持久化 Token 用量统计与紧凑的供应商/模型明细。
 - [yangyongzhen/dsh-session-report](https://github.com/yangyongzhen/dsh-session-report) — 会话成本与耗时报表：tokens / 缓存命中 / 耗时。
 - [Ychris12138/dsh-usage-stats](https://github.com/Ychris12138/dsh-usage-stats) — 多供应商用量看板：按供应商/模型统计 Token 与日期下钻，统一展示账户余额，并追踪 OpenCode Go / Z.ai 订阅额度。
 - [yflmq001/dsh-cost-tracker](https://github.com/yflmq001/dsh-cost-tracker) — 按模型追踪 token 成本：可配置缓存命中/未命中、输出与高峰时段单价，实时会话花费条，并标记未配置价格的模型。

--- a/data/plugins/y2zyyr__dsh-token-usage-sidebar.yml
+++ b/data/plugins/y2zyyr__dsh-token-usage-sidebar.yml
@@ -2,5 +2,5 @@ url: https://github.com/y2zyyr/dsh-token-usage-sidebar
 name: y2zyyr/dsh-token-usage-sidebar
 category: usage
 description:
-  en: Persistent provider-reported token usage for DSH Web, with a sidebar summary and settings-page breakdowns by range, token type, provider, and model.
-  zh: 为 DSH Web 持久保存 provider 上报的 Token 用量，提供侧边栏摘要，以及按范围、Token 类别、供应商和模型查看的设置页明细。
+  en: Persistent local token-usage accounting for DSH Web with automatic history discovery and compact provider/model details.
+  zh: 为 DSH Web 提供自动发现历史记录的本地持久化 Token 用量统计与紧凑的供应商/模型明细。


### PR DESCRIPTION
## Summary

- Update the existing y2zyyr/dsh-token-usage-sidebar entry to describe the v1.1.5 automatic history-discovery and compact-settings features.
- Regenerate README.md and README.zh.md from the entry data.
- The plugin repository now declares its English and Simplified Chinese screenshots in screenshots.json; both screenshots redact provider and model values.
- The fixed v1.1.6 package is now published on npm with DSH host packages declared as peer dependencies instead of production dependencies.

This PR changes only the existing dsh-token-usage-sidebar entry.