### PR TITLE
Add qixin-ai-data/dsh-qixin-insight-mcp-oauth (tools)

### DIFF
--- a/data/plugins/qixin-ai-data__dsh-qixin-insight-mcp-oauth.yml
+++ b/data/plugins/qixin-ai-data__dsh-qixin-insight-mcp-oauth.yml
@@ -1,0 +1,7 @@
+url: https://github.com/qixin-ai-data/dsh-qixin-insight-mcp-oauth
+name: qixin-ai-data/dsh-qixin-insight-mcp-oauth
+category: tools
+description:
+  en: 'Connects the Qixin Insight MCP server over OAuth 2.1 with PKCE as a single plugin entry, mounting its tools as mcp__qixin_insight__* with automatic 
+token refresh and revocation on disconnect.'
+  zh: '通过 OAuth 2.1 + PKCE 授权接入启信慧眼 MCP 服务，以单条插件条目把它的工具挂载为 mcp__qixin_insight__*，token 到期前自动刷新，断开时吊销。'

--- a/data/plugins/qixin-ai-data__dsh-qixin-insight-mcp-oauth.yml
+++ b/data/plugins/qixin-ai-data__dsh-qixin-insight-mcp-oauth.yml
@@ -2,6 +2,5 @@ url: https://github.com/qixin-ai-data/dsh-qixin-insight-mcp-oauth
 name: qixin-ai-data/dsh-qixin-insight-mcp-oauth
 category: tools
 description:
-  en: 'Connects the Qixin Insight MCP server over OAuth 2.1 with PKCE as a single plugin entry, mounting its tools as mcp__qixin_insight__* with automatic 
-token refresh and revocation on disconnect.'
+  en: 'Connects the Qixin Insight MCP server over OAuth 2.1 with PKCE as a single plugin entry, mounting its tools as mcp__qixin_insight__* with automatic token refresh and revocation on disconnect.'
   zh: '通过 OAuth 2.1 + PKCE 授权接入启信慧眼 MCP 服务，以单条插件条目把它的工具挂载为 mcp__qixin_insight__*，token 到期前自动刷新，断开时吊销。'


### PR DESCRIPTION
Adds one entry: `qixin-ai-data/dsh-qixin-insight-mcp-oauth`.

  A DSH plugin that connects the Qixin Insight MCP server (`https://mcp.qixin.com/mcp`)
  through OAuth 2.1 + PKCE, so its company-data tools appear in conversation as
  `mcp__qixin_insight__*`. No API key to paste, no token in any config file.

  **Checklist**

  - [x] `dsh.bundle` declared in `package.json` (`{"dsh":{"bundle":{"patch":"./cordis.patch.yml"}}}`),
        with `cordis.patch.yml` inserting a single row — no `dsh.client`, this plugin ships no browser UI
  - [x] Repo older than 1 day, 11 commits
  - [x] `dsh-plugin` topic added
  - [x] Published to npm as `dsh-qixin-insight-mcp-oauth`, whose `repository` field
        points back at this repo (prebuilt install, no `allowBuilds` approval needed)
  - [x] `screenshots.json` declared in the plugin repo
  - [x] `@deepseek-ai/*` declared as `peerDependencies`, with an explicit prerelease
        branch so harness rc builds are not silently excluded
  - [x] Only one entry added; no existing entries touched

  **On the description's claims** — each is checkable in the source:

  | Claim | Where |
  | --- | --- |
  | OAuth 2.1 + PKCE | `src/oauth/pkce.ts` — S256 only, rejects a server that advertises PKCE without it |
  | `mcp__qixin_insight__*` | `DEFAULT_SERVER_NAME = 'qixin_insight'` in `src/config.ts` |
  | automatic token refresh | `src/session.ts` `#scheduleRefresh` |
  | revocation on disconnect | RFC 7009, `src/oauth/token.ts` `revokeToken` |

  No tool count is claimed: the three control tools (`qixin_insight_mcp_connect` /
  `_status` / `_disconnect`) are ours, but how many `mcp__qixin_insight__*` tools
  appear comes from the server's `tools/list` and is not something this repo can assert.

  Tests: 185 passing — real HTTP against an in-process mock authorization server and
  a real loopback listener, so discovery, PKCE, dynamic registration, code exchange,
  rotation and revocation actually execute rather than being asserted against stubs.