### PR TITLE
Add dsh-lit-search and dsh-latex-guard

### DIFF
--- a/data/plugins/Flan246__dsh-latex-guard.yml
+++ b/data/plugins/Flan246__dsh-latex-guard.yml
@@ -1,0 +1,6 @@
+url: https://github.com/Flan246/dsh-latex-guard
+name: Flan246/dsh-latex-guard
+category: docs
+description:
+  en: "LaTeX and BibTeX guardrails for DeepSeek Harness: compile checks with automatic xelatex/lualatex detection, BibTeX entry deduplication and field filling from Crossref, and \\cite key audits against the .bib file."
+  zh: "为 DeepSeek Harness 提供的 LaTeX 与 BibTeX 检查工具：编译检查（自动识别 xelatex/lualatex），基于 Crossref 的 BibTeX 条目去重与字段补全，以及 \\cite 键与 .bib 文件的一致性审计。"

--- a/data/plugins/Flan246__dsh-lit-search.yml
+++ b/data/plugins/Flan246__dsh-lit-search.yml
@@ -1,0 +1,6 @@
+url: https://github.com/Flan246/dsh-lit-search
+name: Flan246/dsh-lit-search
+category: tools
+description:
+  en: "Academic literature search and citation tools for DeepSeek Harness: paper search via Crossref and OpenAlex with no API key, related-works discovery, and citation formatting in GB/T 7714, APA and BibTeX."
+  zh: "为 DeepSeek Harness 提供的学术文献检索与引用工具：基于 Crossref 与 OpenAlex 检索论文（无需 API key），支持相关工作发现，并可按 GB/T 7714、APA 与 BibTeX 格式生成引用。"


### PR DESCRIPTION
Adds two published DeepSeek Harness plugins:

- **dsh-lit-search** — academic literature search (Crossref + OpenAlex, no API key), related-works discovery, and citation formatting in GB/T 7714 / APA / BibTeX. https://github.com/Flan246/dsh-lit-search
- **dsh-latex-guard** — LaTeX compile checks with automatic xelatex/lualatex detection, BibTeX dedup/fill from Crossref, and \cite key audits against the .bib file. https://github.com/Flan246/dsh-latex-guard

Both repos declare a `dsh.bundle` manifest, carry the `dsh-plugin` topic, and have 10+ commits. One YAML file per plugin under `data/plugins/`, per contributing.md; READMEs left untouched for post-merge regeneration.