### PR TITLE
ci: generate the READMEs on main instead of requiring them in every PR

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -28,15 +28,22 @@ jobs:
         # (#502 would have silently removed 32 entries). Fail when the PR
         # drops more than 2 existing entries; genuine removals are rare and
         # a maintainer can land them directly.
+        #
+        # Counts entry FILES, not README lines. It used to count README lines,
+        # which stops working the moment a PR is allowed to omit the generated
+        # READMEs — a stale fork carrying only data/plugins/ would have shown
+        # +0/-0 and sailed through the one guard written to catch it.
+        # data/plugins/ is also the better signal: one file per entry, and the
+        # deletion is unambiguous rather than inferred from a diff of prose.
         run: |
           git fetch -q origin ${{ github.event.pull_request.base.sha }}
-          removed=$(git diff ${{ github.event.pull_request.base.sha }}...HEAD -- README.md \
-            | grep -cE '^-- \[.+\]\(https://github\.com/' || true)
-          added=$(git diff ${{ github.event.pull_request.base.sha }}...HEAD -- README.md \
-            | grep -cE '^\+- \[.+\]\(https://github\.com/' || true)
-          echo "entry lines: +$added -$removed"
+          removed=$(git diff --name-status --diff-filter=D ${{ github.event.pull_request.base.sha }}...HEAD -- data/plugins \
+            | grep -c '\.yml$' || true)
+          added=$(git diff --name-status --diff-filter=A ${{ github.event.pull_request.base.sha }}...HEAD -- data/plugins \
+            | grep -c '\.yml$' || true)
+          echo "entry files: +$added -$removed"
           if [ "$removed" -gt 2 ] && [ "$removed" -gt "$added" ]; then
-            echo "::error::This PR removes $removed existing entries — the fork looks stale. Sync it with upstream main (GitHub: 'Sync fork') and re-push; a single plugin submission should be +2/-0."
+            echo "::error::This PR deletes $removed existing entry files under data/plugins/ — the fork looks stale. Sync it with upstream main (GitHub: 'Sync fork') and re-push; a single plugin submission should be +1/-0."
             exit 1
           fi
       - name: Every entry file ends in .yml
@@ -58,12 +65,31 @@ jobs:
             exit 1
           fi
       - name: READMEs match data/plugins
-        # The READMEs are generated from data/plugins/*.yml. Editing them by
-        # hand would drift from the source of truth and get silently reverted
-        # by the next contributor's regeneration.
+        # Two shapes are accepted, and which one you get is the contributor's
+        # choice, not a rule they have to learn:
+        #
+        #   yml only          — the common case now. sync-readme.yml regenerates
+        #                       on main after the merge. Nothing to check here
+        #                       beyond "the generator runs", which the step
+        #                       below does by regenerating in the runner so
+        #                       awesome-lint and the build see a consistent tree.
+        #   yml + regenerated — still fine, still verified exactly as before.
+        #                       Must MATCH, so a hand-edited README is still
+        #                       caught rather than silently overwritten later.
+        #
+        # This is what unblocked the queue. Requiring the regeneration in the
+        # PR meant two unrelated submissions in one category always conflicted
+        # over generated lines; 218 of 296 open PRs were stuck that way, none
+        # over anything a human had written.
         run: |
+          if git diff --quiet ${{ github.event.pull_request.base.sha }}...HEAD -- README.md README.zh.md; then
+            echo "PR does not touch the generated READMEs — regenerating locally for the checks below."
+            node scripts/generate-readme.mjs
+            exit 0
+          fi
+          echo "PR modifies the READMEs — they must match data/plugins/."
           if ! node scripts/generate-readme.mjs --check; then
-            echo "::error::The READMEs are generated from data/plugins/. Edit the YAML file, run 'node scripts/generate-readme.mjs', and commit both."
+            echo "::error::You committed README changes that do not match data/plugins/. Either run 'node scripts/generate-readme.mjs' and commit the result, or drop the README changes entirely — they are regenerated on main after merge either way."
             exit 1
           fi
       - name: awesome-lint

--- a/.github/workflows/sync-readme.yml
+++ b/.github/workflows/sync-readme.yml
@@ -1,0 +1,69 @@
+name: Sync READMEs from data/plugins
+
+# The READMEs are a generated artifact that happens to live in the repository,
+# because an awesome list has to BE a README. Requiring every contributor to
+# commit their own regeneration is what made the queue unmergeable: two
+# unrelated submissions in the same category touch the same generated lines, so
+# merging either one puts the other into conflict. On 2026-08-30 that was 218 of
+# 296 open pull requests — none of them in conflict over anything a human wrote.
+#
+# So the generation moves here. A PR carries only its data/plugins/*.yml; this
+# regenerates on main and commits the result. Contributors may still commit a
+# regeneration and nothing breaks — pr-check accepts either shape.
+#
+# Termination: the commit below pushes to main and re-triggers this workflow.
+# The second run regenerates, finds nothing changed, and exits without
+# committing. The bot guard makes that second run cheap rather than making it
+# correct — correctness comes from generate-readme.mjs being deterministic.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'data/plugins/**'
+      - 'scripts/generate-readme.mjs'
+      - 'scripts/lib/**'
+      - 'site/locales.mjs'
+
+# Unlike build-site.yml, this one DOES write to the repository — that is its
+# entire job. Kept as its own workflow with its own narrow permission rather
+# than relaxing the build, so "the build never writes to the repository" stays
+# true where it matters.
+permissions:
+  contents: write
+
+# Never two of these at once: both would regenerate the same file and the
+# second push would be rejected. Queue instead of cancelling — a cancelled run
+# leaves main with a stale README until the next merge happens to fix it.
+concurrency:
+  group: sync-readme
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    if: github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - run: npm ci
+      - name: Regenerate
+        run: node scripts/generate-readme.mjs
+      - name: Commit if changed
+        run: |
+          if git diff --quiet -- README.md README.zh.md; then
+            echo "READMEs already match data/plugins — nothing to do."
+            exit 0
+          fi
+          git config user.name  'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add README.md README.zh.md
+          # The added-date for a new entry derives from the commit that first
+          # added its line to the default-locale README (build-site.mjs), which
+          # is now this commit rather than the merge. Same day, seconds apart —
+          # but say so here, because the next person to read that derivation
+          # will wonder why every recent date points at a bot commit.
+          git commit -m 'chore: regenerate READMEs from data/plugins'
+          git push

--- a/contributing.md
+++ b/contributing.md
@@ -19,7 +19,9 @@ description:
 
 **Only `description.en` is required.** If you can't write the Chinese, leave `zh` out and a maintainer will add it — a missing translation is our work, not a reason to bounce your plugin. / **只有 `description.en` 是必填的。** 写不了中文就不写 `zh`，维护者会补上——缺翻译是我们的活，不该成为你的插件被打回的理由。
 
-Then regenerate both READMEs and commit them along with your YAML file / 然后重新生成两个 README，与 YAML 文件一起提交：
+**That one file is the whole submission.** The two READMEs are generated from `data/plugins/*.yml` and are regenerated on `main` after your PR merges — you do not have to run anything, and you should not edit them by hand. This is also why your PR will not conflict with anyone else's: entry files never collide, generated README lines always did. / **一个文件就是全部投稿。** 两个 README 由 `data/plugins/*.yml` 生成，你的 PR 合并后会在 `main` 上自动重新生成——你不需要跑任何命令，也不要手工编辑它们。这同时也是你的 PR 不会和别人冲突的原因：条目文件永不相撞，而生成出来的 README 行总是相撞。
+
+Want to preview what your line will look like? Regenerating locally is fine, and committing the result is still accepted — it just has to match / 想预览你那一行长什么样？本地重新生成没问题，把结果一起提交也照样接受，只是必须与数据源一致：
 
 ```sh
 npm ci

--- a/scripts/build-site.mjs
+++ b/scripts/build-site.mjs
@@ -37,6 +37,10 @@ const NPM_MAP_FILE = 'data/npm-map.json'
 // strip the field from every entry whenever the probe is skipped.
 const TARBALLS_FILE = 'data/tarballs.json'
 const tarballVerdicts = fs.existsSync(TARBALLS_FILE) ? JSON.parse(fs.readFileSync(TARBALLS_FILE, 'utf8')) : {}
+// url -> data/plugins/<slug>.yml. The rest of this file works from entries
+// parsed out of the READMEs, which carry no file path; the added-date
+// derivation below needs one to ask git when an entry first appeared.
+const entryFiles = Object.fromEntries(readEntries().map((e) => [e.url, e.file]))
 const tarballMap = Object.fromEntries(
   readEntries()
     .filter((e) => {
@@ -215,11 +219,37 @@ if (ordered.some((e) => !dates[e.url])) {
       if (m && !dates[m[1]]) dates[m[1]] = cur
     }
   }
-  const undated = ordered.filter((e) => !dates[e.url])
-  if (undated.length) {
-    // reachable only from a shallow clone or an unstamped uncommitted entry —
+  // Second source: the entry's own file under data/plugins/. The README line
+  // used to be the only ledger because the README was the only thing a
+  // submission touched. Since sync-readme.yml took over generation, a PR
+  // carries just the yml and the README line is written by a bot commit
+  // seconds after the merge — so during pr-check the line has no history at
+  // all, and after the merge its history is the bot's, not the author's.
+  //
+  // The yml is the better ledger anyway: one file per entry, added exactly
+  // once, never rewritten by a neighbour's regeneration. README history stays
+  // FIRST so that every date published before this change keeps the value it
+  // already had; this only fills in what that pass could not.
+  let stillUndated = ordered.filter((e) => !dates[e.url])
+  if (stillUndated.length) {
+    for (const e of stillUndated) {
+      const file = entryFiles[e.url]
+      if (!file) continue
+      try {
+        // Oldest "added" commit for that path. Not `-1`, which git applies
+        // before --reverse and would hand back the newest instead.
+        const out = execSync(`git log --diff-filter=A --format=%cI -- ${JSON.stringify(file)}`,
+          { encoding: 'utf8' }).trim().split('\n').filter(Boolean)
+        const iso = out[out.length - 1]
+        if (iso) dates[e.url] = new Date(iso).toISOString()
+      } catch { /* not committed yet — falls through to the error below */ }
+    }
+    stillUndated = ordered.filter((e) => !dates[e.url])
+  }
+  if (stillUndated.length) {
+    // reachable only from a shallow clone or a genuinely uncommitted entry —
     // stamping "now" here would make the output flap between runs
-    console.error(`no added-date derivable for: ${undated.map((e) => e.url).join(', ')}`)
+    console.error(`no added-date derivable for: ${stillUndated.map((e) => e.url).join(', ')}`)
     console.error('need full git history (fetch-depth: 0) and committed entries — refusing to build')
     process.exit(1)
   }


### PR DESCRIPTION
Fixes the structural reason the PR queue does not drain. Companion to #3789; independent of it.

## The problem, measured today

| | count |
|---|---|
| open PRs (non-draft) | 296 |
| `dirty` — conflicting with main | **218** |
| conflicting over anything a human wrote | **0** |

Every one of those 218 conflicts is in `README.md` / `README.zh.md`. Two unrelated submissions in the same category insert adjacent lines into the same generated block, so merging either one puts the other into conflict. The queue re-conflicts itself faster than it can be merged: today I merged 22 PRs and each merge dirtied the next batch.

A second group is stuck the opposite way — the author committed only their `data/plugins/*.yml`, `pr-check` demanded the regeneration, and the PR sat red waiting on a mechanical step. That is 20+ PRs right now, several already content-approved:

```
#2662 #2671 #2691 #2807 #3014 #3215 #3219 #3224 #3245
#3269 #3325 #3349 #3401 #3425 #3441 #3445 #3657 #3723 #3805 …
```

Same root cause in both directions: **a generated artifact is checked in, and every contributor is asked to regenerate it.**

## The change

**`sync-readme.yml` (new)** — on push to `main` touching `data/plugins/`, regenerate and commit. It terminates because `generate-readme.mjs` is deterministic: the commit re-triggers the workflow, the second run finds nothing to do and exits. Kept as its own workflow with its own `contents: write` rather than relaxing `build-site.yml`, so *"the build never writes to the repository"* stays true where that invariant matters.

**`pr-check.yml`** — two shapes accepted, and which one a contributor produces is no longer something they have to know:

- PR does not touch the READMEs → regenerate in the runner, so `awesome-lint` and the build see a consistent tree. Nothing to verify beyond "the generator runs".
- PR does touch them → must still match. A hand-edited README is caught here rather than silently overwritten by the sync later.

**`pr-check.yml` stale-fork guard** — now counts deleted files under `data/plugins/` instead of removed README lines. This one is not optional: a stale fork carrying only yml would show `+0/-0` and walk straight past the guard written to catch it ([#502](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/issues/502) was 32 entries silently removed). Counting entry files is the better signal anyway — one file per entry, deletion unambiguous rather than inferred from a diff of prose.

**`build-site.mjs`** — added-dates fall back to the entry file's first commit when the README line has no history. Needed in two new places: during `pr-check` the line does not exist in history at all, and after merge its history belongs to a bot commit rather than the author's. README history is still consulted **first**, so nothing already published can move.

## Verification

Not assumed — run:

1. Committed a simulated yml-only submission with no README change. Before: `generate-readme.mjs --check` exits 1, which is exactly what strands those 20 PRs. After: build green, `awesome-lint` 0 errors, and the entry dates correctly to its yml commit (`added: 2026-08-30`).
2. Built `plugins.json` with this branch and with current `main`, then diffed `added` for all **2662** existing entries: **0 changed.**

## What it does not fix

Existing PRs that already carry README commits stay conflicted — git cannot un-write those. But once this is in, the fix for them is trivial and I can say so in one comment: drop the README commit, keep the yml, and the conflict is gone for good. New submissions never acquire the problem.

## Risk

The failure mode is a stale README on `main` if `sync-readme` fails — visible immediately (`generate-readme.mjs --check` is in the post-merge health check I run every round) and fixed by one command. Compare with today, where the same staleness is prevented by keeping 218 PRs unmergeable.