### PR TITLE
Add dsh-tool-autoexpand plugin

### DIFF
--- a/data/plugins/better-er__dsh-tool-autoexpand.yml
+++ b/data/plugins/better-er__dsh-tool-autoexpand.yml
@@ -1,0 +1,6 @@
+url: https://github.com/better-er/dsh-tool-autoexpand
+name: better-er/dsh-tool-autoexpand
+category: ui
+description:
+  en: 'Auto-expands newly arrived tool-call cards in the DSH Web UI, with a sidebar toggle cycling no-op/expand/collapse and the state persisted to localStorage.'
+  zh: '自动展开 DSH 界面里新到达的工具调用卡片，侧栏开关在不干预/展开/折叠三态间循环，档位持久化到 localStorage。'


### PR DESCRIPTION
## Summary

This PR adds [dsh-tool-autoexpand](https://github.com/better-er/dsh-tool-autoexpand), a client plugin that auto-expands newly arrived tool-call cards in the DSH Web UI, to the `ui` category.

Only the source plugin entry is added; generated README files are intentionally omitted.
