### PR TITLE
Add LoopX DSH plugin

### DIFF
--- a/data/plugins/huangruiteng__loopx--packages-dsh-loopx-plugin.yml
+++ b/data/plugins/huangruiteng__loopx--packages-dsh-loopx-plugin.yml
@@ -2,6 +2,6 @@ url: https://github.com/huangruiteng/loopx/tree/main/packages/dsh-loopx-plugin
 name: huangruiteng/loopx#dsh-loopx-plugin
 category: workflow
 description:
-  en: 'LoopX integration that bootstraps the CLI and skills, continues admitted same-session work, and adds a local GoalBar for bound Goal and Todo status.'
-  zh: 'LoopX 集成：引导安装 CLI 与技能，续跑已准入的同会话任务，并为已绑定的 Goal 与 Todo 状态提供本地 GoalBar。'
+  en: 'Connects DeepSeek Harness to LoopX, the provider-neutral, local-first control plane for long-horizon agents, with CLI and skill bootstrap, governed same-session continuation, and a local GoalBar for bound Goal and Todo status.'
+  zh: '将 DeepSeek Harness 接入 LoopX——面向长周期 Agent 的供应商中立、本地优先控制平面，并提供 CLI 与技能引导安装、受治理的同会话续跑，以及展示已绑定 Goal 与 Todo 状态的本地 GoalBar。'
 tarball: https://github.com/huangruiteng/loopx/releases/download/dsh-loopx-plugin-v0.1.1-beta.3/dsh-loopx-plugin-0.1.1-beta.3.tgz

--- a/data/plugins/huangruiteng__loopx--packages-dsh-loopx-plugin.yml
+++ b/data/plugins/huangruiteng__loopx--packages-dsh-loopx-plugin.yml
@@ -2,6 +2,6 @@ url: https://github.com/huangruiteng/loopx/tree/main/packages/dsh-loopx-plugin
 name: huangruiteng/loopx#dsh-loopx-plugin
 category: workflow
 description:
-  en: 'Connects DeepSeek Harness to LoopX, the provider-neutral, local-first control plane for long-horizon agents, with CLI and skill bootstrap, governed same-session continuation, and a local GoalBar for bound Goal and Todo status.'
-  zh: '将 DeepSeek Harness 接入 LoopX——面向长周期 Agent 的供应商中立、本地优先控制平面，并提供 CLI 与技能引导安装、受治理的同会话续跑，以及展示已绑定 Goal 与 Todo 状态的本地 GoalBar。'
+  en: 'LoopX, a provider-neutral, local-first state kernel and control plane for long-horizon agents: keeps Goal, Todo, gate, evidence, quota, recovery, and handoff state above DeepSeek Harness, while the plugin bootstraps the CLI and skills, admits bounded same-session continuation, and adds a loopback GoalBar for the exact bound loop.'
+  zh: 'LoopX——面向长周期 Agent 的提供商中立、本地优先状态内核与控制平面：在 DeepSeek Harness 执行层之上持久化 Goal、Todo、门禁、证据、配额、恢复与交接状态；插件负责引导安装 CLI 与技能、准入有界的同会话续跑，并为精确绑定的工作循环提供本地 GoalBar。'
 tarball: https://github.com/huangruiteng/loopx/releases/download/dsh-loopx-plugin-v0.1.1-beta.3/dsh-loopx-plugin-0.1.1-beta.3.tgz

--- a/data/plugins/huangruiteng__loopx--packages-dsh-loopx-plugin.yml
+++ b/data/plugins/huangruiteng__loopx--packages-dsh-loopx-plugin.yml
@@ -1,0 +1,7 @@
+url: https://github.com/huangruiteng/loopx/tree/main/packages/dsh-loopx-plugin
+name: huangruiteng/loopx#dsh-loopx-plugin
+category: workflow
+description:
+  en: 'LoopX integration that bootstraps the CLI and skills, continues admitted same-session work, and adds a local GoalBar for bound Goal and Todo status.'
+  zh: 'LoopX 集成：引导安装 CLI 与技能，续跑已准入的同会话任务，并为已绑定的 Goal 与 Todo 状态提供本地 GoalBar。'
+tarball: https://github.com/huangruiteng/loopx/releases/download/dsh-loopx-plugin-v0.1.1-beta.3/dsh-loopx-plugin-0.1.1-beta.3.tgz


### PR DESCRIPTION
## LoopX: the control plane above an agent harness

DeepSeek Harness executes agent turns. [LoopX](https://github.com/huangruiteng/loopx) governs the durable state that lets those turns form a long-running, reviewable loop.

Technically, LoopX is an open, provider-neutral, local-first state kernel and control plane for long-horizon agents. It sits above Codex, Claude Code, Cursor, DeepSeek Harness, or another execution runtime and keeps the cross-turn contract stable:

- **Goal and Todo identity** — what outcome is active, what work is runnable, and who owns it;
- **typed decisions and human gates** — whether the next action is admitted, blocked, or requires an explicit owner decision;
- **evidence, quota, recovery, and handoff** — what changed, whether another bounded turn is worth running, how interrupted work resumes, and how peer agents continue without sharing chat memory.

That distinction matters. LoopX is not another model provider, agent runtime, task-board UI, or unconditional auto-continue timer. The harness performs one bounded turn; LoopX remains the source of truth for why that turn may run and what must survive after it ends.

## What the DSH plugin adds

The plugin makes DeepSeek Harness a native LoopX execution surface while preserving that ownership boundary:

1. **CLI and skill bootstrap** — installs or upgrades LoopX in a plugin-owned runtime, loads the packaged workflow skills before DSH becomes ready, and retains `/loopx-init` as an explicit repair path. It supports externally managed Python environments without mutating system Python.
2. **Bounded same-session continuation** — only after the exact DSH Session successfully invokes the exact `loopx` skill does a passive Driver ask LoopX whether another turn is admitted. It queues the authoritative continuation into that live Session; it does not invent a timer, binding, Todo, or quota decision.
3. **Exact-loop GoalBar** — a loopback-only web row shows the single bound Goal/Agent lane and Todo counts, then fences Start/Pause by re-resolving the live Session binding. LoopX—not the browser—owns Goal, Agent, Todo, quota, activation, and durable binding state.

For DSH users, this enables multi-turn engineering, research, issue/PR, monitoring, and peer-agent work whose objective, gates, evidence, and next action remain durable across restarts and handoffs.

## Why this catalog description looks this way

The top entries in this marketplace use a compact technical pattern: identify the product category, then enumerate verifiable mechanisms. This submission follows that style. The catalog sentence defines LoopX as a state kernel/control plane, names the durable state it owns, and then names the plugin's three concrete DSH surfaces. It avoids superlatives, performance claims, and unauditable autonomy language.

`workflow` is the closest category because the product contract is governed cross-turn continuation, not merely UI or a developer tool.

## Install and submission evidence

- The monorepo URL resolves directly to `packages/dsh-loopx-plugin/package.json`, which declares `dsh.bundle` and an adjacent patch manifest.
- The repository carries the required `dsh-plugin` topic and meets the maintenance, age, and commit-count gates.
- Official `@deepseek-ai/*` packages are peer dependencies with explicit prerelease branches for the tested `0.1.1-rc.*` tuple.
- The pinned GitHub Release tarball was downloaded and checksum-read back, then passed a real isolated DSH add/load/remove flow and the packed GoalBar runtime smoke: first skill readback, boot graph, client materialization, loopback fence, Start/Pause, and cleanup.
- Marketplace-native dependency install, bilingual README generation, authenticated submission gate, tarball reachability, and diff hygiene pass.

Only one plugin YAML is changed. Generated READMEs and unrelated entries remain untouched.
