### PR TITLE
Add dsh-web-search-litellm (LiteLLM Responses API web search provider)

### DIFF
--- a/data/plugins/yunxiyang__dsh-web-search-litellm.yml
+++ b/data/plugins/yunxiyang__dsh-web-search-litellm.yml
@@ -1,0 +1,6 @@
+url: https://github.com/yunxiyang/dsh-web-search-litellm
+name: yunxiyang/dsh-web-search-litellm
+category: tools
+description:
+  en: 'Web search provider for the ctx.web seam that routes the DeepSeek web_search tool through a LiteLLM proxy using the OpenAI Responses API, reusing LITELLM_API_KEY.'
+  zh: 'ctx.web 搜索提供方：通过 LiteLLM 代理走 OpenAI Responses API 调用 DeepSeek 原生服务端 web_search，复用 LITELLM_API_KEY，无需新密钥。'


### PR DESCRIPTION
Adds one entry: `yunxiyang__dsh-web-search-litellm`.

**Plugin:** `dsh-web-search-litellm` — a `WebSearchProvider` for the `ctx.web`
seam that routes the DeepSeek `web_search` tool through a LiteLLM proxy using
the OpenAI Responses protocol. DeepSeek's Responses API executes the search
server-side; the provider reuses the existing `LITELLM_API_KEY` credential and
returns the grounded answer plus the real `open_page` URLs as sources.

- npm: https://www.npmjs.com/package/dsh-web-search-litellm (v0.1.0)
- repo: https://github.com/yunxiyang/dsh-web-search-litellm (MIT, CI green)
- manifest: `dsh.bundle.patch` → `cordis.patch.yml` ✅; repo topic `dsh-plugin` ✅
- category: `tools`
- test coverage: standalone e2e (`tests/search-e2e.mjs`) and timeout
  regression (`tests/timeout.test.mjs`)

Only the one entry file is added; no generated READMEs touched.
