### PR TITLE
Add TryDing-T Chinese chess plugin

### DIFF
--- a/data/plugins/TryDing-T__dsh-Plugin--ChineseChess.yml
+++ b/data/plugins/TryDing-T__dsh-Plugin--ChineseChess.yml
@@ -1,0 +1,6 @@
+url: https://github.com/TryDing-T/dsh-Plugin--ChineseChess
+name: TryDing-T/dsh-Plugin--ChineseChess
+category: fun
+description:
+  en: 'Side-panel Xiangqi board for DSH: play as red while the current DSH model chooses black moves, with Host-side rule and revision checks.'
+  zh: DSH 侧边栏中国象棋棋盘：用户执红，当前 DSH 模型执黑，Host 负责棋规与局面版本校验。


### PR DESCRIPTION
Adds one plugin entry for TryDing-T/dsh-Plugin--ChineseChess.

- Changed only `data/plugins/TryDing-T__dsh-Plugin--ChineseChess.yml`.
- The repository declares `dsh.bundle` and has the `dsh-plugin` topic.
- The repository is over one day old and has more than 10 commits.
- Local validation passed: typecheck, 63 tests, build, and pack dry-run.

The current contribution guide accepts a YAML-only PR; generated README files are intentionally not included.