### PR TITLE
Add fallow5/dsh-pin-sessions

### DIFF
--- a/data/plugins/fallow5__dsh-pin-sessions.yml
+++ b/data/plugins/fallow5__dsh-pin-sessions.yml
@@ -1,0 +1,6 @@
+url: https://github.com/fallow5/dsh-pin-sessions
+name: fallow5/dsh-pin-sessions
+category: session
+description:
+  en: Pin and unpin sessions to the top of the Web sidebar with a dedicated pinned panel, archive section, and native three-dot menu integration.
+  zh: 把会话置顶到 Web 侧边栏顶部：独立置顶面板、归档区、原生三点菜单集成。


### PR DESCRIPTION
## Plugin submission

- **Repo:** https://github.com/fallow5/dsh-pin-sessions
- **Category:** session
- **dsh.bundle manifest:** ✅ declared in package.json
- **GitHub topics:** dsh-plugin, deepseek-harness, pin

### Description
Pin and unpin sessions to the top of the Web sidebar with a dedicated pinned panel, archive section, and native three-dot menu integration.

### What it does
- Pin/unpin sessions from the native three-dot menu (injected after Rename)
- Pinned sessions appear in a dedicated section at the top of the sidebar
- Archive section in settings for managing pinned sessions
- iOS 26 SF Symbol style pushpin icons
- No dependency on other context-menu plugins — works with DSH's native menu