### PR TITLE
Add Aik358/dsh-literature

### DIFF
--- a/data/plugins/Aik358__dsh-literature.yml
+++ b/data/plugins/Aik358__dsh-literature.yml
@@ -1,0 +1,5 @@
+url: https://github.com/Aik358/dsh-literature
+name: Aik358/dsh-literature
+category: tools
+description:/n  en: 'Self-contained literature library for DSH with optional Zotero export: full-text PDF fetching (Unpaywall/arXiv/custom URL templates), loose Crossref-backed search, APA/GB-T 7714/MLA/Chicago citation generation, a side-panel PDF reader with highlights and notes, and AI-assisted Q&A/translation steered into the current conversation.'
+  zh: 'DSH 内置文献库（可选导出到 Zotero）：通过 Unpaywall/arXiv/自定义 URL 模板获取全文 PDF，Crossref 候选式宽松搜索，APA/GB-T 7714/MLA/Chicago 引用生成，侧窗 PDF 阅读器（高亮与笔记），以及注入当前对话的 AI 问答/翻译。'

--- a/data/plugins/Aik358__dsh-literature.yml
+++ b/data/plugins/Aik358__dsh-literature.yml
@@ -1,5 +1,6 @@
 url: https://github.com/Aik358/dsh-literature
 name: Aik358/dsh-literature
 category: tools
-description:/n  en: 'Self-contained literature library for DSH with optional Zotero export: full-text PDF fetching (Unpaywall/arXiv/custom URL templates), loose Crossref-backed search, APA/GB-T 7714/MLA/Chicago citation generation, a side-panel PDF reader with highlights and notes, and AI-assisted Q&A/translation steered into the current conversation.'
+description:
+  en: 'Self-contained literature library for DSH with optional Zotero export: full-text PDF fetching (Unpaywall/arXiv/custom URL templates), loose Crossref-backed search, APA/GB-T 7714/MLA/Chicago citation generation, a side-panel PDF reader with highlights and notes, and AI-assisted Q&A/translation steered into the current conversation.'
   zh: 'DSH 内置文献库（可选导出到 Zotero）：通过 Unpaywall/arXiv/自定义 URL 模板获取全文 PDF，Crossref 候选式宽松搜索，APA/GB-T 7714/MLA/Chicago 引用生成，侧窗 PDF 阅读器（高亮与笔记），以及注入当前对话的 AI 问答/翻译。'


### PR DESCRIPTION
Adds one entry: `data/plugins/Aik358__dsh-literature.yml`.

**Plugin**: [Aik358/dsh-literature](https://github.com/Aik358/dsh-literature) — a literature manager for DSH: a self-contained built-in library (no external app required to read/write) with optional Zotero export, full-text PDF fetching across Unpaywall / arXiv / custom URL templates, loose Crossref-backed search, APA / GB-T 7714 / MLA / Chicago citation generation, and a side-panel PDF reader with highlights, notes, and AI-assisted Q&A / translation steered into the current DSH conversation.

**Self-check**
- `dsh.bundle` manifest declared in `package.json` (`cordis.patch.yml` at repo root)
- Repo is 1+ day old, 15+ commits
- `dsh-plugin` topic added
- npm package [`@a9i5k4/dsh-literature`](https://www.npmjs.com/package/@a9i5k4/dsh-literature) published; its `repository` field points back at the GitHub repo above
- One entry only; READMEs untouched (they are generated from `data/plugins/*.yml`)
- `description.en` matches the code at `main` (v0.2.6)

**Category**: `tools` — closest to existing `tools` entries `Hongcheng-LI/dsh-zotero` and `STARDUSTLC666/dsh-cite`. Distinct positioning: this plugin ships its own built-in library, a side-panel PDF reader (highlights/notes), and AI-assisted reading actions wired into the active conversation.
