### PR TITLE
ci: stop push builds from cancelling the nightly probe run

### DIFF
--- a/.github/workflows/build-site.yml
+++ b/.github/workflows/build-site.yml
@@ -29,10 +29,24 @@ permissions:
   pages: write
   id-token: write
 
-# docs/ is a pure function of main's tip, so an older run can only produce
-# stale output — supersede it rather than queueing it.
+# docs/ is a pure function of main's tip, so an older PUSH build can only
+# produce stale output — supersede it rather than queueing it.
+#
+# Two groups, not one, and the second group is the whole point. The nightly is
+# the only run that probes with PROBE_ALL and the only run that publishes the
+# catalog and update notes to npm, and a cancelled nightly does neither: the
+# cache-save post-steps are skipped along with everything after them, so a run
+# killed 47 minutes into the probe throws that work away instead of banking it.
+# A push shares nothing with that — it must not be able to cancel it.
+#
+# This was not theoretical. The 02:23 cron is routinely delayed hours into the
+# busy part of the day (2026-08-27 12:54, 2026-08-28 14:25), where the next
+# merge cancelled it mid-probe. Symptoms filed separately, one cause:
+#   #3512 — npm catalog frozen 2026-08-26 → 08-29, the two cancelled nights
+#   #3417, #3698 — detail-page READMEs stuck on their last good fetch, because
+#           readmes.json only ever advances in the cache the nightly saves
 concurrency:
-  group: build-site
+  group: build-site-${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && 'probe' || 'push' }}
   cancel-in-progress: true
 
 jobs:
@@ -158,6 +172,12 @@ jobs:
           path: docs
       - id: deployment
         uses: actions/deploy-pages@v4
+        # The concurrency split above means a push build and the nightly can now
+        # be in flight together, and Pages accepts one deployment at a time.
+        # Losing that race must not abort the nightly before the two publish
+        # steps below — they are the reason the run exists, and the site is
+        # about to be redeployed by whichever push won anyway.
+        continue-on-error: ${{ github.event_name == 'schedule' }}
 
       # The same plugins.json, published to npm — see
       # scripts/publish-catalog.mjs for why it has to exist in two places.


### PR DESCRIPTION
Root cause behind three separately-filed issues: #3512, #3417, #3698.

## What is wrong

`build-site.yml` puts every trigger in one concurrency group with `cancel-in-progress: true`. That is right for push-vs-push — `docs/` is a pure function of main's tip, so an older push build can only publish stale bytes. It is wrong for push-vs-nightly.

The scheduled run is the **only** one that probes with `PROBE_ALL=1` and the **only** one that publishes the catalog and update notes to npm. When a merge cancels it, the run loses everything:

Run [33180051647](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/actions/runs/33180051647) (2026-08-28), started 14:25, cancelled 15:12 — 47 minutes into `Build`:

| step | conclusion |
|---|---|
| Build | **cancelled** |
| upload-pages-artifact / deploy-pages | skipped |
| publish the catalog to npm | skipped |
| publish the update notes to npm | skipped |
| `Post Run actions/cache@v4` ×3 | **skipped** |

The cache-save post-steps being skipped is the expensive part: 47 minutes of probing is discarded, not banked, so the next push build restores the *previous* cache and the data never advances.

The `23 2 * * *` cron is routinely delayed hours past its slot into the busy part of the day (2026-08-27 → 12:54, 2026-08-28 → 14:25), which is why this hits some nights and not others. Nights that actually ran near 03:20 all succeeded.

## Matching symptoms

- **#3512** — `dsh-plugin-catalog` npm publish times: `2026.825.2368` (08-25), `2026.826.2432` (08-26), then nothing until `2026.829.2828` (08-29). The gap is exactly the two cancelled nights.
- **#3417 / #3698** — `data/readmes.json` only ever advances in the cache the nightly saves; the committed copy is a cold-start floor and is 1,235 entries against 2,659 listed. `Yiipu/dsh-agentmemory` is still served from its 2026-08-18 fetch; `kanchengw/dsh-assembly.resume` has no committed entry at all, so its page renders with no README.

## The change

- Nightly and `workflow_dispatch` get their own concurrency group. Push builds keep superseding each other and can no longer touch a run that is mid-probe.
- The nightly's `deploy-pages` step is `continue-on-error`. The two groups mean a push build and the nightly can now be in flight together, and Pages takes one deployment at a time — losing that race must not abort the nightly before the publish steps, and the site is about to be redeployed by whichever push won anyway.

No change to what any run does, only to what can kill it.

## Verifying

Merge, then `workflow_dispatch` with `probe_all` while pushing something — the run should survive. The real signal is the next few nights: a `dsh-plugin-catalog` version every day, and `Yiipu/dsh-agentmemory` picking up its current README.