### PR TITLE
Add KongFangXun/sofagent to security category

### DIFF
--- a/data/plugins/KongFangXun__sofagent--engine-dsh-plugins-cordis-plugin-sofagent-audit.yml
+++ b/data/plugins/KongFangXun__sofagent--engine-dsh-plugins-cordis-plugin-sofagent-audit.yml
@@ -1,0 +1,6 @@
+url: https://github.com/KongFangXun/sofagent/tree/main/engine/dsh-plugins/cordis-plugin-sofagent-audit
+name: KongFangXun/sofagent#cordis-plugin-sofagent-audit
+category: security
+description:
+  en: "Commit-time audit harness for AI coding agents: 24 git-diff rules (secrets, out-of-scope edits, prompt injection), HMAC-signed audit trail, snapshot rollback, and an MCP server with 79 tools. Installable via dsh plugin add."
+  zh: "面向 AI 编程 agent 的提交时审计 harness——24 条 git diff 规则（密钥泄漏、越界改动、提示注入）、HMAC 签名审计链、快照回滚、79 工具 MCP server；dsh plugin add 即装。"

--- a/data/plugins/KongFangXun__sofagent.yml
+++ b/data/plugins/KongFangXun__sofagent.yml
@@ -1,0 +1,1 @@
+@/tmp/adp-plugin.yml

--- a/data/plugins/KongFangXun__sofagent.yml
+++ b/data/plugins/KongFangXun__sofagent.yml
@@ -1,1 +1,6 @@
-@/tmp/adp-plugin.yml
+url: https://github.com/KongFangXun/sofagent
+name: KongFangXun/sofagent
+category: security
+description:
+  en: 'Commit-time audit harness for AI coding agents: 24 git-diff rules (secrets, out-of-scope edits, prompt injection), HMAC-signed audit trail, snapshot rollback, and an MCP server with 79 tools. Ships as 9 Cordis plugins installable via dsh plugin add.'
+  zh: '面向 AI 编程 agent 的提交时审计 harness——24 条 git diff 规则（密钥泄漏、越界改动、提示注入）、HMAC 签名审计链、快照回滚、79 工具 MCP server；以 9 个 Cordis 插件形态发布，dsh plugin add 即装。'

--- a/data/plugins/KongFangXun__sofagent.yml
+++ b/data/plugins/KongFangXun__sofagent.yml
@@ -1,6 +1,0 @@
-url: https://github.com/KongFangXun/sofagent
-name: KongFangXun/sofagent
-category: security
-description:
-  en: 'Commit-time audit harness for AI coding agents: 24 git-diff rules (secrets, out-of-scope edits, prompt injection), HMAC-signed audit trail, snapshot rollback, and an MCP server with 79 tools. Ships as 9 Cordis plugins installable via dsh plugin add.'
-  zh: '面向 AI 编程 agent 的提交时审计 harness——24 条 git diff 规则（密钥泄漏、越界改动、提示注入）、HMAC 签名审计链、快照回滚、79 工具 MCP server；以 9 个 Cordis 插件形态发布，dsh plugin add 即装。'


### PR DESCRIPTION
Adds [KongFangXun/sofagent](https://github.com/KongFangXun/sofagent) as `data/plugins/KongFangXun__sofagent--engine-dsh-plugins-cordis-plugin-sofagent-audit.yml` (category: `security`).

**Disclosure: this is a self-submission.** I am the author and maintainer of sofagent.

sofagent is a commit-time audit harness for AI coding agents: 24 git-diff rules (secrets, out-of-scope edits, prompt injection), HMAC-signed tamper-evident audit trail, snapshot rollback, and an MCP server with 79 tools. It ships as **9 Cordis plugins** (cordis-plugin-sofagent-audit/gate/inject/rollback/...) that bring these guardrails into DeepSeek Harness — each declares a `dsh.bundle` manifest in its package.json and installs with `dsh plugin add`.

Requirements check:
- `dsh.bundle` manifest: declared in all 9 plugin packages (engine/dsh-plugins/)
- Real working code, not a placeholder: 2903 tests passing on the main repo
- Repo age ≥ 1 day and ≥ 10 commits: yes (created June 2026, 100+ commits)
- `dsh-plugin` topic: just added to the repo topics
- Descriptions are factual, no marketing

Related listings: [0xsline/awesome-deepseek-harness #547](https://github.com/0xsline/awesome-deepseek-harness/pull/547), [Anil-matcha/awesome-dsh-plugin #122](https://github.com/Anil-matcha/awesome-dsh-plugin/pull/122), [beancookie/awesome-dsh-plugin #137](https://github.com/beancookie/awesome-dsh-plugin/pull/137), [Alex-Yanggg/awesome-DSH-plugin #108](https://github.com/Alex-Yanggg/awesome-DSH-plugin/pull/108).

One entry file added: `data/plugins/KongFangXun__sofagent--engine-dsh-plugins-cordis-plugin-sofagent-audit.yml` (monorepo subpackage slug per contributing guide — url points at the cordis-plugin-sofagent-audit subpackage that declares the dsh.bundle manifest) (READMEs regenerate on merge per contributing guide).
