### PR TITLE
docs: add duyanta123/dsh-refactor-insight

### DIFF
--- a/data/plugins/duyanta123__dsh-refactor-insight.yml
+++ b/data/plugins/duyanta123__dsh-refactor-insight.yml
@@ -1,0 +1,6 @@
+url: https://github.com/duyanta123/dsh-refactor-insight
+name: duyanta123/dsh-refactor-insight
+category: dev
+description:
+  en: 'Turn codebase smells into an executable, priority-ordered refactoring plan: file-length / deep-nesting / function-length / god-object heuristics plus a staged runbook (read-only, no auto-rewrite).'
+  zh: 重构入口诊断：把代码库坏味道（超长文件/深嵌套/超长函数/上帝对象）转成带定位、优先级与依赖顺序的重构计划（只读不自动改码）。


### PR DESCRIPTION
Adds `data/plugins/duyanta123__dsh-refactor-insight.yml`.

- Repo declares `dsh.bundle.patch: ./cordis.patch.yml` (config-tree `- insert:` format) — installable via `dsh plugin --profile web add github:duyanta123/dsh-refactor-insight`.
- Plugin entry registers skills via the official `@deepseek-ai/dsh-skill-filesystem` provider.
- Current release: v0.1.1 (tagged, CI green: ubuntu + windows × Node 18/22, 25 contract tests).