### PR TITLE
Add dsh-side-session plugin (旁会话 / side-chat)

### DIFF
--- a/data/plugins/123dbl__dsh-side-session.yml
+++ b/data/plugins/123dbl__dsh-side-session.yml
@@ -1,0 +1,6 @@
+url: https://github.com/123dbl/dsh-side-session
+name: 123dbl/dsh-side-session
+category: session
+description:
+  en: 'Launches a fresh, continuable parallel session from the composer command menu (/side-chat) while the main session keeps running.'
+  zh: '主会话进行中也能一键新开独立的可续聊旁会话：从输入框 ＋ 命令菜单选 side-chat 即开即用，主会话不受影响。'


### PR DESCRIPTION
Add [dsh-side-session](https://github.com/123dbl/dsh-side-session) — launches a fresh, continuable parallel session from the composer command menu (`/side-chat`) while the main session keeps running. Declares `dsh.bundle` (cordis.patch.yml) + web client; category `session`.

Note: the repo was created 2026-09-03 UTC+8 with 12 commits; its age is under the 1-day automatic check until 2026-09-04, so this PR may show that CI check red for the first ~24h.