### PR TITLE
Add ZK-Andy/dsh-frecency (tools)

### DIFF
--- a/data/plugins/ZK-Andy__dsh-frecency.yml
+++ b/data/plugins/ZK-Andy__dsh-frecency.yml
@@ -1,0 +1,6 @@
+url: https://github.com/ZK-Andy/dsh-frecency
+name: ZK-Andy/dsh-frecency
+category: tools
+description:
+  en: 'Resident-index grep for DeepSeek Harness that shadows the built-in grep/glob tools under the same names: repeated content searches hit an in-memory index ranked by access/modification frecency, and glob serves the built-in ripgrep semantics when available, falling back to the index otherwise.'
+  zh: '为 DeepSeek Harness 提供常驻索引 grep，以同名遮蔽内置 grep/glob 工具：重复内容检索命中按访问/修改 frecency 排序的内存索引，glob 在可用时对齐内置 ripgrep 语义、不可用时回退索引。'


### PR DESCRIPTION
Adds [dsh-frecency](https://github.com/ZK-Andy/dsh-frecency) under `tools`.

A DeepSeek Harness plugin that shadows the built-in `grep`/`glob` file-search tools under the same names: repeated content searches hit a resident in-memory index ranked by access/modification frecency, and glob mirrors the built-in ripgrep semantics when available, degrading to the index otherwise.

- `dsh.bundle` manifest declared (`cordis.patch.yml`)
- Published on npm: `dsh-frecency` (v0.1.1)
- Repo topic `dsh-plugin` set
- 67 tests green