### PR TITLE
perf(site): debounce plugin search filtering

### DIFF
--- a/site/template.html
+++ b/site/template.html
@@ -406,9 +406,16 @@ function applyFilter() {
 }
 const q = document.getElementById('q');
 q.value = query;
+const SEARCH_DEBOUNCE_MS = 180;
+let searchTimer;
 q.addEventListener('input', (e) => {
   query = e.target.value.trim().toLowerCase();
-  applyFilter();
+  clearTimeout(searchTimer);
+  if (!query) {
+    applyFilter();
+    return;
+  }
+  searchTimer = setTimeout(applyFilter, SEARCH_DEBOUNCE_MS);
 });
 document.getElementById('filters').addEventListener('click', (e) => {
   const chip = e.target.closest('button.chip');


### PR DESCRIPTION
## Summary

- debounce non-empty plugin search updates by 180 ms so a typing burst does not traverse all 2,628 cards and rewrite the URL once per keypress
- cancel the pending search update on every new input
- keep clearing the search synchronous so the complete list and clean URL return immediately

Closes #3741.

## Baseline -> candidate

Base `a4eeadf1358dfdbede67098fabeb8cafac67cba2` updates the generated page from `2628 / 2628` to `0 / 2628` before a rapid `no-such-plugin-3741` input sequence returns, with `?q=no-such-plugin-3741` already written.

Exact head `45d6dc4a338192f76a734e5a982776b8311f6d65` leaves the count and URL unchanged immediately after the same typing burst, then applies the final query after the 180 ms quiet period. Keyboard-clearing the field immediately restores `2628 / 2628` and removes `?q=`.

## Verification

- [Hosted PR check](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/actions/runs/33285872160/job/99188867169): passed (stale-fork guard, generated README consistency, awesome-lint, and complete site build)
- `node scripts/generate-readme.mjs --check`
- `SKIP_PUBLISH_CHECKS=1 node scripts/build-site.mjs`
- real generated-page browser checks for debounced input, settled results, URL synchronization, and immediate clear
- browser console: no warnings or errors
- `git diff HEAD^ --check`
- TruffleHog exact commit range: 0 verified or unverified findings

Local `npx awesome-lint` reports the same 62 existing spelling warnings and one `awesome-github` remote-identity error because the exact head exists only on the contributor fork. The target repository's exact-head PR check passes.

## Template checklist

This is a site runtime performance fix and does not add or modify a plugin entry, so the plugin-submission checklist in the repository template is not applicable.
