### PR TITLE
Add Taojian (dsh-theme-taojian)

### DIFF
--- a/data/plugins/Waldsatte__dsh-theme-taojian.yml
+++ b/data/plugins/Waldsatte__dsh-theme-taojian.yml
@@ -1,0 +1,6 @@
+url: https://github.com/Waldsatte/dsh-theme-taojian
+name: Waldsatte/dsh-theme-taojian
+category: theme
+description:
+  en: 'Taojian (陶笺): Claude-inspired DSH theme with warm paper, clay accent, Noto Serif SC, and Cascadia Mono.'
+  zh: 陶笺：奶油纸浅色主题，陶橙强调色，界面思源宋，代码 Cascadia Mono。非官方，与 Anthropic、DeepSeek 无关。


### PR DESCRIPTION
Add `Waldsatte/dsh-theme-taojian` under Themes.

- category: theme
- unofficial Claude-inspired warm-paper skin for DSH Web
- repo: https://github.com/Waldsatte/dsh-theme-taojian
- topic: dsh-plugin

One YAML file only; READMEs are generated.