### PR TITLE
add dsh-expert-market (market category)

### DIFF
--- a/data/plugins/yangyizhu8__dsh-expert-market.yml
+++ b/data/plugins/yangyizhu8__dsh-expert-market.yml
@@ -1,0 +1,7 @@
+url: https://github.com/yangyizhu8/dsh-expert-market
+name: yangyizhu8/dsh-expert-market
+category: market
+tarball: https://github.com/yangyizhu8/dsh-expert-market/releases/download/v1.0.0/dsh-expert-market-1.0.0.tgz
+description:
+  en: "Expert market for DeepSeek Harness: WorkBuddy expert/expert-team system ported onto native agent presets, 425-expert catalog installed on demand, capability subtraction, and team delegation tools."
+  zh: "DeepSeek Harness 专家市场：WorkBuddy 专家/专家团体系原生 agent preset 移植，425 个官方专家目录按需安装，内置能力减法声明、开场白与团队委派工具。"


### PR DESCRIPTION
Add dsh-expert-market to the market category: a WorkBuddy expert/expert-team system ported onto native dsh agent presets, 425-expert catalog install-on-demand, capability subtraction, team delegation tools. Installs via `dsh plugin --profile web add dsh-expert-market`. Release v1.0.0 with tarball attached. Verifiable per the review checklist: installs with dsh plugin add, description one-liner, right category, maintained.