### PR TITLE
docs: align dsh-minimal-ptc entry with dsh alpha.4

### DIFF
--- a/data/plugins/STARDUSTLC666__dsh-minimal-ptc.yml
+++ b/data/plugins/STARDUSTLC666__dsh-minimal-ptc.yml
@@ -2,5 +2,5 @@ url: https://github.com/STARDUSTLC666/dsh-minimal-ptc
 name: STARDUSTLC666/dsh-minimal-ptc
 category: workflow
 description:
-  en: 'Minimal prompt x full PTC tools: one-line persona, Code Mode SDK, subagents, workflows, web search, and Windows Git Bash.'
-  zh: 极简提示词 × PTC 全量工具：一句人格、Code Mode SDK、子代理、工作流、联网搜索与 Windows Git Bash。
+  en: 'Minimal prompt x Web PTC capabilities: one-line persona, run_code SDK, subagents, Ralph, web search/fetch, and Windows Git Bash; the general-purpose workflow tool stays hidden.'
+  zh: '极简提示词 × Web PTC 能力：一句人格、run_code SDK、子代理、Ralph、网页搜索/抓取与 Windows Git Bash；通用 workflow 工具保持隐藏。'


### PR DESCRIPTION
## Summary

- Updates the existing `STARDUSTLC666/dsh-minimal-ptc` entry for DSH `v0.1.2-alpha.4`.
- Replaces the outdated generic-workflow claim with the current Web PTC surface: `run_code`, subagents, Ralph, web search/fetch, and Windows Git Bash.
- Leaves the generated READMEs and all unrelated plugin entries untouched, as required by the current contribution guide.

## Verification

- `dsh-minimal-ptc` test suite: 11 passed, 1 platform-specific test skipped.
- Source-run DSH `v0.1.2-alpha.4` Web-profile smoke test returned authenticated HTTP 200.
- `data/plugins` validation completed with no errors.
- The plugin repository declares `dsh.bundle` and has the `dsh-plugin` topic.
