### PR TITLE
Add Yeelight/dsh-yeelight-smart-home

### DIFF
--- a/data/plugins/Yeelight__dsh-yeelight-smart-home.yml
+++ b/data/plugins/Yeelight__dsh-yeelight-smart-home.yml
@@ -1,0 +1,6 @@
+url: https://github.com/Yeelight/dsh-yeelight-smart-home
+name: Yeelight/dsh-yeelight-smart-home
+category: tools
+description:
+  en: Control, organize, diagnose, design, personalize, and answer product knowledge questions for a Yeelight smart home, powered by the local yeelight-home runtime.
+  zh: 控制、组织、诊断、设计、个性化 Yeelight 智能家居，解答产品知识问题，由本地 yeelight-home 运行时驱动。


### PR DESCRIPTION
## Plugin submission

**Repo:** [Yeelight/dsh-yeelight-smart-home](https://github.com/Yeelight/dsh-yeelight-smart-home)

One entry: `data/plugins/Yeelight__dsh-yeelight-smart-home.yml` (category: `tools`).

### What it does

A DeepSeek Harness plugin for Yeelight Smart Home, powered by the local `yeelight-home` runtime:

- **Three model-facing tools** — `yeelight_home` (one-call Skill Runtime invocation), `yeelight_reference` (routing docs / asset catalogs / schemas), `yeelight_product_select` (offline product candidate selection).
- **In-memory skill** with the full adapted routing rule set.
- **Top-level settings section** — runtime status, configuration (region/locale selects), authentication, invoke logs, and one-click runtime install.

### Checklist

- [x] Declares `dsh.bundle` manifest in `package.json` (`./cordis.patch.yml`)
- [x] Repo age ≥ 1 day, commits ≥ 10 (19 commits)
- [x] `dsh-plugin` topic added
- [x] Description is factual (no marketing/superlatives)
- [x] Only `description.en` provided; `zh` translation included for maintainer convenience