### PR TITLE
chore: update Lorvaste/DSH-Project-Initialization entry to v1.1.0 (atomic skills)

### DIFF
--- a/data/plugins/Lorvaste__DSH-Project-Initialization.yml
+++ b/data/plugins/Lorvaste__DSH-Project-Initialization.yml
@@ -2,5 +2,5 @@ url: https://github.com/Lorvaste/DSH-Project-Initialization
 name: Lorvaste/DSH-Project-Initialization
 category: workflow
 description:
-  en: A single agent preset that turns a one-line idea into requirements, tech plan and maintenance baseline — every step is restated and confirmed by you before proceeding (requirement establishment / pre-development / maintenance).
-  zh: '单 agent preset 场景「想法落地」：一句话想法 → 需求规格 → 技术方案 → 维护基准；每一步先复述、你确认、再继续。场景最小预设：需求确立 / 开发前 / 维护。'
+  en: An agent preset that turns a one-line idea into requirements, tech plan and maintenance baseline — every step is restated and confirmed by you before proceeding. No scenario presets: 73 atomic skills (6 master skills + a verify dispatcher + 66 sub-skills) load by context.
+  zh: '「想法落地」agent preset：一句话想法 → 需求规格 → 技术方案 → 维护基准；每一步先复述、你确认、再继续。无场景预设：73 个原子 skill（6 主 + verify 调度 + 66 子）按上下文加载。'


### PR DESCRIPTION
Update the entry description for Lorvaste/DSH-Project-Initialization to reflect v1.1.0:

- v1.1.0 released (2026-09-01): atomic refactor — 73 skills (6 master skills + a verify dispatcher + 66 atomic sub-skills), no scenario presets (skills load by context)
- description now states: no scenario presets; 73 atomic skills load by context (zh/en)
- previous description (v1.0.3, PR #4010) mentioned scenario minimal presets (requirement establishment / pre-development / maintenance), which no longer exist in v1.1