### PR TITLE
Add evanfang0054/dsh-init

### DIFF
--- a/data/plugins/evanfang0054__dsh-init.yml
+++ b/data/plugins/evanfang0054__dsh-init.yml
@@ -1,0 +1,6 @@
+url: https://github.com/evanfang0054/dsh-init
+name: evanfang0054/dsh-init
+category: workflow
+description:
+  en: 'Claude Code style /init command and tool that writes a minimal CLAUDE.md and symlinks AGENTS.md to it.'
+  zh: 提供 Claude Code 风格的 /init 命令与工具，生成极简 CLAUDE.md，并将 AGENTS.md 以相对软链指向它。


### PR DESCRIPTION
## What it does

Claude Code style `/init` for DSH. Registers a slash command **and** a model tool named `init`; both inject the same seven-phase workflow prompt (adapted from Claude Code's NEW_INIT flow): interview, codebase survey, gap-fill, write a minimal `CLAUDE.md`, symlink `AGENTS.md` to it (relative link, never silently overwriting an existing regular file), optional personal `CLAUDE.local.md`, summary.

- Repo: https://github.com/evanfang0054/dsh-init
- npm: https://www.npmjs.com/package/dsh-init (the `repository` field points back at the repo)

## Install

    dsh plugin --profile web add dsh-init
    # or: dsh plugin --profile web add github:evanfang0054/dsh-init

## Checklist

- [x] `dsh.bundle.patch` declared in `package.json`, with `cordis.patch.yml` at the repo root (host-only plugin, no `dsh.client`)
- [x] Real working code — published and installable; v0.1.2 live on npm
- [x] `dsh-plugin` topic added to the repo
- [x] 10 commits
- [x] Description states what the code does, no marketing

## Note on the repo-age check

The repo was created **2026-09-01**; the 1-day age check will turn green after **2026-09-02 (UTC)**. Commit count (10) already passes. Feel free to hold the merge until then and re-run CI — everything else should be green.
