### PR TITLE
Add dsh-notify-xc plugin entry (notify)

### DIFF
--- a/data/plugins/xchannel1987__dsh-notify-xc.yml
+++ b/data/plugins/xchannel1987__dsh-notify-xc.yml
@@ -1,0 +1,6 @@
+url: https://github.com/xchannel1987/dsh-notify-xc
+name: xchannel1987/dsh-notify-xc
+category: notify
+description:
+  en: 'System notifications for DeepSeek Harness: browser Notification API toasts when an agent finishes a task or needs your input, approval, or plan review; clicking a toast focuses the page and opens the owning session.'
+  zh: 'DeepSeek Harness 系统通知：agent 完成任务或需要你输入/批准/审阅计划时，通过浏览器 Notification API 弹出系统通知；点击气泡聚焦页面并打开对应会话。'


### PR DESCRIPTION
## 收录插件 / Plugin submission

- **插件 / Plugin**: [dsh-notify-xc](https://github.com/xchannel1987/dsh-notify-xc)
- **分类 / Category**: `notify`
- **npm 包 / npm package**: [dsh-notify-xc@0.1.0](https://www.npmjs.com/package/dsh-notify-xc)

DSH 浏览器系统通知插件（基于 dsh-agent-notify 针对新版 DSH 的兼容重写）：
agent 完成任务或需要你输入 / 批准 / 审阅计划时，通过浏览器 Notification API 弹出系统通知，点击气泡聚焦页面并打开对应会话。纯浏览器端插件，设置页在 设置 → 任务通知。

Browser notifications for DeepSeek Harness (compatibility rewrite of dsh-agent-notify for current DSH): system toasts via the browser Notification API when an agent finishes a task or needs your input, approval, or plan review — clicking a toast focuses the page and opens the owning session.

包已声明 `dsh.bundle` manifest 与 `cordis.patch.yml`，可通过 `dsh plugin add dsh-notify-xc` 安装。
