### PR TITLE
Add RGarvel/dsh-channel-view (session)

### DIFF
--- a/data/plugins/RGarvel__dsh-channel-view.yml
+++ b/data/plugins/RGarvel__dsh-channel-view.yml
@@ -1,0 +1,6 @@
+url: https://github.com/RGarvel/dsh-channel-view
+name: RGarvel/dsh-channel-view
+category: session
+description:
+  en: "Channel-grouped session view injected into the sidebar — Workspace/Channels tabs with live-running dots, archived grouping, orphan tagging, built purely on official extension surfaces and serving as the RFC-0001 reference implementation."
+  zh: "侧边栏注入的按渠道分组会话视图——工作区/Channels 双标签、运行中绿点、归档折叠与孤儿工作区标注，完全基于官方扩展面实现，兼作 RFC-0001（discussion #3897）的参考实现。"


### PR DESCRIPTION
## What / 添加内容

Single entry file `data/plugins/RGarvel__dsh-channel-view.yml` (+1/-0), per the one-YAML-per-entry workflow.

重开自上游 main，仅含一个条目文件（+1/-0），替代过时的 #3517。

## The plugin / 插件是什么

[dsh-channel-view](https://github.com/RGarvel/dsh-channel-view) — channel-grouped session view for the sidebar: Workspace/Channels 双标签, per-channel buckets (qq/c2c, qq/group, declared channels, subagent), live-running pulse dots, archived collapsed group, duplicate-title disambiguation and orphan-workspace tagging.

- Zero host modification: bundle client module, `sidebar.footer.action` slot, session projections, official react-dom portal.
- Doubles as the reference implementation evidence for RFC-0001 / [discussion #3897](https://github.com/deepseek-ai/deepseek-harness/discussions/3897) (session `channel` field), and ships the GUI-seam evidence for [deepseek-harness#4879](https://github.com/deepseek-ai/deepseek-harness/discussions/4879).
- Honest spike identity: `0.0.x-spike` line; DOM-anchor fragility and the migration path to official slots are documented in the README.

## Prereqs / 门槛自检

- `dsh.bundle` manifest declared in package.json (`dsh.bundle.patch`) ✅
- Repo age > 1 day (created 2026-08-27), 14 commits ✅
- `dsh-plugin` topic set ✅
- No `tarball` field (no GitHub release; npm `dsh-channel-view`, bundle-config install) — omission is valid per existing entries

Closes #3517 (stale-fork wholesale README diff, superseded by this clean submission).
