### PR TITLE
Add theBigGavin/marketingdashboard — zero-key market data MCP server (dsh bundle)

### DIFF
--- a/data/plugins/theBigGavin__marketingdashboard.yml
+++ b/data/plugins/theBigGavin__marketingdashboard.yml
@@ -1,0 +1,6 @@
+url: https://github.com/theBigGavin/marketingdashboard
+name: theBigGavin/marketingdashboard
+category: tools
+description:
+  en: 'Zero-key market data MCP server (dsh bundle): 5 MCP tools for A-share/HK/US quotes, sector rankings, futures, money flow and 7x24 news, with a three-tier upstream fallback.'
+  zh: 零密钥行情数据 MCP server（dsh bundle）：5 个 MCP 工具覆盖 A股/港股/美股行情、板块排行、期货、资金流与 7×24 快讯，三层上游降级兜底。


### PR DESCRIPTION
## What
Adds [theBigGavin/marketingdashboard](https://github.com/theBigGavin/marketingdashboard) — a zero-key market data MCP server (dsh bundle).

## Why
mrd ships a built-in MCP server (Streamable HTTP) with 5 public market-data tools: get_quotes / get_boards / get_futures / get_money_flow / get_news. It bridges through the in-box `@deepseek-ai/dsh-mcp-client` via a `dsh.bundle` manifest (`cordis.patch.yml`), so `dsh plugin add github:theBigGavin/marketingdashboard` installs it as a remote endpoint — no local server, no API key.

## Checklist
- [x] `dsh.bundle` manifest in package.json (+ cordis.patch.yml) — installable via `dsh plugin add`
- [x] Real working code (MCP server in-process, v1.4.0 release), not a placeholder
- [x] Repo >1 day old and well over 10 commits
- [x] Actively maintained
- [x] `dsh-plugin` topic added
- [x] Description states functionality only, no marketing superlatives