### PR TITLE
Add dsh-dev-git-graph (Git & Code Review)

### DIFF
--- a/data/plugins/kp-z__dsh-dev-git-graph--packages-dsh-dev-git-graph.yml
+++ b/data/plugins/kp-z__dsh-dev-git-graph--packages-dsh-dev-git-graph.yml
@@ -1,5 +1,5 @@
-url: https://github.com/kp-z/dsh-dev-git-graph
-name: kp-z/dsh-dev-git-graph
+url: https://github.com/kp-z/dsh-dev-git-graph/tree/main/packages/dsh-dev-git-graph
+name: kp-z/dsh-dev-git-graph#dsh-dev-git-graph
 category: git
 description:
   en: "A Git Graph tab for DSH Web: a faithful port of vscode-git-graph 1.30.0 that registers a native tab in the dsh-better-sidebar right rail (prerequisite), auto-binds to the session workspace, runs the full git operations (checkout/merge/rebase/push/tag/stash) directly on the host, and opens file diffs in the built-in DiffTab."

--- a/data/plugins/kp-z__dsh-dev-git-graph.yml
+++ b/data/plugins/kp-z__dsh-dev-git-graph.yml
@@ -1,0 +1,6 @@
+url: https://github.com/kp-z/dsh-dev-git-graph
+name: kp-z/dsh-dev-git-graph
+category: git
+description:
+  en: "A Git Graph tab for DSH Web: a faithful port of vscode-git-graph 1.30.0 that registers a native tab in the dsh-better-sidebar right rail (prerequisite), auto-binds to the session workspace, runs the full git operations (checkout/merge/rebase/push/tag/stash) directly on the host, and opens file diffs in the built-in DiffTab."
+  zh: DSH Web 的 vscode-git-graph 1.30.0 忠实移植：入驻 dsh-better-sidebar 右侧栏的原生 Git Graph 提交图 tab（前置依赖），自动绑定会话工作区，host 直跑全套 git 操作（checkout/merge/rebase/push/tag/stash），文件 diff 复用内置 DiffTab 打开。


### PR DESCRIPTION
## 插件信息

- **仓库**: https://github.com/kp-z/dsh-dev-git-graph
- **npm**: [`dsh-dev-git-graph@0.1.1`](https://www.npmjs.com/package/dsh-dev-git-graph)（已发布，`dsh plugin --profile web add dsh-dev-git-graph`）
- **分类**: Git & Code Review（按字母序插在 DamonKoy 之前）

## 简介

vscode-git-graph 1.30.0 的忠实移植：DSH Web 会话 Git Graph 面板，自动绑定会话工作区，支持 checkout / merge / rebase / push / tag / stash 全套 git 操作（host 直跑 git，数组参数无 shell 注入），明暗主题跟随 `--dsw-alias-*` token。装了 dsh-better-sidebar 自动注册原生侧边栏 tab，文件 diff 复用其 DiffTab 打开；未装回退右侧 overlay 面板。

合规：含 vendor/git-graph（© mhutchie, MIT）源码级移植，LICENSE 与 README 已做归属声明。