### PR TITLE
Add LAU-MARS/dsh-cad

### DIFF
--- a/data/plugins/LAU-MARS__dsh-cad.yml
+++ b/data/plugins/LAU-MARS__dsh-cad.yml
@@ -1,0 +1,6 @@
+url: https://github.com/LAU-MARS/dsh-cad
+name: LAU-MARS/dsh-cad
+category: tools
+description:
+  en: Views and builds CAD models (STL, OBJ, STEP, IGES, DXF, SVG) via cad_view/cad_info and OCCT parametric modeling tools, with an interactive viewer card and a resident CAD panel in the Web UI.
+  zh: 通过 cad_view/cad_info 与 OCCT 参数化建模工具查看和构建 CAD 模型（STL、OBJ、STEP、IGES、DXF、SVG），并在 Web UI 中提供交互式查看卡片与常驻 CAD 面板。


### PR DESCRIPTION
Adds [LAU-MARS/dsh-cad](https://github.com/LAU-MARS/dsh-cad) to the registry under `tools`.

**What it is:** a CAD plugin for DeepSeek Harness — an embedded 3D/2D viewer card (STL, OBJ, STEP, IGES, BREP, DXF, SVG) plus an OCCT-based parametric modeling tool family (`cad_view`, `cad_info`, `cad_create_prim`, `cad_extrude_profile`, `cad_boolean`, `cad_fillet`, `cad_drawing`, assembly tools, STEP/STL export, and more), rendered in an interactive card and a resident panel in the Web UI.

**Registry checks:**
- `dsh.bundle` manifest declared in [`package.json`](https://github.com/LAU-MARS/dsh-cad/blob/main/package.json) (`patch: ./cordis.patch.yml`, added in a630f00 so the repo installs from source via `dsh plugin add github:LAU-MARS/dsh-cad`; `dsh.client` was already declared alongside)
- Repo is public, MIT-licensed, 12 days old with 30+ commits, `dsh-plugin` topic set
- Category `tools` — the plugin's core is the registered CAD tool family (the viewer card is their display surface)

Description is factual, one line, no superlatives; `zh` included.