### PR TITLE
Add errrepe/dsh-codegraph-plugin

### DIFF
--- a/data/plugins/errrepe__dsh-codegraph-plugin.yml
+++ b/data/plugins/errrepe__dsh-codegraph-plugin.yml
@@ -1,0 +1,6 @@
+url: https://github.com/errrepe/dsh-codegraph-plugin
+name: errrepe/dsh-codegraph-plugin
+category: tools
+description:
+  en: Codegraph CLI as eight code-intelligence tools for DSH — symbol search, callers/callees, impact analysis, codebase exploration, symbol/file reading, index status and sync.
+  zh: 将 Codegraph CLI 封装为 DSH 的八个代码智能工具：符号搜索、调用者/被调用者、影响分析、代码库探索、符号/文件读取、索引状态与同步。


### PR DESCRIPTION
Adds `errrepe/dsh-codegraph-plugin` — DSH profile bundle exposing the installed `codegraph` CLI as eight code-intelligence tools.

- **Install:** `dsh plugin --profile web add github:errrepe/dsh-codegraph-plugin`
- **Tools (8):** `codegraph_query`, `codegraph_callers`, `codegraph_callees`, `codegraph_impact`, `codegraph_explore`, `codegraph_node`, `codegraph_status`, `codegraph_sync`
- **Manifest:** `dsh.bundle` at `cordis.patch.yml` (id: codegraph)
- **Verified:** installs via `dsh plugin add`, composes in dump-config, and all 8 tools exercise against the oMLX workspace (941 files, 36k nodes) — including the WAL-aware sandbox policy for the SQLite index.

Repo: https://github.com/errrepe/dsh-codegraph-plugin (topic `dsh-plugin` set, 10 commits).

Note: repo was created 2026-08-30T08:03:25Z; if the 1-day age check is still red, it will pass within hours (UTC 2026-08-31 08:03Z).