### PR TITLE
Add Lzh3070/dsh-search-hub

### DIFF
--- a/data/plugins/Lzh3070__dsh-search-hub.yml
+++ b/data/plugins/Lzh3070__dsh-search-hub.yml
@@ -2,5 +2,5 @@ url: https://github.com/Lzh3070/dsh-search-hub
 name: Lzh3070/dsh-search-hub
 category: browser
 description:
-  en: Configurable web search hub for the built-in web_search tool: switch the active entry between DeepSeek official native search and Zhipu GLM web_search, with entry and credential management on a Settings page tab.
-  zh: 可配置的原生 web_search 后端：在 DeepSeek 官方原生搜索与智谱 GLM web_search 之间切换当前生效入口，并在设置页管理搜索入口与凭证引用。
+  en: 'Configurable web search hub for the built-in web_search tool: switch the active entry between DeepSeek official native search and Zhipu GLM web_search, with entry and credential management on a Settings page tab.'
+  zh: '可配置的原生 web_search 后端：在 DeepSeek 官方原生搜索与智谱 GLM web_search 之间切换当前生效入口，并在设置页管理搜索入口与凭证引用。'

--- a/data/plugins/Lzh3070__dsh-search-hub.yml
+++ b/data/plugins/Lzh3070__dsh-search-hub.yml
@@ -1,0 +1,6 @@
+url: https://github.com/Lzh3070/dsh-search-hub
+name: Lzh3070/dsh-search-hub
+category: browser
+description:
+  en: Configurable web search hub for the built-in web_search tool: switch the active entry between DeepSeek official native search and Zhipu GLM web_search, with entry and credential management on a Settings page tab.
+  zh: 可配置的原生 web_search 后端：在 DeepSeek 官方原生搜索与智谱 GLM web_search 之间切换当前生效入口，并在设置页管理搜索入口与凭证引用。


### PR DESCRIPTION
### Summary

- Adds `Lzh3070/dsh-search-hub` to the `browser` category.
- One-file entry submission, as required by `contributing.md`; generated READMEs are intentionally untouched.
- The plugin ships a `dsh.bundle` manifest, a Settings-page management UI, and routes the built-in `web_search` tool through configurable DeepSeek/Zhipu GLM entries.
- Published npm package: [dsh-search-hub@0.1.0](https://www.npmjs.com/package/dsh-search-hub) (maintainer: `phynez_1103`); its `repository` field points back to the listed repository.