### PR TITLE
Fix dsh-voco name and repository link

### DIFF
--- a/data/plugins/lgquan__dsh-voco.yml
+++ b/data/plugins/lgquan__dsh-voco.yml
@@ -1,5 +1,5 @@
-url: https://github.com/lgquan/dsh-voco/tree/main/packages/voice-app
-name: lgquan/dsh-voco#voice-app
+url: https://github.com/lgquan/dsh-voco
+name: lgquan/dsh-voco
 category: voice
 description:
   en: Continuous voice conversations for DSH with hands-free listening, push-to-talk, speech recognition, TTS replies, and background Agent delegation.


### PR DESCRIPTION
Corrects the existing dsh-voco catalog entry so the public name is `dsh-voco` and the link opens the repository homepage. The repository root now declares a real `dsh.bundle` entry backed by `@flowingspring/dsh-voco@0.3.8`, so `dsh plugin --profile web add github:lgquan/dsh-voco` installs and activates the plugin successfully.

Validation:
- `check-submission.mjs`: all checked entries pass
- GitHub source install adds `dsh-voco` to the profile bundle stack
- DSH Web discovers `@flowingspring/dsh-voco/client.js` (HTTP 200)

The category, descriptions, and release tarball remain unchanged.