### PR TITLE
Update dsh-llm-mlx tarball to v0.3.0

### DIFF
--- a/data/plugins/robbywang25__dsh-llm-mlx.yml
+++ b/data/plugins/robbywang25__dsh-llm-mlx.yml
@@ -4,4 +4,4 @@ category: model
 description:
   en: Use local MLX-LM or MLX-VLM models in DeepSeek Harness through a loopback OpenAI-compatible provider, with optional DSH-owned server startup.
   zh: 通过回环 OpenAI-compatible 提供方在 DeepSeek Harness 中使用本机 MLX-LM 或 MLX-VLM 模型，并可选由 DSH 托管模型服务进程。
-tarball: https://github.com/robbywang25/dsh-llm-mlx/releases/download/v0.2.0/dsh-llm-mlx-0.2.0.tgz
+tarball: https://github.com/robbywang25/dsh-llm-mlx/releases/download/v0.3.0/dsh-llm-mlx-0.3.0.tgz


### PR DESCRIPTION
Updates only the existing `robbywang25/dsh-llm-mlx` catalog entry to the verified v0.3.0 release tarball. The release adds an optional loopback CC Switch / Claude Desktop compatibility proxy and an explicit chat-only mode; the tarball is published, its SHA-256 is recorded by GitHub, the plugin CI passes on Node 22 and 24, and the release was installed and exercised locally through a real Claude Desktop response.