### PR TITLE
Add OME engineering delivery preset

### DIFF
--- a/data/plugins/oh-my-engine__dsh-plugin-oh-my-engine.yml
+++ b/data/plugins/oh-my-engine__dsh-plugin-oh-my-engine.yml
@@ -1,0 +1,7 @@
+url: https://github.com/oh-my-engine/dsh-plugin-oh-my-engine
+name: oh-my-engine/dsh-plugin-oh-my-engine
+category: workflow
+tarball: https://github.com/oh-my-engine/dsh-plugin-oh-my-engine/releases/download/v0.1.6/dsh-plugin-oh-my-engine-0.1.6.tgz
+description:
+  en: An approval-gated OME engineering delivery preset with session-isolated lifecycle evidence.
+  zh: 采用阶段审批门禁和会话隔离证据记录的 OME 工程交付 Agent 预设。


### PR DESCRIPTION
Adds the OME engineering delivery Agent Preset to the workflow category.

- Approval-gated Define -> Plan -> Build -> Test -> Review -> Ship lifecycle
- Session-isolated evidence and explicit user approval
- Web and Desktop support for DSH 0.1.1-rc.2
- Prebuilt GitHub Release tarball; npm publication is not required

Verification:
- Plugin npm run verify: 9/9 tests passed
- Marketplace check-submission: all checked entries pass
- Release tarball installed and exercised in a clean DSH Web profile