### PR TITLE
Add theinfluencecompany/dsh-realtimeavatar (Realtime Avatar tools)

### DIFF
--- a/data/plugins/theinfluencecompany__dsh-realtimeavatar.yml
+++ b/data/plugins/theinfluencecompany__dsh-realtimeavatar.yml
@@ -1,0 +1,6 @@
+url: https://github.com/theinfluencecompany/dsh-realtimeavatar
+name: theinfluencecompany/dsh-realtimeavatar
+category: tools
+description:
+  en: 'Realtime Avatar (realtimeavatar.ai) for agents: the developer API key held by the harness credentials store, the public docs as five on-demand skills, rta_* tools over the public REST API (balance, avatars, clips, sessions, usage) with approval-gated credit spending, and a /rta command that walks a developer from no key to a live avatar call.'
+  zh: 'Realtime Avatar（realtimeavatar.ai）实时数字人工具：开发者 API key 由 harness 凭据存储保管，公开文档打包为五个按需加载的技能，rta_* 工具封装公开 REST API（余额、数字人、动作片段、会话、用量），消耗额度的操作需审批，/rta 命令引导开发者从零到一次真实的数字人通话。'


### PR DESCRIPTION
Adds `data/plugins/theinfluencecompany__dsh-realtimeavatar.yml` (category: `tools`).

Repo: https://github.com/theinfluencecompany/dsh-realtimeavatar — Realtime Avatar (realtimeavatar.ai) for the DeepSeek Harness: the developer API key held by the harness credentials store, the public docs as five on-demand skills, `rta_*` tools over the public REST API with approval-gated credit spending, and a `/rta` onboarding command. Zero runtime dependencies, MIT, CI green.

- [x] I added **one file** at `data/plugins/<owner>__<repo>.yml`
- [ ] I ran `node scripts/generate-readme.mjs` — left the READMEs untouched on purpose; PR check accepts that and regenerates them on main after merge
- [x] My repo's `package.json` declares **`dsh.bundle`** (`dsh.bundle.patch` → `cordis.patch.yml`)
- [ ] My repo is at least **1 day old** with **10+ commits** — created 2026-09-03T05:10Z, 4 commits so far; the gate will go green once the repo ages in and the first release commits land (the daily re-check will pick it up)
- [x] `category` is `tools`
- [x] Description states what the plugin does, no superlatives
- [x] My repo has the `dsh-plugin` topic

npm publish (`dsh-realtimeavatar`) is queued behind the release workflow in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
