### PR TITLE
Add Icstick/dsh-work-continuity to the list

### DIFF
--- a/data/plugins/Icstick__dsh-work-continuity.yml
+++ b/data/plugins/Icstick__dsh-work-continuity.yml
@@ -1,0 +1,6 @@
+url: https://github.com/Icstick/dsh-work-continuity
+name: Icstick/dsh-work-continuity
+category: workflow
+description:
+  zh: "跨会话工作状态显式持久化：目标、决策与下一步从宿主事件自动捕获，或由模型经 work_state 工具主动记录，/checkpoint 随时可查。"
+  en: "Explicit cross-session work state for DeepSeek Harness: goals, decisions and next steps captured automatically from host events or via a model-visible work_state tool, inspectable with /checkpoint."


### PR DESCRIPTION
### Plugin
[Icstick/dsh-work-continuity](https://github.com/Icstick/dsh-work-continuity) — DeepSeek Harness 的 Work Continuity 插件：跨会话工作状态显式持久化，与通用记忆分开管理。

- category: workflow
- 三层捕获：宿主事件自动捕获（goal/change、todo/write）+ LLM 自主决断（work_state 工具）+ `/checkpoint` 显式命令
- 仓库声明 `dsh.bundle` manifest（`cordis.patch.yml`），`dsh plugin add github:Icstick/dsh-work-continuity` 可装
- 已加 `dsh-plugin` topic

One entry file only, per contributing.md.