### PR TITLE
add nicecx/dsh-reset-handoff (dev)

### DIFF
--- a/data/plugins/nicecx__dsh-reset-handoff.yml
+++ b/data/plugins/nicecx__dsh-reset-handoff.yml
@@ -1,0 +1,6 @@
+url: https://github.com/nicecx/dsh-reset-handoff
+name: nicecx/dsh-reset-handoff
+category: dev
+description:
+  en: 'Hands DSH reset requests to an external ops agent via a versioned JSON protocol: preflight snapshot, pre-restart maturity gate (no pending approvals, free disk, cooldown), restart, health check, and interrupted-work recovery, with the result delivered back to the requesting session.'
+  zh: '把 DSH 重置请求经带版本的 JSON 协议交给外部运维 agent：预检快照、重启前成熟度门禁（无待审批、磁盘充足、冷却期）、重启、健康检查与业务恢复，结果投递回发起会话。'


### PR DESCRIPTION
## 收录 dsh-reset-handoff

DSH 重置托管插件：把重置请求经版本化 JSON 协议交给外部运维 agent（预检快照 → 重启前门禁 → 重启 → 健康检查 → 业务恢复），结果投递回发起会话。

- 分类: dev
- 仓库: https://github.com/nicecx/dsh-reset-handoff（18 提交，dsh-plugin topic，dsh.bundle manifest 已声明）
- 描述与代码一致（门禁三项/恢复流程/广播投递均已实现并验证）

一个 PR 一个条目。