### PR TITLE
Add hmlyx/dsh-memory and hmlyx/dsh-notify

### DIFF
--- a/data/plugins/hmlyx__dsh-memory.yml
+++ b/data/plugins/hmlyx__dsh-memory.yml
@@ -1,0 +1,6 @@
+url: https://github.com/hmlyx/dsh-memory
+name: hmlyx/dsh-memory
+category: memory
+description:
+  en: 'Persistent conversation memory for DeepSeek Harness: memory tab, automatic AI naming, per-AI privacy isolation, sidebar AI names, and automatic experience archiving. A static profile plugin available in every preset without disappearing on restart.'
+  zh: '简单的插件，让你的每个 AI 记录经验和记忆。'

--- a/data/plugins/hmlyx__dsh-notify.yml
+++ b/data/plugins/hmlyx__dsh-notify.yml
@@ -1,0 +1,6 @@
+url: https://github.com/hmlyx/dsh-notify
+name: hmlyx/dsh-notify
+category: notify
+description:
+  en: 'Reminder bubbles beside the input for DeepSeek Harness: any plugin or AI can push reminders (text/link) with chat-style stacking, drag-resize, AI summary, and quick restart. A static profile plugin available in every preset without disappearing on restart.'
+  zh: '在输入框右边加了一个泡泡窗口，你可以接入插件或者告诉 AI 什么时候使用它。'

--- a/data/plugins/hmlyx__dsh-notify.yml
+++ b/data/plugins/hmlyx__dsh-notify.yml
@@ -2,5 +2,5 @@ url: https://github.com/hmlyx/dsh-notify
 name: hmlyx/dsh-notify
 category: notify
 description:
-  en: 'Reminder bubbles beside the input for DeepSeek Harness: any plugin or AI can push reminders (text/link) with chat-style stacking, drag-resize, AI summary, and quick restart. A static profile plugin available in every preset without disappearing on restart.'
+  en: 'Reminder bubbles beside the input for DeepSeek Harness: any plugin or AI can push reminders (text/link) with chat-style stacking, drag-resize, AI summary, visual customization and random outfit presets. A static profile plugin available in every preset without disappearing on restart.'
   zh: '在输入框右边加了一个泡泡窗口，你可以接入插件或者告诉 AI 什么时候使用它。'


### PR DESCRIPTION
Add two static profile plugins:
- hmlyx/dsh-memory (memory): persistent conversation memory with automatic AI naming, privacy isolation and experience archiving.
- hmlyx/dsh-notify (notify): reminder bubbles beside the input; any plugin or AI can push reminders.