### PR TITLE
add screenshots for wenbin-wb/dsh-bridge

### DIFF
--- a/data/plugins/wenbin-wb__dsh-bridge.yml
+++ b/data/plugins/wenbin-wb__dsh-bridge.yml
@@ -2,5 +2,5 @@ url: https://github.com/wenbin-wb/dsh-bridge
 name: wenbin-wb/dsh-bridge
 category: remote
 description:
-  zh: "DeepSeek Harness 远程与移动端接入插件：支持局域网二维码、Cloudflare/自建公网隧道，以及微信、QQ、飞书、Telegram 机器人实时交互与审批，内置访问安全门禁与防篡改控制。"
-  en: "Remote and mobile access for DeepSeek Harness: supports LAN QR code, Cloudflare/custom tunnels, and WeChat, QQ, Feishu, and Telegram bots with approval cards and security access guards."
+  en: 'Remote and mobile access for DeepSeek Harness: provides LAN QR code connection, Cloudflare/custom tunnels, WeChat, QQ, Feishu, Telegram bot integration, and security authentication.'
+  zh: 'DeepSeek Harness 远程与移动端接入插件：提供局域网扫码直连、Cloudflare 与自建公网隧道，以及微信、QQ、飞书、Telegram 机器人交互，内置安全认证与访问控制。'


### PR DESCRIPTION
## 补充 wenbin-wb/dsh-bridge 截图

在 `data/screenshots.json` 中为 [wenbin-wb/dsh-bridge](https://github.com/wenbin-wb/dsh-bridge) 添加 6 张代表性截图：

1. **mobile-chat.jpg** — 手机端对话（移动端核心场景）
2. **wechat-chat.jpg** — 微信 Bot 对话
3. **qq-group.jpg** — QQ 群聊 @机器人
4. **feishu-chat.jpg** — 飞书对话
5. **qr-scan.jpg** — 扫码访问
6. **security-auth-config.jpg** — 安全认证配置

覆盖：移动端 + 微信 + QQ + 飞书 + 扫码 + 安全。