### PR TITLE
docs: list dsh-tool-highlight (UI Enhancements, zh/en)

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,6 +442,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 - [vibeinging/dsh-turn-navigator](https://github.com/vibeinging/dsh-turn-navigator) - Turn navigation for the DSH Web UI.
 - [vlln/dsh-navbar](https://github.com/vlln/dsh-navbar) - Conversation node navigation bar for quick jumps between user messages.
 - [vlln/dsh-task-status](https://github.com/vlln/dsh-task-status) - Background task status bar: progress plus live output tail on the chat page.
+- [vollegrewar/dsh-tool-highlight](https://github.com/vollegrewar/dsh-tool-highlight) - Layered syntax highlighting for bash/pwsh command and read code output in the DSH web GUI (VS Code Dark+ palette: keywords/strings/numbers/functions/comments each get a color); colors only what it recognizes, keeps tables/logs plain; pure frontend, zero token overhead.
 - [vvvspec/better-reasoning-slider](https://github.com/vvvspec/better-reasoning-slider) - Official-style composer model trigger with a floating reasoning-effort slider popup.
 - [waknow/dsh-web-icon-indicator](https://github.com/waknow/dsh-web-icon-indicator) - Browser tab favicon mirrors the DSH session state (idle / running / asking / done), recolored and animated from one base SVG entirely in the browser, with colors and effects configurable from the Settings page.
 - [warmwine/dsh-ui-font](https://github.com/warmwine/dsh-ui-font) - Font engine for the Web GUI: system font enumeration, global and per-component font-size tuning with a Spy++-style picker, settings page.

--- a/README.zh.md
+++ b/README.zh.md
@@ -442,6 +442,7 @@ dsh plugin --profile web add dshmarket
 - [vibeinging/dsh-turn-navigator](https://github.com/vibeinging/dsh-turn-navigator) — 对话轮次导航。
 - [vlln/dsh-navbar](https://github.com/vlln/dsh-navbar) — 对话节点导航条，右缘节点串快速跳转 user 消息。
 - [vlln/dsh-task-status](https://github.com/vlln/dsh-task-status) — 后台任务状态条：对话页任务进度 + 实时输出 tail。
+- [vollegrewar/dsh-tool-highlight](https://github.com/vollegrewar/dsh-tool-highlight) — DSH web 插件：给 bash/pwsh 命令与 read 的代码输出做分层语法染色（VS Code Dark+ 配色：关键字/字符串/数字/函数名/注释各一色）；认得出来才染，表格/日志保持原样；纯前端渲染，零 token 开销。
 - [vvvspec/better-reasoning-slider](https://github.com/vvvspec/better-reasoning-slider) — 官方风格输入框 + 浮动推理能力滑块弹窗，节点与滑块对齐，弹窗跟随 Harness 主题自适应。
 - [waknow/dsh-web-icon-indicator](https://github.com/waknow/dsh-web-icon-indicator) — 浏览器标签页 favicon 实时反映 DSH 会话状态（待机 / 运行中 / 提问 / 完成）：单个 base.svg 在浏览器端上色与动画，颜色与特效均可在设置页配置。
 - [warmwine/dsh-ui-font](https://github.com/warmwine/dsh-ui-font) — 网页界面字体引擎：系统字体枚举、准星点选的全局与逐组件字号微调、设置页。老花眼友好，自定义字体和页面部件字体和字体大小，支持SPY模式扫UI和其他插件。

--- a/data/plugins/vollegrewar__dsh-tool-highlight.yml
+++ b/data/plugins/vollegrewar__dsh-tool-highlight.yml
@@ -1,0 +1,6 @@
+url: https://github.com/vollegrewar/dsh-tool-highlight
+name: vollegrewar/dsh-tool-highlight
+category: ui
+description:
+  en: 'Layered syntax highlighting for bash/pwsh command and read code output in the DSH web GUI (VS Code Dark+ palette: keywords/strings/numbers/functions/comments each get a color); colors only what it recognizes, keeps tables/logs plain; pure frontend, zero token overhead.'
+  zh: DSH web 插件：给 bash/pwsh 命令与 read 的代码输出做分层语法染色（VS Code Dark+ 配色：关键字/字符串/数字/函数名/注释各一色）；认得出来才染，表格/日志保持原样；纯前端渲染，零 token 开销。


### PR DESCRIPTION
## What

Add dsh-tool-highlight to the UI Enhancements list (one line in README.md + README.zh.md, inserted in alphabetical order between lln and vvspec).

## Plugin

- Repo: https://github.com/vollegrewar/dsh-tool-highlight
- Topics: dsh-plugin, deepseek-harness, syntax-highlighting, web-ui
- What it does: layers syntax highlighting onto bash/pwsh command output and read code output in the DSH web GUI (VS Code Dark+ palette: keywords/strings/numbers/functions/comments); colors only what it recognizes, keeps tables/logs plain; pure frontend, zero token overhead. Includes LICENSE (MIT), README and install instructions.