### PR TITLE
add dsh-voice-control: composer-integrated voice control with TTS playback

### DIFF
--- a/data/plugins/SuCriss__dsh-voice-control.yml
+++ b/data/plugins/SuCriss__dsh-voice-control.yml
@@ -1,0 +1,6 @@
+url: https://github.com/SuCriss/dsh-voice-control
+name: SuCriss/dsh-voice-control
+category: voice
+description:
+  en: 'Composer-integrated voice control: mic button beside the send button (Web Speech API push-to-talk, Chrome/Edge), optional auto-send, and automatic TTS playback of assistant replies with settle debounce and markdown cleanup. Dynamic voice list per browser/OS, zero dependencies.'
+  zh: 输入框集成声控：发送键旁麦克风语音输入（Web Speech API 推式识别，Chrome/Edge），可选自动发送；语音指令的回复自动朗读（1.5s 稳定去抖 + Markdown 口语化清洗），音色按浏览器/系统动态适配，零依赖。


### PR DESCRIPTION
## What

Adds [SuCriss/dsh-voice-control](https://github.com/SuCriss/dsh-voice-control) to the curated list under category: voice.

## Plugin

Voice control for DSH web, fully browser-side (no backend, no API key):

- **Composer-integrated mic** — rendered inside the composer trailing cluster, left of the send button, styled after the native + button; located via stable data-composer-card / data-input-scroll anchors with a MutationObserver fallback
- **Push-to-talk STT** — Web Speech API (Chrome/Edge built-in), optional auto-send via the session-scoped conversation.send(), or fill-the-draft mode
- **Auto TTS playback** — the reply to a voice command is spoken automatically; uses a 1.5s text-settle debounce over the session snapshot (survives token streaming and tool-call gaps) and strips markdown into speakable prose
- **Dynamic voices** — the picker reflects the browser/OS at runtime (getVoices + oiceschanged), grouped by language, graceful fallback across machines
- Wave animation while recording, Ctrl+M hotkey, right-click settings popover persisted to localStorage

## Declaration

- Declares dsh.bundle (cordis.patch.yml) and installs via dsh plugin --profile web add github:SuCriss/dsh-voice-control
- Pure ESM, no build scripts, no prepare hooks — installs cleanly with pnpm build-script blocking on
- Peer deps only (eact, optional @deepseek-ai/cordis); client half is a dependency-free hand-rolled __ModuleLoader__ bundle

## Similar entries

I noticed the voice category already has several entries; this one's differentiator is the deep composer integration (in-input mic + native notices instead of a separate bar/overlay) combined with reply-side TTS in one zero-dependency package.