### PR TITLE
Add mackwan84/dsh-ui-mockup#ui-mockup

### DIFF
--- a/data/plugins/mackwan84__dsh-ui-mockup--bundle-ui-mockup.yml
+++ b/data/plugins/mackwan84__dsh-ui-mockup--bundle-ui-mockup.yml
@@ -1,0 +1,6 @@
+url: https://github.com/mackwan84/dsh-ui-mockup/tree/main/bundle/ui-mockup
+name: mackwan84/dsh-ui-mockup#ui-mockup
+category: ui
+description:
+  en: Generates UI wireframes and high-fidelity mockups in DeepSeek Harness with selectable DashScope and Volcengine image providers.
+  zh: 在 DeepSeek Harness 中使用可切换的阿里云百炼与火山方舟图像服务生成 UI 线框图和高保真设计稿。


### PR DESCRIPTION
Adds the installable `bundle/ui-mockup` subpackage from `mackwan84/dsh-ui-mockup` to the UI category.

- [x] Added one entry file under `data/plugins/`; generated READMEs are intentionally not committed per the current one-file workflow.
- [x] The target subpackage declares `dsh.bundle` and ships `cordis.patch.yml`.
- [x] The repository is older than one day and has more than 10 commits.
- [x] Category is `ui`; descriptions are factual and contain no superlatives.
- [x] The repository has the `dsh-plugin` topic.
- [x] The install bundle is published on npm as `@mackwan84/dsh-ui-mockup-bundle@0.1.2`.

Local validation:

- `node scripts/check-submission.mjs`: all checked entries pass
- `npx awesome-lint`: pass (existing catalog warnings only)
- `SKIP_PUBLISH_CHECKS=1 node scripts/build-site.mjs`: pass