### PR TITLE
add leogottadothebest/dsh-settings-beautify (ui)

### DIFF
--- a/data/plugins/leogottadothebest__dsh-settings-beautify.yml
+++ b/data/plugins/leogottadothebest__dsh-settings-beautify.yml
@@ -1,0 +1,6 @@
+url: https://github.com/leogottadothebest/dsh-settings-beautify
+name: leogottadothebest/dsh-settings-beautify
+category: ui
+description:
+  en: 'Normalize the DSH settings UI onto one design language: unified typography, cards, controls, focus and motion across every settings page, including pages contributed by other plugins.'
+  zh: '将 DSH 设置界面归一为同一套设计语言：统一各设置页的排版、卡片、控件、焦点与动效，包括其他插件贡献的页面。'


### PR DESCRIPTION
## What

Adds one entry for [leogottadothebest/dsh-settings-beautify](https://github.com/leogottadothebest/dsh-settings-beautify), category `ui`.

dsh-settings-beautify normalizes every DSH settings page onto a single design language: unified typography (titles/explanations/descriptions), cards, controls, focus and motion — including pages contributed by other plugins, via an opt-in `data-dshb-scan` marker. Colors come from DSH's own `--dsw-*` tokens, so light/dark/system themes keep working; no settings page of its own is added (headless, preferences live in `localStorage`).

## Checklist

- [x] `dsh.bundle` declared in package.json (`bundle.patch: ./cordis.patch.yml`) with `cordis.patch.yml` at repo root
- [x] Published on npm as `dsh-settings-beautify` (v0.2.10)
- [x] Repo has the `dsh-plugin` topic
- [x] Repo created 2026-09-01, 18+ commits
- [x] Single entry file; READMEs left for the merge-time regeneration
