### PR TITLE
feat(catalog): add xiaoshi7915/dsh-kb-manager (tools)

### DIFF
--- a/data/plugins/xiaoshi7915__dsh-kb-manager.yml
+++ b/data/plugins/xiaoshi7915__dsh-kb-manager.yml
@@ -2,5 +2,5 @@ url: https://github.com/xiaoshi7915/dsh-kb-manager
 name: xiaoshi7915/dsh-kb-manager
 category: tools
 description:
-  en: 'Local knowledge base manager for DSH agents: multi-format import, CJK-aware chunking, sqlite-vec vector index and BM25 + vector hybrid search, exposed as 13 agent tools plus a settings page.'
-  zh: 本地知识库管理：多格式导入、CJK 感知分块、sqlite-vec 向量索引与 BM25+向量混合检索，提供 13 个 agent 工具与设置页。
+  en: 'Local knowledge base manager for DSH agents: multi-format import, CJK-aware chunking, sqlite-vec vector + BM25 hybrid search with bge-reranker-base rerank, snapshots, kbpack export/import and cross-KB search — 22 agent tools plus a Web panel.'
+  zh: 本地知识库管理：多格式导入、CJK 感知分块、sqlite-vec 向量 + BM25 混合检索与 bge-reranker-base 重排序、快照恢复、kbpack 导入导出与跨库检索，提供 22 个 agent 工具与 Web 面板。


### PR DESCRIPTION
## Summary

- add `xiaoshi7915/dsh-kb-manager` to the tools category
- regenerate the English and Chinese plugin lists

## Plugin

Local knowledge base manager for DSH agents: multi-format import, CJK-aware chunking, sqlite-vec vector + BM25 hybrid search with bge-reranker-base rerank, snapshots, kbpack export/import and cross-KB search — 22 agent tools plus a Web panel.

## Validation

- repository has the `dsh-plugin` topic
- package description updated to v0.0.2 capabilities
- YAML entry matches `data/plugins/<owner>__<repo>.yml` convention
