### PR TITLE
docs: add PerryLink/dsh-plugin-kit

### DIFF
--- a/data/plugins/PerryLink__dsh-plugin-kit.yml
+++ b/data/plugins/PerryLink__dsh-plugin-kit.yml
@@ -1,0 +1,6 @@
+url: https://github.com/PerryLink/dsh-plugin-kit
+name: PerryLink/dsh-plugin-kit
+category: dev
+description:
+  en: 'Meta package for plugin development and review: the PerryLink plugin quality checklist, review rules, and shared development resources for the dsh plugin family.'
+  zh: '插件开发与评审元包：PerryLink 插件质量清单、评审规则与 dsh 插件家族的共享开发资源。'


### PR DESCRIPTION
One new entry for the 0.1.2-alpha.5 release wave. dsh-plugin-kit declares a dsh.bundle manifest, has the dsh-plugin topic, and ships the PerryLink plugin quality checklist and review rules.