### PR TITLE
Add Witherwithwinter/DeepSeek-Balance-Whale-Widget-Bowl

### DIFF
--- a/data/plugins/Witherwithwinter__DeepSeek-Balance-Whale-Widget-Bowl.yml
+++ b/data/plugins/Witherwithwinter__DeepSeek-Balance-Whale-Widget-Bowl.yml
@@ -1,0 +1,6 @@
+url: https://github.com/Witherwithwinter/DeepSeek-Balance-Whale-Widget-Bowl
+name: Witherwithwinter/DeepSeek-Balance-Whale-Widget-Bowl
+category: ui
+description:
+  en: 'A fixed-corner DeepSeek balance whale widget for the DSH web GUI: three switchable skins (default / bowl-on-head / bowl-in-hand), balance with today usage, per-turn cost popups, peak/off-peak price conversion, press sound effects and random talk lines. Modified from MeteorNOX/DeepSeek-Balance-Whale-Widget.'
+  zh: 'DSH Web 界面右下角的 DeepSeek 余额鲸鱼挂件：三套形象切换（默认 / 顶碗 / 拿碗）、余额与今日已用、每轮对话消耗提示、峰谷价换算、按压音效与随机台词。基于 MeteorNOX/DeepSeek-Balance-Whale-Widget 修改。'


### PR DESCRIPTION
Adds one entry under `ui`: [Witherwithwinter/DeepSeek-Balance-Whale-Widget-Bowl](https://github.com/Witherwithwinter/DeepSeek-Balance-Whale-Widget-Bowl).

A fixed-corner DeepSeek balance whale widget for the DSH web GUI: three switchable skins (default / bowl-on-head / bowl-in-hand), balance with today usage, per-turn cost popups, peak/off-peak price conversion, press sound effects and random talk lines.

- One file added: `data/plugins/Witherwithwinter__DeepSeek-Balance-Whale-Widget-Bowl.yml`. The generated READMEs are untouched, and no existing entry is modified.
- `dsh.bundle` is declared in the root `package.json` (`"dsh": { "bundle": { "patch": "./cordis.patch.yml" } }`) with `cordis.patch.yml` next to it.
- Repo created 2026-08-29, 12 commits, `dsh-plugin` topic set, MIT.
- Real code: `lib/index.js` is the host-side plugin — it registers the `/dsh-whale-bowl/*` routes (`balance.json`, `size.json`, `image.png`, `sound/*.mp3`, `last-turn.json`, `widget.js`) and injects the browser widget. No runtime dependencies beyond Node builtins. `npm test` runs a self-check of the pricing and settings helpers.
- Description checked against the code: the three skins are `SKIN_FILES` / the `skin` menu (`default` / `bowl` / `hold`), peak/off-peak conversion is `PEAK_HOURS` + `PRICING` in `isPeakTime()`, per-turn cost comes from the session-event listener (real `usage`, not an estimate), and the three sound sets are the `soundSet` menu.

**Relation to an existing entry:** this is a modified version of `MeteorNOX/DeepSeek-Balance-Whale-Widget`, which is already listed. It adds the skin switcher and the steel-pipe sound set, and it uses its own plugin id and route prefix (`/dsh-whale-bowl/` vs `/dsh-whale/`) so both can be installed side by side. The derivation is stated in the entry description, the README and the LICENSE. If you consider it too close to the upstream entry, feel free to close this — no hard feelings.