### PR TITLE
Add dsh-sidepanel (side chat + artifacts panel) and dsh-user-addons (drop upload + usage pill + archives)

### DIFF
--- a/data/plugins/Yur0918__dsh-sidepanel.yml
+++ b/data/plugins/Yur0918__dsh-sidepanel.yml
@@ -1,0 +1,6 @@
+url: https://github.com/Yur0918/dsh-sidepanel
+name: Yur0918/dsh-sidepanel
+category: ui
+description:
+  en: A Codex-style right side panel for the DSH Web UI — session artifacts browser (live file tree, scan include, preview, reveal) plus a side chat that forks the current session with a model picker, human-pacing scheduled runs and smart send-to-bottom scrolling.
+  zh: DSH Web 界面的 Codex 式右侧面板——会话产物浏览（文件树、扫描收录、预览、访达定位）+ 继承当前会话上下文的侧聊，支持模型选择器、拟人化定时调用、发送吸顶与智能滚动。

--- a/data/plugins/Yur0918__dsh-user-addons.yml
+++ b/data/plugins/Yur0918__dsh-user-addons.yml
@@ -1,0 +1,6 @@
+url: https://github.com/Yur0918/dsh-user-addons
+name: Yur0918/dsh-user-addons
+category: tools
+description:
+  en: Drag-and-drop file upload into the conversation composer, token usage pill with quota tracking, and session archive management — a three-in-one daily-driver addon.
+  zh: 会话输入区拖拽上传文件、Token 用量胶囊与额度跟踪、会话归档管理，三合一日常插件。


### PR DESCRIPTION
Submitting two plugins from Yur0918:

- **Yur0918/dsh-sidepanel** (category: ui) — Codex-style right panel: session artifacts browser + side chat (model picker, scheduled human-pacing runs, smart scrolling). Declares `dsh.bundle` with `cordis.patch.yml`; 26 unit tests green.
- **Yur0918/dsh-user-addons** (category: tools) — drag-drop composer upload, usage pill, archive management. `dsh.bundle` declared.

Both repos carry real working code, are actively maintained today, and are installed and running on my local DSH profile.