### PR TITLE
Add Orbis remote DSH plugin

### DIFF
--- a/data/plugins/icodesign__orbis--packages-orbis-remote-dsh.yml
+++ b/data/plugins/icodesign__orbis--packages-orbis-remote-dsh.yml
@@ -2,5 +2,5 @@ url: https://github.com/icodesign/orbis/tree/main/packages/orbis-remote-dsh
 name: icodesign/orbis#orbis-remote-dsh
 category: remote
 description:
-  en: Encrypted device pairing for remote DeepSeek Harness access, with workspace browsing and real-time session updates.
-  zh: 为远程访问 DeepSeek Harness 提供加密设备配对、工作区浏览和会话实时更新。
+  en: Native iOS and Android apps for remote control of DeepSeek Harness, with end-to-end encryption, workspace browsing, and real-time session updates.
+  zh: 提供 DeepSeek Harness 远程控制功能的原生 iOS/Android 应用，支持端到端加密、工作区浏览和会话实时更新等。

--- a/data/plugins/icodesign__orbis--packages-orbis-remote-dsh.yml
+++ b/data/plugins/icodesign__orbis--packages-orbis-remote-dsh.yml
@@ -1,0 +1,6 @@
+url: https://github.com/icodesign/orbis/tree/main/packages/orbis-remote-dsh
+name: icodesign/orbis#orbis-remote-dsh
+category: remote
+description:
+  en: Encrypted device pairing for remote DeepSeek Harness access, with workspace browsing and real-time session updates.
+  zh: 为远程访问 DeepSeek Harness 提供加密设备配对、工作区浏览和会话实时更新。


### PR DESCRIPTION
## Summary

This PR adds [Orbis](https://github.com/icodesign/orbis), a native iOS and Android companion app for remotely controlling DeepSeek Harness (DSH), to the `remote` category.

The [`@orbisapp/remote-dsh`](https://github.com/icodesign/orbis/tree/main/packages/orbis-remote-dsh) plugin connects DSH Web with the Orbis app. Once a device is paired, it provides an end-to-end encrypted connection for browsing the configured workspace, viewing and interacting with DSH sessions, and receiving real-time session updates across devices. The plugin handles the host-side integration in DSH Web, while Orbis provides the mobile remote-control experience.

The entry points to the installable package at `packages/orbis-remote-dsh` and adds only the source plugin file; generated README files are intentionally omitted.

## Checks

- `node scripts/generate-readme.mjs --check`
- `npx --yes awesome-lint` (passes; existing spelling warnings only)
- `SKIP_PUBLISH_CHECKS=1 node scripts/build-site.mjs`
