### PR TITLE
fix: align dshmobile screenshot key

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -963,7 +963,7 @@
   "https://raw.githubusercontent.com/yyyyukari/dsh-plugin-workshop/master/assets/installed-view.jpg",
   "https://raw.githubusercontent.com/yyyyukari/dsh-plugin-workshop/master/assets/sidebar-entry.jpg"
  ],
- "https://github.com/zdx8637-gitdog/dshmobile/tree/main/plugins/dshmobile-plugin": [
+ "https://github.com/zdx8637-gitdog/dshmobile/tree/main/plugins": [
   "https://raw.githubusercontent.com/zdx8637-gitdog/dshmobile/main/docs/images/plugin-panel.jpg",
   "https://raw.githubusercontent.com/zdx8637-gitdog/dshmobile/main/docs/images/phone-1.jpg",
   "https://raw.githubusercontent.com/zdx8637-gitdog/dshmobile/main/docs/images/phone-2.jpg",


### PR DESCRIPTION
The latest main deployments fail in scripts/build-site.mjs because data/screenshots.json keys must exactly match a listed README URL. The dshmobile entry was moved to https://github.com/zdx8637-gitdog/dshmobile/tree/main/plugins in #3304, while the screenshot key still points one directory deeper.

This changes only that JSON key. The four image URLs are unchanged.

Validation:
- JSON parse and node scripts/generate-readme.mjs --check
- npx awesome-lint
- SKIP_PUBLISH_CHECKS=1 node scripts/build-site.mjs