### PR TITLE
dsh-workspace-git-badge: entry subpackage renamed (plugin → dsh-git-badge)

### DIFF
--- a/data/plugins/Kevin-McIsaac__dsh-workspace-git-badge--dsh-git-badge.yml
+++ b/data/plugins/Kevin-McIsaac__dsh-workspace-git-badge--dsh-git-badge.yml
@@ -1,5 +1,5 @@
-url: https://github.com/Kevin-McIsaac/dsh-workspace-git-badge/tree/main/plugin
-name: Kevin-McIsaac/dsh-workspace-git-badge#plugin
+url: https://github.com/Kevin-McIsaac/dsh-workspace-git-badge/tree/main/dsh-git-badge
+name: Kevin-McIsaac/dsh-workspace-git-badge#dsh-git-badge
 category: git
 description:
   en: 'Git status badges for DSH: sidebar workspace-row badges and an input-row chip showing the current conversation''s workspace git state, with event-driven freshness over SSE.'


### PR DESCRIPTION
Follow-up to #4227 (merged as `data/plugins/Kevin-McIsaac__dsh-workspace-git-badge--plugin.yml`).

The plugin's subpackage directory has been renamed from `plugin/` to `dsh-git-badge/` ([commit 577a5da](https://github.com/Kevin-McIsaac/dsh-workspace-git-badge/commit/577a5da)) to match the npm package name, so the merged entry now points at a nonexistent path. This PR renames the entry file and updates:

- url: `https://github.com/Kevin-McIsaac/dsh-workspace-git-badge/tree/main/dsh-git-badge`
- name: `Kevin-McIsaac/dsh-workspace-git-badge#dsh-git-badge`

No other changes.