### PR TITLE
docs: add PerryLink/dsh-fast

### DIFF
--- a/data/plugins/PerryLink__dsh-fast.yml
+++ b/data/plugins/PerryLink__dsh-fast.yml
@@ -1,0 +1,6 @@
+url: https://github.com/PerryLink/dsh-fast
+name: PerryLink/dsh-fast
+category: dev
+description:
+  en: Performance profiling and LLM cache diagnostics for DeepSeek Harness — context engineering, latency profiling, and cache behavior reports.
+  zh: DeepSeek Harness 的性能剖析与 LLM 缓存诊断：上下文工程、延迟剖析与缓存行为报告。


### PR DESCRIPTION
Adds dsh-fast (npm: dsh-fast@0.2.4). Repo has the dsh-plugin topic and a dsh.bundle manifest. One new data file only; the READMEs regenerate on main.