### PR TITLE
docs: add PerryLink/dsh-talk

### DIFF
--- a/data/plugins/PerryLink__dsh-talk.yml
+++ b/data/plugins/PerryLink__dsh-talk.yml
@@ -1,0 +1,6 @@
+url: https://github.com/PerryLink/dsh-talk
+name: PerryLink/dsh-talk
+category: voice
+description:
+  en: Voice I/O for DeepSeek Harness — speech-to-text and text-to-speech over the microphone and audio output.
+  zh: DeepSeek Harness 的语音输入输出：麦克风语音转文字与文字转语音。


### PR DESCRIPTION
Adds dsh-talk (npm: dsh-talk@0.3.3). Repo has the dsh-plugin topic and a dsh.bundle manifest. One new data file only; the READMEs regenerate on main.