### PR TITLE
add jackyytche/dsh-hindsight-memory (memory)

### DIFF
--- a/data/plugins/jackyytche__dsh-hindsight-memory.yml
+++ b/data/plugins/jackyytche__dsh-hindsight-memory.yml
@@ -1,0 +1,9 @@
+# awesome-dsh-plugin registry entry for dsh-hindsight-memory.
+# File goes to data/plugins/<OWNER>__dsh-hindsight-memory.yml in a PR against
+# https://github.com/awesome-dsh-plugin/awesome-dsh-plugin
+url: https://github.com/jackyytche/dsh-hindsight-memory
+name: jackyytche/dsh-hindsight-memory
+category: memory
+description:
+  en: 'Hindsight long-term memory for DeepSeek Harness: injects relevant memories before each turn and retains finished turns to a Hindsight bank.'
+  zh: '接入 Hindsight 长期记忆：每轮开始前自动注入相关记忆，回合结束后自动沉淀对话。'


### PR DESCRIPTION
## Plugin

**[jackyytche/dsh-hindsight-memory](https://github.com/jackyytche/dsh-hindsight-memory)** - Hindsight long-term memory for DeepSeek Harness.

Pipelines [Hindsight](https://github.com/vectorize-io/hindsight) into DSH as pipeline-level long-term memory - no agent tools exposed; injection and retention happen automatically around the LLM loop:

- **Auto-Recall** (agent/pre-step): once per turn at the first LLM call, recalls relevant memories and injects them as a plugin-sourced user message; trivial prompts (ok / thanks / slash commands) skip recall entirely. Harness system-reminder blocks are stripped so only the user's actual words become the query.
- **Auto-Retain** (session/event): after each turn ends, assembles the turn's user/assistant text and retains it to Hindsight (fire-and-forget, never blocks the loop).
- **Web settings card**: live-editable enabled / apiUrl / apiKey / bankId / recallBudget in the settings sidebar (written to the user layer of settings.yaml, no restart needed).
- Failures are fully contained: a recall miss means no injection; retain errors are log-only, chat never breaks. Recall has an 8s timeout with one retry for transient failures (cold-start friendly).

## Checklist

- [x] dsh.bundle manifest declared in package.json (dsh.bundle.patch + browser client) - installable via dsh plugin add
- [x] Real working code, actively used on a daily-driver profile, MIT licensed, CI runs the test suite
- [x] dsh-plugin topic set
- [x] Category: memory
- [x] Repo age >= 1 day and >= 10 commits at submission time

Thanks for reviewing!