### PR TITLE
Add dsh-pc-pilot

### DIFF
--- a/data/plugins/JeremyWangCY__dsh-pc-pilot.yml
+++ b/data/plugins/JeremyWangCY__dsh-pc-pilot.yml
@@ -1,0 +1,10 @@
+# awesome-dsh-plugin catalog entry (data/plugins/JeremyWangCY__dsh-pc-pilot.yml)
+# Listing requirements met: public repo, age > 1 day, >= 10 commits, package.json declares dsh.bundle.
+url: https://github.com/JeremyWangCY/PC-Pilot
+name: dsh-pc-pilot
+owner: JeremyWangCY
+category: tools
+description:
+  en: "Windows computer-use for DeepSeek Harness: one 'computer' tool combining a UIA accessibility tree, PrintWindow screenshots, background synthetic-cursor input (UIA patterns / window messages, never steals focus) and real SendInput, with a codex-style click-through on-screen cursor indicator (soft blue glow, auto-hides after the turn)."
+  zh: "适用于 DeepSeek Harness 的 Windows 电脑操作插件：单一 computer 工具整合 UIA 无障碍树、PrintWindow 截图、后台合成输入（UIA 模式/窗口消息，不抢焦点）与真实 SendInput，并带 codex 风格点击穿透屏幕光标指示器（柔和蓝光，回合结束自动隐藏）。"
+tarball: https://github.com/JeremyWangCY/PC-Pilot/releases/download/v0.1.0-beta.1/dsh-pc-pilot-0.1.0-beta.1.tgz

--- a/data/plugins/JeremyWangCY__dsh-pc-pilot.yml
+++ b/data/plugins/JeremyWangCY__dsh-pc-pilot.yml
@@ -1,10 +1,7 @@
-# awesome-dsh-plugin catalog entry (data/plugins/JeremyWangCY__dsh-pc-pilot.yml)
-# Listing requirements met: public repo, age > 1 day, >= 10 commits, package.json declares dsh.bundle.
-url: https://github.com/JeremyWangCY/PC-Pilot
-name: dsh-pc-pilot
-owner: JeremyWangCY
+url: https://github.com/JeremyWangCY/dsh-pc-pilot
+name: JeremyWangCY/dsh-pc-pilot
 category: tools
 description:
-  en: "Windows computer-use for DeepSeek Harness: one 'computer' tool combining a UIA accessibility tree, PrintWindow screenshots, background synthetic-cursor input (UIA patterns / window messages, never steals focus) and real SendInput, with a codex-style click-through on-screen cursor indicator (soft blue glow, auto-hides after the turn)."
-  zh: "适用于 DeepSeek Harness 的 Windows 电脑操作插件：单一 computer 工具整合 UIA 无障碍树、PrintWindow 截图、后台合成输入（UIA 模式/窗口消息，不抢焦点）与真实 SendInput，并带 codex 风格点击穿透屏幕光标指示器（柔和蓝光，回合结束自动隐藏）。"
-tarball: https://github.com/JeremyWangCY/PC-Pilot/releases/download/v0.1.0-beta.1/dsh-pc-pilot-0.1.0-beta.1.tgz
+  en: "Windows computer-use host plugin for DeepSeek Harness with UIA accessibility navigation, window screenshots, background-first synthetic input, and a virtual cursor overlay."
+  zh: "适用于 DeepSeek Harness 的 Windows 电脑控制宿主插件，整合 UIA 无障碍树、窗口截图、后台无感合成输入与屏幕虚拟光标指示器。"
+tarball: https://github.com/JeremyWangCY/dsh-pc-pilot/releases/download/v0.1.0-beta.1/dsh-pc-pilot-0.1.0-beta.1.tgz


### PR DESCRIPTION
## Add dsh-pc-pilot

**PC-Pilot (dsh-pc-pilot)** — a high-performance Windows computer-use host plugin for DeepSeek Harness.

### What it does
Registers a single computer tool with 16 actions:
list_apps, get_app_state, click_element, click, set_value, 	ype, key, hold_key, scroll, drag, mouse_down, mouse_up, ead_clipboard, write_clipboard, list_displays, open_app.

- **UIA Accessibility Tree**: Full indexed element hierarchy with roles, names, values, automation IDs, and bounding rectangles.
- **Window Screenshots**: Direct PrintWindow capture with dark-mode verification and automatic file pruning.
- **Background-First Synthetic Input**: UIA invoke/toggle/select patterns + window messages, never steals focus or hijacks user mouse.
- **Persistent JSONL Daemon**: ~130ms warm execution latency (85% reduction over cold spawn), zero third-party native binary dependencies.
- **Codex-Style On-Screen Cursor Indicator**: Win32 layered per-pixel-alpha window with blue glow and auto-fadeout.
- **Clipboard & Multi-Monitor**: Direct STA clipboard read/write and multi-monitor topology discovery.

### Install
`
pnpm add https://github.com/JeremyWangCY/dsh-pc-pilot/releases/download/v0.1.0-beta.1/dsh-pc-pilot-0.1.0-beta.1.tgz
`

### Checklist
- [x] Public repo: https://github.com/JeremyWangCY/dsh-pc-pilot
- [x] package.json declares dsh.bundle.patch (cordis.patch.yml present in the package)
- [x] Prebuilt GitHub Release tarball (matches this entry's owner/repo)
- [x] Category: tools

v0.1.0-beta.1 — MIT.
