### PR TITLE
Update wowyuarm/dsh-agent-team description

### DIFF
--- a/data/plugins/wowyuarm__dsh-agent-team.yml
+++ b/data/plugins/wowyuarm__dsh-agent-team.yml
@@ -2,5 +2,5 @@ url: https://github.com/wowyuarm/dsh-agent-team
 name: wowyuarm/dsh-agent-team
 category: workflow
 description:
-  en: 'Helps a human manage tasks in an orderly way with collaborating agents: persistent agent identities, per-project Workspaces, responsibility-bearing Channels, and Task Threads chaining session agents.'
-  zh: '帮助 human 有序管理任务：Agent 是持久身份，Workspace 按项目组织，Channel 承载职责分派，Task Thread 串联多个 session agent 协作推进。'
+  en: 'A persistent agent team for long-running collaboration in DeepSeek Harness: durable agent identities, per-project Workspaces, responsibility-bearing Channels, and Task Threads chaining session agents.'
+  zh: '给 DSH 一个可长期协作的持久 Agent 团队：Agent 是持久身份，Workspace 按项目组织，Channel 承载职责分派，Task Thread 串联多个 session agent 协作推进。'


### PR DESCRIPTION
Updating the description of my own entry to match the project's current positioning.

The original wording ("Helps a human manage tasks in an orderly way…") read like a project-management tool. The project's positioning has been clarified across its README and release notes: it provides a persistent agent team for long-running collaboration, not task management.

- en: "A persistent agent team for long-running collaboration in DeepSeek Harness: durable agent identities, per-project Workspaces, responsibility-bearing Channels, and Task Threads chaining session agents."
- zh: "给 DSH 一个可长期协作的持久 Agent 团队：Agent 是持久身份，Workspace 按项目组织，Channel 承载职责分派，Task Thread 串联多个 session agent 协作推进。"

Only this one entry file is touched, per the contributing guide. The READMEs regenerate on main after merge.