### PR TITLE
ci: keep manual probe reruns publishable

### DIFF
--- a/.github/workflows/build-site.yml
+++ b/.github/workflows/build-site.yml
@@ -174,15 +174,21 @@ jobs:
           node scripts/build-site.mjs
       - uses: actions/upload-pages-artifact@v3
         with:
+          # A rerun keeps artifacts from prior attempts under the same run id.
+          # Give each attempt one deployable artifact instead of making
+          # deploy-pages reject multiple artifacts named "github-pages".
+          name: github-pages-${{ github.run_attempt }}
           path: docs
       - id: deployment
         uses: actions/deploy-pages@v4
-        # The concurrency split above means a push build and the nightly can now
+        with:
+          artifact_name: github-pages-${{ github.run_attempt }}
+        # The concurrency split above means a push build and a probe run can now
         # be in flight together, and Pages accepts one deployment at a time.
-        # Losing that race must not abort the nightly before the two publish
-        # steps below — they are the reason the run exists, and the site is
-        # about to be redeployed by whichever push won anyway.
-        continue-on-error: ${{ github.event_name == 'schedule' }}
+        # Losing that race must not abort a scheduled or manually dispatched
+        # probe before the two publish steps below — they are the reason the run
+        # exists, and the site is about to be redeployed by whichever push won.
+        continue-on-error: ${{ github.event_name != 'push' }}
 
       # The same plugins.json, published to npm — see
       # scripts/publish-catalog.mjs for why it has to exist in two places.


### PR DESCRIPTION
## Summary

- give every workflow attempt a distinct Pages artifact name and deploy that exact artifact
- keep Pages deployment non-fatal for both scheduled and manually dispatched probe/publish runs
- keep push-triggered Pages deployment strict

Related to #3916.

## Reproduction

Manual run [33294325780](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/actions/runs/33294325780) completed `Build` and `upload-pages-artifact` on both attempts, then failed at `deploy-pages`. The catalog publish, update-notes publish, and all three cache-save post-steps were skipped on both attempts.

Attempt 2 failed with the exact deployment error:

```text
Multiple artifacts named "github-pages" were unexpectedly found for this workflow run. Artifact count is 2.
```

GitHub retains artifacts from earlier attempts under the same run id. The run now has two artifacts named `github-pages`, one from each attempt.

The second attempt's uploaded `plugins.json` already contains the correct result for #3916:

```json
{
  "url": "https://github.com/hjj345/dsh-sm-context-piano",
  "npm": "@hjj345345/dsh-sm-context-piano",
  "downloads": 557,
  "install": "dsh plugin --profile web add @hjj345345/dsh-sm-context-piano"
}
```

The live catalog still reports `npm: null` and the GitHub fallback command because the successful probe output was neither cached nor published.

## Baseline -> candidate

Base `6ffccc6fb1cd0cecdb80639ea8ed0334765903a5` lets `upload-pages-artifact` use its constant default name, so a rerun can make `deploy-pages` see multiple matching artifacts. It also makes Pages failure non-fatal only for `schedule`, although `workflow_dispatch` runs the same probes and the same two npm publication steps.

Exact head `9aecbdaf22cdc1e724db5fe10631ce41817351ab` binds both actions to `github-pages-${{ github.run_attempt }}` and makes Pages non-fatal for every non-push probe/publish run. Push deployment failures remain fatal.

The published action contracts support both inputs:

- `actions/upload-pages-artifact@v3`: `name`
- `actions/deploy-pages@v4`: `artifact_name`

## Verification

- official `actionlint v1.7.12 .github/workflows/build-site.yml`
- parsed-workflow assertions: upload/deploy artifact identities match and probe-run continuation is preserved
- `node scripts/generate-readme.mjs --check`
- `SKIP_PUBLISH_CHECKS=1 node scripts/build-site.mjs`
- `git diff HEAD^..HEAD --check`
- TruffleHog exact commit range: 2 chunks / 900 bytes scanned, 0 verified or unverified findings

The first attempted Actionlint invocation through the Go module proxy timed out before execution; it is not counted above. The checks use no paid or quota-backed CI.

## Deployment note

This PR deliberately does not add a hand-written npm field. After merge, a maintainer still needs to dispatch `build-site.yml` with `probe_all: true` (or let the next successful scheduled run complete) to publish the already-proven mapping to the live catalog.

## Template checklist

This is a CI recovery fix and does not add or modify a plugin entry, so the plugin-submission checklist in the repository template is not applicable.
