### PR TITLE
seo: give short descriptions context, and fit compound names into the title budget

### DIFF
--- a/scripts/build-site.mjs
+++ b/scripts/build-site.mjs
@@ -693,14 +693,23 @@ for (const loc of LOCALES) {
     // "conf…" is the one line a searcher reads before deciding to click. Prefer
     // ending on a sentence, else the last word; CJK has no spaces, so the word
     // fallback simply does not fire there and the hard cut stands.
-    const metaDesc = (() => {
-      if (desc.length <= 155) return desc
-      const head = desc.slice(0, 152)
+    const clampMeta = (s) => {
+      if (s.length <= 155) return s
+      const head = s.slice(0, 152)
       const stop = Math.max(head.lastIndexOf('. '), head.lastIndexOf('。'), head.lastIndexOf('；'), head.lastIndexOf('; '))
-      if (stop > 90) return desc.slice(0, stop + 1).trim()
+      if (stop > 90) return s.slice(0, stop + 1).trim()
       const space = head.lastIndexOf(' ')
       return (space > 90 ? head.slice(0, space) : head).trimEnd() + '…'
-    })()
+    }
+    // A twelve-character description is a fine list entry but a bare meta
+    // description — Bing flags 162 of them as too short. Below the threshold,
+    // wrap it in the locale's context sentence (what this is, what the page
+    // offers); at or above it, the description stands on its own as before.
+    const metaDesc = clampMeta(
+      desc.length < 60
+        ? loc.P_META_SHORT.replace('{DESC}', desc).replace('{NAME}', shortName(e.name)).replace('{CAT}', loc.categories[e.cat])
+        : desc,
+    )
 
     const short = shortName(e.name)
     const h1 = `<span class="owner">${esc(e.owner)}/</span><wbr><span class="name">${esc(short)}</span>`
@@ -812,9 +821,17 @@ ${readmeHtml}
       .replaceAll('__P_README_SECTION__', () => readmeSection)
       .replaceAll('__P_COMMENTS_SECTION__', () => commentsSection)
       .replaceAll('__LANG__', () => loc.htmlLang)
-      .replaceAll('__TITLE__', () => esc(loc.P_TITLE
-        .replace('{NAME}', e.name)
-        .replace('{CAT}', loc.categories[e.cat])))
+      // Compound entry names (owner/repo#subpath) push some titles past what a
+      // result page shows — Bing flags them and search engines truncate mid-
+      // name. Fall back through progressively shorter forms of the name until
+      // the title fits: full name, then without the owner, then the bare
+      // package name after '#' — which is what plugin-name queries actually
+      // contain. The owner stays in the URL and on the page either way.
+      .replaceAll('__TITLE__', () => {
+        const render = (n) => loc.P_TITLE.replace('{NAME}', n).replace('{CAT}', loc.categories[e.cat])
+        const candidates = [e.name, short, short.split('#').pop()]
+        return esc(render(candidates.find((n) => render(n).length <= 65) ?? candidates[candidates.length - 1]))
+      })
       .replaceAll('__DESC__', () => esc(metaDesc))
       .replaceAll('__URL__', () => url)
       .replaceAll('__HREFLANGS__', () => dHreflangs)

--- a/site/locales.mjs
+++ b/site/locales.mjs
@@ -55,6 +55,9 @@ export default [
     // category, and showing who wrote a plugin is worth more in a result list
     // than showing which of twenty categories it sits in.
     P_TITLE: '{NAME} — dsh plugin · {CAT}',
+    // Used only when an entry's one-line description is too short to stand
+    // alone as a meta description (Bing flags those). {DESC} is the original.
+    P_META_SHORT: '{DESC} · {NAME} is a DeepSeek Harness (dsh) plugin in {CAT}, with the install command, source links and community comments on this page.',
     COPY_LABEL: 'Copy install command',
     COPY_TEXT: 'copy install',
     categories: {
@@ -174,6 +177,9 @@ export default [
     CAT_TITLE: '{CAT} — {N} 个 dsh 插件',
     CAT_DESC: 'DeepSeek Harness（dsh）{CAT}插件共 {N} 个，包括 {TOP}。含安装命令、功能描述与仓库链接，持续更新。',
     P_TITLE: '{NAME} — dsh 插件 · {CAT}',
+    // 仅在条目一句话描述太短、不足以独立作为 meta description 时使用（Bing 会
+    // 标记这类页面）。{DESC} 为原始描述。
+    P_META_SHORT: '{DESC}——{NAME} 是 DeepSeek Harness（dsh）「{CAT}」类插件，本页提供安装命令、来源链接与社区评论。',
     COPY_LABEL: '复制安装命令',
     COPY_TEXT: '复制安装命令',
     categories: {


### PR DESCRIPTION
Bing Webmaster's SEO report flags two things on the detail pages: **162 meta descriptions too short** (moderate) and **titles too long** (high; local audit finds 86 over 65 chars).

**Short descriptions** — below 60 chars, the description is wrapped in a new `P_META_SHORT` locale context sentence (what this is, which category, what the page offers); longer ones stand alone as before. The 155-char boundary-aware clamp applies to both paths. After: **0** detail pages under 50 chars.

**Long titles** — compound names (`owner/repo#subpath`) now fall back through shorter forms until the title fits 65 chars: full name → without owner → bare package name after `#` (what plugin-name queries actually contain). After: **23** of 5,994 over 65 decoded chars (extreme package names at their shortest form already).

**Verification** — `SKIP_PUBLISH_CHECKS=1 node scripts/build-site.mjs` builds clean (2,997 rows × 2 locales); full audit over all 5,994 detail pages confirms the numbers above; already-fine pages byte-unchanged.