### PR TITLE
add WuJiaoJue/dsh-herdr-site and WuJiaoJue/dsh-suggest-ghost

### DIFF
--- a/data/plugins/WuJiaoJue__dsh-herdr-site.yml
+++ b/data/plugins/WuJiaoJue__dsh-herdr-site.yml
@@ -1,0 +1,6 @@
+url: https://github.com/WuJiaoJue/dsh-herdr-site
+name: WuJiaoJue/dsh-herdr-site
+category: remote
+description:
+  en: Reports the dsh/cc-tui agent's working, idle and blocked states to the Herdr terminal workspace manager over its custom-integration protocol, so a dsh pane gets state, panel jump and --wait support.
+  zh: 通过 Herdr 自定义集成协议把 dsh/cc-tui agent 的 working / idle / blocked 状态上报给终端工作区管理器 Herdr，让 dsh 面板获得状态显示、面板跳转与 --wait 支持。

--- a/data/plugins/WuJiaoJue__dsh-herdr-site.yml
+++ b/data/plugins/WuJiaoJue__dsh-herdr-site.yml
@@ -2,5 +2,5 @@ url: https://github.com/WuJiaoJue/dsh-herdr-site
 name: WuJiaoJue/dsh-herdr-site
 category: remote
 description:
-  en: Reports the dsh/cc-tui agent's working, idle and blocked states to the Herdr terminal workspace manager over its custom-integration protocol, so a dsh pane gets state, panel jump and --wait support.
+  en: 'Reports the dsh/cc-tui agent working, idle and blocked states to the Herdr terminal workspace manager over its custom-integration protocol, so a dsh pane gets state, panel jump and --wait support.'
   zh: 通过 Herdr 自定义集成协议把 dsh/cc-tui agent 的 working / idle / blocked 状态上报给终端工作区管理器 Herdr，让 dsh 面板获得状态显示、面板跳转与 --wait 支持。

--- a/data/plugins/WuJiaoJue__dsh-suggest-ghost.yml
+++ b/data/plugins/WuJiaoJue__dsh-suggest-ghost.yml
@@ -1,0 +1,6 @@
+url: https://github.com/WuJiaoJue/dsh-suggest-ghost
+name: WuJiaoJue/dsh-suggest-ghost
+category: ui
+description:
+  en: Input prediction for the DSH Web GUI: after each turn an auxiliary LLM call suggests the next prompt rendered as ghost text in the empty input box, and history prefix completion fills in while typing, with Tab and arrow-key acceptance.
+  zh: DSH Web 输入预测插件：回合结束后 LLM 生成下一条建议，输入框空草稿时以幽灵文本渲染，输入时按会话历史做前缀补全，Tab / 方向键采纳。

--- a/data/plugins/WuJiaoJue__dsh-suggest-ghost.yml
+++ b/data/plugins/WuJiaoJue__dsh-suggest-ghost.yml
@@ -2,5 +2,5 @@ url: https://github.com/WuJiaoJue/dsh-suggest-ghost
 name: WuJiaoJue/dsh-suggest-ghost
 category: ui
 description:
-  en: Input prediction for the DSH Web GUI: after each turn an auxiliary LLM call suggests the next prompt rendered as ghost text in the empty input box, and history prefix completion fills in while typing, with Tab and arrow-key acceptance.
+  en: 'Input prediction for the DSH Web GUI: after each turn an auxiliary LLM call suggests the next prompt rendered as ghost text in the empty input box, and history prefix completion fills in while typing, with Tab and arrow-key acceptance.'
   zh: DSH Web 输入预测插件：回合结束后 LLM 生成下一条建议，输入框空草稿时以幽灵文本渲染，输入时按会话历史做前缀补全，Tab / 方向键采纳。


### PR DESCRIPTION
Two community plugins, one entry file each:

- **dsh-herdr-site** (`category: remote`) — reports the dsh/cc-tui agent's working / idle / blocked states to the Herdr terminal workspace manager over its custom-integration protocol.
- **dsh-suggest-ghost** (`category: ui`) — input prediction for the DSH Web GUI: LLM next-turn suggestion as ghost text plus history prefix completion, Tab/arrow acceptance.

Both repos declare `dsh.bundle` in package.json, carry the `dsh-plugin` topic, and meet the age/commit bar. Bilingual descriptions included.