### PR TITLE
Add woosh2010/dsh-usage-dashboard (usage)

### DIFF
--- a/data/plugins/woosh2010__dsh-usage-dashboard.yml
+++ b/data/plugins/woosh2010__dsh-usage-dashboard.yml
@@ -1,0 +1,6 @@
+url: https://github.com/woosh2010/dsh-usage-dashboard
+name: woosh2010/dsh-usage-dashboard
+category: usage
+description:
+  en: 'DeepSeek Harness usage analytics dock on the composer: Beijing-time peak/valley pricing with all-day weekend valley rate, live balance, cross-session history, by-date drill-down and charts.'
+  zh: 'DSH 用量分析坞：输入框峰谷计费坞（周末全天谷时）、实时余额、跨会话历史、按日期下钻与图表。'


### PR DESCRIPTION
Add [woosh2010/dsh-usage-dashboard](https://github.com/woosh2010/dsh-usage-dashboard) — a usage analytics plugin for the DeepSeek Harness web composer dock.

What it does (matching the `usage` category):
- Peak/valley billing dock on the composer: Beijing-time peak (workdays 9:00–12:00 / 14:00–18:00) and valley (half price) periods with progress bar and countdown; weekends billed all-day at the valley rate with a "weekend valley" badge (DeepSeek rule effective 2026-08-23) and countdown to Monday 9:00 peak; historical weekend bills are re-priced automatically
- Live account balance via a proxied official `/user/balance` route (API key never leaves the host), 60 s auto-refresh
- Cross-session token/cost/model history persisted to JSONL with per-step peak/valley pricing
- Dashboard with cost trend (click a day to drill down: 24-hour hourly distribution, per-session ranking, that day's records), token structure and per-model charts, peak/valley comparison, global time-range/session/model filters

Entry file only — no README edits. Thanks for reviewing.
