### PR TITLE
Add bgjobs(独立后台任务插件) to the plugin list.

### DIFF
--- a/data/plugins/bitsmug__dsh-bgjobs.yml
+++ b/data/plugins/bitsmug__dsh-bgjobs.yml
@@ -1,0 +1,6 @@
+url: https://github.com/bitsmug/dsh-bgjobs
+name: bitsmug/dsh-bgjobs
+category: tools
+description:
+  en: Runs commands as background jobs that keep executing when DSH exits, with a live web panel and offline CLI/GUI management.
+  zh: 将命令提交为独立于 DSH 进程的后台任务，关闭 DSH 也不影响运行，并提供实时网页面板与离线 CLI/GUI 管理。

--- a/data/plugins/bitsmug__dsh-bgjobs.yml
+++ b/data/plugins/bitsmug__dsh-bgjobs.yml
@@ -2,5 +2,5 @@ url: https://github.com/bitsmug/dsh-bgjobs
 name: bitsmug/dsh-bgjobs
 category: tools
 description:
-  en: Runs commands as background jobs that keep executing when DSH exits, with a live web panel and offline CLI/GUI management.
-  zh: 将命令提交为独立于 DSH 进程的后台任务，关闭 DSH 也不影响运行，并提供实时网页面板与离线 CLI/GUI 管理。
+  en: Runs commands as background jobs that keep executing when DSH exits, with an optional sandbox to constrain file effects, plus a live web panel and offline CLI/GUI management.
+  zh: 将命令提交为独立于 DSH 进程的后台任务（可选沙箱），关闭 DSH 也不影响运行，并提供实时网页面板与离线 CLI/GUI 管理。


### PR DESCRIPTION
bgjobs runs commands as **Windows background jobs that outlive the DSH process** — a
job handed to Task Scheduler keeps running even when you close DSH, the web page,
or the terminal that started it:

- Submit a command (bat or PowerShell engine) → it runs on its own, live output
  streams to the web panel; on exit an optional toast / agent notify fires.
- Recover after restarts: jobs started while DSH was down are picked up again, no
  lost tasks; restrict file effects with the optional dsh sandbox (read-only /
  workspace-write) instead of always running full-access.
- Manage everything offline too: standalone CLI/GUI (list / status / log / submit /
  kill / cleanup) work without DSH; panel copy follows the DSH UI language, and the
  offline GUI/toast follows the Windows UI language.

---

**补充说明 / Update (v0.1.42)** — this submission now includes UI-language support:

- 网页面板文案跟随 DSH 主界面语言（中文 DSH → 中文面板，其他 → 英文）；
- 离线 GUI 与 Toast 提醒跟随 Windows 系统 UI 语言（zh → 简体中文，其他 → 英文）；离线 CLI 输出固定为英文；
- 最新 npm 版已发布：`bgjobs@0.1.42`。

- The web panel copy follows the DSH UI language (Chinese DSH → Chinese panel, otherwise English).
- The offline GUI and Toast notifications follow the Windows UI language (zh* → Simplified Chinese, otherwise English); the offline CLI prints English.
- Latest npm release: `bgjobs@0.1.41`.

---

<!- Quick checklist / 提交前已自查 -->

- [x] I added **one file** at `data/plugins/bitsmug__dsh-bgjobs.yml` — that single file is the whole submission. The READMEs are regenerated on `main` after merge: don't edit them by hand, and you don't need to commit them either / 我新增了一个 `data/plugins/bitsmug__dsh-bgjobs.yml` 文件——**这一个文件就是全部投稿**。README 会在合并后由 `main` 自动重新生成：不要手工编辑，也不需要提交
- [x] My repo's `package.json` declares **`dsh.bundle`** (not just `dsh.client`) — `cordis.patch.yml` / 仓库 `package.json` 已声明 `dsh.bundle`（patch 指向 `cordis.patch.yml`）
- [x] My repo is at least **1 day old** / 仓库创建满 1 天
- [x] `category` is one of `agi ui usage theme model identity session memory tools wsl browser vision voice docs skill workflow git notify dev security remote market fun`, and themes/skins go under `theme` / `category` 取值正确（`tools`）
- [x] Description states what the plugin does, no superlatives / 描述只说功能，不带营销词
- [x] My repo has the `dsh-plugin` topic / 仓库已打 `dsh-plugin` topic

**Recommended (not required) / 推荐但不强制：**

- [x] 📦 Publish to npm — npm installs are prebuilt and skip the `allowBuilds` approval / 已发布 npm（`bgjobs@0.1.42`）
- [x] 🔗 Declare official `@deepseek-ai/*` packages as `peerDependencies` (not `dependencies`) — avoids duplicate runtimes inside the profile / 官方 `@deepseek-ai/*` 已用 `peerDependencies`（`dsh-client-ui-primitives` 走 peer + prerelease 分支；`dsh-sandbox-windows-acl` 是私有子进程工具、运行时从插件目录 createRequire 解析，故保留在 dependencies）
