### PR TITLE
Add Milbaxter/dsh-critique-loop (workflow)

### DIFF
--- a/data/plugins/Milbaxter__dsh-critique-loop.yml
+++ b/data/plugins/Milbaxter__dsh-critique-loop.yml
@@ -1,0 +1,6 @@
+url: https://github.com/Milbaxter/dsh-critique-loop
+name: Milbaxter/dsh-critique-loop
+category: workflow
+description:
+  en: Intercepts turn-stopping to force one critique-and-improve round after each completed turn before the agent stops.
+  zh: 在 Agent 轮次结束时拦截停机，强制执行一轮自我批评与改进再停机。


### PR DESCRIPTION
# PR body for dsh-critique-loop

Adds [Milbaxter/dsh-critique-loop](https://github.com/Milbaxter/dsh-critique-loop) under **Workflow** — an automated self-critique and improvement loop plugin for DeepSeek Harness.

Intercepts the `agent/turn-stopping` boundary to prompt the model with a self-critique instruction, forcing one round of reflection and improvement before stopping.

- [x] I added **one file** at `data/plugins/Milbaxter__dsh-critique-loop.yml` — the READMEs are generated, don't edit them by hand
- [x] My repo's `package.json` declares **`dsh.bundle`** (patch: ./cordis.patch.yml)
- [x] `category` is `workflow`
- [x] Description states what the plugin does, no superlatives
- [x] My repo has the `dsh-plugin` topic
