### PR TITLE
add Physicolor/dsh-lifeline

### DIFF
--- a/data/plugins/Physicolor__dsh-lifeline.yml
+++ b/data/plugins/Physicolor__dsh-lifeline.yml
@@ -1,0 +1,6 @@
+url: https://github.com/Physicolor/dsh-lifeline
+name: Physicolor/dsh-lifeline
+category: navigation
+description:
+  en: 'Right-side message navigation rail for DeepSeek Harness: per-message tick marks, hover-to-expand preview drawer, smooth jump to any historical message, star bookmarks, realtime slide animation with interrupt support, full session index with virtualization, dynamic panel avoidance, official --dsw-* token styling.'
+  zh: DeepSeek Harness 右侧消息导航轨道：逐条消息刻度、悬浮预览抽屉、平滑跳转、星标回看、实时平移动画（可打断）、完整会话索引与虚拟化、面板动态避让、官方 --dsw-* token 样式。

--- a/data/plugins/Physicolor__dsh-lifeline.yml
+++ b/data/plugins/Physicolor__dsh-lifeline.yml
@@ -1,6 +1,6 @@
 url: https://github.com/Physicolor/dsh-lifeline
 name: Physicolor/dsh-lifeline
-category: navigation
+category: ui
 description:
   en: 'Right-side message navigation rail for DeepSeek Harness: per-message tick marks, hover-to-expand preview drawer, smooth jump to any historical message, star bookmarks, realtime slide animation with interrupt support, full session index with virtualization, dynamic panel avoidance, official --dsw-* token styling.'
   zh: DeepSeek Harness 右侧消息导航轨道：逐条消息刻度、悬浮预览抽屉、平滑跳转、星标回看、实时平移动画（可打断）、完整会话索引与虚拟化、面板动态避让、官方 --dsw-* token 样式。


### PR DESCRIPTION
Add dsh-lifeline (right-side message navigation rail for DeepSeek Harness) to the plugin registry.

- GitHub: https://github.com/Physicolor/dsh-lifeline
- npm: https://www.npmjs.com/package/dsh-lifeline
- Category: navigation