### PR TITLE
Add opdsh/unity-plugin

### DIFF
--- a/data/plugins/opdsh__unity-plugin.yml
+++ b/data/plugins/opdsh__unity-plugin.yml
@@ -1,0 +1,6 @@
+url: https://github.com/opdsh/unity-plugin
+name: opdsh/unity-plugin
+category: tools
+description:
+  en: "Drive the Unity Editor from DSH through the official unity CLI: live-Editor scene commands, in-Editor C# eval and runtime command discovery over a warm unity shell session, plus a raw CLI escape hatch for project creation, tests and builds. Mounts Unity's official skill collection alongside its own Unity workflow and Asset Store skills."
+  zh: "通过官方 unity CLI 在 DSH 中操作 Unity 编辑器：实时场景命令、编辑器内 C# 求值、运行时命令发现，均复用常驻的 unity shell 会话；另有原始 CLI 通道用于建工程、跑测试与构建。同时挂载 Unity 官方技能集，以及插件自带的 Unity 工作流与 Asset Store 技能。"


### PR DESCRIPTION
[opdsh/unity-plugin](https://github.com/opdsh/unity-plugin) — drives the Unity Editor from DSH through the official `unity` CLI. Five tools (`unity_status`, `unity_list_commands`, `unity_command`, `unity_eval`, `unity_cli`), with the four live-Editor ones sharing a warm `unity shell --protocol ndjson` session, plus mounted Unity skill collections.

- [x] I added **one file** at `data/plugins/opdsh__unity-plugin.yml`
- [ ] ~~I ran `node scripts/generate-readme.mjs` and committed the regenerated READMEs~~ — deliberately not done, per `contributing.md`: "That one file is the whole submission… they are regenerated on `main` after your PR merges — you do not have to run anything, and you should not edit them by hand." Happy to add the regenerated output if you'd rather have it.
- [x] `package.json` declares **`dsh.bundle`** (`{ "bundle": { "patch": "./cordis.patch.yml" }, "client": { "platform": "web" } }`), with `cordis.patch.yml` at the repo root
- [x] Repo is 2 days old with 10 commits
- [x] `category: tools`
- [x] Description states what the plugin does, no superlatives
- [x] Repo has the `dsh-plugin` topic

**Recommended:**

- 📦 Published to npm as [`@opdsh/unity-plugin`](https://www.npmjs.com/package/@opdsh/unity-plugin) (0.1.3)
- 🔗 Official `@deepseek-ai/*` packages are declared as `peerDependencies`, not `dependencies`
- 🖼️ No `screenshots.json` yet

Validated locally against `scripts/lib/entries.mjs` — the entry parses, the filename matches `slugFor(url)`, and the validator reports no problems.