### PR TITLE
Add QianLuo-Ly/dsh-weather — top weather bar for the DSH Web UI

### DIFF
--- a/data/plugins/QianLuo-Ly__dsh-weather.yml
+++ b/data/plugins/QianLuo-Ly__dsh-weather.yml
@@ -1,0 +1,6 @@
+url: https://github.com/QianLuo-Ly/dsh-weather
+name: QianLuo-Ly/dsh-weather
+category: ui
+description:
+  en: 'Top-centered weather bar for the DSH Web UI: geolocation, current conditions, 12h/7d forecasts and severe-weather notifications via Open-Meteo (free, no API key).'
+  zh: 'DSH Web 顶部居中的天气栏：定位 + 当前天气 + 未来 12 小时/7 天预报与恶劣天气提醒，数据来自 Open-Meteo（免费、无需 API key）。'


### PR DESCRIPTION
Adds **QianLuo-Ly/dsh-weather**: a top-centered weather bar for the DSH Web UI — geolocation (browser GPS with IP fallback), current conditions, 12-hour / 7-day forecasts, air quality, and severe-weather browser notifications. Data via Open-Meteo (free, no API key, no data collection).

Entry file: `data/plugins/QianLuo-Ly__dsh-weather.yml`

Checklist:
- `dsh.bundle` manifest + `cordis.patch.yml` at repo root — installable via `dsh plugin add` ✅
- Repo public, created 2026-09-02 (over 1 day old), 21 commits, `dsh-plugin` topic added ✅
- Category: `ui` (the weather bar is a UI enhancement)
- Description matches the code: geolocation + current conditions + 12h/7d forecasts + severe-weather notifications via Open-Meteo ✅