### PR TITLE
Add frank-fan-818/dsh-f1-skin

### DIFF
--- a/data/plugins/frank-fan-818__dsh-f1-skin.yml
+++ b/data/plugins/frank-fan-818__dsh-f1-skin.yml
@@ -1,0 +1,6 @@
+url: https://github.com/frank-fan-818/dsh-f1-skin
+name: frank-fan-818/dsh-f1-skin
+category: theme
+description:
+  en: An F1 Race Control theme for DSH Web with four switchable team skins, broadcast-photo backgrounds, light and dark modes, and native appearance controls.
+  zh: 一款适用于 DSH Web 的 F1 赛事控制中心主题，提供四支车队皮肤、赛事摄影背景、浅色与深色模式及原生外观设置。


### PR DESCRIPTION
## Summary

- add `frank-fan-818/dsh-f1-skin` to the Themes & Appearance category
- describe its four switchable F1 team skins, photo backgrounds, appearance modes, and native controls
- link the published npm package automatically through its repository metadata

## Verification

- `node scripts/generate-readme.mjs --check`
- `SKIP_PUBLISH_CHECKS=1 node scripts/build-site.mjs`

The plugin repository declares `dsh.bundle`, has the `dsh-plugin` topic, and provides a repository-owned `screenshots.json` gallery.
