### PR TITLE
Add MasterBenC/shangshi-dsh

### DIFF
--- a/data/plugins/MasterBenC__shangshi-dsh.yml
+++ b/data/plugins/MasterBenC__shangshi-dsh.yml
@@ -1,0 +1,6 @@
+url: https://github.com/MasterBenC/shangshi-dsh
+name: MasterBenC/shangshi-dsh
+category: tools
+description:
+  en: Local Qimen business-timing workbench for DeepSeek Harness, with nine palaces, deterministic scoring, future-window ranking, and direction advice.
+  zh: 在 DeepSeek Harness 中本地完成奇门排盘、商务评分、未来择时和方位建议。


### PR DESCRIPTION
Add Shangshi, a local Qimen business-timing workbench for DeepSeek Harness. It installs from github:MasterBenC/shangshi-dsh, declares dsh.bundle, and provides nine palaces, deterministic scoring, future-window ranking, and direction advice.