### PR TITLE
Add gzhflow (Andiii208/gzhflow) — six-stage WeChat OA publishing workflow

### DIFF
--- a/data/plugins/Andiii208__gzhflow.yml
+++ b/data/plugins/Andiii208__gzhflow.yml
@@ -1,0 +1,6 @@
+url: https://github.com/Andiii208/gzhflow
+name: Andiii208/gzhflow
+category: workflow
+description:
+  en: Six-stage WeChat Official Account content-publishing workflow with quality-gate tools and a bundled skill.
+  zh: 六阶段公众号内容发布工作流，带质检门工具与配套 skill。


### PR DESCRIPTION
Adds gzhflow to the **Workflow & Automation** category.

- **Repo**: https://github.com/Andiii208/gzhflow
- **What it does**: a six-stage WeChat Official Account content-publishing workflow (material-first → writing → de-AI → illustration → layout → draft box). Packaged as a DSH plugin that registers seven `gzhflow_*` tools (six quality gates plus an env self-check) and ships the `gzhflow` skill as a bundled provider.
- **Manifest**: declares `dsh.bundle` in `package.json` (`patch: ./cordis.patch.yml`), so it installs via `dsh plugin add https://github.com/Andiii208/gzhflow`.
- **Category**: `workflow`.

Verified locally: `pnpm add https://github.com/Andiii208/gzhflow` installs cleanly and the `gzhflow/tools` and `gzhflow/skill` package exports resolve.
