### PR TITLE
docs: add PerryLink/dsh-budget, dsh-click, dsh-draw

### DIFF
--- a/data/plugins/PerryLink__dsh-budget.yml
+++ b/data/plugins/PerryLink__dsh-budget.yml
@@ -1,0 +1,6 @@
+url: https://github.com/PerryLink/dsh-budget
+name: PerryLink/dsh-budget
+category: usage
+description:
+  en: 'Per-plugin usage budgets and cost caps on the llm/stream waterfall: per-model usage accounting, session and monthly budgets with warn/block transitions, latency windows, and a carbon-footprint estimate.'
+  zh: '在 llm/stream 瀑布上做按插件粒度的用量预算与费用上限：按模型用量记账、会话与月度预算的预警/阻断、延迟窗口与碳足迹估算。'

--- a/data/plugins/PerryLink__dsh-click.yml
+++ b/data/plugins/PerryLink__dsh-click.yml
@@ -1,0 +1,6 @@
+url: https://github.com/PerryLink/dsh-click
+name: PerryLink/dsh-click
+category: tools
+description:
+  en: 'Windows desktop computer-use tools (click, type, key, screenshot) with freshness checks, approval gating, process-identity verification around every action, and a sanitized audit trail.'
+  zh: 'Windows 桌面电脑操作工具（点击、输入、按键、截屏）：每次动作都带新鲜度校验、审批门、进程身份核验与脱敏审计。'

--- a/data/plugins/PerryLink__dsh-draw.yml
+++ b/data/plugins/PerryLink__dsh-draw.yml
@@ -1,0 +1,6 @@
+url: https://github.com/PerryLink/dsh-draw
+name: PerryLink/dsh-draw
+category: vision
+description:
+  en: 'Multi-engine text-to-image generation (OpenAI Images and Zhipu CogView presets) with per-session quota tracking, engine failover, credential-safe config, and a result card with regenerate.'
+  zh: '多引擎文生图（OpenAI Images 与智谱 CogView 预设）：按会话配额、引擎故障切换、凭证安全配置，结果卡片支持重新生成。'


### PR DESCRIPTION
Three new entries for the 0.1.2-alpha.5 release wave. Each repo declares a dsh.bundle manifest, ships a cordis.patch.yml, has the dsh-plugin topic, and publishes on npm (budget/click/draw). Descriptions are factual one-liners.