### PR TITLE
fix: normalize README line endings before sync checks

### DIFF
--- a/scripts/generate-readme.mjs
+++ b/scripts/generate-readme.mjs
@@ -46,6 +46,11 @@ const TOC_SHELL = {
   zh: { top: '插件', tail: ['徽章', '免责声明'] },
 }
 
+// Git may check text files out with CRLF on Windows. The generated blocks use
+// LF internally, so comparing the raw checkout would report a clean README as
+// stale even though Git sees no content diff. Compare logical text instead.
+const normalizeNewlines = (text) => text.replace(/\r\n?/g, '\n')
+
 function replaceBlock(text, [open, close], body, file) {
   const i = text.indexOf(open)
   const j = text.indexOf(close)
@@ -147,7 +152,7 @@ for (const loc of LOCALES) {
     })
     .join('\n\n')
 
-  const before = fs.readFileSync(loc.readme, 'utf8')
+  const before = normalizeNewlines(fs.readFileSync(loc.readme, 'utf8'))
   let after = replaceBlock(before, MARKERS.toc, toc, loc.readme)
   after = replaceBlock(after, MARKERS.plugins, plugins, loc.readme)
 


### PR DESCRIPTION
## Problem

On a normal Windows checkout, Git converts the generated READMEs to CRLF. `generate-readme.mjs` rebuilt its marker blocks with LF and compared the raw strings, so `--check` exited 1 for a clean checkout even though Git reported no content diff.

## Change

Normalize checked-out README text to LF before replacing and comparing generated blocks. This keeps the comparison about logical Markdown content rather than platform checkout endings.

Closes #4005.

## Verification

Reproduced both README failures before the change in a fresh Windows clone at `db181e1a`. With this change, in the same CRLF checkout:

- `node --check scripts/generate-readme.mjs`
- `node scripts/generate-readme.mjs --check` (both READMEs up to date, 2,777 entries)
- `SKIP_PUBLISH_CHECKS=1 node scripts/build-site.mjs` (2,777 rows × 2 locales plus sitemap/count badge)
- `git diff --check`
- `git status --short` shows only `scripts/generate-readme.mjs`; neither README is modified.

