### PR TITLE
feat: add Tazio7/dsh-web-search-glm

### DIFF
--- a/data/plugins/Tazio7__dsh-web-search-glm.yml
+++ b/data/plugins/Tazio7__dsh-web-search-glm.yml
@@ -1,0 +1,6 @@
+url: https://github.com/Tazio7/dsh-web-search-glm
+name: Tazio7/dsh-web-search-glm
+category: tools
+description:
+  en: 'Web search provider powered by ZAI GLM MCP: search and fetch via Open BigModel API with credentials auto-injection from ~/.dsh/.credentials.yaml or environment variables — no API key in config files.'
+  zh: 基于智谱 GLM MCP 的网络搜索插件：通过 Open BigModel API 搜索和抓取网页内容，API Key 自动从 ~/.dsh/.credentials.yaml 或环境变量注入，配置文件中无需存放密钥。


### PR DESCRIPTION
## Plugin

**Repo:** [Tazio7/dsh-web-search-glm](https://github.com/Tazio7/dsh-web-search-glm)

**What it does:** Web search provider powered by ZAI GLM MCP — provides `web_search_prime` (search) and `webReader` (fetch) tools via Open BigModel's MCP protocol. The API key is auto-injected from `~/.dsh/.credentials.yaml` or environment variables (`ZAI_CODING_CN_API_KEY` / `ZAI_API_KEY`), so no secrets ever appear in config files.

**Category:** `tools` — it's a search provider that replaces the default web search backend.

## Checklist

- [x] `dsh.bundle` manifest in `package.json` (with `cordis.patch.yml`)
- [x] Working code — tested in production against live ZAI GLM MCP endpoint
- [x] Repo is public with `dsh-plugin` topic
- [ ] Repo ≥1 day old (created today — will pass tomorrow)
- [x] ≥10 commits
- [x] Description is accurate and factual
- [x] No secrets in the repo

> ⚠️ This repo was created today (Sep 1). The CI age check will pass after ~24 hours. Will re-trigger or re-open once the constraint is met.