### PR TITLE
Add dsh-musage AppStore screenshots

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -1363,4 +1363,10 @@
   "https://raw.githubusercontent.com/kenny2077/dsh-web-search-doubao/main/docs/img/settings-card.png",
   "https://raw.githubusercontent.com/kenny2077/dsh-web-search-doubao/main/docs/img/console.png"
  ]
+,
+ "https://github.com/Thedeergod666/dsh-musage": [
+  "https://raw.githubusercontent.com/Thedeergod666/dsh-musage/main/docs/assets/screenshots/screenshot-2-minimax.png",
+  "https://raw.githubusercontent.com/Thedeergod666/dsh-musage/main/docs/assets/screenshots/screenshot-1-deepseek.png",
+  "https://raw.githubusercontent.com/Thedeergod666/dsh-musage/main/docs/assets/screenshots/screenshot-3-openrouter.png"
+ ]
 }


### PR DESCRIPTION
This PR adds 3 AppStore-style screenshots for the existing dsh-musage entry (merged earlier in #2558) under data/screenshots.json.

Files changed:
- data/screenshots.json (+6 lines, no other modifications — entry added before the final brace, matching the file CRLF style)

Screenshots (in order):
1. screenshot-2-minimax.png — MiniMax 5h/7d dual-window view
2. screenshot-1-deepseek.png — DeepSeek CNY balance view
3. screenshot-3-openrouter.png — OpenRouter USD balance view

Why this order: minimax first (most distinctive data format — dual percentage windows), then the two balance formats follow. Same order as the PROVIDERS map in dsh/index.js.

Image URLs are hosted on raw.githubusercontent.com and return HTTP 200. Keys match the url field in data/plugins/Thedeergod666__dsh-musage.yml exactly.