### PR TITLE
Add dsh-tinyfish-search: TinyFish-backed web search provider for built-in web_search

### DIFF
--- a/data/plugins/maxwell-feng__dsh-tinyfish-search.yml
+++ b/data/plugins/maxwell-feng__dsh-tinyfish-search.yml
@@ -1,0 +1,6 @@
+url: https://github.com/maxwell-feng/dsh-tinyfish-search
+name: maxwell-feng/dsh-tinyfish-search
+category: browser
+description:
+  en: 'TinyFish-backed web search provider for the built-in web_search tool: each search is one GET to the TinyFish Search API, no model call.'
+  zh: '基于 TinyFish 的网页搜索提供方：把内置 web_search 接到 TinyFish Search API，每次搜索一次 GET，不消耗模型调用。'


### PR DESCRIPTION
Adds [maxwell-feng/dsh-tinyfish-search](https://github.com/maxwell-feng/dsh-tinyfish-search): a TinyFish-backed web search provider that takes over the built-in `web_search` tool — each search is one GET to the TinyFish Search API, no model call.

Install: `dsh plugin --profile web add dsh-tinyfish-search`

Category: browser