### PR TITLE
Add lhuans/dsh-genui

### DIFF
--- a/data/plugins/lhuans__dsh-genui.yml
+++ b/data/plugins/lhuans__dsh-genui.yml
@@ -1,0 +1,6 @@
+url: https://github.com/lhuans/dsh-genui
+name: lhuans/dsh-genui
+category: ui
+description:
+  en: 'Renders OpenTiny GenUI charts, forms, calculators and mini apps inline in DSH replies via schemaJson fences, with user actions flowing back into the conversation.'
+  zh: 通过 schemaJson 代码块在 DSH 回复内渲染 OpenTiny GenUI 图表、表单、计算器等迷你应用，用户操作自动回传对话。


### PR DESCRIPTION
## Summary
- Add plugin entry for [lhuans/dsh-genui](https://github.com/lhuans/dsh-genui), an OpenTiny GenUI plugin that renders interactive charts, forms, and mini apps inline in DSH web replies via `schemaJson` fences.
- Category: `ui`.
- Plugin repo declares `dsh.bundle`, ships `cordis.patch.yml`, is published on npm as `dsh-genui`, and includes `screenshots.json` with three showcase images.

## 已验证功能

- 目标仓库 `lhuans/dsh-genui` 已声明 `dsh.bundle` manifest 与 `cordis.patch.yml`
- 仓库 commit 数 ≥ 10，且已添加 `dsh-plugin` topic
- npm 包 `dsh-genui` 已发布，支持 `dsh plugin --profile web add dsh-genui` 安装