### PR TITLE
feat: add 173787247/dsh-wsl-clock

### DIFF
--- a/README.md
+++ b/README.md
@@ -1565,6 +1565,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 
 - [173787247/dsh-wsl-browser](https://github.com/173787247/dsh-wsl-browser) - Opens http(s) URLs from WSL in the Windows default browser.
 - [173787247/dsh-wsl-clipboard](https://github.com/173787247/dsh-wsl-clipboard) - Reads and writes the Windows clipboard from WSL.
+- [173787247/dsh-wsl-clock](https://github.com/173787247/dsh-wsl-clock) - Detects WSL2 clock skew versus Windows that can break TLS and tokens.
 - [173787247/dsh-wsl-cred](https://github.com/173787247/dsh-wsl-cred) - Safe Git Credential Manager hints for WSL without exposing secrets.
 - [173787247/dsh-wsl-distro](https://github.com/173787247/dsh-wsl-distro) - Reports the current WSL distro and warns about multi-distro setups.
 - [173787247/dsh-wsl-env](https://github.com/173787247/dsh-wsl-env) - Injects WSL distro, Linux path mapping, /mnt/c CRLF and git caveats, and NODE_USE_ENV_PROXY into the system prompt.

--- a/README.zh.md
+++ b/README.zh.md
@@ -1565,6 +1565,7 @@ dsh plugin --profile web add dshmarket
 
 - [173787247/dsh-wsl-browser](https://github.com/173787247/dsh-wsl-browser) — 在 Windows 默认浏览器中打开来自 WSL 的 http(s) 链接。
 - [173787247/dsh-wsl-clipboard](https://github.com/173787247/dsh-wsl-clipboard) — 从 WSL 读写 Windows 剪贴板。
+- [173787247/dsh-wsl-clock](https://github.com/173787247/dsh-wsl-clock) — 检测相对 Windows 的 WSL2 时钟偏差，避免 TLS 与 token 异常。
 - [173787247/dsh-wsl-cred](https://github.com/173787247/dsh-wsl-cred) — 提供 WSL 下 Git Credential Manager 的安全指引，不回传密钥。
 - [173787247/dsh-wsl-distro](https://github.com/173787247/dsh-wsl-distro) — 报告当前 WSL 发行版，并提醒多发行版混用风险。
 - [173787247/dsh-wsl-env](https://github.com/173787247/dsh-wsl-env) — 向 system prompt 注入 WSL 发行版、Linux 路径映射、/mnt/c 的 CRLF 与 git 注意点，以及 NODE_USE_ENV_PROXY。

--- a/data/plugins/173787247__dsh-wsl-clock.yml
+++ b/data/plugins/173787247__dsh-wsl-clock.yml
@@ -1,0 +1,6 @@
+url: https://github.com/173787247/dsh-wsl-clock
+name: 173787247/dsh-wsl-clock
+category: wsl
+description:
+  en: Detects WSL2 clock skew versus Windows that can break TLS and tokens.
+  zh: 检测相对 Windows 的 WSL2 时钟偏差，避免 TLS 与 token 异常。


### PR DESCRIPTION
## Summary
- Add `173787247/dsh-wsl-clock` under `wsl`.
- Part of the personal [dsh-wsl-kit](https://github.com/173787247/dsh-wsl-kit) install pack (kit itself is not submitted).

## Test plan
- [ ] Submission gate / README generate CI green
- [ ] Description matches the plugin README and tools
