### PR TITLE
Add dsh-preview-plugin (ui) and dsh-pwa-plugin (dev)

### DIFF
--- a/data/plugins/RaulLazaro__dsh-preview-plugin.yml
+++ b/data/plugins/RaulLazaro__dsh-preview-plugin.yml
@@ -1,0 +1,5 @@
+url: https://github.com/RaulLazaro/dsh-preview-plugin
+name: RaulLazaro/dsh-preview-plugin
+category: ui
+description:
+  en: "Live preview tab for DSH — embed any dev server in an iframe with transparent SPA proxying."

--- a/data/plugins/RaulLazaro__dsh-pwa-plugin.yml
+++ b/data/plugins/RaulLazaro__dsh-pwa-plugin.yml
@@ -1,0 +1,5 @@
+url: https://github.com/RaulLazaro/dsh-pwa-plugin
+name: RaulLazaro/dsh-pwa-plugin
+category: dev
+description:
+  en: "PWA plugin for DSH — adds offline support, service worker caching, and install-as-app capability."


### PR DESCRIPTION
Adds two community plugins:

1. **dsh-preview-plugin** — Live preview tab for DSH: embed any dev server in an iframe with transparent SPA proxying, path-based routing, and per-session port management.

2. **dsh-pwa-plugin** — PWA plugin for DSH: adds offline support, service worker caching, install-as-app capability, and automatic silent updates.

Both plugins:
- Have MIT license
- Include README, cordis.patch.yml, and proper dsh.bundle manifest
- Pass the ≥10 commits and ≥1 day requirements
- Use the dsh-plugin topic on GitHub