### PR TITLE
Add MarchLiu/dsh-farm (dev)

### DIFF
--- a/data/plugins/MarchLiu__dsh-farm.yml
+++ b/data/plugins/MarchLiu__dsh-farm.yml
@@ -1,0 +1,6 @@
+url: https://github.com/MarchLiu/dsh-farm
+name: MarchLiu/dsh-farm
+category: dev
+description:
+  en: 'Service farm for DSH: register, start, stop and restart long-running project services, with agent tools (farm_status/start/stop/restart/logs/register), farm.yaml declarations and an overview drawer UI with live log follow, search and export.'
+  zh: 'DSH 服务农场：注册、启动、停止、重启长驻项目服务，提供 agent 工具（farm_status/start/stop/restart/logs/register）与 farm.yaml 声明式服务，总览抽屉支持按工作区分组、实时日志 follow、搜索与导出。'


### PR DESCRIPTION
## Submission

- **Plugin**: [MarchLiu/dsh-farm](https://github.com/MarchLiu/dsh-farm) — also on npm as `dsh-farm`
- **Category**: dev
- **dsh.bundle**: declared in `package.json` (`dsh.bundle.patch: ./cordis.patch.yml`), dual-face (`dsh.client` browser half included)
- **Install**: `dsh plugin --profile web add github:MarchLiu/dsh-farm` or `dsh plugin add dsh-farm`
- **What it does**: process supervisor for long-running project services — spawn/stop/restart with auto-restart backoff, ring-buffer + on-disk logs, SSE live follow; agent tools (farm_status/start/stop/restart/logs/register); per-workspace farm.yaml declarations; browser half adds a sidebar footer button with a running-services badge and a shell.overlay overview drawer (workspace groups, lifecycle buttons, log follow/search/export).

Data file: `data/plugins/MarchLiu__dsh-farm.yml` only, READMEs untouched.