### PR TITLE
Add dsh-version-badge entry (mervin1944/dsh-version-badge)

### DIFF
--- a/data/plugins/mervin1944__dsh-version-badge.yml
+++ b/data/plugins/mervin1944__dsh-version-badge.yml
@@ -1,0 +1,6 @@
+url: https://github.com/mervin1944/dsh-version-badge
+name: mervin1944/dsh-version-badge
+category: ui
+description:
+  en: 'Version badge above the sidebar settings button: shows the current dsh version, expands to list every core package version, and checks npm for updates with one-click deploy.'
+  zh: '侧边栏设置按钮上方的版本徽标：常驻显示当前 dsh 版本，展开可查看全部核心包版本，并支持检查 npm 更新与一键部署。'


### PR DESCRIPTION
## Plugin

**mervin1944/dsh-version-badge** — a version badge above the sidebar settings button.

- Shows the current dsh version; expands to list every core package version.
- Checks npm for updates (60s cache); one-click deploy of a newer dsh.
- Theme-aware: uses DSH theme variables (light/dark), zero dependencies.
- Published on npm: dsh-version-badge@0.1.1.

Category: ui (UI enhancement, badge/widget in the sidebar).