### PR TITLE
docs: add runcat-tommy/dsh-panda-calendar (ui)

### DIFF
--- a/data/plugins/runcat-tommy__dsh-panda-calendar.yml
+++ b/data/plugins/runcat-tommy__dsh-panda-calendar.yml
@@ -1,0 +1,6 @@
+url: https://github.com/runcat-tommy/dsh-panda-calendar
+name: runcat-tommy/dsh-panda-calendar
+category: ui
+description:
+  en: A conversation-view tab for DeepSeek Harness Web showing solar/lunar dates, ganzhi year/month/day, Chinese zodiac, 24 solar terms, festivals, China public holidays including make-up workdays, and multi-city weather from free sources without an API key.
+  zh: '会话页头的「熊猫日历」标签页：公历/农历、干支、生肖、24 节气、传统与外国节日、中国法定节假日（含调休）与多城市天气，数据免费、无需 API Key。'


### PR DESCRIPTION
Add one entry file: data/plugins/runcat-tommy__dsh-panda-calendar.yml

What it does: Panda Calendar (熊猫日历) — a DSH Web client-plugin that registers a conversation-view tab (id panda-calendar). Shows solar/lunar dates, ganzhi year/month/day, Chinese zodiac, 24 solar terms, traditional & international festivals, China public holidays incl. make-up workdays (offline snapshot + rule fallback) and multi-city weather (Open-Meteo geocoding/forecast + reverse geocode/ip-api). Offline lunar tables 1900-2100, zh/en bilingual, city list persisted in localStorage.

Entry standard compliance:
- Repo declares dsh.bundle.patch = ./cordis.patch.yml with cordis.patch.yml at the repo root, plus dsh.client.platform web.
- Real working code: lib/client.js (~2.1k lines) + 56 unit tests (node --test, zero network).
- Topic dsh-plugin added. Descriptions are factual, no marketing claims.