### PR TITLE
Add SuCriss/dsh-voice-control plugin

### DIFF
--- a/data/plugins/SuCriss__dsh-voice-control.yml
+++ b/data/plugins/SuCriss__dsh-voice-control.yml
@@ -1,0 +1,6 @@
+url: https://github.com/SuCriss/dsh-voice-control
+name: SuCriss/dsh-voice-control
+category: voice
+description:
+  en: "Voice control for the DSH web composer: push-to-talk speech-to-text into the input box (with optional auto-send), spoken playback of assistant replies via the Web Speech API, right-click settings popover, and a global Ctrl+M hotkey."
+  zh: "DSH 网页端语音控制：按住说话将语音转文字输入发送框（可自动发送），用浏览器语音合成朗读助手回复；右键麦克风打开设置面板，支持 Ctrl+M 全局快捷键。"


### PR DESCRIPTION
﻿Add SuCriss/dsh-voice-control plugin to the registry

## 提交内容

添加 SuCriss/dsh-voice-control 插件到数据目录。

### 插件信息

- 仓库: https://github.com/SuCriss/dsh-voice-control
- 分类: voice（语音）
- 描述: DSH 网页端语音控制：按住说话将语音转文字输入发送框（可自动发送），用浏览器语音合成朗读助手回复；右键麦克风打开设置面板，支持 Ctrl+M 全局快捷键。
- package.json: 已声明 dsh.bundle + dsh.client，可安装
- Topic: 已添加 dsh-plugin
- 提交数: 11 个提交
- 仓库创建: 2026-08-31（超过 1 天）

### 验证

本地 check-submission.mjs 通过：ok: true, checked: 1, failures: []
