### PR TITLE
Use npm package for dsh-voco installation

### DIFF
--- a/data/plugins/lgquan__dsh-voco.yml
+++ b/data/plugins/lgquan__dsh-voco.yml
@@ -1,7 +1,7 @@
 url: https://github.com/lgquan/dsh-voco
 name: lgquan/dsh-voco
+npm: '@flowingspring/dsh-voco'
 category: voice
 description:
   en: Continuous voice conversations for DSH with hands-free listening, push-to-talk, speech recognition, TTS replies, and background Agent delegation.
   zh: 为 DSH 提供持续语音对话，支持免提监听、按住说话、语音识别、TTS 语音回复和后台 Agent 任务委派。
-tarball: https://github.com/lgquan/dsh-voco/releases/download/v0.3.8/flowingspring-dsh-voco-0.3.8.tgz

--- a/data/plugins/lgquan__dsh-voco.yml
+++ b/data/plugins/lgquan__dsh-voco.yml
@@ -1,6 +1,5 @@
 url: https://github.com/lgquan/dsh-voco
 name: lgquan/dsh-voco
-npm: '@flowingspring/dsh-voco'
 category: voice
 description:
   en: Continuous voice conversations for DSH with hands-free listening, push-to-talk, speech recognition, TTS replies, and background Agent delegation.


### PR DESCRIPTION
Update the dsh-voco market entry to use the published npm package.

Changes:
- Keep the GitHub repository homepage as the listing URL.
- Add npm package: @flowingspring/dsh-voco.
- Remove the fixed v0.3.8 GitHub tarball fallback so future releases are installed from npm.

This changes only data/plugins/lgquan__dsh-voco.yml.