### PR TITLE
docs: add PerryLink/dsh-personal-directive

### DIFF
--- a/data/plugins/PerryLink__dsh-personal-directive.yml
+++ b/data/plugins/PerryLink__dsh-personal-directive.yml
@@ -1,0 +1,6 @@
+url: https://github.com/PerryLink/dsh-personal-directive
+name: PerryLink/dsh-personal-directive
+category: identity
+description:
+  en: Personal directives for DeepSeek Harness — system-prompt injection, tools, and a top-bar runtime toggle, shipping neutral placeholder instructions you replace with your own.
+  zh: DeepSeek Harness 的个人指令插件：系统提示词注入、工具与顶部运行时开关，内置中性占位指令可自行替换。


### PR DESCRIPTION
Adds dsh-personal-directive (framework version of the infinite-gen concept, published by PerryLink with neutral placeholder instructions; upstream credit in README). Repo has the dsh-plugin topic and a dsh.bundle manifest. One new data file only; the READMEs regenerate on main.