### PR TITLE
Add dsh-netassist

### DIFF
--- a/README.md
+++ b/README.md
@@ -1198,6 +1198,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 - [ZSeven-W/dsh-noema](https://github.com/ZSeven-W/dsh-noema) - Long-term memory for DSH agents — durable, inspectable memories with recall, search, browse and knowledge-graph tools, import from ten other AI coding tools, and a settings page.
 
 ### Tools & Capabilities
+- [Edge-Echo/dsh-netassist](https://github.com/Edge-Echo/dsh-netassist) - Network & proxy assistant for DeepSeek Harness: one-shot GitHub connectivity check, system proxy status, proxy port probing, full diag chain (DNS/TCP/HTTP) and hosts conflict scan.
 
 - [0xRabit/dsh-crypto-portfolio](https://github.com/0xRabit/dsh-crypto-portfolio) - Crypto portfolio tracker for DSH: BTC / EVM (DeBank free+paid) / Solana / Hyperliquid L1 / CEX balances with multi-provider API failover, per-profile configs, scheduled daily refresh and trend charts (self-contained web dashboard).
 - [1321928757/dsh-mysql](https://github.com/1321928757/dsh-mysql) - MySQL connector for DeepSeek Harness: configure multiple connections in the settings page with per-connection table allowlist and write permission, switch the active connection from the composer, and expose mysql_query / mysql_tables / mysql_execute tools to every agent preset.

--- a/README.zh.md
+++ b/README.zh.md
@@ -1198,6 +1198,7 @@ dsh plugin --profile web add dshmarket
 - [ZSeven-W/dsh-noema](https://github.com/ZSeven-W/dsh-noema) — 为 DSH Agent 提供长期记忆——可检索、可检视的持久记忆，带回忆、搜索、浏览与知识图谱工具，支持从十个其他 AI 编码工具导入记忆，并附设置页。
 
 ### 🛠️ 工具与能力
+- [Edge-Echo/dsh-netassist](https://github.com/Edge-Echo/dsh-netassist) - 网络与代理助手：一键检查 GitHub 连通性、系统代理状态、代理端口探测、完整诊断链（DNS/TCP/HTTP）与 hosts 冲突扫描。
 
 - [0xRabit/dsh-crypto-portfolio](https://github.com/0xRabit/dsh-crypto-portfolio) — 加密货币组合追踪器：BTC / EVM（DeBank 免费+付费双源）/ Solana / Hyperliquid L1 / CEX 余额，多 API 源自动切换、多 Profile 配置、每日定时刷新与趋势图（自带 Web 仪表盘）。
 - [1321928757/dsh-mysql](https://github.com/1321928757/dsh-mysql) — DeepSeek Harness 的 MySQL 连接插件：在设置页配置多套连接（每连接可配表白名单与写权限），输入栏一键切换当前会话的连接，并为所有 Agent 预设提供 mysql_query / mysql_tables / mysql_execute 工具。


### PR DESCRIPTION
Adds the network & proxy assistant plugin (**dsh-netassist**) to the **Tools & Capabilities** category in both README.md and README.zh.md.

- One-shot GitHub connectivity check, system proxy status, proxy port probing, full DNS/TCP/HTTP diag chain, hosts conflict scan.
- All input crosses the PowerShell boundary as Base64 - injection-proof by construction.
- Repo has the `dsh-plugin` topic set.