### PR TITLE
Add James-web11/dsh-matlab-mcp

### DIFF
--- a/data/plugins/James-web11__dsh-matlab-mcp.yml
+++ b/data/plugins/James-web11__dsh-matlab-mcp.yml
@@ -1,0 +1,6 @@
+url: https://github.com/James-web11/dsh-matlab-mcp
+name: James-web11/dsh-matlab-mcp
+category: tools
+description:
+  en: Registers the MathWorks MATLAB/Simulink MCP server into a dsh profile, so agent sessions get mcp__matlab__* tools for running MATLAB code and reading, editing and testing Simulink models.
+  zh: 把 MathWorks MATLAB/Simulink MCP 服务器注册进 dsh profile，让会话获得 mcp__matlab__* 工具，用于运行 MATLAB 代码以及读取、编辑与测试 Simulink 模型。


### PR DESCRIPTION
## dsh-matlab-mcp

Registers the MathWorks MATLAB/Simulink MCP server into a DeepSeek Harness profile, so agent sessions get `mcp__matlab__*` tools.

- **MATLAB**: `evaluate_matlab_code`, `run_matlab_file`, `run_matlab_test_file`, `check_matlab_code`, `detect_matlab_toolboxes`
- **Simulink**: `model_overview`, `model_read`, `model_edit`, `model_check`, `model_query_params`, `model_resolve_params`, `model_test`

Install: `dsh plugin --profile web add github:James-web11/dsh-matlab-mcp`

> Prerequisite: the MathWorks MATLAB Agentic Toolkit (which provides the MCP server binary) and a running MATLAB session.