### PR TITLE
Update Jacky Creator tarball to v0.1.0-beta.8

### DIFF
--- a/data/plugins/Jackywxsz__DSH-Creator.yml
+++ b/data/plugins/Jackywxsz__DSH-Creator.yml
@@ -1,7 +1,7 @@
 url: https://github.com/Jackywxsz/DSH-Creator
 name: Jackywxsz/DSH-Creator
 category: workflow
-tarball: https://github.com/Jackywxsz/DSH-Creator/releases/download/v0.1.0-beta.7/jacky-creator-0.1.0-beta.7.tgz
+tarball: https://github.com/Jackywxsz/DSH-Creator/releases/download/v0.1.0-beta.8/jacky-creator-0.1.0-beta.8.tgz
 description:
   en: "Local-first content production and operations workspace for DSH: manage ideas, scripts, media assets, schedules, goals, publishing status, and post-publication reviews."
   zh: "面向 DSH 的本地内容生产与运营工作台：管理灵感、脚本、媒体资产、档期、目标、发布状态和发布后复盘。"


### PR DESCRIPTION
Update the Jacky Creator marketplace tarball to the verified v0.1.0-beta.8 GitHub Release asset.