### PR TITLE
Update Lorvaste/DSH-Project-Initialization description (v1.0.3 redesign)

### DIFF
--- a/data/plugins/Lorvaste__DSH-Project-Initialization.yml
+++ b/data/plugins/Lorvaste__DSH-Project-Initialization.yml
@@ -2,5 +2,5 @@ url: https://github.com/Lorvaste/DSH-Project-Initialization
 name: Lorvaste/DSH-Project-Initialization
 category: workflow
 description:
-  en: "Single alignment scenario that aligns AI-built products with the user's idea: requirement establishment, pre-development and maintenance presets, with ten on-demand skills covering Q&A, confirmation, integration, spec organization, terminology unification, verification, change management, regression, maintenance init and token compression."
-  zh: "DSH 单场景对齐插件：需求确立 / 开发前 / 维护三个最小预设，10 个按上下文加载的功能 skill（问答、确认、统合、规格化、术语一致化、验证、变更管理、回归、维护初始化、token 压缩），让 AI 创建产品每一步对齐用户想法。"
+  en: "Single alignment scenario aligning AI-built products with the user's idea: three presets (requirement establishment, pre-development, maintenance) and ten on-demand skills."
+  zh: "单场景对齐插件：需求确立/开发前/维护三个预设 + 10 个按需加载 skill，让 AI 创建产品每一步对齐用户想法。"

--- a/data/plugins/Lorvaste__DSH-Project-Initialization.yml
+++ b/data/plugins/Lorvaste__DSH-Project-Initialization.yml
@@ -2,5 +2,5 @@ url: https://github.com/Lorvaste/DSH-Project-Initialization
 name: Lorvaste/DSH-Project-Initialization
 category: workflow
 description:
-  en: Two agent presets that align AI-built products with the user's original idea — from-scratch runs a six-step Q&A to a frozen spec and task breakdown; confirm-first reviews understanding before refining or changing a plan with versioned change records.
-  zh: '两个 agent preset 场景，让 AI 从零创建产品的每一步与用户想法对齐——从零开始：六步问答出规格与任务拆分；先等等，让我确认一下：复核理解后再完善或变更方案，变更留版本记录。'
+  en: "Single alignment scenario that aligns AI-built products with the user's idea: requirement establishment, pre-development and maintenance presets, with ten on-demand skills covering Q&A, confirmation, integration, spec organization, terminology unification, verification, change management, regression, maintenance init and token compression."
+  zh: "DSH 单场景对齐插件：需求确立 / 开发前 / 维护三个最小预设，10 个按上下文加载的功能 skill（问答、确认、统合、规格化、术语一致化、验证、变更管理、回归、维护初始化、token 压缩），让 AI 创建产品每一步对齐用户想法。"


### PR DESCRIPTION
Updates the entry description for Lorvaste/DSH-Project-Initialization to match the v1.0.3 redesign: the plugin now ships a single alignment scenario (requirement establishment / pre-development / maintenance presets) with ten on-demand skills, replacing the old two-preset description.

- Only my own entry file is touched (data/plugins/Lorvaste__DSH-Project-Initialization.yml).
- dsh.bundle manifest declared in package.json; repo age and commit count well above the bar.
- No README edits (generated on merge).