### PR TITLE
Add yushenghai1106/dsh-memory-plugin (memory)

### DIFF
--- a/data/plugins/yushenghai1106__dsh-memory-plugin.yml
+++ b/data/plugins/yushenghai1106__dsh-memory-plugin.yml
@@ -1,0 +1,6 @@
+url: https://github.com/yushenghai1106/dsh-memory-plugin
+name: yushenghai1106/dsh-memory-plugin
+category: memory
+description:
+  zh: 为 DeepSeek Harness 提供人工记忆、自动对话保留以及图谱和向量排序召回的持久记忆插件。
+  en: Persistent memory for DeepSeek Harness with curated facts, automatic turn retention, and graph- and vector-ranked recall.


### PR DESCRIPTION
## Summary
- Add the marketplace entry for yushenghai1106/dsh-memory-plugin in the memory category.

## Validation
- The PR adds only data/plugins/yushenghai1106__dsh-memory-plugin.yml.
- The plugin repository is public, declares dsh.bundle, has the dsh-plugin topic, is over one day old, and has 14 commits.