### PR TITLE
chore: update DSH Live Voice preview artifact

### DIFF
--- a/data/plugins/Jstn-1g__dsh-live-voice.yml
+++ b/data/plugins/Jstn-1g__dsh-live-voice.yml
@@ -4,4 +4,4 @@ category: voice
 description:
   en: 'Experimental one-turn Qwen Audio preview for the DSH Web UI with active-session disclosure, bounded microphone input, and explicit final-user-transcript insertion into the editable composer draft without automatic submission.'
   zh: 'DSH Web UI 的单轮 Qwen Audio 实验性预览：在当前会话披露后接收有界麦克风输入，并仅通过明确操作将最终用户转写写入可编辑草稿，不会自动提交。'
-tarball: https://github.com/Jstn-1g/dsh-live-voice/releases/download/v0.3.0-preview.2/dsh-live-voice-0.3.0-preview.2.tgz
+tarball: https://github.com/Jstn-1g/dsh-live-voice/releases/download/v0.3.0-preview.3/dsh-live-voice-0.3.0-preview.3.tgz


### PR DESCRIPTION
Updates the existing DSH Live Voice catalog entry from the superseded
`v0.3.0-preview.2` tarball to the verified lifecycle hotfix
[`v0.3.0-preview.3`](https://github.com/Jstn-1g/dsh-live-voice/releases/tag/v0.3.0-preview.3).

- exact release commit: `10bd8bf504cf17fb24523f2c18e9f8a586a41167`
- tarball SHA-256: `016ce06f37e635413734cdb2aa814d1714651b92ff8ac92306bd56dfd64af33d`
- release asset range request: HTTP 206
- README generator check: both generated READMEs are current
- scope: one YAML field in the existing entry; description/category unchanged

The release remains explicitly experimental. Credential-backed Qwen, physical
devices, packaged Desktop, and broad alpha compatibility are not claimed.

The repository-wide strict tarball probe currently reports 15 unrelated stale
third-party assets; this updated asset itself resolves successfully.
