### PR TITLE
Add kenz1117/dsh-engram (memory)

### DIFF
--- a/data/plugins/kenz1117__dsh-engram.yml
+++ b/data/plugins/kenz1117__dsh-engram.yml
@@ -1,7 +1,6 @@
 url: https://github.com/kenz1117/dsh-engram
 name: kenz1117/dsh-engram
 category: memory
-npm: '@kenz1117/dsh-engram'
 description:
   en: 'Cross-session long-term memory: dual-scope user/project SQLite stores, FTS5 + offline local vector hybrid retrieval, 9 engram_* tools, per-turn automatic capture, a distillation flywheel, provenance audit, and a bilingual Settings memory-library panel.'
   zh: '跨会话长期记忆：用户/项目双层 SQLite 分库、FTS5 与离线本地向量混合检索、9 个 engram_* 工具、逐轮自动摄取、蒸馏飞轮、来源审计，以及设置页中英双语的记忆库管理面板。'

--- a/data/plugins/kenz1117__dsh-engram.yml
+++ b/data/plugins/kenz1117__dsh-engram.yml
@@ -1,0 +1,7 @@
+url: https://github.com/kenz1117/dsh-engram
+name: kenz1117/dsh-engram
+category: memory
+npm: '@kenz1117/dsh-engram'
+description:
+  en: 'Cross-session long-term memory: dual-scope user/project SQLite stores, FTS5 + offline local vector hybrid retrieval, 9 engram_* tools, per-turn automatic capture, a distillation flywheel, provenance audit, and a bilingual Settings memory-library panel.'
+  zh: '跨会话长期记忆：用户/项目双层 SQLite 分库、FTS5 与离线本地向量混合检索、9 个 engram_* 工具、逐轮自动摄取、蒸馏飞轮、来源审计，以及设置页中英双语的记忆库管理面板。'


### PR DESCRIPTION
## Plugin

**Repo**: https://github.com/kenz1117/dsh-engram
**npm**: `@kenz1117/dsh-engram` (published, `dsh plugin add @kenz1117/dsh-engram`)
**Category**: `memory`

Cross-session long-term memory plugin for DeepSeek Harness, pure TypeScript (no Python, no external processes):

- Dual-scope SQLite stores: `user.db` (global) + `project-<cwd>.db` (per working directory)
- Hybrid retrieval: FTS5 (unicode61 + Chinese 2-gram) fused with offline local vectors (Xenova/bge-small-zh-v1.5, q8) via RRF; explicit keyword-only degradation marker when the model is unavailable
- 9 `engram_*` tools (save/search/timeline/update/forget/review/stats/export/distill)
- Automatic per-turn capture from the session log (`ingest: off | light | eager`, off by default)
- Distillation flywheel: contradiction candidates → hit reinforcement → cluster merge with supersedes chains → decay/archive
- Provenance audit: source session/turn/seq per entry, full operation-log table
- Settings → "Memory Library" tab (settings.section slot): stat cards, filters, inline detail/edit, forget/restore, Markdown/JSON export; zh/en UI via the host locale service

## Checklist

- [x] `package.json` declares `dsh.bundle` (`dsh.bundle.patch: ./cordis.patch.yml`) and `dsh.client` (`platform: web`)
- [x] `cordis.patch.yml` with a single `insert` entry next to it
- [x] Published to npm (`@kenz1117/dsh-engram`), install verified via `dsh plugin add`
- [x] Repo has the `dsh-plugin` topic (plus `awesome-dsh-plugin`, `deepseek-harness`)
- [x] MIT LICENSE, bilingual README (README.md / README.en.md)
- [x] Description states only what the code does — 9 tools, dual stores, bilingual panel all verifiable in source

One note: the repo was created within the last 24h, so the age check may report red at submission time — happy to re-run CI / resubmit once it passes the 1-day mark.