### PR TITLE
Add cayan0x/Lume (identity category)

### DIFF
--- a/README.md
+++ b/README.md
@@ -901,6 +901,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 ### Identity & Communication
 
 - [AgentConnect/dsh-awiki](https://github.com/AgentConnect/dsh-awiki) - Provides DeepSeek Harness agents with native identities based on the open Agent Network Protocol (ANP), plus identity-based direct, group, mail, and Agent-to-Agent communication.
+- [cayan0x/Lume](https://github.com/cayan0x/Lume) - Named personas with long-term memory and evolving style — switch identities, create new personas through dialogue, and let each persona remember facts across sessions.
 - [chenbin-dev/dsh-auth-everying](https://github.com/chenbin-dev/dsh-auth-everying) - Import local Claude, Codex, Grok, Gemini, Copilot, OpenCode, and CC Switch config into DeepSeek Harness with OAuth login for supported providers.
 - [lw-storm/dsh-plugin-masterprompt](https://github.com/lw-storm/dsh-plugin-masterprompt) - Per-conversation persona / master prompt plugin: create, edit, switch and delete persona templates from the composer toolbar, with highest-priority system-prompt injection, fixed interaction guardrails, subagent inheritance, new-conversation default, and local JSON persistence.
 - [MengYuil/dsh-ponytail](https://github.com/MengYuil/dsh-ponytail) - Port of ponytail: an always-on lazy-senior-developer coding persona with intensity levels, persistence of the default level, and review, audit, debt, gain and help skills for DeepSeek Harness.

--- a/README.zh.md
+++ b/README.zh.md
@@ -901,6 +901,7 @@ dsh plugin --profile web add dshmarket
 ### 🆔 身份与通信
 
 - [AgentConnect/dsh-awiki](https://github.com/AgentConnect/dsh-awiki) — 为 DeepSeek Harness 智能体提供基于开放协议ANP的原生身份，以及基于该身份的私聊、群聊、邮件和智能体间通信能力。
+- [cayan0x/Lume](https://github.com/cayan0x/Lume) — 具名、带长期记忆与进化风格的人设——切换身份、通过对话创建新人设，并让每个人设跨会话记住事实。
 - [chenbin-dev/dsh-auth-everying](https://github.com/chenbin-dev/dsh-auth-everying) — 把本机的 Claude、Codex、Grok、Gemini、Copilot、OpenCode 与 CC Switch 配置导入 DeepSeek Harness，支持的提供方可直接 OAuth 登录。
 - [lw-storm/dsh-plugin-masterprompt](https://github.com/lw-storm/dsh-plugin-masterprompt) — 每对话独立的人设 / 主提示词插件：在输入框工具栏创建、编辑、切换和删除人设模板，最高优先级系统提示注入，附带固定交互护栏、子代理继承、新对话默认继承与本地 JSON 持久化。
 - [MengYuil/dsh-ponytail](https://github.com/MengYuil/dsh-ponytail) — ponytail 移植：常驻的「懒惰资深开发者」编码人设，带强度档位与 review、audit、debt、gain、help 技能，适用于 DeepSeek Harness。

--- a/data/plugins/cayan0x__Lume.yml
+++ b/data/plugins/cayan0x__Lume.yml
@@ -1,0 +1,6 @@
+url: https://github.com/cayan0x/Lume
+name: cayan0x/Lume
+category: identity
+description:
+  en: "Named personas with long-term memory and evolving style — switch identities, create new personas through dialogue, and let each persona remember facts across sessions."
+  zh: "具名、带长期记忆与进化风格的人设——切换身份、通过对话创建新人设，并让每个人设跨会话记住事实。"


### PR DESCRIPTION
Add Lume — a DSH persona system with long-term memory and evolving style.

- `dsh.bundle` manifest + `cordis.patch.yml` in repo root
- `dsh-plugin` topic added
- `screenshots.json` declares 6 screenshots for the storefront
- Repo is actively maintained (v0.3.1)