### PR TITLE
Add Heeweelee/dsh-session-plugin

### DIFF
--- a/data/plugins/Heeweelee__dsh-session-plugin.yml
+++ b/data/plugins/Heeweelee__dsh-session-plugin.yml
@@ -1,0 +1,6 @@
+url: https://github.com/Heeweelee/dsh-session-plugin
+name: Heeweelee/dsh-session-plugin
+category: session
+description:
+  en: Recall previously sent messages in the input box with Up/Down, and archive a workspace session from its right-click menu.
+  zh: 在输入框内按 ↑/↓ 回填历史消息，并支持右键归档（隐藏）工作区会话。


### PR DESCRIPTION
Add Heeweelee/dsh-session-plugin

- [x] I added **one file** at `data/plugins/Heeweelee__dsh-session-plugin.yml` — the READMEs are generated, don't edit them by hand
- [ ] I ran `node scripts/generate-readme.mjs` and committed the regenerated READMEs — *not done: contributing.md states the one entry file is the whole submission and the READMEs are regenerated on `main` after merge*
- [x] My repo's `package.json` declares **`dsh.bundle`** — `"dsh": { "bundle": { "patch": "./cordis.patch.yml" } }`, with `cordis.patch.yml` present at the repo root (verified on `main`, not just locally)
- [x] My repo is at least **1 day old** with **10+ commits** — created 2026-08-21, 17 commits on `main`
- [x] `category` is `session`
- [x] Description states what the plugin does, no superlatives
- [x] My repo has the `dsh-plugin` topic

**Recommended items that also apply:**

- 📦 Published to npm as `@heeweelee/dsh-session-plugin`, so installs are prebuilt and skip the `allowBuilds` approval
- 🔗 Official `@deepseek-ai/*` packages are declared as `peerDependencies`, not `dependencies`
- No runtime npm dependencies and no `scripts` field, so nothing runs at install time

**What the plugin does**

- `↑`/`↓` in the input box recalls previously sent messages from the current session; `↓` past the last entry lands on an empty input. A `↑ 历史` button is added to the session header.
- Right-click a session in the workspace sidebar → "删除该会话…" archives it through the native `workspaceRegistry.archiveSession` (hidden from the list, files on disk untouched), behind a confirmation step.

Host registers three same-origin routes (`/api/dsh-session-plugin/history`, `/sessions`, `/archive`); the two reads are read-only, and `archive` requires a custom `x-dsh-csrf: 1` header plus an empty-or-same-origin `Origin`, so a cross-site simple POST is rejected with 403.
