### PR TITLE
新增收录 Fishquito7/dsh-skill-mcp-panel

### DIFF
--- a/data/plugins/Fishquito7__dsh-skill-mcp-panel.yml
+++ b/data/plugins/Fishquito7__dsh-skill-mcp-panel.yml
@@ -1,0 +1,7 @@
+url: https://github.com/Fishquito7/dsh-skill-mcp-panel
+name: Fishquito7/dsh-skill-mcp-panel
+category: dev
+tarball: https://github.com/Fishquito7/dsh-skill-mcp-panel/releases/download/v2.0.2/dsh-skill-mcp-panel-2.0.2.tgz
+description:
+  en: 'Manages DSH skills and MCP servers from the web settings: skill cards with hot enable/disable, workspace scopes, groups, batch migration and drag-and-drop import, plus stdio/HTTP MCP CRUD with connection tests, secret redaction and the unified dsh-panel CLI.'
+  zh: '在 DSH Web 设置中管理技能与 MCP 服务器：技能卡片热启停、工作区作用域、分组、批量迁移与拖拽导入，以及 stdio/HTTP MCP 增删改查、连接测试、密钥脱敏，并附带统一 dsh-panel 命令行。'


### PR DESCRIPTION
## 简介

新增收录 `Fishquito7/dsh-skill-mcp-panel` —— DSH Web 设置页插件，用于管理技能（卡片列表、热启停、工作区作用域、分组、批量迁移、拖拽导入）与 MCP 服务器（stdio/HTTP 增删改查、连接测试、密钥脱敏），并附带统一 `dsh-panel` 命令行。

## 收录检查

- [x] `package.json` 声明了 `dsh.bundle`，仓库包含 `cordis.patch.yml`
- [x] 仓库已添加 `dsh-plugin` topic
- [x] 仓库创建满 1 天且提交数 ≥ 10（2026-08-14 创建，86 commits）
- [x] 活跃维护（最新 release v2.0.2，2026-09-02）
- [x] 通过钉住 tag 的 `tarball:` 字段提供预构建 tarball
- [x] 仅新增一个条目文件：`data/plugins/Fishquito7__dsh-skill-mcp-panel.yml`

## 说明

- 本 PR 未手工修改 README，README 由合并后的 `sync-readme.yml` 重新生成。
- 描述只陈述功能，所有提到的能力（热启停、作用域、分组、迁移、拖拽导入、MCP CRUD、连接测试、脱敏、`dsh-panel` CLI）均可在仓库 README 与源码中核对。
