### PR TITLE
lamost423/dsh-trace-compare: renamed to lamost423/dsh-maze

### DIFF
--- a/data/plugins/lamost423__dsh-maze.yml
+++ b/data/plugins/lamost423__dsh-maze.yml
@@ -1,0 +1,6 @@
+url: https://github.com/lamost423/dsh-maze
+name: lamost423/dsh-maze
+category: session
+description:
+  en: "Execution maze for DSH sessions: the agent's real path — main advance, failed or dead-end detours, backtracks, request retries and subagent branches — drawn on one wall-clock timeline, with three tracks under each lane sharing that axis (tool-call density, token pulse, context pressure) and a deterministic analysis panel below it (tool result matrix, failure-recovery chains, duration distribution); watch it grow live in a session tab, or upload up to 5 session logs for a same-axis compare."
+  zh: 执行迷宫：把智能体真实的执行过程——主干推进、失败或扑空的支路、折返、请求重试与子代理分支——画在同一根墙钟时间轴上；泳道下方是与它共用时间轴的三条数据轨道（工具调用密度、Token 脉冲、上下文压力），再下方是确定性的执行分析面板（工具结果矩阵、失败恢复链、耗时分布）；可在会话页签里实时生长，也可上传最多 5 个 session log 做同轴对比。

--- a/data/plugins/lamost423__dsh-trace-compare.yml
+++ b/data/plugins/lamost423__dsh-trace-compare.yml
@@ -1,6 +1,0 @@
-url: https://github.com/lamost423/dsh-trace-compare
-name: lamost423/dsh-trace-compare
-category: session
-description:
-  en: "Trace Compare & Live Maze: draw the agent's real exploration — main path, failed or dead-end detours, backtracks, and subagent branches — on one wall-clock timeline; upload 1–2 session logs for a same-axis compare, or watch it grow live in a session tab."
-  zh: 轨迹对比与实时迷宫：把智能体真实的探索过程——主干推进、失败或扑空的支路、折返点与子代理支路——画在同一根墙钟时间轴上；可上传 1–2 个 session log 做同轴对比，或在会话页签里实时生长。


### PR DESCRIPTION
Updates my own entry only: the repo was renamed `dsh-trace-compare` → `dsh-maze` in v1.0.0 (2026-08-26), so the listed URL is now a redirect and the catalog resolves no npm package for it — the install line falls back to a from-source GitHub install even though `dsh-maze` has been on npm since the rename.

- `url` / `name` → `lamost423/dsh-maze` (the old URL 301-redirects here; stars, issues and history are preserved)
- npm: `dsh-maze`, `latest` is `1.1.0` — `dsh plugin --profile web add dsh-maze`
- `category` unchanged (`session`)
- Description rewritten. The old one was written in August and only covered the maze and the file compare; the lane data tracks (tool-call density / token pulse / context pressure) and the deterministic execution-analysis panel (tool result matrix, failure-recovery chains, duration distribution) shipped in v0.7.0, and compare went from 2 files to 5. Everything named in the new line exists in the code — the analysis aggregations live in `src/client/verdict.js` with unit tests, and none of it calls an LLM.

The entry file is renamed rather than edited in place, so this is one deletion plus one addition and touches no other entry. Per `contributing.md` I did not regenerate the READMEs by hand — they regenerate on `main` after merge.

Checklist:

- [x] One file under `data/plugins/` (rename: old removed, new added); READMEs untouched
- [x] `package.json` declares `dsh.bundle` (`{"bundle": {"patch": "./cordis.patch.yml"}}`) alongside `dsh.client`
- [x] Repo is well past 1 day old with far more than 10 commits
- [x] `category: session`, unchanged from the existing entry
- [x] Description states what the plugin does, no superlatives
- [x] Repo carries the `dsh-plugin` topic
- [x] Published to npm; official `@deepseek-ai/*` packages are declared as `peerDependencies`
