### PR TITLE
feat: add 173787247/dsh-wsl-browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -1540,6 +1540,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 
 ### WSL & Windows Interop
 
+- [173787247/dsh-wsl-browser](https://github.com/173787247/dsh-wsl-browser) - Opens http(s) URLs from WSL in the Windows default browser.
 - [173787247/dsh-wsl-env](https://github.com/173787247/dsh-wsl-env) - Injects WSL distro, Linux path mapping, /mnt/c CRLF and git caveats, and NODE_USE_ENV_PROXY into the system prompt.
 - [173787247/dsh-wsl-net](https://github.com/173787247/dsh-wsl-net) - Adds a net_doctor tool that reports proxy environment, NODE_USE_ENV_PROXY, and reachability of the DeepSeek API and the npm registry, and sets NODE_USE_ENV_PROXY on bash and npm child processes.
 - [173787247/dsh-wsl-open](https://github.com/173787247/dsh-wsl-open) - Opens WSL Linux paths from DeepSeek Harness chat in the Windows default app or Explorer.

--- a/README.zh.md
+++ b/README.zh.md
@@ -1540,6 +1540,7 @@ dsh plugin --profile web add dshmarket
 
 ### 🐧 WSL 与 Windows 互操作
 
+- [173787247/dsh-wsl-browser](https://github.com/173787247/dsh-wsl-browser) — 在 Windows 默认浏览器中打开来自 WSL 的 http(s) 链接。
 - [173787247/dsh-wsl-env](https://github.com/173787247/dsh-wsl-env) — 向 system prompt 注入 WSL 发行版、Linux 路径映射、/mnt/c 的 CRLF 与 git 注意点，以及 NODE_USE_ENV_PROXY。
 - [173787247/dsh-wsl-net](https://github.com/173787247/dsh-wsl-net) — 提供 net_doctor 工具，报告代理环境、NODE_USE_ENV_PROXY，以及 DeepSeek API 与 npm registry 的连通性，并为 bash 和 npm 子进程设置 NODE_USE_ENV_PROXY。
 - [173787247/dsh-wsl-open](https://github.com/173787247/dsh-wsl-open) — 把 DeepSeek Harness 聊天里的 WSL Linux 路径在 Windows 默认程序或资源管理器中打开。

--- a/data/plugins/173787247__dsh-wsl-browser.yml
+++ b/data/plugins/173787247__dsh-wsl-browser.yml
@@ -1,0 +1,6 @@
+url: https://github.com/173787247/dsh-wsl-browser
+name: 173787247/dsh-wsl-browser
+category: wsl
+description:
+  en: Opens http(s) URLs from WSL in the Windows default browser.
+  zh: 在 Windows 默认浏览器中打开来自 WSL 的 http(s) 链接。


### PR DESCRIPTION
## Summary
- Add [`173787247/dsh-wsl-browser`](https://github.com/173787247/dsh-wsl-browser) (category `wsl`).
- Single-entry PR to satisfy the submission gate.
- READMEs regenerated via `node scripts/generate-readme.mjs`.

## Test plan
- [ ] CI + Submission gate green
