### PR TITLE
Add dsh-windows-native

### DIFF
--- a/data/plugins/lucifergzsz414__dsh-windows-native.yml
+++ b/data/plugins/lucifergzsz414__dsh-windows-native.yml
@@ -1,0 +1,5 @@
+url: https://github.com/lucifergzsz414/dsh-windows-native
+name: lucifergzsz414/dsh-windows-native
+category: wsl
+description:
+  en: Injects native-Windows (non-WSL) PowerShell, encoding, filesystem, and cross-platform-build gotchas into the system prompt.


### PR DESCRIPTION
Adds `dsh-windows-native` — injects native-Windows (non-WSL) shell/encoding/filesystem/cross-platform-build gotchas into the DeepSeek Harness system prompt.

The existing WSL & Windows Interop entries all assume `dsh` is running *inside* WSL and bridging out to Windows. This covers the opposite case: running `dsh` directly on Windows with PowerShell, no WSL involved.

Repo: https://github.com/lucifergzsz414/dsh-windows-native
- `dsh.bundle` manifest present (`cordis.patch.yml`), installable via `dsh plugin add`
- Tested end-to-end against a real local `dsh` instance (installed via a local `file:` dependency, confirmed in `dsh --dump-config`, confirmed the injected text reaches an actual chat response)
- CI runs the test suite on Node 18/20/22
- `dsh-plugin` topic added

Category picked: `wsl` (closest fit — no better-suited category exists yet for "native Windows, not WSL").