### PR TITLE
feat: add dsh-session-lab

### DIFF
--- a/data/plugins/zhangguiping-xydt__dsh-session-lab.yml
+++ b/data/plugins/zhangguiping-xydt__dsh-session-lab.yml
@@ -1,0 +1,7 @@
+url: https://github.com/zhangguiping-xydt/dsh-session-lab
+name: zhangguiping-xydt/dsh-session-lab
+category: skill
+description:
+  en: DSH session workflows for packaging verifiable capsules, evaluating reusable Skills, and comparing controlled session trajectories.
+  zh: 用于打包可验证会话、评测可复用技能和对比受控会话轨迹的 DSH 工作流。
+tarball: https://github.com/zhangguiping-xydt/dsh-session-lab/releases/download/v0.1.0/dsh-session-lab-v0.1.0.tgz


### PR DESCRIPTION
<!-- Thanks for reviewing. The entry is intentionally one YAML file; generated READMEs are not edited here. -->
- [x] I added one file at \`data/plugins/zhangguiping-xydt__dsh-session-lab.yml\`.
- [x] The repository declares a \`dsh.bundle\` manifest and installs with \`dsh plugin add\`.
- [x] The repository is older than 1 day and now has 10 commits.
- [x] The repository has the \`dsh-plugin\` topic.
- [x] The description states the shipped workflow without superlatives.
- [x] A GitHub Release tarball is declared for a prebuilt install.
- [x] A repository-owned \`screenshots.json\` points to an installation screenshot.

The bundle provides three independently documented Skills: \`dsh-capsule\`, \`dsh-teach\`, and \`dsh-time-machine\`. The repository includes a checked-in six-task baseline/treatment evaluation with safety and routing checks. The latest release tarball is hosted on GitHub and the source repository remains the canonical install target.