### PR TITLE
dsh-net-proxy: declare prebuilt release tarball

### DIFF
--- a/data/plugins/mafeis__dsh-net-proxy.yml
+++ b/data/plugins/mafeis__dsh-net-proxy.yml
@@ -4,3 +4,4 @@ category: tools
 description:
   en: Route agent network requests through a local HTTP/CONNECT/SOCKS5 proxy.
   zh: 让 agent 的网络请求走本机 HTTP/CONNECT/SOCKS5 代理。
+tarball: https://github.com/mafeis/dsh-net-proxy/releases/latest/download/dsh-net-proxy.tgz


### PR DESCRIPTION
<!-- Thanks for contributing! Quick checklist / ??????? -->

Updating **my own entry only** (`data/plugins/mafeis__dsh-net-proxy.yml`): adding the optional `tarball:` field pointing at the prebuilt release asset on my repo's GitHub Releases (v0.2.6).

- [x] Only my own entry (`mafeis__dsh-net-proxy.yml`) is touched  no README hand-edits needed (tarball is not rendered in READMEs; the storefront reads it from the entry)
- [x] `tarball` is an `https` `.tgz` on GitHub's own release hosting, **version-free asset name** (`dsh-net-proxy.tgz`) so `releases/latest/download/` never rots
- [x] The repo's `package.json` declares `dsh.bundle` (+ `dsh.client` for the settings UI) with `cordis.patch.yml`  unchanged
- [x] Repo has the `dsh-plugin` topic  unchanged
- [x] Screenshots are declared in **my own repository** via `screenshots.json` (`assets/screenshot-net-proxy.png`, `assets/screenshot-home.png`)  nothing needed in this PR
- [x] Description unchanged (still accurate, no marketing words)

???? / Related:
- Release: https://github.com/mafeis/dsh-net-proxy/releases/tag/v0.2.6
- Tarball: https://github.com/mafeis/dsh-net-proxy/releases/latest/download/dsh-net-proxy.tgz