### PR TITLE
收录：xiagaogaozi/dsh-subagent-pool

### DIFF
--- a/data/plugins/xiagaogaozi__dsh-subagent-pool.yml
+++ b/data/plugins/xiagaogaozi__dsh-subagent-pool.yml
@@ -1,0 +1,6 @@
+url: https://github.com/xiagaogaozi/dsh-subagent-pool
+name: xiagaogaozi/dsh-subagent-pool
+category: workflow
+description:
+  en: 'Maintains reusable named subagent profiles for DeepSeek Harness and runs them with per-profile model, reasoning effort, and agent-preset settings.'
+  zh: '为 DeepSeek Harness 维护可复用的命名子代理配置，并按配置的模型、推理强度和 Agent 预设运行子代理。'


### PR DESCRIPTION
## 变更

按贡献指南新增 `data/plugins/xiagaogaozi__dsh-subagent-pool.yml`，收录我的 DeepSeek Harness 命名子代理池插件。

- 插件仓库：`https://github.com/xiagaogaozi/dsh-subagent-pool`
- 分类：`workflow`
- 已声明可安装的 `dsh.bundle` manifest
- 当前仓库包含真实可用代码，并已完成 DSH alpha.4 兼容修复
- 仅新增一个插件条目文件，未修改生成的 README 或其他插件条目