### PR TITLE
add NattoCB/dsh-plugin-sidebar-views

### DIFF
--- a/data/plugins/NattoCB__dsh-plugin-sidebar-views.yml
+++ b/data/plugins/NattoCB__dsh-plugin-sidebar-views.yml
@@ -1,0 +1,6 @@
+url: https://github.com/NattoCB/dsh-plugin-sidebar-views
+name: NattoCB/dsh-plugin-sidebar-views
+category: ui
+description:
+  en: Adds a Workspaces / Recent-sessions switcher above the sidebar list, with a pinned-sessions group, a per-row menu (pin/unpin, copy session id), title filtering, and browser-local pin storage with a one-shot migration from dsh-plugin-pin-session.
+  zh: 在侧栏列表上方加「工作区 / 最新会话」切换条，含固定会话分组、行级菜单（固定/取消固定、复制 Session ID）、标题过滤；pin 存于浏览器 localStorage，并对 dsh-plugin-pin-session 做一次性迁移与过渡双写。


### PR DESCRIPTION
Adds [NattoCB/dsh-plugin-sidebar-views](https://github.com/NattoCB/dsh-plugin-sidebar-views), a client-side sidebar enhancement: Workspaces / Recent-sessions view switcher, pinned-sessions group, per-row menu with pin/unpin and copy-session-id, title filter. Client-only ModuleLoader bundle; browser-local pin storage (localStorage) with one-shot migration and dual-writes for the legacy dsh-plugin-pin-session API. Repo meets the gates: declares dsh.bundle, 10 commits, dsh-plugin topic, yml generated per schema (category: ui). Verified locally with scripts/check-submission.mjs (only the 1-day age gate remained, which this PR now clears).