### PR TITLE
Use evergreen StrataGate DSH tarball

### DIFF
--- a/data/plugins/diqierjia__StrataGate-AgentMemory--integrations-deepseek-harness.yml
+++ b/data/plugins/diqierjia__StrataGate-AgentMemory--integrations-deepseek-harness.yml
@@ -1,5 +1,5 @@
 url: https://github.com/diqierjia/StrataGate-AgentMemory/tree/main/integrations/deepseek-harness
-tarball: https://github.com/diqierjia/StrataGate-AgentMemory/releases/download/stratagate-dsh-v0.2.40/stratagate-dsh-0.2.40.tgz
+tarball: https://github.com/diqierjia/StrataGate-AgentMemory/releases/latest/download/stratagate-dsh.tgz
 name: diqierjia/StrataGate-AgentMemory
 category: memory
 description:


### PR DESCRIPTION
## Summary

- switch StrataGate DSH from the version-pinned 0.2.40 asset to the evergreen fixed-name release asset
- follow the maintainer suggestion in #3963 so future package releases do not require marketplace version-bump PRs

## Verification

- added stratagate-dsh.tgz to the latest stratagate-dsh-v0.2.40 GitHub Release
- downloaded the releases/latest URL successfully
- verified package manifest: stratagate-dsh@0.2.40
- verified size: 7,836,501 bytes
- verified SHA-256: 5be01cbde8b1a238942d64c1e9012f67497d99daa106c84f441818137fe3cf62
- updated the source entry only; generated READMEs remain unchanged