### PR TITLE
Add ash-qw/dsh-theme-prts

### DIFF
--- a/data/plugins/ash-qw__dsh-theme-prts.yml
+++ b/data/plugins/ash-qw__dsh-theme-prts.yml
@@ -1,0 +1,6 @@
+url: https://github.com/ash-qw/dsh-theme-prts
+name: ash-qw/dsh-theme-prts
+category: theme
+description:
+  en: An unofficial Arknights P.R.T.S.-inspired interface theme for DSH Web with appearance presets, accessibility controls, and conversation navigation.
+  zh: 面向 DSH Web 的非官方明日方舟 P.R.T.S. 风格界面主题，提供外观预设、辅助功能与会话导航。


### PR DESCRIPTION
## Summary

- Add `ash-qw/dsh-theme-prts` under the `theme` category.
- Describe its P.R.T.S.-inspired DSH Web interface, appearance presets, accessibility controls, and conversation navigation.
- The plugin is publicly available on npm as `@ash-qw/dsh-theme-prts`.

## Checklist

- [x] Added one file under `data/plugins/`; generated READMEs are intentionally left for the post-merge sync workflow.
- [x] Root `package.json` declares `dsh.bundle`.
- [x] Repository is more than one day old and has 15 commits.
- [x] Repository has the `dsh-plugin` topic.
- [x] Description is factual and uses the `theme` category.
- [x] Ran the README generator, `awesome-lint`, and the site build locally.
