### PR TITLE
Add chrisx9z/dsh-chat-share (chat segment share as Markdown/HTML/TXT)

### DIFF
--- a/data/plugins/chrisx9z__dsh-chat-share.yml
+++ b/data/plugins/chrisx9z__dsh-chat-share.yml
@@ -1,0 +1,6 @@
+url: https://github.com/chrisx9z/dsh-chat-share
+name: chrisx9z/dsh-chat-share
+category: session
+description:
+  en: Share a selected chat segment as Markdown, HTML, or plain text; Header button, sidebar ... menu, and /share command.
+  zh: 将选中的聊天片段分享为 Markdown、HTML 或纯文本；支持 Header 按钮、侧边栏 ... 菜单与 /share 命令。


### PR DESCRIPTION
## Add chrisx9z/dsh-chat-share (latest: v1.3.0)

Share a selected range of chat messages as Markdown, HTML, TXT, or a long PNG — a community plugin for DeepSeek Harness.

**Features (v1.3.0):**
- Web `/share` slash command: `/share`, `/share txt`, `/share last <n>`
- Header Share button + sidebar session `...` menu rows (Share, Save TXT) via ui-workspace's `sessionRowMenu` registry
- Range-selection dialog with GFM rendered preview; multi-select mode merges chosen rows
- GFM-lite HTML export with session images embedded as data URIs; PNG export rasterizes the artifact
- Best-effort redaction (credential shapes + local absolute/home paths, default on); opt-in bounded tool-call rows; opt-in subagent descendant conversations
- Artifact headers carry session title + last model route and follow the UI locale
- Host-side auto-save on turn/end (`autoSaveDir` config)
- Reads history/images/subagents through existing RPCs (`session.history`, `session.attachment`, `subagents.list/history`) — no Host endpoint, zero model tokens

Ships prebuilt host + browser halves and a GitHub Release tarball; MIT. Reference implementation lives in the deepseek-harness repository as `packages/session-query/session-chat-share` (branch `feat/session-chat-share` on the upstream fork).

Category `session` follows the dsh-local-share precedent (chat export tooling).
