### PR TITLE
Add que3sui/dsh-darwin（双插件自进化：会话日志挖掘 + 评测门技能合成）

### DIFF
--- a/data/plugins/que3sui__dsh-darwin--packages-forge.yml
+++ b/data/plugins/que3sui__dsh-darwin--packages-forge.yml
@@ -1,0 +1,6 @@
+url: https://github.com/que3sui/dsh-darwin/tree/main/packages/forge
+name: que3sui/dsh-darwin#forge
+category: workflow
+description:
+  en: 'Self-evolution actuator: consumes problem tickets mined from session logs, synthesizes skill candidates (zero-code tiers by default) behind an eval gate with hold-out canaries, then promotes to project .dsh/skills with human confirm and deterministic rollback.'
+  zh: '自进化执行器：消费会话日志挖掘出的问题工单，在评测门（hold-out canary 防作弊）下合成技能候选，人工确认晋级到项目 .dsh/skills 并支持确定性回滚。'

--- a/data/plugins/que3sui__dsh-darwin--packages-sentinel.yml
+++ b/data/plugins/que3sui__dsh-darwin--packages-sentinel.yml
@@ -1,0 +1,6 @@
+url: https://github.com/que3sui/dsh-darwin/tree/main/packages/sentinel
+name: que3sui/dsh-darwin#sentinel
+category: session
+description:
+  en: 'Session health-check: mechanically mines session logs into structured problem tickets (retry loops, tool-error clusters, interrupted turns, token waste) over the official session-query seam; works standalone.'
+  zh: '会话体检：基于官方 session-query 接缝，机械挖掘会话日志为结构化问题工单（重试环/工具错误簇/中断回合/Token 浪费）；可独立安装使用。'

--- a/data/plugins/que3sui__dsh-darwin.yml
+++ b/data/plugins/que3sui__dsh-darwin.yml
@@ -1,0 +1,6 @@
+url: https://github.com/que3sui/dsh-darwin
+name: que3sui/dsh-darwin
+category: workflow
+description:
+  en: 'Two-plugin self-evolution: mines session logs into problem tickets (retry loops, tool-error clusters, interruptions, token waste), then synthesizes skills behind an eval gate with deterministic rollback. Verified on DSH 0.1.1-rc.2.'
+  zh: '双插件自进化：从会话日志机械挖掘问题工单（重试环/工具错误簇/高频中断/Token 浪费），经评测门合成技能并支持确定性回滚。已在 DSH 0.1.1-rc.2 实测。'

--- a/data/plugins/que3sui__dsh-darwin.yml
+++ b/data/plugins/que3sui__dsh-darwin.yml
@@ -1,6 +1,0 @@
-url: https://github.com/que3sui/dsh-darwin
-name: que3sui/dsh-darwin
-category: workflow
-description:
-  en: 'Two-plugin self-evolution: mines session logs into problem tickets (retry loops, tool-error clusters, interruptions, token waste), then synthesizes skills behind an eval gate with deterministic rollback. Verified on DSH 0.1.1-rc.2.'
-  zh: '双插件自进化：从会话日志机械挖掘问题工单（重试环/工具错误簇/高频中断/Token 浪费），经评测门合成技能并支持确定性回滚。已在 DSH 0.1.1-rc.2 实测。'


### PR DESCRIPTION
按 contributing 流程提交一个 YAML 条目文件（未动生成的 README）。

**[dsh-darwin](https://github.com/que3sui/dsh-darwin)** 是一个双插件：sentinel 机械挖掘会话日志生成问题工单，forge 经评测门（回归套件 + hold-out canary）合成技能并支持确定性回滚；默认零代码执行两级 + 人工确认。

可核查性：实机验证记录（DSH 0.1.1-rc.2，Windows，六步全链路）见 [v0.1.1 release](https://github.com/que3sui/dsh-darwin/releases/tag/v0.1.1)；模拟实验 `pnpm lab` 可复现；bundle 清单齐全。

分类拿不准（workflow / session / skill 皆有交集），选了 workflow，望审核者定夺。感谢维护 🙏