### PR TITLE
docs: add dsh-dream & dsh-suite; refresh dsh-email, dsh-hyperframes, dsh-ffmpeg and dsh-ppt entries

### DIFF
--- a/data/plugins/STARDUSTLC666__dsh-dream.yml
+++ b/data/plugins/STARDUSTLC666__dsh-dream.yml
@@ -1,0 +1,6 @@
+url: https://github.com/STARDUSTLC666/dsh-dream
+name: STARDUSTLC666/dsh-dream
+category: session
+description:
+  en: 'Dreaming for agents: replay recent conversations between sessions (dream_digest), reflect and write a dream journal (dream_save/journal/recall), and idempotently bridge recurring lessons into AGENTS.md (dream_bridge). Reads multi-frame zstd session archives with privacy masking on by default; six tools including a health self-check; zero runtime dependencies.'
+  zh: DSH 做梦插件：agent 在会话间隙回放近期对话（dream_digest）、反思并写入梦境日记（dream_save/journal/recall），高频教训幂等桥接进 AGENTS.md（dream_bridge）。多帧 zstd 会话读取，默认隐私脱敏，六工具含健康自检，零运行时依赖。

--- a/data/plugins/STARDUSTLC666__dsh-email.yml
+++ b/data/plugins/STARDUSTLC666__dsh-email.yml
@@ -2,5 +2,5 @@ url: https://github.com/STARDUSTLC666/dsh-email
 name: STARDUSTLC666/dsh-email
 category: notify
 description:
-  en: IMAP/SMTP email tools (list/read/search/send/folders/attachment/health) with since/until date-range filters, QQ/163/126/Sina/Aliyun/Gmail/Outlook/iCloud presets, multi-account support and a send-approval gate.
-  zh: 邮件工具插件：IMAP/SMTP 收/发/搜/列文件夹/附件下载与健康自检，since/until 日期范围过滤，内置 QQ/163/126/新浪/阿里/Gmail/Outlook/iCloud 预设，多账号、连接复用与发信审批门。
+  en: IMAP/SMTP email tools (list/read/search/send/folders/attachment/health/watch) with since/until date-range filters, QQ/163/126/Sina/Aliyun/Gmail/Outlook/iCloud presets, multi-account support, a send-approval gate, a web settings page and a whale-girl new-mail popup driven by the incremental email_watch checker.
+  zh: 邮件工具插件：含 email_watch 增量新邮件检查的八工具，Web 设置页与鲸鱼娘递信新邮件弹窗，since/until 日期范围过滤，内置 QQ/163/126/新浪/阿里/Gmail/Outlook/iCloud 预设，多账号、连接复用与发信审批门。

--- a/data/plugins/STARDUSTLC666__dsh-email.yml
+++ b/data/plugins/STARDUSTLC666__dsh-email.yml
@@ -2,5 +2,5 @@ url: https://github.com/STARDUSTLC666/dsh-email
 name: STARDUSTLC666/dsh-email
 category: notify
 description:
-  en: IMAP/SMTP email tools (list/read/search/send/folders/attachment/health/watch) with since/until date-range filters, QQ/163/126/Sina/Aliyun/Gmail/Outlook/iCloud presets, multi-account support, a send-approval gate, a web settings page and a whale-girl new-mail popup driven by the incremental email_watch checker.
-  zh: 邮件工具插件：含 email_watch 增量新邮件检查的八工具，Web 设置页与鲸鱼娘递信新邮件弹窗，since/until 日期范围过滤，内置 QQ/163/126/新浪/阿里/Gmail/Outlook/iCloud 预设，多账号、连接复用与发信审批门。
+  en: IMAP/SMTP email tools (list/read/search/send/folders/attachment/health/watch/mark) with since/until date-range filters, email_mark for read/unread/star/move, QQ/163/126/Sina/Aliyun/Gmail/Outlook/iCloud presets, multi-account support, a send-approval gate, a web settings page and a whale-girl new-mail popup driven by the incremental email_watch checker.
+  zh: 邮件工具插件：含 email_watch 增量新邮件检查与 email_mark（已读/未读/星标/移动文件夹）的九工具，Web 设置页与鲸鱼娘递信新邮件弹窗，since/until 日期范围过滤，内置 QQ/163/126/新浪/阿里/Gmail/Outlook/iCloud 预设，多账号、连接复用与发信审批门。

--- a/data/plugins/STARDUSTLC666__dsh-email.yml
+++ b/data/plugins/STARDUSTLC666__dsh-email.yml
@@ -2,5 +2,5 @@ url: https://github.com/STARDUSTLC666/dsh-email
 name: STARDUSTLC666/dsh-email
 category: notify
 description:
-  en: IMAP/SMTP email tools (list/read/search/send/folders/attachment/health/watch/mark) with since/until date-range filters, email_mark for read/unread/star/move, QQ/163/126/Sina/Aliyun/Gmail/Outlook/iCloud presets, multi-account support, a send-approval gate, a web settings page and a whale-girl new-mail popup driven by the incremental email_watch checker.
-  zh: 邮件工具插件：含 email_watch 增量新邮件检查与 email_mark（已读/未读/星标/移动文件夹）的九工具，Web 设置页与鲸鱼娘递信新邮件弹窗，since/until 日期范围过滤，内置 QQ/163/126/新浪/阿里/Gmail/Outlook/iCloud 预设，多账号、连接复用与发信审批门。
+  en: IMAP/SMTP email tools (list/read/search/send/folders/attachment/health/watch/mark/reply) with since/until date-range filters, email_mark for read/unread/star/move, email_reply for reply/reply-all/forward with threading headers, QQ/163/126/Sina/Aliyun/Gmail/Outlook/iCloud presets, multi-account support, a send-approval gate, a web settings page and a whale-girl new-mail popup driven by the incremental email_watch checker.
+  zh: 邮件工具插件：含 email_watch 增量新邮件检查、email_mark（已读/未读/星标/移动文件夹）与 email_reply（回复/回复全部/转发，自动线程头+引文）的十工具，Web 设置页与鲸鱼娘递信新邮件弹窗，since/until 日期范围过滤，内置 QQ/163/126/新浪/阿里/Gmail/Outlook/iCloud 预设，多账号、连接复用与发信审批门。

--- a/data/plugins/STARDUSTLC666__dsh-ffmpeg.yml
+++ b/data/plugins/STARDUSTLC666__dsh-ffmpeg.yml
@@ -2,5 +2,5 @@ url: https://github.com/STARDUSTLC666/dsh-ffmpeg
 name: STARDUSTLC666/dsh-ffmpeg
 category: tools
 description:
-  en: 'Nine video tools (probe/cut/concat/encode/subtitle/extract/gif/frames/health) on the official subprocess service: probe summaries, batch frame extraction, shell-free argv, zero runtime dependencies.'
-  zh: 视频处理九工具（探测/剪辑/拼接/转码/字幕烧录/抽帧/批量抽帧/GIF/健康自检）：探测摘要、官方 subprocess 服务、argv 无 shell 注入、零运行时依赖。
+  en: 'Ten video tools (probe/cut/concat/encode/subtitle/extract/gif/frames/adjust/health) on the official subprocess service: probe summaries, batch frame extraction, speed/volume/mute/rotate adjust, shell-free argv, zero runtime dependencies.'
+  zh: 视频处理十工具（探测/剪辑/拼接/转码/字幕烧录/抽帧/批量抽帧/GIF/调整/健康自检）：探测摘要、变速/音量/静音/旋转调整、官方 subprocess 服务、argv 无 shell 注入、零运行时依赖。

--- a/data/plugins/STARDUSTLC666__dsh-hyperframes.yml
+++ b/data/plugins/STARDUSTLC666__dsh-hyperframes.yml
@@ -2,5 +2,5 @@ url: https://github.com/STARDUSTLC666/dsh-hyperframes
 name: STARDUSTLC666/dsh-hyperframes
 category: skill
 description:
-  en: 'Five official HyperFrames by HeyGen skills: HTML video / CLI / registry / website-to-video / GSAP reference, plus a bundled-resource health check.'
-  zh: HyperFrames by HeyGen 官方移植技能五件套：HTML 写视频 / CLI / 注册表 / 网址转视频 / GSAP 参考，附随包资源完整性自检。
+  en: 'Twenty HyperFrames by HeyGen skills synced from the official upstream (HTML video authoring, animation, keyframes, audio/music-to-video, CLI, registry, slideshow, talking-head recut, website/product/PR-to-video and more), plus a bundled-resource health check.'
+  zh: 同步 HyperFrames by HeyGen 官方上游的二十技能：HTML 写视频/动画/关键帧/音频与音乐转视频/CLI/注册表/幻灯片/口播重剪/网址·产品·PR 转视频等，附随包资源完整性自检。

--- a/data/plugins/STARDUSTLC666__dsh-ppt.yml
+++ b/data/plugins/STARDUSTLC666__dsh-ppt.yml
@@ -2,5 +2,5 @@ url: https://github.com/STARDUSTLC666/dsh-ppt
 name: STARDUSTLC666/dsh-ppt
 category: docs
 description:
-  en: 'Presentation skill and tools: one sentence or one document to an HTML slideshow plus editable PPTX, with five built-in themes, default theme/language config and bilingual support.'
-  zh: 演示文稿技能与工具：一句话或一篇文档生成 HTML 放映与可编辑 PPTX，内置 5 套主题，可配置默认主题/语言，中英双语。
+  en: 'Presentation skill and tools: one sentence or one document to an HTML slideshow plus editable PPTX, seven layouts (incl. quote and native PPTX tables), speaker notes (HTML S-key panel and native notes slides), five built-in themes, default theme/language config and bilingual support.'
+  zh: 演示文稿技能与工具：一句话或一篇文档生成 HTML 放映与可编辑 PPTX，7 种页型（含金句与原生 PPTX 表格），演讲者备注（HTML 按 S 呼出 + PPTX 原生备注页），内置 5 套主题，可配置默认主题/语言，中英双语。

--- a/data/plugins/STARDUSTLC666__dsh-suite.yml
+++ b/data/plugins/STARDUSTLC666__dsh-suite.yml
@@ -1,0 +1,6 @@
+url: https://github.com/STARDUSTLC666/dsh-suite
+name: STARDUSTLC666/dsh-suite
+category: workflow
+description:
+  en: 'All-in-one combo patch for STARDUSTLC''s 18 DSH plugins: one command injects shared default configs across office, media, DevOps and notification presets; each component installs directly via a one-line add command (flat design, no git subdependencies).'
+  zh: STARDUSTLC 插件全家桶·组合补丁：与 18 个组件插件配套，一条命令统一注入默认配置（办公流/媒体工坊/DevOps/通知/预设）；组件经一行 add 命令直装（扁平化设计，无 git 子依赖）。


### PR DESCRIPTION
## Summary
- Add entries: `STARDUSTLC666/dsh-dream` (session: dreaming/replay/journal/bridge tools) and `STARDUSTLC666/dsh-suite` (workflow: combo patch bundling 18 plugins).
- Refresh `dsh-email` to ten tools (v0.10.1): `email_watch` incremental new-mail checker with web settings page and whale-girl popup, `email_mark` (read/unread/star/move), `email_reply` (reply/reply-all/forward with threading headers).
- Refresh `dsh-hyperframes`: synced to the official HyperFrames upstream, twenty skills (v0.3.0).
- Refresh `dsh-ffmpeg` to ten tools (v0.4.0): new `ffmpeg_adjust` (speed/volume/mute/rotate).
- Refresh `dsh-ppt` (v0.3.0): speaker notes, quote and table layouts.

Supersedes #3974 (closed).

## Verification
- All listed repos are public, active and declare `dsh.bundle.patch` (gate criteria).
- Wording for every entry is taken from the plugin's own README/package.json at the stated version.
- Entries follow the `data/plugins/*.yml` schema with bilingual descriptions.