### PR TITLE
Add alchemistwu/dsh-tool-call-guard

### DIFF
--- a/data/plugins/alchemistwu__dsh-tool-call-guard.yml
+++ b/data/plugins/alchemistwu__dsh-tool-call-guard.yml
@@ -1,0 +1,6 @@
+url: https://github.com/alchemistwu/dsh-tool-call-guard
+name: alchemistwu/dsh-tool-call-guard
+category: session
+description:
+  en: Neutralize tool calls with invalid JSON arguments on the wire so one malformed model generation cannot brick a session against strict OpenAI-compatible servers.
+  zh: 在 wire 层中性化 arguments 为非法 JSON 的 tool call，避免一次模型畸形输出让 session 在严格 OpenAI 兼容服务端上永久 400。


### PR DESCRIPTION
## What

[alchemistwu/dsh-tool-call-guard](https://github.com/alchemistwu/dsh-tool-call-guard) — neutralizes tool calls whose `arguments` are not valid JSON, on the wire, before they reach the provider.

## Why this matters

A model can emit a tool call with malformed arguments (unescaped inner quotes are the classic). OpenAI-compatible servers (vLLM and friends) are asymmetric about it: the **streaming generation path** accepts the malformed call — it streams through, gets persisted into the session log, the turn appears fine. The **history-replay path** validates strictly and rejects the entire request with `400 "Assistant tool call function.arguments must be valid JSON"`. From then on every later request in that session fails — the session is bricked until its log is hand-repaired.

Same failure class exists across ecosystems: openai-agents-python #2061, vLLM #41122.

## How it works

Intercepts the `llm/stream` waterfall:
- the invalid call becomes an honest text record (the model sees exactly the arguments it emitted, and can re-issue a corrected call),
- the matching tool result is re-expressed as a plain user message (the orphaned-result-as-user pattern from upstream discussion #4668), keeping the conversation protocol-balanced.

Zero overhead on clean history, append-only log never rewritten, provider-agnostic, fail-open, zero config. First observed in production with GLM-5.3-Flash on vLLM 0.27; details and repro in the README.

Category: `session` — it is the wire-side complement to dsh-session-repair's load-path recovery (prevention vs. cure).