### PR TITLE
feat: add better-basicfun

### DIFF
--- a/data/plugins/CDeZT__better-basicfun.yml
+++ b/data/plugins/CDeZT__better-basicfun.yml
@@ -1,0 +1,6 @@
+url: https://github.com/CDeZT/better-basicfun
+name: CDeZT/better-basicfun
+category: memory
+description:
+  en: 'Native DSH foundation bundle that registers a persistent default workspace, provides paged read-only inspection of plugins, skills, memory, sessions, storage, settings, credentials, and DSH_HOME files, and synchronizes rich CLIProxyAPI model capabilities into native provider settings.'
+  zh: '原生 DSH 基础插件：注册持久化默认工作区，分页只读查看插件、skills、memory、会话、storage、settings、credentials 与 DSH_HOME 文件，并将 CLIProxyAPI 的模型能力同步到原生 Provider 设置。'


### PR DESCRIPTION
## Summary

- Add `CDeZT/better-basicfun` to the `memory` plugin registry.
- Describe the current `v1.3.0` host-only bundle: default Workspace registration, paged native resource inspection, and CLIProxyAPI catalog synchronization.

Repository: https://github.com/CDeZT/better-basicfun
Latest release: https://github.com/CDeZT/better-basicfun/releases/tag/v1.3.0

The repository declares the required root `dsh.bundle` manifest, contains working host-side code, and uses the native DSH services documented in its README. The current release is source-installable and has no release asset, so this entry intentionally omits `tarball` rather than pointing users at the older `v1.0.0` asset.

Validation:

- `npm test` passes all 19 tests.
- `npm pack --dry-run` passes and includes the bundle manifest and runtime files.
- The official submission checker reports no entry-specific issues; the only temporary gate is that the repository is not yet 24 hours old.
