### PR TITLE
add dsh-table-attach (tools): attach tables & documents to the DSH composer

### DIFF
--- a/data/plugins/yybukn__dsh-table-attach.yml
+++ b/data/plugins/yybukn__dsh-table-attach.yml
@@ -1,0 +1,6 @@
+url: https://github.com/yybukn/dsh-table-attach
+name: yybukn/dsh-table-attach
+category: tools
+description:
+  en: 'Attach tables and documents (xlsx, csv, pdf, zip…) to the DSH composer via paste or drag-and-drop: files are saved into the session workspace and an @reference is inserted.'
+  zh: '把表格与文档（xlsx、csv、pdf、zip…）粘贴或拖拽进 DSH 输入框即可附加：文件会保存到会话工作区并插入 @引用。'


### PR DESCRIPTION
Add [yybukn/dsh-table-attach](https://github.com/yybukn/dsh-table-attach) to the **Tools & Capabilities** category.

- url: https://github.com/yybukn/dsh-table-attach
- category: `tools`
- description.en + description.zh included
- Repo declares `dsh.bundle` manifest — installable via `dsh plugin add github:yybukn/dsh-table-attach`
- `dsh-plugin` topic on repo — verified
- What it does: paste or drag tables & documents (xlsx/csv/pdf/zip…) into the DSH web composer — files are saved into the session workspace and an @reference is inserted at the caret