### PR TITLE
Add MannixHu/dsh-statusbar-config (ui)

### DIFF
--- a/data/plugins/MannixHu__dsh-statusbar-config.yml
+++ b/data/plugins/MannixHu__dsh-statusbar-config.yml
@@ -4,6 +4,4 @@ category: ui
 description:
   en: 'Configurable statistics row below the composer via a ${variable} display template — which segments appear and how they are labelled is fully user-defined.'
   zh: '用 ${变量} 显示模板自定义输入框下方的会话统计行——显示哪些统计段、单位文案怎么写，全部由模板决定。'
-screenshots:
-  - https://raw.githubusercontent.com/MannixHu/dsh-statusbar-config/HEAD/assets/stats-bar.png
 tarball: https://github.com/MannixHu/dsh-statusbar-config/releases/latest/download/dsh-statusbar-config.tgz

--- a/data/plugins/MannixHu__dsh-statusbar-config.yml
+++ b/data/plugins/MannixHu__dsh-statusbar-config.yml
@@ -6,4 +6,4 @@ description:
   zh: '用 ${变量} 显示模板自定义输入框下方的会话统计行——显示哪些统计段、单位文案怎么写，全部由模板决定。'
 screenshots:
   - https://raw.githubusercontent.com/MannixHu/dsh-statusbar-config/HEAD/assets/stats-bar.png
-tarball: https://github.com/MannixHu/dsh-statusbar-config/releases/latest/download/dsh-statusbar-config-0.2.0.tgz
+tarball: https://github.com/MannixHu/dsh-statusbar-config/releases/latest/download/dsh-statusbar-config.tgz

--- a/data/plugins/MannixHu__dsh-statusbar-config.yml
+++ b/data/plugins/MannixHu__dsh-statusbar-config.yml
@@ -1,0 +1,9 @@
+url: https://github.com/MannixHu/dsh-statusbar-config
+name: MannixHu/dsh-statusbar-config
+category: ui
+description:
+  en: 'Configurable statistics row below the composer via a ${variable} display template — which segments appear and how they are labelled is fully user-defined.'
+  zh: '用 ${变量} 显示模板自定义输入框下方的会话统计行——显示哪些统计段、单位文案怎么写，全部由模板决定。'
+screenshots:
+  - https://raw.githubusercontent.com/MannixHu/dsh-statusbar-config/HEAD/assets/stats-bar.png
+tarball: https://github.com/MannixHu/dsh-statusbar-config/releases/latest/download/dsh-statusbar-config-0.2.0.tgz


### PR DESCRIPTION
Adds `MannixHu/dsh-statusbar-config` — template-driven statistics row below the composer (`ui`).

- Installs with `dsh plugin --profile web add github:MannixHu/dsh-statusbar-config`; declares `dsh.bundle` (patch) + `dsh.client` (web)
- What the description claims is what it does: one `${variable}` display template (`${ttft}` `${tps}` `${cache}` `${input}` `${output}` `${turns}` `${steps}` `${llm}` `${tool}`) replaces the shipped stats row; empty template renders the default official-style segments; settings card with click-to-insert variable chips and bilingual hover descriptions
- Prebuilt tarball attached to the releases under a version-less name (`dsh-statusbar-config.tgz`), so the `releases/latest/download/` link in the entry stays stable across versions — installs without build scripts
- `dsh-plugin` topic added; in-repo CI (typecheck/build/test, 17 tests) green on every push
- Screenshot is the rendered bar only (composited from real session values; no other UI content)
