### PR TITLE
ci(gate): name the extensionless-entry case instead of blaming the gate

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -251,7 +251,39 @@ jobs:
             // have examined some. If it examined none, the two disagree and we
             // do not know whether the submission is sound — say that instead of
             // vouching for checks that never ran.
+            //
+            // But one cause of that disagreement is knowable from here, and
+            // blaming the gate for it sends the contributor to re-run a
+            // workflow that will fail identically forever. The extract step
+            // collects every changed path under data/plugins/ regardless of
+            // name, while check-submission.mjs reads only *.yml — so an entry
+            // file committed without its extension is counted, never parsed,
+            // and lands in this branch. #1477 sat here for 13 days being told
+            // to re-run the workflow. Name the real problem instead.
             if (result.checked === 0) {
+              const changed = (() => {
+                try { return fs.readFileSync('/tmp/prdata/changed.txt', 'utf8').split('\n').map((s) => s.trim()).filter(Boolean) } catch { return [] }
+              })()
+              const nonYml = changed.filter((f) => !f.endsWith('.yml'))
+              if (changed.length && nonYml.length === changed.length) {
+                await post('failure', `${nonYml.length} entry file(s) missing the .yml extension`,
+                  [
+                    'Every file this PR adds under `data/plugins/` is missing its `.yml` extension:',
+                    '',
+                    ...nonYml.map((f) => `- \`data/plugins/${f}\` → should be \`data/plugins/${f}.yml\``),
+                    '',
+                    'Entries are read with a `*.yml` glob, so a file named without the extension is',
+                    'skipped in silence: it is never parsed, never listed, and never checked. Nothing',
+                    'is wrong with the plugin — this is a filename.',
+                    '',
+                    '```bash',
+                    ...nonYml.map((f) => `git mv "data/plugins/${f}" "data/plugins/${f}.yml"`),
+                    'git commit -m "add the .yml extension" && git push',
+                    '```',
+                  ].join('\n'))
+                core.setFailed(`entry file(s) without .yml: ${nonYml.join(', ')}`)
+                return
+              }
               await post('failure', 'The gate checked nothing',
                 'This PR adds entries under `data/plugins/`, but the submission checker examined none of them, so no verdict was reached. Re-run the workflow; if it persists this is a bug in the gate, not in the submission.')
               core.setFailed('gate examined no entries despite changed files')


### PR DESCRIPTION
`Submission gate` has a branch that fires when the extract step says a PR adds entries but `check-submission.mjs` examined none. It currently reports:

> The gate checked nothing … Re-run the workflow; if it persists this is a bug in the gate, not in the submission.

That is the right thing to say when the two genuinely disagree. But one cause of the disagreement is knowable right there, and for it that message is actively harmful: it sends the contributor to re-run a workflow that will fail identically, forever.

## The case

The extract step collects **every** changed path under `data/plugins/`, regardless of name:

```sh
git diff -z --name-only --diff-filter=AR "$BASE...pr-head" -- data/plugins
```

`check-submission.mjs` reads only `*.yml`. So an entry committed **without its extension** is counted by the first and never parsed by the second — `checked === 0`, and the gate blames itself.

[#1477](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/pull/1477) is exactly this: it adds `data/plugins/zmm863-commits__dsh-dice-game`, no `.yml`. It has been sitting for 13 days being told to re-run the workflow. I re-ran it today; it failed identically, which is what the message says indicates a gate bug. It is not a gate bug.

This is the same silent-skip failure `pr-check.yml` already guards ("Every entry file ends in .yml", added in #2495 — for `zmm863-commits__dsh-paperclip`, the same contributor). That guard did not catch #1477 because the PR predates it, and re-running a `pull_request` run replays the workflow file **as it was at the time**, so old PRs never pick up new guards. The gate, being `workflow_run`, always runs current code — so fixing it here reaches every stale PR immediately.

## The change

Before falling back to the generic message, read `/tmp/prdata/changed.txt` (already written by the extract step, `data/plugins/` prefix stripped). If it is non-empty and **every** entry lacks `.yml`, report that instead, with the exact `git mv`:

```
2 entry file(s) missing the .yml extension

- `data/plugins/foo__bar` → should be `data/plugins/foo__bar.yml`

git mv "data/plugins/foo__bar" "data/plugins/foo__bar.yml"
git commit -m "add the .yml extension" && git push
```

A mixed PR (some `.yml`, some not) falls through to the generic message on purpose — the checker would have examined the valid ones, so `checked === 0` would not fire.

## Verification

Logic run against the real shapes before opening this:

| changed.txt | expected | actual |
|---|---|---|
| `["zmm863-commits__dsh-dice-game"]` (#1477) | fires | fires, emits the correct `git mv` |
| `["someone__dsh-thing.yml"]` | falls through | falls through |
| `["a__b.yml","c__d"]` (mixed) | falls through | falls through |
| `[]` | falls through | falls through |

`pr-gate.yml` still parses as YAML (7 steps in the `gate` job).

## Note

`Repository config guard` will be red here — it flags any PR touching `.github/`, which is correct for contributor submissions and unavoidable for a CI change. Same as #3832, #3789, #3956.
