### PR TITLE
Add whiteS18/dsh-handoff-button (session)

### DIFF
--- a/data/plugins/whiteS18__dsh-handoff-button.yml
+++ b/data/plugins/whiteS18__dsh-handoff-button.yml
@@ -1,0 +1,6 @@
+url: https://github.com/whiteS18/dsh-handoff-button
+name: whiteS18/dsh-handoff-button
+category: session
+description:
+  en: Adds a handoff button to every assistant message that writes an LLM-summarized handoff document of the current conversation into the workspace handoff/ directory.
+  zh: 为每条 AI 回复添加 Handoff 按钮，点击后由 LLM 将当前会话总结为交接文档，写入该会话工作区的 handoff/ 目录。


### PR DESCRIPTION
Adds one entry: `data/plugins/whiteS18__dsh-handoff-button.yml`.

**[whiteS18/dsh-handoff-button](https://github.com/whiteS18/dsh-handoff-button)** — Adds a handoff button to every assistant message that writes an LLM-summarized handoff document of the current conversation into the workspace handoff/ directory.

- Category: `session`
- `dsh.bundle` manifest declared in package.json (`patch: ./cordis.patch.yml`, file present in repo root); `dsh.client` declared for the web UI half
- Repo has the `dsh-plugin` topic, is past the 1-day age bar, and has 11 commits
- Verified locally: `node scripts/generate-readme.mjs` renders the entry line in both READMEs (generated output not committed, per the guide)
- Only this one new file is touched