### PR TITLE
Add wjf1/dsh-commandcode plugin entry

### DIFF
--- a/data/plugins/wjf1__dsh-commandcode.yml
+++ b/data/plugins/wjf1__dsh-commandcode.yml
@@ -1,0 +1,6 @@
+url: https://github.com/wjf1/dsh-commandcode
+name: wjf1/dsh-commandcode
+category: model
+description:
+  en: 'DSH-Desktop LLM provider for Command Code: live model catalog, retry with backoff, multi-account rotation, usage dashboard, and bilingual settings UI.'
+  zh: 'DSH-Desktop 的 Command Code 模型接入插件：实时模型目录、带退避的重试、多账号轮换、用量看板与双语设置界面。'

--- a/data/plugins/wjf1__dsh-commandcode.yml
+++ b/data/plugins/wjf1__dsh-commandcode.yml
@@ -2,5 +2,5 @@ url: https://github.com/wjf1/dsh-commandcode
 name: wjf1/dsh-commandcode
 category: model
 description:
-  en: 'DSH-Desktop LLM provider for Command Code: live model catalog, retry with backoff, multi-account rotation, usage dashboard, and bilingual settings UI.'
-  zh: 'DSH-Desktop 的 Command Code 模型接入插件：实时模型目录、带退避的重试、多账号轮换、用量看板与双语设置界面。'
+  en: 'Command Code LLM provider plugin adapted for DSH-Desktop 0.7.1: registers a commandcode route, with a live model catalog, reasoning-effort support, and real-time plan usage display.'
+  zh: 'Command Code 模型接入插件，适配 DSH-Desktop 0.7.1，注册 commandcode 路由，带实时模型目录与推理强度支持，实时查看套餐用量。'


### PR DESCRIPTION
## What

Adds one entry: `wjf1/dsh-commandcode` (category: `model`), file `data/plugins/wjf1__dsh-commandcode.yml`.

## About the plugin

`dsh-commandcode` is a DSH-Desktop LLM provider plugin for Command Code. It registers a `commandcode` provider route on `ctx.llm`, with a live model catalog (SWR + on-disk cache), configurable timeout/retry with exponential backoff, multi-account rotation on 429/401, a usage & billing dashboard, image input support, and a bilingual (zh/en) settings UI. Built for DSH-Desktop 0.7.1 / DeepSeek Harness 0.1.2-alpha.1.

## Checklist

- Repo declares a `dsh.bundle` manifest in `package.json` (with `cordis.patch.yml` at the root) — installable via `dsh plugin add`.
- Repo has the `dsh-plugin` topic, is MIT-licensed, not archived, actively maintained (19 commits; created 2026-08-30).
- Description states only what the plugin does; both `en` and `zh` provided.
- Only this one entry file is touched; generated READMEs are left for the merge-time regeneration.