### PR TITLE
Add huanghai-lab/dsh-custom-instructions

### DIFF
--- a/data/plugins/huanghai-lab__dsh-custom-instructions.yml
+++ b/data/plugins/huanghai-lab__dsh-custom-instructions.yml
@@ -1,0 +1,6 @@
+url: https://github.com/huanghai-lab/dsh-custom-instructions
+name: huanghai-lab/dsh-custom-instructions
+category: ui
+description:
+  en: Manage global AGENTS.md in DSH Web with Markdown preview, reusable templates, version history, import/export, failed-import rollback, and revision-conflict protection.
+  zh: 在 DSH Web 中管理全局 AGENTS.md，支持 Markdown 预览、可复用模板、版本历史、导入导出、失败导入回滚与修订冲突保护。


### PR DESCRIPTION
## What

Adds `huanghai-lab/dsh-custom-instructions` to the UI category.

The entry describes the plugin's current, released behavior: global `AGENTS.md` editing in DSH Web, Markdown preview, reusable templates, version history, import/export with failed-import rollback, and revision-conflict protection.

## Why it is a separate entry

The list already includes basic global-rules editors. This plugin also provides reusable templates, restorable history, portable import/export, rollback when an import fails, and disk-derived revision checks that reject stale writes. The submitted description names those concrete differences without comparative or quality claims.

## Source checks

- the repository declares `dsh.bundle` on `master`
- the repository is older than one day, has 23 commits, and carries the `dsh-plugin` topic
- `v0.5.0-alpha.2` is published to npm under `next` with provenance
- Windows and Ubuntu checks, DSH `0.1.2-alpha.1` compatibility, and isolated browser E2E are green
- repository-owned `screenshots.json` lists two existing screenshots

## Local validation

- entry schema validation passed
- `node scripts/generate-readme.mjs` generated both locales with 2711 entries

Only the new YAML entry is committed; generated READMEs are left for the repository's post-merge sync workflow.
