### PR TITLE
Add hr98w/dsh-memory

### DIFF
--- a/data/plugins/hr98w__dsh-memory.yml
+++ b/data/plugins/hr98w__dsh-memory.yml
@@ -1,0 +1,6 @@
+url: https://github.com/hr98w/dsh-memory
+name: hr98w/dsh-memory
+category: memory
+description:
+  en: Claude Code-inspired Auto Memory meets Codex-inspired Session consolidation, bringing simple, transparent, and context-efficient long-term memory to DeepSeek Harness.
+  zh: 融合 Claude Code 的 Auto Memory 与 Codex 的 Session 记忆整理，为 DeepSeek Harness 提供简单、透明、上下文友好的长期记忆。


### PR DESCRIPTION
## Summary

- add `hr98w/dsh-memory` to the Memory category
- include English and Chinese descriptions

## Submission

This PR adds only `data/plugins/hr98w__dsh-memory.yml` as required by the contribution guide.