### PR TITLE
Add taoser258/dsh-client-ui-skin-qingxiao

### DIFF
--- a/data/plugins/taoser258__dsh-client-ui-skin-qingxiao.yml
+++ b/data/plugins/taoser258__dsh-client-ui-skin-qingxiao.yml
@@ -1,0 +1,6 @@
+url: https://github.com/taoser258/dsh-client-ui-skin-qingxiao
+name: taoser258/dsh-client-ui-skin-qingxiao
+category: theme
+description:
+  en: 'Qingxiao (Wuthering Waves) themed skin for the DSH web GUI, with ice-blue/jade/moon-white palette, sword-light motes and user-swappable backgrounds.'
+  zh: '以《鸣潮》清宵为主题的 DSH Web 界面皮肤，冰蓝·青碧·月白配色，含剑气流光与可更换背景。'


### PR DESCRIPTION
Add [taoser258/dsh-client-ui-skin-qingxiao](https://github.com/taoser258/dsh-client-ui-skin-qingxiao) under **Themes & Appearance (theme)**.

- Qingxiao (Wuthering Waves) themed skin for the DSH web GUI: ice-blue/jade/moon-white palette, sword-light motes, user-swappable backgrounds, frosted-glass panels and a new-session welcome page; light/dark forms follow the host theme.
- Latest release **v0.1.3** (2026-09-01): `dsh.client.version` compatibility now spans **0.1.0-rc.6 → 0.1.2-alpha.1**, verified with headless Edge + CDP on both light and dark forms.
- The repo declares a `dsh.bundle` manifest in its root `package.json` (`./cordis.patch.yml`, with the matching insert entry next to it), plus `dsh.client` for the browser UI, and carries the `dsh-plugin` topic.
- All `@deepseek-ai/*` packages are `peerDependencies` with prerelease-aware ranges (`>=0.1.0-rc.6 <0.1.1-0 || >=0.1.1-rc.1 <0.2.0-0`); the package has zero runtime `dependencies`.
- Screenshots are declared via `screenshots.json` at the repo root (light + dark).
- Re-based onto current `main`: the PR now adds **only** `data/plugins/taoser258__dsh-client-ui-skin-qingxiao.yml` (+1/-0). The previously committed generated-README edits are dropped so they can no longer collide with other submissions — `sync-readme.yml` regenerates them on merge either way.

Note: the `Repository config guard` flagged the previous head (02e0b88) with "No checks ran on this pull request". This push re-triggers `PR check` as the guard suggests — if the run is sitting in the first-time-contributor approval queue, a maintainer approving it should get CI verdicts flowing. Thanks!
