### PR TITLE
docs: add duyanta123/dsh-repo-scanner

### DIFF
--- a/data/plugins/duyanta123__dsh-repo-scanner.yml
+++ b/data/plugins/duyanta123__dsh-repo-scanner.yml
@@ -1,0 +1,6 @@
+url: https://github.com/duyanta123/dsh-repo-scanner
+name: duyanta123/dsh-repo-scanner
+category: dev
+description:
+  en: 'Read-only repository fact scanner kernel for DSH analysis plugins: deterministic probe / file index / modules / dependencies / entry points / symbols / graphs and git facts over a stable JSON schema (CLI + library + skill runbook).'
+  zh: 只读仓库事实扫描内核：为分析型插件提供可复现的仓库探测、文件索引、模块、依赖、入口、符号与 Git 变更等硬事实（CLI + 库接口 + 技能 runbook）。


### PR DESCRIPTION
Adds `data/plugins/duyanta123__dsh-repo-scanner.yml`.

- Repo declares `dsh.bundle.patch: ./cordis.patch.yml` (config-tree `- insert:` format), aligned with the current bundle contract (2026-09) — installable via `dsh plugin --profile web add github:duyanta123/dsh-repo-scanner`.
- Plugin entry registers the `repo-scanner-runbook` skill via the official `@deepseek-ai/dsh-skill-filesystem` provider; scanning kernel exposed as a library at `dsh-repo-scanner/scanner`.
- Read-only safety red lines (no writes, no subprocess, no network) enforced by an executable security-audit test suite.
- Current release: v0.1.0 (tagged, CI green: ubuntu + windows × Node 18/20/22, 33 tests incl. security audit).