### PR TITLE
feat: add randomix777/dsh-opencode-zen

### DIFF
--- a/data/plugins/randomix777__dsh-opencode-zen.yml
+++ b/data/plugins/randomix777__dsh-opencode-zen.yml
@@ -1,0 +1,6 @@
+url: https://github.com/randomix777/dsh-opencode-zen
+name: randomix777/dsh-opencode-zen
+category: model
+description:
+  en: 'Bring OpenCode Zen free models to DSH: 8 live-discovered providers with zero config, no API key; includes persistent quota tracker with rate-limit detection and reset countdown.'
+  zh: '把 OpenCode Zen 免费模型接入 DSH：8 个实时发现的免费模型，零配置无需 API key；内置持久化额度检测器，自动追踪 429 限流并显示重置倒计时。'


### PR DESCRIPTION
Add randomix777/dsh-opencode-zen to the awesome-dsh-plugin list.

This plugin brings OpenCode Zen's free models to DeepSeek Harness with:
- 8 live-discovered free models (no hardcoded list)
- Zero config, no API key required
- Persistent quota tracker detecting 429 rate limits with reset countdown
- File-based catalog caching that survives DSH restarts
- Retry with exponential backoff

Forked and optimized from [keman-ai/dsh-opencode-zen](https://github.com/keman-ai/dsh-opencode-zen).