### PR TITLE
feat: add lee259/dsh-workbench

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 - [LCQ-1024/dsh-prompt-enhancer](https://github.com/LCQ-1024/dsh-prompt-enhancer) - Adds a prompt-enhancement button to the DSH composer that rewrites drafts into agent-ready prompts.
 - [lcthe/dsh-skills-hub](https://github.com/lcthe/dsh-skills-hub) - DSH Skill Manager: browse, enable/disable, import from Codex/Claude Code/ZCode/WorkBuddy/QCoderWork, auto-discover skills with symlink support.
 - [lcthe/dsh-timeline-rail](https://github.com/lcthe/dsh-timeline-rail) - Message timeline rail for DeepSeek Harness web chat: evenly spaced ticks for each user message on the right edge, click to jump, hover to preview.
+- [lee259/dsh-workbench](https://github.com/lee259/dsh-workbench) - A right-side file workspace for DeepSeek Harness Web with source previews, captured DSH diffs, tabs, and a workspace tree.
 - [LeemanCheung/dsh-whale-animation](https://github.com/LeemanCheung/dsh-whale-animation) - A 60-frame theme-aware monochrome whale-dive animation with reactive water for the DSH Web turn status: embedded assets, seamless closed-loop playback, a reduced-motion PNG fallback, and lifecycle-clean removal.
 - [lemonorangeapple/dsh-effort-switcher](https://github.com/lemonorangeapple/dsh-effort-switcher) - A Codex-like effort switcher for Deepseek Harness.
 - [LHF198/dsh-prompt-optimizer](https://github.com/LHF198/dsh-prompt-optimizer) - Improve the current chat draft before sending with a confirm-before-apply comparison.

--- a/README.zh.md
+++ b/README.zh.md
@@ -279,6 +279,7 @@ dsh plugin --profile web add dshmarket
 - [LCQ-1024/dsh-prompt-enhancer](https://github.com/LCQ-1024/dsh-prompt-enhancer) — 在 DSH 输入框添加提示词增强按钮，将草稿改写为可直接交给 Agent 执行的提示词。
 - [lcthe/dsh-skills-hub](https://github.com/lcthe/dsh-skills-hub) — DSH 技能管理器：浏览、启用/禁用、从 Codex/Claude Code/ZCode/WorkBuddy/QCoderWork 导入，自动发现技能并支持软链接。
 - [lcthe/dsh-timeline-rail](https://github.com/lcthe/dsh-timeline-rail) — DeepSeek Harness 网页会话消息时间轴导航条：消息区右侧等间距刻度，点击跳转，悬浮预览。
+- [lee259/dsh-workbench](https://github.com/lee259/dsh-workbench) — DeepSeek Harness Web 右侧文件工作区，提供源码预览、DSH 捕获差异、多文件标签页和工作区文件树。
 - [LeemanCheung/dsh-whale-animation](https://github.com/LeemanCheung/dsh-whale-animation) — DSH Web 回合状态旁的 60 帧随主题适配的单色鲸鱼深潜动画：传播式水面、无缝闭环、资源内嵌、减少动态效果 PNG 回退，且随生命周期完整清理。
 - [lemonorangeapple/dsh-effort-switcher](https://github.com/lemonorangeapple/dsh-effort-switcher) — 为DSH添加一个类似于Codex的推理强度切换器。
 - [LHF198/dsh-prompt-optimizer](https://github.com/LHF198/dsh-prompt-optimizer) — 在发送前优化当前聊天输入，采用前先对比原文与优化结果。

--- a/data/plugins/lee259__dsh-workbench.yml
+++ b/data/plugins/lee259__dsh-workbench.yml
@@ -1,0 +1,6 @@
+url: https://github.com/lee259/dsh-workbench
+name: lee259/dsh-workbench
+category: ui
+description:
+  en: A right-side file workspace for DeepSeek Harness Web with source previews, captured DSH diffs, tabs, and a workspace tree.
+  zh: DeepSeek Harness Web 右侧文件工作区，提供源码预览、DSH 捕获差异、多文件标签页和工作区文件树。


### PR DESCRIPTION
## What

Add `lee259/dsh-workbench` to the plugin catalog.

## Description

A right-side file workspace for DeepSeek Harness Web with source previews,
captured DSH diffs, tabs, and a workspace tree.

## Checks

- `node scripts/generate-readme.mjs --check`
- `git diff --check`
