### PR TITLE
Update Jacky Creator tarball to v0.1.0-beta.7

### DIFF
--- a/data/plugins/Jackywxsz__DSH-Creator.yml
+++ b/data/plugins/Jackywxsz__DSH-Creator.yml
@@ -1,7 +1,7 @@
 url: https://github.com/Jackywxsz/DSH-Creator
 name: Jackywxsz/DSH-Creator
 category: workflow
-tarball: https://github.com/Jackywxsz/DSH-Creator/releases/download/v0.1.0-beta.6/jacky-creator-0.1.0-beta.6.tgz
+tarball: https://github.com/Jackywxsz/DSH-Creator/releases/download/v0.1.0-beta.7/jacky-creator-0.1.0-beta.7.tgz
 description:
   en: "Local-first content production and operations workspace for DSH: manage ideas, scripts, media assets, schedules, goals, publishing status, and post-publication reviews."
   zh: "面向 DSH 的本地内容生产与运营工作台：管理灵感、脚本、媒体资产、档期、目标、发布状态和发布后复盘。"


### PR DESCRIPTION
Updates only the existing Jacky Creator entry so the marketplace installs the verified `v0.1.0-beta.7` GitHub Release tarball.

- Release: https://github.com/Jackywxsz/DSH-Creator/releases/tag/v0.1.0-beta.7
- Asset SHA-256: `ddf48324984fe9bfae0e5904fb723c3f1b26c989e807e499a48f7a5772496a57`
- `node scripts/generate-readme.mjs`: both generated READMEs are up to date.
