### PR TITLE
feat: add huaweicloud/huaweicloud-devkit

### DIFF
--- a/data/plugins/huaweicloud__huaweicloud-devkit.yml
+++ b/data/plugins/huaweicloud__huaweicloud-devkit.yml
@@ -1,0 +1,6 @@
+url: https://github.com/huaweicloud/huaweicloud-devkit
+name: huaweicloud/huaweicloud-devkit
+category: dev
+description:
+  en: Huawei Cloud DevKit — MCP server, 30+ skills, safety hooks, and sandbox deployment for coding agents.
+  zh: 华为云开发工具包——MCP 服务器、30+ Agent Skills、安全护栏与沙箱部署，面向编程智能体。


### PR DESCRIPTION
Add Huawei Cloud DevKit — MCP server with 30+ skills, safety hooks, and sandbox deployment for coding agents.