### PR TITLE
feat: add dsh-default-workspace

### DIFF
--- a/data/plugins/CDeZT__dsh-default-workspace.yml
+++ b/data/plugins/CDeZT__dsh-default-workspace.yml
@@ -1,0 +1,7 @@
+url: https://github.com/CDeZT/dsh-default-workspace
+name: CDeZT/dsh-default-workspace
+category: memory
+tarball: https://github.com/CDeZT/dsh-default-workspace/releases/download/v1.0.0/dsh-default-workspace-1.0.0.tgz
+description:
+  en: 'Creates a persistent DSH default workspace and exposes paged read-only access to plugins, skills, memory, sessions, storage, settings, credentials, and DSH_HOME files.'
+  zh: '创建持久化的 DSH 默认工作区，并提供对插件、skills、memory、会话、storage、settings、credentials 及 DSH_HOME 文件的分页只读访问。'


### PR DESCRIPTION
## Summary

- Add `CDeZT/dsh-default-workspace` to the `memory` plugin registry.
- Pin the installable tarball to the `v1.0.0` GitHub Release asset.

Plugin repository: https://github.com/CDeZT/dsh-default-workspace
Release: https://github.com/CDeZT/dsh-default-workspace/releases/tag/v1.0.0

The plugin declares the required `dsh.bundle` manifest and uses native DSH services for workspace registration and read-only discovery of plugins, skills, memory, sessions, storage, settings, credentials, and `DSH_HOME` files. The registry description is limited to behavior implemented by the plugin, and the tarball URL is pinned to a versioned GitHub Release asset.

Validation:

- The official submission checker reports no entry-specific failures; the only current gate is the repository-age requirement, which will clear after the repository is 24 hours old.
- The plugin test suite passes 11 tests.
- The GitHub Release asset is present and its SHA-256 was verified locally.
