### PR TITLE
add XINY11451/dsh-wsl (wsl)

### DIFF
--- a/data/plugins/XINY11451__dsh-wsl.yml
+++ b/data/plugins/XINY11451__dsh-wsl.yml
@@ -1,6 +1,6 @@
-url: https://github.com/XINY11451/dsh-wsl
+url: http/mnt/s//github.com/XINY11451/dsh-wsl
 name: XINY11451/dsh-wsl
 category: wsl
 description:
-  en: Runs Linux commands through wsl.exe from Windows and returns stdout/stderr with exit markers.
-  zh: 在 Windows 上通过 wsl.exe 执行 Linux 命令，返回 stdout/stderr 与退出码标记。
+  en: 'WSL tools for DSH: run Linux commands, convert Windows/WSL paths, and summarize the WSL environment.'
+  zh: 'DSH 的 WSL 工具：执行 Linux 命令、转换 Windows/WSL 路径、汇总 WSL 环境。'

--- a/data/plugins/XINY11451__dsh-wsl.yml
+++ b/data/plugins/XINY11451__dsh-wsl.yml
@@ -1,0 +1,6 @@
+url: https://github.com/XINY11451/dsh-wsl
+name: XINY11451/dsh-wsl
+category: wsl
+description:
+  en: Runs Linux commands through wsl.exe from Windows and returns stdout/stderr with exit markers.
+  zh: 在 Windows 上通过 wsl.exe 执行 Linux 命令，返回 stdout/stderr 与退出码标记。

--- a/data/plugins/XINY11451__dsh-wsl.yml
+++ b/data/plugins/XINY11451__dsh-wsl.yml
@@ -1,4 +1,4 @@
-url: http/mnt/s//github.com/XINY11451/dsh-wsl
+url: https://github.com/XINY11451/dsh-wsl
 name: XINY11451/dsh-wsl
 category: wsl
 description:


### PR DESCRIPTION
Add [XINY11451/dsh-wsl](https://github.com/XINY11451/dsh-wsl) under the `wsl` category.

- Declares a `dsh.bundle` manifest (`package.json` -> `cordis.patch.yml`) registering the `tool-wsl` plugin in agent presets.
- The plugin registers a model-facing `wsl` tool that runs Linux commands through `wsl.exe` and returns stdout/stderr with exit-code markers.
- Repo carries the `dsh-plugin` topic; 10+ commits; MIT licensed.