### PR TITLE
docs: add dsh-theme-manager (theme)

### DIFF
--- a/data/plugins/runcat-tommy__dsh-theme-manager.yml
+++ b/data/plugins/runcat-tommy__dsh-theme-manager.yml
@@ -1,0 +1,6 @@
+url: https://github.com/runcat-tommy/dsh-theme-manager
+name: runcat-tommy/dsh-theme-manager
+category: theme
+description:
+  en: 'Two-level theme manager for the DSH Web UI: pick a culture / scene, a national flag, a developer palette, or a high-contrast pairing first, then a concrete style (58 built-in palettes, light and dark).'
+  zh: 'DSH Web 两级主题管理器：先选文化 / 场景、国旗、开发者配色或强烈对比配色，再选具体风格，内置 58 套浅色 / 深色配色。'


### PR DESCRIPTION
Adds one entry file: data/plugins/runcat-tommy__dsh-theme-manager.yml.

dsh-theme-manager is a two-level theme manager for the DSH Web UI (58 built-in palettes across culture / scene, national flags, developer and high-contrast categories, light and dark bases). The repo declares dsh.bundle (cordis.patch.yml), is published on npm, is >1 day old with 11 commits, and carries the dsh-plugin topic. Both description.en and description.zh are included.