### PR TITLE
Add Luawig/dsh-cloudflare-access

### DIFF
--- a/data/plugins/Luawig__dsh-cloudflare-access.yml
+++ b/data/plugins/Luawig__dsh-cloudflare-access.yml
@@ -1,0 +1,6 @@
+url: https://github.com/Luawig/dsh-cloudflare-access
+name: Luawig/dsh-cloudflare-access
+category: security
+description:
+  en: Re-validates Cloudflare Access JWTs at the DSH origin so Settings, Credentials, Agent Preset management, and model discovery work from a remote hostname.
+  zh: 在 DSH Origin 校验 Cloudflare Access JWT，使 Settings、凭据、Agent Preset 管理与模型发现可在远程主机名下使用。


### PR DESCRIPTION
## Summary
- Add [Luawig/dsh-cloudflare-access](https://github.com/Luawig/dsh-cloudflare-access) under **Security & Permissions**.
- The plugin re-validates `Cf-Access-Jwt-Assertion` at the DSH origin so Settings, Credentials, Agent Preset management, and model discovery work from a remote hostname behind Cloudflare Access.

## Checklist
- `dsh.bundle` is declared in `package.json` with `cordis.patch.yml` (`id: cloudflare-access`)
- Published to npm as [dsh-cloudflare-access](https://www.npmjs.com/package/dsh-cloudflare-access); `repository` points back at this repo
- Repo has the `dsh-plugin` topic; created 2026-08-27, 19 commits
- One YAML file only; READMEs left to the generator

## Test plan
- [ ] CI: entry count, `dsh.bundle`, repo age/commit count, awesome-lint
- [ ] Description matches origin JWT verification and remote privileged APIs