### PR TITLE
Add alpacachen/dsh-automation

### DIFF
--- a/data/plugins/alpacachen__dsh-automation.yml
+++ b/data/plugins/alpacachen__dsh-automation.yml
@@ -1,0 +1,6 @@
+url: https://github.com/alpacachen/dsh-automation
+name: alpacachen/dsh-automation
+category: workflow
+description:
+  en: Runs one-time and RFC 5545 recurring Agent tasks in fresh DSH sessions, with visual schedule editing and session-linked history.
+  zh: 在全新的 DSH 会话中运行单次或 RFC 5545 周期 Agent 任务，支持可视化计划编辑和会话关联历史。


### PR DESCRIPTION
## Summary

Adds `alpacachen/dsh-automation` to the workflow category.

The plugin supports one-time tasks and full RFC 5545 recurring schedules, including a visual daily/weekly/monthly editor and an advanced RRULE mode. Each run starts in a fresh persisted DSH session, and run history links back to its session.

It is published as the public npm package [`@alpacachen/dsh-automation`](https://www.npmjs.com/package/@alpacachen/dsh-automation). Screenshots are declared in the plugin repository through `screenshots.json` and use repository-owned image files.

## Validation

- `npm ci`
- `node scripts/generate-readme.mjs`
- `node scripts/generate-readme.mjs --check`
- `npx awesome-lint`
- `SKIP_PUBLISH_CHECKS=1 node scripts/build-site.mjs`