### PR TITLE
Add dsh-capyreporter (CapyReporter) to the list

### DIFF
--- a/data/plugins/linkbag__dsh-capyreporter.yml
+++ b/data/plugins/linkbag__dsh-capyreporter.yml
@@ -1,0 +1,6 @@
+url: https://github.com/linkbag/dsh-capyreporter
+name: linkbag/dsh-capyreporter
+category: ui
+description:
+  en: 'Always-on-top capybara task reporter for DSH Web — a transparent floating pet that narrates each trajectory step in a speech bubble, names the project it reports for, and alerts you when a task completes while you work elsewhere.'
+  zh: '为 DSH Web 打造的永远置顶的水豚任务播报宠物——透明悬浮气泡逐条播报运行轨迹、标明所属项目，任务完成时提醒正在别处忙碌的你。'


### PR DESCRIPTION
## Submission

Adding one entry: \data/plugins/linkbag__dsh-capyreporter.yml\ (readme docs are generated; this PR touches no other entry and no README).

**dsh-capyreporter** - Always-on-top capybara task reporter for the DeepSeek Harness Web UI.

- Transparent always-on-top floating window (Electron) with an in-page fallback; click-through except on the pet.
- Narrates each trajectory step (tool calls, writing, steering, workflow phases, errors/retries) in a speech bubble; single click expands the scrollable step log, double-click dismisses, right-click restores.
- Project-aware headers: the bubble names the workspace the run belongs to.
- Completion alert stays visible while you work elsewhere; clicking the pet returns to DSH.
- Replaceable pet art (upload any transparent PNG), wheel-resize, settings page, persistent preferences.
- Bilingual README (EN / ??). Declares \dsh.bundle\ + \dsh.client\.

Repo: https://github.com/linkbag/dsh-capyreporter