### PR TITLE
add kongshan-zhuyu/dsh-balance-quota

### DIFF
--- a/data/plugins/kongshan-zhuyu__dsh-balance-quota--packages-dsh-balance.yml
+++ b/data/plugins/kongshan-zhuyu__dsh-balance-quota--packages-dsh-balance.yml
@@ -1,5 +1,5 @@
-url: https://github.com/kongshan-zhuyu/dsh-balance-quota
-name: kongshan-zhuyu/dsh-balance-quota
+url: https://github.com/kongshan-zhuyu/dsh-balance-quota/tree/main/packages/dsh-balance
+name: kongshan-zhuyu/dsh-balance-quota#dsh-balance
 category: usage
 description:
   en: Provider balance and quota status bar for DSH Web, with model capability settings, external JSON health monitoring, visual field binding, and per-model status details.

--- a/data/plugins/kongshan-zhuyu__dsh-balance-quota.yml
+++ b/data/plugins/kongshan-zhuyu__dsh-balance-quota.yml
@@ -1,0 +1,6 @@
+url: https://github.com/kongshan-zhuyu/dsh-balance-quota
+name: kongshan-zhuyu/dsh-balance-quota
+category: usage
+description:
+  en: Provider balance and quota status bar for DSH Web, with model capability settings, external JSON health monitoring, visual field binding, and per-model status details.
+  zh: DSH Web 的供应商余额与额度状态栏，支持模型能力设置、外部 JSON 健康监测、可视化字段绑定和逐模型状态详情。


### PR DESCRIPTION
## Plugin submission

Adds `kongshan-zhuyu/dsh-balance-quota` to the Usage & Billing category.

- npm: https://www.npmjs.com/package/dsh-balance-quota
- repository: https://github.com/kongshan-zhuyu/dsh-balance-quota
- release: https://github.com/kongshan-zhuyu/dsh-balance-quota/releases/tag/v0.3.3

The plugin provides provider balance and quota status in DSH Web, model capability settings, external JSON health monitoring, visual field binding, and per-model health details.

- [x] Added one file under `data/plugins/`
- [x] Repository declares a `dsh.bundle` manifest
- [x] Repository has the `dsh-plugin` topic
- [x] Plugin is published to npm
- [x] Description matches the implemented functionality