### PR TITLE
Add antnesswcm/dsh-shell-card-plus (ui)

### DIFF
--- a/data/plugins/antnesswcm__dsh-shell-card-plus.yml
+++ b/data/plugins/antnesswcm__dsh-shell-card-plus.yml
@@ -1,0 +1,6 @@
+url: https://github.com/antnesswcm/dsh-shell-card-plus
+name: antnesswcm/dsh-shell-card-plus
+category: ui
+description:
+  en: 'Replaces the stock bash/pwsh terminal rows in the DSH web UI with shell command cards: long commands soft-wrap with line numbers instead of truncating, plus separate copy-command and copy-output buttons.'
+  zh: '用自定义 Shell 命令卡片替换 DSH Web 原版 bash/pwsh 工具行：长命令自动换行带行号不再截断，并提供独立的复制命令/复制输出按钮。'


### PR DESCRIPTION
# PR body for dsh-shell-card-plus

Adds [antnesswcm/dsh-shell-card-plus](https://github.com/antnesswcm/dsh-shell-card-plus) under **UI Enhancements** — a bash/pwsh command-card enhancer for the DSH web UI.

Replaces the official terminal tool rows with fully custom React cards: long commands soft-wrap with line numbers instead of truncating, plus separate copy-command and copy-output buttons. Status display follows the official convention (quiet when normal, red exit-code/signal pill on failure). Pure presentation layer — command, cwd, output and exit status all come from existing official ToolCallBlock data; no host changes.

- [x] I added **one file** at `data/plugins/antnesswcm__dsh-shell-card-plus.yml` — the READMEs are generated, don't edit them by hand
- [ ] I ran `node scripts/generate-readme.mjs` and committed the regenerated READMEs (READMEs regenerate automatically on main after merge)
- [x] My repo's `package.json` declares **`dsh.bundle`** (patch: ./cordis.patch.yml)
- [x] My repo is at least **1 day old** with **10+ commits** (created 2026-08-29, 11 commits)
- [x] `category` is `ui` (UI Enhancements)
- [x] Description states what the plugin does, no superlatives
- [x] My repo has the `dsh-plugin` topic
- [x] `screenshots.json` declared in the plugin repo (2 comparison screenshots in `docs/preview/`)
