### PR TITLE
Update entry for leogottadothebest: repo renamed to dsh-plugin-archived-conversations

### DIFF
--- a/data/plugins/leogottadothebest__dsh-plugin-archived-conversations.yml
+++ b/data/plugins/leogottadothebest__dsh-plugin-archived-conversations.yml
@@ -1,5 +1,5 @@
-url: https://github.com/leogottadothebest/DSH-Archived-Delete
-name: leogottadothebest/DSH-Archived-Delete
+url: https://github.com/leogottadothebest/dsh-plugin-archived-conversations
+name: leogottadothebest/dsh-plugin-archived-conversations
 category: session
 description:
   en: 'Manage archived conversations in the Settings UI: unarchive them back to the sidebar, or permanently delete them with confirmation.'


### PR DESCRIPTION
This PR updates the existing entry for the archived-conversations management plugin (originally listed in #4087) after its repository was renamed from `DSH-Archived-Delete` to `dsh-plugin-archived-conversations`.

Changes:
- Rename `data/plugins/leogottadothebest__DSH-Archived-Delete.yml` → `data/plugins/leogottadothebest__dsh-plugin-archived-conversations.yml` (file follows the `<owner>__<repo>.yml` convention)
- Update `url` and `name` to the renamed repository

The old URL 301-redirects to the new name, but the entry should match the repository's own `package.json` `repository` field (anti-impersonation check). Only this single existing entry is touched.