### PR TITLE
Add oppnc/dsh-kernel-mesh

### DIFF
--- a/data/plugins/oppnc__dsh-kernel-mesh.yml
+++ b/data/plugins/oppnc__dsh-kernel-mesh.yml
@@ -1,0 +1,7 @@
+url: https://github.com/oppnc/dsh-kernel-mesh
+name: oppnc/dsh-kernel-mesh
+category: model
+tarball: https://github.com/oppnc/dsh-kernel-mesh/releases/latest/download/dsh-kernel-mesh.tgz
+description:
+  en: "Registers Kimi, Grok, Codex, and MiniMax as DeepSeek Harness model routes, vendor subagent recipes, and kernel_status / kernel_run / kernel_switch tools."
+  zh: "把 Kimi、Grok、Codex、MiniMax 注册成 DeepSeek Harness 的模型路由、各家子代理配方，以及 kernel_status / kernel_run / kernel_switch 工具。"


### PR DESCRIPTION
Adds `oppnc/dsh-kernel-mesh` under `model`.

- Bundle: `dsh.bundle` + `cordis.patch.yml`
- Topic: `dsh-plugin`
- Prebuilt tarball: https://github.com/oppnc/dsh-kernel-mesh/releases/latest/download/dsh-kernel-mesh.tgz
- Screenshots: `screenshots.json` in the plugin repo

This bundle registers the Kimi / Grok / Codex / MiniMax model routes, vendor subagent recipes, and `kernel_status` / `kernel_run` / `kernel_switch`. The four vendor surface packages are plain plugins (no `dsh.bundle`) and are not listed separately.