### PR TITLE
Add Crosery/dsh-viewer

### DIFF
--- a/data/plugins/Crosery__dsh-viewer.yml
+++ b/data/plugins/Crosery__dsh-viewer.yml
@@ -1,0 +1,7 @@
+url: https://github.com/Crosery/dsh-viewer
+name: Crosery/dsh-viewer
+category: ui
+description:
+  en: 'Model-facing display_file tool that renders 36 file extensions inline in the web UI: images with a click-to-zoom lightbox, seekable video, audio, PDF, Office and OpenDocument files converted to PDF on the host via LibreOffice, and local HTML in a sandboxed frame; bytes stream from a signed HTTP route with range support, and PNG/JPEG/WebP/GIF also enter model context on image-capable routes.'
+  zh: '面向模型的 display_file 工具，在网页 UI 内联渲染 36 种扩展名：图片（点击开灯箱）、可拖进度条的视频、音频、PDF、经 LibreOffice 在 Host 转为 PDF 的 Office 与 OpenDocument 文件，以及沙箱 iframe 中的本地 HTML；字节由带 Range 支持的签名 HTTP 路由流式传输，PNG/JPEG/WebP/GIF 在支持图像输入的路由上同时进入模型上下文。'
+tarball: https://github.com/Crosery/dsh-viewer/releases/latest/download/dsh-viewer.tgz


### PR DESCRIPTION
Adds **[Crosery/dsh-viewer](https://github.com/Crosery/dsh-viewer)** under `ui` — one entry, one file (`data/plugins/Crosery__dsh-viewer.yml`). No existing entry is touched.

### What it does

A model-facing `display_file` tool that renders files inline in the web UI instead of reporting a filename and a byte count. **36 file extensions across 6 render kinds**, all verifiable in [`src/contract.ts`](https://github.com/Crosery/dsh-viewer/blob/main/src/contract.ts):

| Kind | Extensions | Count |
| --- | --- | --- |
| image | png jpg jpeg webp gif svg avif bmp ico apng | 10 |
| video | mp4 m4v webm ogv mov | 5 |
| audio | mp3 m4a aac wav flac ogg oga opus | 8 |
| pdf | pdf | 1 |
| document | docx doc rtf odt xlsx xls ods pptx ppt odp | 10 |
| html | html htm | 2 |

Office and OpenDocument files are converted to PDF on the host with LibreOffice and cached; everything else is served as-is. Bytes stream from a signed HTTP route with range support, which is what makes `<video>` seekable. On a model route that accepts image input, PNG/JPEG/WebP/GIF also enter model context, so one call both shows the user the file and lets the model see it.

Every number in the description is checked against the code, not rounded up.

### Not a duplicate of an existing entry

The closest listed plugin is `3403473060/dsh-inline-images` (`session`), which renders **image paths appearing in assistant reply text**. This one is a different mechanism and a different scope: a tool the model calls deliberately, covering video, audio, PDF, Office and HTML in addition to images, with host-side conversion and a signed streaming route. They can coexist without overlapping.

### Requirements checklist

- [x] `package.json` declares `dsh.bundle` (`{"dsh":{"bundle":{"patch":"./cordis.patch.yml"}}}`), with `cordis.patch.yml` at the repo root — not `dsh.client` alone
- [x] Real, working code — 66 test cases, including a live `node:http` server exercising real range requests and a LibreOffice round-trip asserting the artifact starts with `%PDF-`
- [x] Repo age ≥ 1 day and ≥ 10 commits
- [x] `dsh-plugin` topic added
- [x] Description states function only, no superlatives
- [x] Category picked for what it does (it adds a rendering surface to the conversation)
- [x] Official `@deepseek-ai/*` packages declared as `peerDependencies`, with an **explicit prerelease branch** (`>=0.1.0-rc.1 <0.1.1-0 || >=0.1.1-rc.0 <0.1.2-0`) so `0.1.x` prereleases actually resolve — the naive broad form silently excludes every one of them
- [x] `tarball:` points at a **version-free** asset on GitHub release hosting (`releases/latest/download/dsh-viewer.tgz`), so `latest/download/` cannot rot on the next release
- [x] `screenshots.json` declared in the plugin repo (3 images, relative paths)
- [x] Not a meta-package; no dependencies re-hosting anyone else's plugin

### Verification

Tested end-to-end against a live harness (dsh `0.1.1-rc.2`, Node 26.7.0), driven headlessly: all six kinds render, video seeks (`currentTime = 4`, `seekable.end = 6`), cards rebuild after a full page reload from persisted result metadata, and the signed route returns `206` for ranges, `416` for unsatisfiable ones, and `404` for forged or unsigned references.

CI runs typecheck/build/test on Node 22.19 and 24, and asserts two things a plain test run cannot: that the client bundle requires only specifiers the loader's module table answers, and that the packed tarball actually contains `cordis.patch.yml`.
