### PR TITLE
ci: fail a PR that adds an entry yml outside data/plugins/

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -64,6 +64,32 @@ jobs:
             echo "::error::Files under data/plugins/ must end in .yml — anything else is silently skipped by readEntries() and drops the entry from the list without failing any other check."
             exit 1
           fi
+      - name: Entry files live in data/plugins/
+        # The mirror of the check above, and the same silent-skip failure seen
+        # from the other side: readEntries() globs data/plugins/*.yml, so a
+        # submission that lands its yml one directory up — data/<owner>__<repo>.yml
+        # — is never read. Every other check still passes for the same reason
+        # the extensionless case passed: the regenerated READMEs omit the entry
+        # too, so the tree is self-consistent and `--check` is happy. Merging it
+        # is a no-op that looks like a successful submission to everyone
+        # involved, including the contributor.
+        #
+        # #3914 did exactly this and went fully green. Found by hand while
+        # reviewing the merge queue, which is not a control.
+        #
+        # Scoped to files this PR adds: data/ legitimately holds non-entry
+        # files (npm-map.json, tarballs.json, screenshots.json, readmes.json),
+        # and a repo-wide find would fail on the first *.yml anyone ever parks
+        # there for another purpose.
+        run: |
+          git fetch -q origin ${{ github.event.pull_request.base.sha }}
+          misplaced=$(git diff --name-only --diff-filter=A ${{ github.event.pull_request.base.sha }}...HEAD -- data \
+            | grep -E '^data/[^/]+\.yml$' || true)
+          if [ -n "$misplaced" ]; then
+            echo "$misplaced" | sed 's/^/  /'
+            echo "::error::Entry files must be added under data/plugins/, not directly in data/. readEntries() only globs data/plugins/*.yml, so a file placed here is never read: the READMEs regenerate without it, every other check passes, and merging the PR changes nothing. Move it with: git mv data/<file>.yml data/plugins/<file>.yml"
+            exit 1
+          fi
       - name: READMEs match data/plugins
         # Two shapes are accepted, and which one you get is the contributor's
         # choice, not a rule they have to learn:


### PR DESCRIPTION
Closes the gap #3914 walked through fully green.

## What happened

[#3914](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/pull/3914) added its entry as:

```
data/goatliamia__dsh-plugin-maker.yml             <- submitted
data/plugins/goatliamia__dsh-plugin-maker.yml     <- where readEntries() looks
```

`readEntries()` globs `data/plugins/*.yml`, so the file is never read. Every check passed — and passed *correctly*, which is the point: the regenerated READMEs omit the entry too, so the tree is self-consistent and `generate-readme.mjs --check` is happy. Merging it would have been a no-op that looks like a successful submission to the contributor, to the maintainer, and to CI.

I found it by hand while reviewing the merge queue. That is not a control.

## Why this is the same bug we already fixed once

The step directly above this one — *"Every entry file ends in .yml"* — exists for the identical failure mode approached from the other side: a file inside `data/plugins/` that loses its `.yml` extension is silently skipped, and its own comment already spells out that "every other check still passes, because the regenerated READMEs omit the entry too and stay self-consistent."

Right directory, wrong name was guarded. Right name, wrong directory was not.

This is **not** a regression from #3832: before that change a misplaced file failed the same way, because regenerating produced no new README line either. The new submission shape just makes it easier to hit, now that a PR is expected to be *only* a yml.

## The check

Scoped to files the PR **adds**, and only one level deep:

```sh
git diff --name-only --diff-filter=A <base>...HEAD -- data | grep -E '^data/[^/]+\.yml$'
```

`data/` legitimately holds non-entry files (`npm-map.json`, `tarballs.json`, `screenshots.json`, `readmes.json`, `stars.json`, `added-dates.json`, …), so this deliberately does **not** do a repo-wide `find` — that would fire on the first `*.yml` anyone ever parks there for an unrelated purpose. `--diff-filter=A` keeps it off files a PR merely touches.

## Verification

Run against real branches before opening this:

| branch | expected | actual |
|---|---|---|
| #3914 head | flag | `data/goatliamia__dsh-plugin-maker.yml` |
| #3946 head (normal 3-entry submission) | no flag | no match |
| current `main`, all of `data/*` | no flag | all 8 files are `.json` |

This PR also self-tests: `pull_request` workflows run from the PR's own merge ref, so the new step executes on this very PR and must come back green.

## Note

`Repository config guard` will be red here — it flags any PR touching `.github/`, which is right for contributor submissions and unavoidable for a CI change. Same as #3832 and #3789.
