### PR TITLE
Add TencentCloud/cloudq-for-dsh

### DIFF
--- a/data/plugins/TencentCloud__cloudq-for-dsh.yml
+++ b/data/plugins/TencentCloud__cloudq-for-dsh.yml
@@ -1,0 +1,6 @@
+url: https://github.com/TencentCloud/cloudq-for-dsh
+name: TencentCloud/cloudq-for-dsh
+category: skill
+description:
+  en: 'Tencent CloudQ integration: AIOps chat mode with usage, inspiration, artifact and architecture panels.'
+  zh: '腾讯云智能顾问集成：CloudQ 对话模式，附用量、灵感、制品与架构图面板。'


### PR DESCRIPTION
Add [TencentCloud/cloudq-for-dsh](https://github.com/TencentCloud/cloudq-for-dsh) to the list.

**What it does**: Tencent CloudQ (智能顾问) integration for DSH — a CloudQ chat mode backed by a bundled skill, plus settings-card credential setup (AK/SK) and capability panels for usage, inspirations, artifacts and architecture diagrams.

**Checklist per contributing.md**:
- `dsh.bundle.patch` declared in package.json with a root `cordis.patch.yml`; installable via `dsh plugin --profile web add dsh-cloudq`
- Repo is 3 days old with 10 commits; `dsh-plugin` topic added
- Published on npm as `dsh-cloudq` with `repository` pointing back at the listed repo
- `screenshots.json` declares 2 screenshots from the repo
- CI on the plugin repo is green (lint, typecheck, unit tests, build, tarball install verification)
