### PR TITLE
Add zexadev/dsh-tether (remote)

### DIFF
--- a/data/plugins/zexadev__dsh-tether.yml
+++ b/data/plugins/zexadev__dsh-tether.yml
@@ -1,0 +1,6 @@
+url: https://github.com/zexadev/dsh-tether
+name: zexadev/dsh-tether
+category: remote
+description:
+  en: Use the dsh web UI on your dev machine from an Android or iOS phone, connected peer-to-peer across networks via iroh with no server in between.
+  zh: 用 Android/iOS 手机远程使用电脑上的 dsh 完整网页界面,经 iroh 跨网点对点直连,中间不经过任何服务器。


### PR DESCRIPTION
Mobile client for dsh: carries the full dsh web UI to an Android/iOS phone over an iroh peer-to-peer connection — hole-punched across networks, no relay of your own, approvals and notifications on the phone.

- `dsh.bundle` manifest with `cordis.patch.yml` at repo root — installable via `dsh plugin --profile web add dsh-plugin-tether`
- npm-published (plugin + per-platform sidecar subpackages), `dsh-plugin` topic set
- verified against dsh 0.1.0-rc.7 / rc.8 / 0.1.2-alpha (incl. the 0.1.2-alpha browser authentication)