### PR TITLE
add dsh-conversation-map (ui): 对话地图 — 会话实时树状图

### DIFF
--- a/data/plugins/xyAxzy__dsh-conversation-map.yml
+++ b/data/plugins/xyAxzy__dsh-conversation-map.yml
@@ -1,0 +1,6 @@
+url: https://github.com/xyAxzy/dsh-conversation-map
+name: xyAxzy/dsh-conversation-map
+category: ui
+description:
+  en: 'A live conversation map for DeepSeek Harness web: real-time session tree with subagent lineage, running state, and one-click navigation.'
+  zh: 'DSH 对话地图：当前工作区全部会话的实时树状图，子代理谱系、运行状态一目了然，双击即跳转。'


### PR DESCRIPTION
## 收录插件

- **url**: https://github.com/xyAxzy/dsh-conversation-map
- **category**: ui
- **name**: xyAxzy/dsh-conversation-map

### 功能

DSH 对话地图：当前工作区全部会话的实时树状图。
- 树状自动排版（父左子右、分叉逐层缩进）
- 父子连线避让、工作区主题色贯穿
- 方格本网格背景 + 透明手绘感工作区框
- 双击卡片跳转会话

### 满足门槛

- ✅ `dsh.bundle` manifest（`cordis.patch.yml` 存在）
- ✅ 真实可用代码（lib/client.js + lib/index.js，非占位）
- ✅ 仓库满 1 天（2026-08-28 创建）
- ✅ 提交数 ≥ 10（当前 10+）
- ✅ 已添加 `dsh-plugin` topic
- ⚠️ 未能本地运行 `generate-readme.mjs`（依赖站点构建产物），本次仅提交 YAML；如需要请维护者重新生成 README，或告知我补充