### PR TITLE
feat: add 173787247/dsh-wsl-encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1567,6 +1567,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 - [173787247/dsh-wsl-clipboard](https://github.com/173787247/dsh-wsl-clipboard) - Reads and writes the Windows clipboard from WSL.
 - [173787247/dsh-wsl-cred](https://github.com/173787247/dsh-wsl-cred) - Safe Git Credential Manager hints for WSL without exposing secrets.
 - [173787247/dsh-wsl-distro](https://github.com/173787247/dsh-wsl-distro) - Reports the current WSL distro and warns about multi-distro setups.
+- [173787247/dsh-wsl-encoding](https://github.com/173787247/dsh-wsl-encoding) - Reports PowerShell, cmd, and LANG encoding for UTF-8 versus code-page issues.
 - [173787247/dsh-wsl-env](https://github.com/173787247/dsh-wsl-env) - Injects WSL distro, Linux path mapping, /mnt/c CRLF and git caveats, and NODE_USE_ENV_PROXY into the system prompt.
 - [173787247/dsh-wsl-github](https://github.com/173787247/dsh-wsl-github) - Uses a GitHub App to report open PRs and the latest Actions run for the current repo without returning secrets.
 - [173787247/dsh-wsl-gpu](https://github.com/173787247/dsh-wsl-gpu) - Probes nvidia-smi and GPU visibility inside WSL.

--- a/README.zh.md
+++ b/README.zh.md
@@ -1567,6 +1567,7 @@ dsh plugin --profile web add dshmarket
 - [173787247/dsh-wsl-clipboard](https://github.com/173787247/dsh-wsl-clipboard) — 从 WSL 读写 Windows 剪贴板。
 - [173787247/dsh-wsl-cred](https://github.com/173787247/dsh-wsl-cred) — 提供 WSL 下 Git Credential Manager 的安全指引，不回传密钥。
 - [173787247/dsh-wsl-distro](https://github.com/173787247/dsh-wsl-distro) — 报告当前 WSL 发行版，并提醒多发行版混用风险。
+- [173787247/dsh-wsl-encoding](https://github.com/173787247/dsh-wsl-encoding) — 报告 PowerShell、cmd 与 LANG 编码，便于排查 UTF-8 与代码页问题。
 - [173787247/dsh-wsl-env](https://github.com/173787247/dsh-wsl-env) — 向 system prompt 注入 WSL 发行版、Linux 路径映射、/mnt/c 的 CRLF 与 git 注意点，以及 NODE_USE_ENV_PROXY。
 - [173787247/dsh-wsl-github](https://github.com/173787247/dsh-wsl-github) — 通过 GitHub App 查询当前仓库未关闭 PR 与最近一次 Actions，不回传密钥。
 - [173787247/dsh-wsl-gpu](https://github.com/173787247/dsh-wsl-gpu) — 探测 WSL 内的 nvidia-smi 与 GPU 可见性。

--- a/data/plugins/173787247__dsh-wsl-encoding.yml
+++ b/data/plugins/173787247__dsh-wsl-encoding.yml
@@ -1,0 +1,6 @@
+url: https://github.com/173787247/dsh-wsl-encoding
+name: 173787247/dsh-wsl-encoding
+category: wsl
+description:
+  en: Reports PowerShell, cmd, and LANG encoding for UTF-8 versus code-page issues.
+  zh: 报告 PowerShell、cmd 与 LANG 编码，便于排查 UTF-8 与代码页问题。


### PR DESCRIPTION
## Summary
- Add `173787247/dsh-wsl-encoding` under `wsl`.
- Part of the personal [dsh-wsl-kit](https://github.com/173787247/dsh-wsl-kit) install pack (kit itself is not submitted).

## Test plan
- [ ] Submission gate / README generate CI green
- [ ] Description matches the plugin README and tools
