### PR TITLE
Add gsh150801/dsh-bioinf-verify

### DIFF
--- a/data/plugins/gsh150801__dsh-bioinf-verify.yml
+++ b/data/plugins/gsh150801__dsh-bioinf-verify.yml
@@ -1,0 +1,6 @@
+url: https://github.com/gsh150801/dsh-bioinf-verify
+name: gsh150801/dsh-bioinf-verify
+category: workflow
+description:
+  en: 'Whole-report verification for scientific reports: per-claim checks against Crossref, PubMed (retraction scan), ClinicalTrials.gov, UniProtKB, GEO/SRA and PatentsView, URL accessibility and title agreement, claim-vs-source meaning at temperature 0, and a durable restartable audit ledger with an annotated report.'
+  zh: '面向科研报告的整篇校验工作流：逐条核对 Crossref、PubMed（含撤稿扫描）、ClinicalTrials.gov、UniProtKB、GEO/SRA 和 PatentsView，核验 URL 可访问性与标题一致性，以温度 0 判定声明与原文含义一致，输出可恢复的审计账本与标注版校验报告。'


### PR DESCRIPTION
Adds one entry: [gsh150801/dsh-bioinf-verify](https://github.com/gsh150801/dsh-bioinf-verify), category **workflow**.

A standalone verification plugin for DeepSeek Harness (`dsh`) that makes every piece of evidence in a biomedical/scientific report auditable:

- per-claim checks against authoritative registries — Crossref (DOI), PubMed (PMID, including a retraction / expression-of-concern scan), ClinicalTrials.gov v2 (status / phase / posted results), UniProtKB (protein accessions), Geo/SRA accessions, PatentsView (patent titles);
- URL accessibility with redirect following and soft-404 detection;
- title agreement (match / close / mismatch) against source titles;
- claim-vs-verbatim-source consistency judged at temperature 0;
- a whole-report workflow (`report_verify_start/step/status/finish/list`) that decomposes a report, runs per-claim aspect checks over a durable restartable JSON ledger, and emits an annotated original report plus an appended verification report.

Installable: the root `package.json` declares `dsh.bundle`, so `dsh plugin add github:gsh150801/dsh-bioinf-verify` works directly.

Category note: our README designates the report-level verification as the core feature, so I chose `workflow` (mirroring the existing `bpc-oss/dsh-verification` verification-gate entry). Happy to move it to `tools` if you prefer.
