### PR TITLE
Update FishBottle7/opencode2dsh entry: point at the repository root

### DIFF
--- a/data/plugins/FishBottle7__opencode2dsh.yml
+++ b/data/plugins/FishBottle7__opencode2dsh.yml
@@ -1,5 +1,5 @@
-url: https://github.com/FishBottle7/opencode2dsh/tree/master/packages/plugin
-name: FishBottle7/opencode2dsh#plugin
+url: https://github.com/FishBottle7/opencode2dsh
+name: FishBottle7/opencode2dsh
 category: model
 description:
   en: Exposes OpenCode Zen free models to DeepSeek Harness, with no API key.


### PR DESCRIPTION
<!-- Thanks for contributing! Quick checklist / 提交前快速自查 -->

- [x] I added **one file** at `data/plugins/<owner>__<repo>.yml` — the READMEs are generated, don't edit them by hand / 我新增了一个 `data/plugins/<owner>__<repo>.yml` 文件（各语言 README 由脚本生成，不要手工编辑）
- [x] I ran `node scripts/generate-readme.mjs` and committed the regenerated READMEs / 我已执行 `node scripts/generate-readme.mjs` 并提交了重新生成的 README
- [x] My repo's `package.json` declares **`dsh.bundle`** (not just `dsh.client`) — [example](../blob/main/contributing.md) / 仓库 `package.json` 已声明 `dsh.bundle`（只有 `dsh.client` 无法安装）
- [x] My repo is at least **1 day old** with **10+ commits** / 仓库创建满 1 天且提交数 ≥ 10
- [x] `category` is one of `ui theme model session memory tools skill workflow notify dev market fun`, and themes/skins go under `theme` / `category` 取值正确，主题/皮肤类请用 `theme`
- [x] Description states what the plugin does, no superlatives / 描述只说功能，不带营销词
- [x] My repo has the `dsh-plugin` topic / 仓库已打 `dsh-plugin` topic

**Recommended (not required) / 推荐但不强制：**

- 📦 Publish to npm — npm installs are prebuilt and skip the `allowBuilds` approval, so users get a one-command install / 发布 npm 包：预构建产物免 `allowBuilds` 授权，用户一条命令装好
- 🔗 Declare official `@deepseek-ai/*` packages as `peerDependencies` (not `dependencies`) — avoids duplicate runtimes inside the profile / 官方 `@deepseek-ai/*` 包用 `peerDependencies` 声明（而非 `dependencies`），避免 profile 里出现重复运行时
- 🖼️ Screenshots go in **your own repository** now: a `screenshots.json` beside your `package.json`, listing image paths. Nothing to add here, and you can change them later without another pull request ([how](../blob/main/contributing.md#screenshots--截图optional-recommended--可选推荐)) / 截图现在放在**你自己的仓库**里：在 `package.json` 旁边放一个 `screenshots.json`，列出图片路径。这个 PR 里不用加任何东西，以后想换也不必再提 PR（[说明](../blob/main/contributing.md#screenshots--截图optional-recommended--可选推荐)）

Updates one entry (own entry only), per the new one-file submission policy —
no README changes included.

Switches `data/plugins/FishBottle7__opencode2dsh.yml` from the
`packages/plugin` subpackage back to the repository root.

**Why** — the entry was originally redirected to the subpackage because the
root `package.json` declared no `dsh.bundle`. The root is now installable on
its own:

- root `package.json` declares `dsh.bundle: { patch: "./cordis.patch.yml" }`
  with a root `cordis.patch.yml`
- the root declares the published npm package `@opencode2dsh/dsh-plugin` as a
  dependency; `dsh plugin --profile web add github:FishBottle7/opencode2dsh`
  was verified end-to-end in a scratch profile (package resolves, insert row
  loads)
- the root URL also lets the auto-collected npm mapping link
  `@opencode2dsh/dsh-plugin` to this entry (the package's `repository` field
  points at the repo root), which the subpackage URL could not match

**Effect** — display name drops the `#plugin` subpackage suffix; the entry
gains the npm package, download counts, and the npm one-liner install command.