### PR TITLE
Add dsh-conversation-archive to session plugins

### DIFF
--- a/data/plugins/yxv1203-collab__dsh-conversation-archive.yml
+++ b/data/plugins/yxv1203-collab__dsh-conversation-archive.yml
@@ -1,0 +1,7 @@
+url: https://github.com/yxv1203-collab/dsh-conversation-archive
+name: yxv1203-collab/dsh-conversation-archive
+category: session
+description:
+  en: Manage archived DSH sessions on Windows with search, batch restore and deletion, AI-assisted file retention, and verified local or network-directory backups.
+  zh: 在 Windows 上管理 DSH 已归档会话，支持搜索、批量取消归档与删除、AI 辅助文件保留，以及经过校验的本地或网络目录备份。
+tarball: https://github.com/yxv1203-collab/dsh-conversation-archive/releases/download/v1.0.0/dsh-conversation-archive-1.0.0.tgz


### PR DESCRIPTION
## Plugin

Adds [DSH Workspace Manager](https://github.com/yxv1203-collab/dsh-conversation-archive) to the `session` category.

A Windows plugin for managing native archived sessions, retaining selected output files before deletion, and creating verified backups of managed session data and retained files. Backups support local and network directories; they are not full project or repository backups.

## Submission checklist

- [x] Adds one entry at `data/plugins/yxv1203-collab__dsh-conversation-archive.yml`.
- [x] Root `package.json` declares `dsh.bundle` with `cordis.patch.yml`.
- [x] Repository is more than one day old and has at least 10 commits.
- [x] Repository has the `dsh-plugin` topic.
- [x] Uses the `session` category and factual English and Chinese descriptions.
- [x] Includes a prebuilt GitHub Release tarball pinned to `v1.0.0`.

Following the current contributing guide, this PR contains only the entry YAML. Generated READMEs are left unchanged for regeneration after merge.

## Compatibility and screenshots

- Windows 10/11; tested with DSH `0.1.1-rc.2`.
- Screenshots are hosted in the plugin repository and referenced in both READMEs.
- The README documents model-provider data handling, backup scope, and restoration restrictions.
