### PR TITLE
git: add dsh-git-plus

### DIFF
--- a/data/plugins/MarioLuLu7__dsh-git-plus.yml
+++ b/data/plugins/MarioLuLu7__dsh-git-plus.yml
@@ -1,0 +1,6 @@
+url: https://github.com/MarioLuLu7/dsh-git-plus
+name: MarioLuLu7/dsh-git-plus
+category: git
+description:
+  en: 'DSH Source Control tab in dsh-better-sidebar that mirrors VS Code Git workflows.'
+  zh: 'dsh-better-sidebar 中的 DSH 源代码管理面板，尽量对齐 VS Code 的 Git 工作流。'


### PR DESCRIPTION
Add MarioLuLu7/dsh-git-plus to the catalog.

- Category: git
- Description: DSH Source Control tab in dsh-better-sidebar that mirrors VS Code Git workflows.
