### PR TITLE
feat: add 173787247/dsh-wsl-github

### DIFF
--- a/README.md
+++ b/README.md
@@ -1541,6 +1541,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 ### WSL & Windows Interop
 
 - [173787247/dsh-wsl-env](https://github.com/173787247/dsh-wsl-env) - Injects WSL distro, Linux path mapping, /mnt/c CRLF and git caveats, and NODE_USE_ENV_PROXY into the system prompt.
+- [173787247/dsh-wsl-github](https://github.com/173787247/dsh-wsl-github) - Uses a GitHub App to report open PRs and the latest Actions run for the current repo without returning secrets.
 - [173787247/dsh-wsl-net](https://github.com/173787247/dsh-wsl-net) - Adds a net_doctor tool that reports proxy environment, NODE_USE_ENV_PROXY, and reachability of the DeepSeek API and the npm registry, and sets NODE_USE_ENV_PROXY on bash and npm child processes.
 - [173787247/dsh-wsl-open](https://github.com/173787247/dsh-wsl-open) - Opens WSL Linux paths from DeepSeek Harness chat in the Windows default app or Explorer.
 - [6Mikao9/dsh-wsl-workspace](https://github.com/6Mikao9/dsh-wsl-workspace) - Add a WSL workspace from the web GUI without needing to install dsh or related tools again inside WSL. Bash commands and file read/write operations run within the local WSL distribution on the host machine, while Windows files remain accessible.

--- a/README.zh.md
+++ b/README.zh.md
@@ -1541,6 +1541,7 @@ dsh plugin --profile web add dshmarket
 ### 🐧 WSL 与 Windows 互操作
 
 - [173787247/dsh-wsl-env](https://github.com/173787247/dsh-wsl-env) — 向 system prompt 注入 WSL 发行版、Linux 路径映射、/mnt/c 的 CRLF 与 git 注意点，以及 NODE_USE_ENV_PROXY。
+- [173787247/dsh-wsl-github](https://github.com/173787247/dsh-wsl-github) — 通过 GitHub App 查询当前仓库未关闭 PR 与最近一次 Actions，不回传密钥。
 - [173787247/dsh-wsl-net](https://github.com/173787247/dsh-wsl-net) — 提供 net_doctor 工具，报告代理环境、NODE_USE_ENV_PROXY，以及 DeepSeek API 与 npm registry 的连通性，并为 bash 和 npm 子进程设置 NODE_USE_ENV_PROXY。
 - [173787247/dsh-wsl-open](https://github.com/173787247/dsh-wsl-open) — 把 DeepSeek Harness 聊天里的 WSL Linux 路径在 Windows 默认程序或资源管理器中打开。
 - [6Mikao9/dsh-wsl-workspace](https://github.com/6Mikao9/dsh-wsl-workspace) — 从 Web GUI 添加 WSL 工作区，无需在 WSL 之中再次安装 dsh 以及相关工具，bash 命令与文件读写运行在本机 WSL 发行版内，Windows 文件仍可访问。

--- a/data/plugins/173787247__dsh-wsl-github.yml
+++ b/data/plugins/173787247__dsh-wsl-github.yml
@@ -1,0 +1,6 @@
+url: https://github.com/173787247/dsh-wsl-github
+name: 173787247/dsh-wsl-github
+category: wsl
+description:
+  en: Uses a GitHub App to report open PRs and the latest Actions run for the current repo without returning secrets.
+  zh: 通过 GitHub App 查询当前仓库未关闭 PR 与最近一次 Actions，不回传密钥。


### PR DESCRIPTION
## Summary
- Add [`173787247/dsh-wsl-github`](https://github.com/173787247/dsh-wsl-github) (category `wsl`).
- Single-entry PR after the 1-day age gate.
- READMEs regenerated.

## Test plan
- [ ] CI + Submission gate green
