### PR TITLE
Add Icstick/dsh-context-maid to the list

### DIFF
--- a/data/plugins/Icstick__dsh-context-maid.yml
+++ b/data/plugins/Icstick__dsh-context-maid.yml
@@ -1,0 +1,6 @@
+url: https://github.com/Icstick/dsh-context-maid
+name: Icstick/dsh-context-maid
+category: session
+description:
+  zh: "自动上下文策展：tool 输出内容感知瘦身、无效日志清理、用户要求与进行中工作钉扎保护、先归档后压缩，全程审计留痕。"
+  en: "Context curation for DeepSeek Harness: content-aware tool-output slimming, dead-log sweep, pinned user requirements and in-flight work, archive-then-compact with an audit trail."


### PR DESCRIPTION
### Plugin
[Icstick/dsh-context-maid](https://github.com/Icstick/dsh-context-maid) — DeepSeek Harness 的自动上下文策展插件：工具输出内容感知瘦身、无效日志清理、关键内容钉扎保护、先归档后压缩。

- category: session
- 接管官方 ctx.compaction（MaidCompactionEngine，阈值映射）+ 审计库 maid_audit
- 仓库声明 `dsh.bundle` manifest（`cordis.patch.yml`），`dsh plugin add github:Icstick/dsh-context-maid` 可装
- 已加 `dsh-plugin` topic

One entry file only, per contributing.md.