### PR TITLE
Add KannaKuron/dsh-better-workspace (ui)

### DIFF
--- a/data/plugins/KannaKuron__dsh-better-workspace.yml
+++ b/data/plugins/KannaKuron__dsh-better-workspace.yml
@@ -1,0 +1,6 @@
+url: https://github.com/KannaKuron/dsh-better-workspace
+name: KannaKuron/dsh-better-workspace
+category: ui
+description:
+  en: 'Hierarchical workspace tree for the DSH sidebar: every slash in a workspace title becomes a virtual folder (arbitrarily deep), the add-workspace directory flow gains a parent-group popup, renames re-derive the tree instantly, sessions nest on the same rule with separate visual styling, and every row carries right-click actions plus per-row appearance customization (color, text-only glow, font weight, primitives-family icon).'
+  zh: 'DSH 侧边栏「工作区」列表的层级树插件：工作区与会话名称中的 / 即虚拟分组（任意多级），添加工作区的目录流附带「所属分组」弹窗，重命名即时重排；每层行均支持右键操作与外观自定义（颜色、文字发光、字体粗细、原版图标库图标）。'


### PR DESCRIPTION
Adds **one file**: `data/plugins/KannaKuron__dsh-better-workspace.yml`.

## Checklist / 自查

- [x] I added **one file** at `data/plugins/<owner>__<repo>.yml` / 只新增一个条目文件
- [ ] READMEs intentionally **not** touched — per contributing.md they are regenerated on `main` after merge / 遵循贡献指南未手工编辑 README，合并后由脚本重新生成
- [x] Repo `package.json` declares **`dsh.bundle`** (`patch: ./cordis.patch.yml` + `client`, web) / 已声明 `dsh.bundle`
- [x] Repo is 1+ day old with 10+ commits (public since 2026-08-30, currently 32 commits) / 满足仓库年龄与提交数门槛
- [x] `category: ui` — sidebar workspace tree enhancement / 分类：UI 增强
- [x] Description states what the plugin does, no superlatives / 描述只陈述功能，无营销词
- [x] Repo has the `dsh-plugin` topic / 仓库已打 `dsh-plugin` topic

## Screenshots / 截图

Declared in the plugin's own repository per the current convention: `screenshots.json` beside `package.json` lists 5 images under `docs/screenshots/`. Nothing to track in this PR. / 按现行约定已在插件仓库自身声明 `screenshots.json`（5 张），本仓库无需维护截图数据。

## Note / 说明

This branch replaces an earlier same-name draft that was never opened as a PR: rebuilt on current `main`, with the hand-edited README lines and the legacy `data/screenshots.json` key removed. / 本分支基于最新 main 重建，替换了此前从未开过 PR 的同名草稿分支；旧稿中的手工 README 改动与旧版 `data/screenshots.json` 截图键均已去除。
