### PR TITLE
Add gbeta/dsh-token-speed

### DIFF
--- a/data/plugins/gbeta__dsh-token-speed.yml
+++ b/data/plugins/gbeta__dsh-token-speed.yml
@@ -1,0 +1,6 @@
+url: https://github.com/gbeta/dsh-token-speed
+name: gbeta/dsh-token-speed
+category: ui
+description:
+  en: Draggable ring gauge showing live model output speed (tok/s) with an expandable per-step detail panel (exact speed, TTFT, cache-hit rate, cache read/write, reasoning and input tokens, model, cumulative tokens).
+  zh: 可拖拽环形表盘，实时显示模型输出速度（tok/s），点击展开每步详情（精确速度、TTFT、缓存命中率、缓存读写、推理/输入 token、模型、累计 token）。


### PR DESCRIPTION
Adds a new plugin entry: **gbeta/dsh-token-speed** — a draggable ring-gauge dashboard showing live model output speed (tok/s) with an expandable per-step detail panel (exact speed, TTFT, cache-hit rate, cache read/write, reasoning and input tokens, model, cumulative tokens).

- Repo: https://github.com/gbeta/dsh-token-speed
- Category: ui
- Declares `dsh.bundle` manifest in `package.json` + `cordis.patch.yml`
- Repo is 1 day+ old with 10 commits, `dsh-plugin` topic set