### PR TITLE
Add dsh-voco and dsh-workspace-memory

### DIFF
--- a/data/plugins/lgquan__dsh-voco--packages-voice-app.yml
+++ b/data/plugins/lgquan__dsh-voco--packages-voice-app.yml
@@ -1,0 +1,7 @@
+url: https://github.com/lgquan/dsh-voco/tree/main/packages/voice-app
+name: lgquan/dsh-voco#voice-app
+category: voice
+description:
+  en: Continuous voice conversations for DSH with hands-free listening, push-to-talk, speech recognition, TTS replies, and background Agent delegation.
+  zh: 为 DSH 提供持续语音对话，支持免提监听、按住说话、语音识别、TTS 语音回复和后台 Agent 任务委派。
+tarball: https://github.com/lgquan/dsh-voco/releases/download/v0.3.8/flowingspring-dsh-voco-0.3.8.tgz

--- a/data/plugins/lgquan__dsh-workspace-memory.yml
+++ b/data/plugins/lgquan__dsh-workspace-memory.yml
@@ -1,0 +1,7 @@
+url: https://github.com/lgquan/dsh-workspace-memory
+name: lgquan/dsh-workspace-memory
+category: memory
+description:
+  en: Workspace-isolated durable memory for DSH, with searchable, auditable, correctable, and removable workspace memories plus controlled global memory.
+  zh: 为 DSH 提供工作区隔离的持久化记忆，让每个工作区拥有可检索、可审计、可纠错和可删除的独立记忆，并支持受控的全局记忆。
+tarball: https://github.com/lgquan/dsh-workspace-memory/releases/download/v0.2.14/flowingspring-dsh-workspace-memory-0.2.14.tgz


### PR DESCRIPTION
Adds two DSH plugins maintained by lgquan:

- **dsh-voco**: continuous voice conversations with hands-free listening, push-to-talk, speech recognition, TTS replies, and background Agent delegation.
- **dsh-workspace-memory**: workspace-isolated durable memory with retrieval, auditing, correction, deletion, and controlled global memory.

Checklist:

- [x] Each plugin has its own `data/plugins/*.yml` entry; generated READMEs are unchanged.
- [x] Both plugin manifests declare `dsh.bundle`.
- [x] Both repositories are more than one day old and have at least 10 commits.
- [x] Both repositories have the `dsh-plugin` topic.
- [x] Descriptions are factual and use the matching `voice` and `memory` categories.
- [x] Both plugins are published to npm and provide prebuilt GitHub Release tarballs.

Local validation:

- `node scripts/generate-readme.mjs`
- `node scripts/generate-readme.mjs --check`