### PR TITLE
Update StrataGate description and 0.2.40 tarball

### DIFF
--- a/data/plugins/diqierjia__StrataGate-AgentMemory--integrations-deepseek-harness.yml
+++ b/data/plugins/diqierjia__StrataGate-AgentMemory--integrations-deepseek-harness.yml
@@ -1,7 +1,7 @@
 url: https://github.com/diqierjia/StrataGate-AgentMemory/tree/main/integrations/deepseek-harness
-tarball: https://github.com/diqierjia/StrataGate-AgentMemory/releases/download/stratagate-dsh-v0.2.38/stratagate-dsh-0.2.38.tgz
+tarball: https://github.com/diqierjia/StrataGate-AgentMemory/releases/download/stratagate-dsh-v0.2.40/stratagate-dsh-0.2.40.tgz
 name: diqierjia/StrataGate-AgentMemory
 category: memory
 description:
-  en: 'StrataGate gives DeepSeek Harness evolving, local-first long-term memory for user preferences, project decisions, conversations, and tool results across sessions; it layers history with user-tunable time decay, reinforces memories through real answer use, shows workspace-aware usage counts, and keeps recalled evidence traceable to its original messages.'
-  zh: 'StrataGate 为 DeepSeek Harness 自动构建持续演化、本地优先的长期记忆：跨会话承接用户偏好、项目决策、历史对话和工具结果，通过用户可调的时间衰减分层沉淀历史，按真实回答使用强化记忆，显示按工作区识别的使用计数，并让召回证据可追溯到原始消息。'
+  en: 'Recent conversations stay vivid. Older ones fade into summaries, not oblivion. StrataGate gives DeepSeek Harness six-layer, time-decaying memory, while lasting events and relationships settle into a knowledge graph. Bring your memories from other AIs with you—no need to start over.'
+  zh: '近期对话保持清晰，久远记忆逐渐化为摘要，而不是消失。StrataGate 为 DeepSeek Harness 带来六层时间衰减记忆，并将长期事件与关系沉淀进知识图谱。还可以把其他 AI 中的已有记忆一起带过来，不必从头开始。'


### PR DESCRIPTION
## Summary

- update StrataGate's English and Chinese marketplace descriptions to foreground its six-layer, time-decaying memory model
- mention knowledge-graph consolidation of lasting events and relationships
- mention importing existing memories from other AI systems
- update the prebuilt release tarball from `0.2.38` to `0.2.40`

## Verification

- confirmed `stratagate-dsh@0.2.40` is published on npm
- confirmed the GitHub release asset is 7,836,501 bytes with SHA-256 `5be01cbde8b1a238942d64c1e9012f67497d99daa106c84f441818137fe3cf62`
- ran `node scripts/generate-readme.mjs`
- ran `SKIP_PUBLISH_CHECKS=1 node scripts/build-site.mjs` (2,777 entries across both locales)

`awesome-lint` is left to the repository's Linux CI because its CLI misinterprets the Windows checkout path as a GitHub URL locally.