### PR TITLE
Add Blackman99/codsh bundle

### DIFF
--- a/data/plugins/Blackman99__codsh--packages-bundle.yml
+++ b/data/plugins/Blackman99__codsh--packages-bundle.yml
@@ -1,0 +1,6 @@
+url: https://github.com/Blackman99/codsh/tree/main/packages/bundle
+name: Blackman99/codsh#codsh-bundle
+category: ui
+description:
+  en: 'Terminal coding agent for DeepSeek Harness with a full-screen alternate-screen UI, turn-aware session navigation, and a gated /ship workflow that takes one-line requirements through specification, TDD, and rerun acceptance checks.'
+  zh: '基于 DeepSeek Harness 的终端编码 Agent，提供全屏备用屏幕 UI、轮次感知的会话导航，以及将一句话需求经过规格、TDD 和验收复跑的分阶段 /ship 流程。'


### PR DESCRIPTION
Adds `codsh-bundle`, the DSH runtime behind [codsh](https://github.com/Blackman99/codsh), as a monorepo subpackage entry.

`codsh` is a terminal coding agent on DeepSeek Harness. Its full-screen alternate-screen UI includes turn-aware session navigation, while `/ship` moves a one-line requirement through specification, independently verifiable tickets, TDD implementation, and rerun acceptance checks.

Install:

```sh
dsh plugin --profile code add codsh-bundle
dsh --profile code
```

### Required checklist

- [x] Added one file at `data/plugins/Blackman99__codsh--packages-bundle.yml`; generated READMEs are intentionally left untouched per the current yml-only workflow.
- [x] Ran `node scripts/generate-readme.mjs` locally to verify generated output.
- [x] `packages/bundle/package.json` declares `dsh.bundle` with `patch: ./cordis.patch.yml`, and that patch file exists.
- [x] The repository is more than 1 day old and had 11 commits at submission time.
- [x] Category is `ui`, matching the directory's other full-screen DSH terminal clients.
- [x] The description is factual and contains no superlatives.
- [x] The repository has the `dsh-plugin` topic.

### Recommended checklist

- [x] Published to npm as `codsh-bundle` (`0.11.0` at submission time).
- [x] Host-provided DSH interfaces are declared as `peerDependencies`. Packages that the codsh patch/preset itself composes remain `dependencies` intentionally: DSH profiles set `autoInstallPeers: false`, and moving those packages to peers would make fresh profile installs miss `agent-presets`, `code-runtime`, LSP, and terminal capabilities.
- [x] Added `packages/bundle/screenshots.json` in the source repository; its GitHub-hosted GIF resolves as `HTTP 200 image/gif`.

### Verification

- `npm ci`
- `node scripts/generate-readme.mjs`
- `npx awesome-lint` (passes; existing catalog warnings remain)
- `SKIP_PUBLISH_CHECKS=1 node scripts/build-site.mjs`
- codsh: `pnpm run typecheck`, `pnpm run build`, and `pnpm test` (32 files / 698 tests pass)
