### PR TITLE
Update SuCriss/dsh-leekbox listing for v0.5.0

### DIFF
--- a/data/plugins/SuCriss__dsh-leekbox.yml
+++ b/data/plugins/SuCriss__dsh-leekbox.yml
@@ -5,5 +5,5 @@ name: SuCriss/dsh-leekbox
 category: tools
 tarball: https://github.com/SuCriss/dsh-leekbox/releases/latest/download/dsh-leekbox.tgz
 description:
-  en: 'A-share market dashboard: realtime indices and quotes, THS-style stock detail popups with candlestick K-line (forward-adjusted, MA5/10/20, volume, crosshair), persistent watchlist, multi-signal screener with score tiers, and a tri-source 7x24 news feed (Sina/Eastmoney/Jin10) with important-item highlighting.'
-  zh: '韭菜盒子：A股看盘助手——实时行情与大盘指数、同花顺式个股详情弹窗（前复权蜡烛图K线+MA均线+成交量+十字光标）、自选股持久化、多信号条件选股评分排序、新浪/东财/金十三源聚合7x24快讯（重要资讯标红）。'
+  en: 'A-share market dashboard: realtime indices and quotes, market sentiment thermometer (up/down breadth, limit-up/limit-down/broken counts, consecutive-board ladder, limit-up pool), THS-style stock detail popups with candlestick K-line (forward-adjusted, MA5/10/20, volume, crosshair), persistent watchlist with JSON/CSV import-export, ETF/convertible-bond/LOF boards, multi-signal screener with score tiers, and a tri-source 7x24 news feed (Sina/Eastmoney/Jin10) with important-item highlighting.'
+  zh: '韭菜盒子：A股看盘助手——实时行情与大盘指数、市场情绪温度计（涨跌家数/涨停跌停炸板/连板梯队/涨停池）、同花顺式个股详情弹窗（前复权蜡烛图K线+MA均线+成交量+十字光标）、自选股持久化（JSON/CSV导入导出）、ETF/可转债/LOF榜单、多信号条件选股评分排序、新浪/东财/金十三源聚合7x24快讯（重要资讯标红）。'


### PR DESCRIPTION
## Summary

Update the SuCriss/dsh-leekbox entry to reflect the v0.5.0 feature set.

### Description updates
- **Market sentiment thermometer**: up/down breadth, limit-up/limit-down/broken counts, consecutive-board ladder, expandable limit-up pool (连板梯队/涨停池)
- **ETF / convertible-bond / LOF boards**
- **Watchlist JSON/CSV import-export**

Tarball URL unchanged — \eleases/latest/download/dsh-leekbox.tgz\ already resolves to the new v0.5.0 release (v0.4.0 + v0.5.0 shipped: watchlist import/export, sentiment thermometer, ETF/bond/LOF support, remove-from-watchlist confirmation).