### PR TITLE
add: dsh-attach-picker (UI Enhancements)

### DIFF
--- a/data/plugins/qwerty-k-de__dsh-attach-picker.yml
+++ b/data/plugins/qwerty-k-de__dsh-attach-picker.yml
@@ -2,5 +2,5 @@ url: https://github.com/qwerty-k-de/dsh-attach-picker
 name: qwerty-k-de/dsh-attach-picker
 category: ui
 description:
-  en: 'Toolbar picture button in the DSH Web composer: click to pick multiple images through the native file dialog — they join the same draft-image rail as drag-and-drop and paste, with the host's image-format, per-message-count and per-image-size limits enforced inline.'
+  en: 'Toolbar picture button in the DSH Web composer: click to pick multiple images through the native file dialog — they join the same draft-image rail as drag-and-drop and paste, with the host image-format, per-message-count and per-image-size limits enforced inline.'
   zh: 'DSH Web 输入框工具栏图片按钮：点击调用系统文件选择器直接多选取图，进入与拖拽/粘贴相同的草稿图片栏，并内联校验宿主的图片格式、单条张数与单张大小限制。'

--- a/data/plugins/qwerty-k-de__dsh-attach-picker.yml
+++ b/data/plugins/qwerty-k-de__dsh-attach-picker.yml
@@ -1,0 +1,6 @@
+url: https://github.com/qwerty-k-de/dsh-attach-picker
+name: qwerty-k-de/dsh-attach-picker
+category: ui
+description:
+  en: 'Toolbar picture button in the DSH Web composer: click to pick multiple images through the native file dialog — they join the same draft-image rail as drag-and-drop and paste, with the host's image-format, per-message-count and per-image-size limits enforced inline.'
+  zh: 'DSH Web 输入框工具栏图片按钮：点击调用系统文件选择器直接多选取图，进入与拖拽/粘贴相同的草稿图片栏，并内联校验宿主的图片格式、单条张数与单张大小限制。'


### PR DESCRIPTION
Adds a picture button to the DSH Web composer toolbar: click to open the native OS file dialog and pick one or more images — they join the same draft-image rail as drag-and-drop/paste, with the host image-format/count/size limits enforced inline.

- Repository: https://github.com/qwerty-k-de/dsh-attach-picker (public, dsh-plugin topic, 15+ commits)
- Declares 'dsh.bundle' manifest (cordis.patch.yml) and ships browser UI via dsh.client
- Also published on npm as 'dsh-attach-picker@0.1.0' (faster install, no build step)
- Screenshots declared via screenshots.json (2 images)

中文:给 DSH Web 输入框工具栏加图片按钮,点一下打开系统文件选择器多选取图,进入与拖拽/粘贴相同的草稿图片栏,内联校验宿主限制。源码在 GitHub,同时发布为 npm 包 dsh-attach-picker。