### PR TITLE
Add dsh-workspace-git-badge

### DIFF
--- a/data/plugins/Kevin-McIsaac__dsh-workspace-git-badge--plugin.yml
+++ b/data/plugins/Kevin-McIsaac__dsh-workspace-git-badge--plugin.yml
@@ -1,0 +1,6 @@
+url: https://github.com/Kevin-McIsaac/dsh-workspace-git-badge/tree/main/plugin
+name: Kevin-McIsaac/dsh-workspace-git-badge#plugin
+category: git
+description:
+  en: 'Git status badges for DSH: sidebar workspace-row badges and an input-row chip showing the current conversation''s workspace git state, with event-driven freshness over SSE.'
+  zh: 'DSH 的 Git 状态徽章：侧边栏工作区行徽章与输入行徽章，显示当前会话工作区的 git 状态，通过 SSE 事件驱动保持实时。'

--- a/data/plugins/Kevin-McIsaac__dsh-workspace-git-badge.yml
+++ b/data/plugins/Kevin-McIsaac__dsh-workspace-git-badge.yml
@@ -1,6 +1,0 @@
-url: https://github.com/Kevin-McIsaac/dsh-workspace-git-badge
-name: Kevin-McIsaac/dsh-workspace-git-badge
-category: git
-description:
-  en: Git status badges for DSH: sidebar workspace-row badges and an input-row chip showing the current conversation's workspace git state, with event-driven freshness over SSE.
-  zh: DSH 的 Git 状态徽章：侧边栏工作区行徽章与输入行徽章，显示当前会话工作区的 git 状态，通过 SSE 事件驱动保持实时。

--- a/data/plugins/Kevin-McIsaac__dsh-workspace-git-badge.yml
+++ b/data/plugins/Kevin-McIsaac__dsh-workspace-git-badge.yml
@@ -1,0 +1,6 @@
+url: https://github.com/Kevin-McIsaac/dsh-workspace-git-badge
+name: Kevin-McIsaac/dsh-workspace-git-badge
+category: git
+description:
+  en: Git status badges for DSH: sidebar workspace-row badges and an input-row chip showing the current conversation's workspace git state, with event-driven freshness over SSE.
+  zh: DSH 的 Git 状态徽章：侧边栏工作区行徽章与输入行徽章，显示当前会话工作区的 git 状态，通过 SSE 事件驱动保持实时。


### PR DESCRIPTION
Adds [Kevin-McIsaac/dsh-workspace-git-badge](https://github.com/Kevin-McIsaac/dsh-workspace-git-badge) under the **git** category.

Git status badges for DeepSeek Harness: sidebar workspace-row badges and an input-row chip showing the current conversation's workspace git state, with event-driven freshness over SSE.

Installable via `dsh plugin add` — the `dsh.bundle` manifest is declared in the `plugin/package.json` subpackage (per the monorepo rule in contributing.md), with `cordis.patch.yml` alongside it. Repo has 40+ commits and carries the `dsh-plugin` topic.

Entry file: `data/plugins/Kevin-McIsaac__dsh-workspace-git-badge.yml` only — generated READMEs untouched.