### PR TITLE
Add Shaw529/dsh-token-saver

### DIFF
--- a/data/plugins/Shaw529__dsh-token-saver.yml
+++ b/data/plugins/Shaw529__dsh-token-saver.yml
@@ -1,0 +1,6 @@
+url: https://github.com/Shaw529/dsh-token-saver
+name: Shaw529/dsh-token-saver
+category: usage
+description:
+  en: 'DeepSeek Harness plugin that aggressively saves tokens without affecting task quality: lossless head/tail truncation of tool results (default), grep-result folding, pressure-triggered dsh-compaction-basic delegation, and an LLM-summary CompactionEngine subclass for the aggressive mode. Saves 97.6% of input tokens on an 8-scenario synthetic suite, with all reductions routed through dsh event flow so model-visible = logged stays intact.'
+  zh: '为 DeepSeek Harness 设计的 token 节省插件：不损失任务效果。默认 conservative 档对工具结果做无损头尾裁剪与 grep 折叠；balanced 档在压力阈值委托 dsh-compaction-basic；aggressive 档以 LLM-summary 引擎子类化替换官方压缩。8 个合成场景累计节省 97.6% 输入 tokens，所有削减走 dsh 事件流，model-visible = logged 不变式仍成立。'


### PR DESCRIPTION
## Add Shaw529/dsh-token-saver

DeepSeek Harness plugin that saves tokens aggressively without affecting task quality.

### Why this plugin

Long-running dsh sessions waste the bulk of input tokens on two kinds of model-visible content:

1. **Tool results from `read` style tools** — a single 1 MB SQL migration consumes ~250 k tokens of prompt
2. **Grep-style search results** — every regex match plus surrounding context, even when the model only needed the file path

`dsh-token-saver` defaults to a `conservative` mode that does **lossless head-and-tail folding**: it keeps the head and tail of every large tool result verbatim, replaces the middle with a one-line metadata marker, and routes the change through `tools/post-execute` so the session log still contains the untruncated content for replay. For most tasks this is invisible to the model.

`balanced` mode additionally delegates to `ctx.compaction.compactIfNeeded` once token pressure crosses 50%. `aggressive` mode replaces the bundled `dsh-compaction-basic` with an `LlmSummaryCompactionEngine` subclass (the user supplies the LLM caller; on failure we fall back to the official path).

### Verification

- 63 vitest cases pass (`pnpm run test`)
- `pnpm run bench:compare` saves **97.6 % of input tokens** on an 8-scenario synthetic suite (3 827 751 → 90 729 tokens), no further-API-key cost
- `pnpm run smoke` exercises the full dsh event flow against a mock scope, validating listener dispatch + telemetry + the conservative-mode pass-through
- `BENCHMARK.md` ships a reproducible template for real dsh runs (two DSH home + 8 tasks + auto-parse + acceptance checklist)

### Compliance with the list rules

- ✅ `dsh.bundle` + `cordis.patch.yml` declared in `package.json` and at the repo root
- ✅ `dsh-plugin` GitHub topic already on the repo
- ✅ Description matches the code: truncation, grep fold, `agent/pre-step` delegation, `LlmSummaryCompactionEngine` subclass are all in source
- ✅ Official `@deepseek-ai/*` packages listed under `peerDependencies` (not `dependencies`)
- ✅ `data/plugins/Shaw529__dsh-token-saver.yml` follows the one-file-per-plugin convention

### Notes for the reviewer

- This is **not** a meta-package / bundle. `dsh-token-saver` is itself a single Cordis plugin with concrete behavior (`Tools/Pre-step/Compaction` listeners + system-prompt cache utility), not a list of pointers to other plugins.
- All reductions go through dsh events, never direct session mutation — the "model-visible = logged" invariant holds end-to-end.
- The LLM-summary engine is optional and fails closed. Without a user-supplied LLM caller it simply does nothing (warn-logged), so adoption is risk-free.
