### PR TITLE
gate: drop the commit-count floor, keep the age floor

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@
 
 - [ ] I added **one file** at `data/plugins/<owner>__<repo>.yml` — that single file is the whole submission. The READMEs are regenerated on `main` after merge: don't edit them by hand, and you don't need to commit them either / 我新增了一个 `data/plugins/<owner>__<repo>.yml` 文件——**这一个文件就是全部投稿**。README 会在合并后由 `main` 自动重新生成：不要手工编辑，也不需要提交
 - [ ] My repo's `package.json` declares **`dsh.bundle`** (not just `dsh.client`) — [example](../blob/main/contributing.md) / 仓库 `package.json` 已声明 `dsh.bundle`（只有 `dsh.client` 无法安装）
-- [ ] My repo is at least **1 day old** with **10+ commits** / 仓库创建满 1 天且提交数 ≥ 10
+- [ ] My repo is at least **1 day old** / 仓库创建满 1 天
 - [ ] `category` is one of `agi ui usage theme model identity session memory tools wsl browser vision voice docs skill workflow git notify dev security remote market fun` ([full list with descriptions](../blob/main/contributing.md)), and themes/skins go under `theme` / `category` 取值正确（完整清单见 contributing.md），主题/皮肤类请用 `theme`
 - [ ] Description states what the plugin does, no superlatives / 描述只说功能，不带营销词
 - [ ] My repo has the `dsh-plugin` topic / 仓库已打 `dsh-plugin` topic

--- a/contributing.md
+++ b/contributing.md
@@ -72,7 +72,7 @@ Requirements / 要求：
         name: your-package-name
   ```
 - The repo contains real, working code — placeholder, name-squat, or README-only repos don't qualify. / 仓库需有真实可用的代码——占位仓库、纯 README 仓库不收。
-- The repo is at least **1 day old** and has **10 or more commits**. / 仓库**创建满 1 天**，且**提交数 ≥ 10**。
+- The repo is at least **1 day old**. (There is no commit-count bar: history length measures development habit, not quality — see #4196.) / 仓库**创建满 1 天**。（没有提交数门槛：历史长短反映的是开发习惯而非质量，见 #4196。）
 
   This is checked automatically. It isn't a judgement about your plugin — it filters out repos created minutes before the PR, which were the bulk of what had to be rejected by hand. If you're just under the bar, finish the work and resubmit; nothing is held against a resubmission. / 这一项由 CI 自动检查。它不是对插件质量的评价，只是为了过滤掉「PR 前几分钟才建好」的仓库——过去人工被迫拒掉的大多是这类。如果暂时没达标，把功能做完再提交即可，重新提交不会有任何影响。
 - The project is actively maintained. A periodic scan flags entries whose repo is gone, archived, or long dormant; they're collected in a tracking issue and removed after review. / 项目处于活跃维护状态。定期扫描会标记仓库消失、已归档或长期停更的条目，汇总到一个跟踪 issue，经确认后移除。
@@ -157,7 +157,7 @@ Every PR runs, in order / 每个 PR 依次运行：
 
 1. **Entry count** — at most 3 per PR (above). Checked first, before anything is fetched. / 每个 PR 最多 3 条（见上）。最先检查，早于任何网络请求。
 2. **`dsh.bundle`** — fetched from your repo's `package.json` (root, or a `packages/` · `plugins/` · `apps/` subpackage). Declaring only `dsh.client` fails here. / 从你仓库的 `package.json` 读取（根包，或 `packages/` · `plugins/` · `apps/` 子包）；只声明 `dsh.client` 会在这里失败。
-3. **Repo age and commit count** — the 1 day / 10 commits bar above. / 上面的 1 天 / 10 提交门槛。
+3. **Repo age** — the 1-day bar above. / 上面的 1 天年龄门槛。
 4. **`awesome-lint`** and the site build — locale parity, separators, dates, screenshots. / `awesome-lint` 与站点构建：双语一致性、分隔符、日期、截图。
 
 If a check fails it says exactly what to change. Push a fix to the same branch — no need to open a new PR. / 检查失败时会明确指出要改什么。在同一分支上推送修复即可，无需重开 PR。

--- a/scripts/check-submission.mjs
+++ b/scripts/check-submission.mjs
@@ -3,12 +3,12 @@
 //   1. package.json declares `dsh.bundle` (anywhere in the repo — monorepos
 //      put it in packages/, plugins/, extensions/, bundle/, npm/, ... so the
 //      whole tree is enumerated rather than a guessed list of directories)
-//   2. the repo is at least MIN_AGE_DAYS old and has >= MIN_COMMITS commits
+//   2. the repo is at least MIN_AGE_DAYS old (no commit floor — see below)
 //   3. the repo exists and isn't archived
 //   4. the repo is not DSH itself (it declares `dsh.bundle` and would pass 1-3)
 //
-// Needs GITHUB_TOKEN: the git-tree enumeration and the commit count are API
-// calls, and unauthenticated (60/hr per IP) is nowhere near enough. That is
+// Needs GITHUB_TOKEN: the git-tree enumeration is API calls, and
+// unauthenticated (60/hr per IP) is nowhere near enough. That is
 // why this runs from pr-gate.yml via workflow_run rather than the fork-safe
 // pull_request job.
 //
@@ -19,14 +19,22 @@ import path from 'node:path'
 import { PLUGINS_DIR, readEntries } from './lib/entries.mjs'
 
 const MIN_AGE_DAYS = 1
-const MIN_COMMITS = 10
+// There is deliberately no commit-count floor any more (dropped 2026-09-03,
+// #4196). The old MIN_COMMITS = 10 filtered by a number that measures
+// development HABIT, not quality: squash-merge repositories with years of
+// real changes show a short main history, while `git commit --allow-empty`
+// clears the bar in ten seconds. In practice it never rejected anything —
+// every blocked submission either padded commits or waited, so its whole
+// effect was delay plus a red X that primed the human review against clean
+// histories. The age floor stays: it is the part that actually blocks
+// hours-old throwaway repositories, and time cannot be counterfeited.
 const CONCURRENCY = 6
 const MAX_TREE_PKGS = 40
 
 // DSH itself declares `dsh.bundle`: packages/bundle/base/package.json is
 // @deepseek-ai/dsh-base, and it is the 19th of 248 manifests in that tree, so
-// the enumeration reaches it well inside MAX_TREE_PKGS and the age and commit
-// thresholds are met by years. The harness would therefore pass the gate as a
+// the enumeration reaches it well inside MAX_TREE_PKGS and the age
+// threshold is met by years. The harness would therefore pass the gate as a
 // plugin for itself. Listing the product in a list of plugins for the product
 // is the one wrong entry every visitor would recognise, so it is refused by
 // identity rather than by contract.
@@ -83,7 +91,7 @@ const ALL = process.argv.includes('--all')
 
 const TOKEN = process.env.GITHUB_TOKEN
 if (!TOKEN) {
-  console.error('GITHUB_TOKEN is required (tree enumeration + commit counts exceed the anonymous quota)')
+  console.error('GITHUB_TOKEN is required (tree enumeration exceeds the anonymous quota)')
   process.exit(1)
 }
 const HEADERS = { accept: 'application/vnd.github+json', authorization: `Bearer ${TOKEN}`, 'user-agent': 'awesome-dsh-plugin-ci' }
@@ -341,19 +349,6 @@ async function hasBundle(repo, sub) {
   return scanned
 }
 
-// Goes through api() rather than fetching directly, so the commit-count bar
-// gets the same rate-limit backoff as everything else. It used to have its own
-// bare fetch, which meant a squeeze made a repository look like it had no
-// commit history rather than like it had not been asked.
-async function commitCount(repo) {
-  const r = await api(`repos/${repo}/commits?per_page=1`)
-  if (r.status !== 200) return null
-  const link = r.headers.get('link') ?? ''
-  const m = link.match(/[?&]page=(\d+)>;\s*rel="last"/)
-  if (m) return Number(m[1])
-  return Array.isArray(r.body) ? r.body.length : null
-}
-
 async function check(entry) {
   const { repo, sub } = decompose(entry.url)
   if (FIRST_PARTY_REPOS.has(repo.toLowerCase())) {
@@ -402,17 +397,10 @@ async function check(entry) {
   const alreadyListed = listedRepos !== null && listedRepos.has(repo.toLowerCase())
   if (gateApplies && !alreadyListed) {
     const ageDays = (Date.now() - new Date(meta.body.created_at).getTime()) / 86400000
-    const commits = await once(`commits:${repo}`, () => commitCount(repo))
     if (ageDays < MIN_AGE_DAYS) {
       const hours = Math.ceil((MIN_AGE_DAYS - ageDays) * 24)
       problems.push(`repository is ${ageDays.toFixed(1)} days old (needs ${MIN_AGE_DAYS}) — resubmit in about ${hours}h, nothing is held against a resubmission`)
     }
-    // A count we could not read is not a count that met the bar. Letting it
-    // through is right — a busy API quota must not reject a good submission —
-    // but the verdict has to say so, or "enough commits" is printed about a
-    // repository nobody counted.
-    if (commits === null) unverified.push('commit count could not be read')
-    else if (commits < MIN_COMMITS) problems.push(`repository has ${commits} commit(s) (needs ${MIN_COMMITS})`)
   }
   return { problems, unverified }
 }


### PR DESCRIPTION
Implements the maintainer decision on #4196 — see the commit message and the inline comment replacing `MIN_COMMITS` for the full rationale.

- `scripts/check-submission.mjs`: age floor stays at 1 day; commit floor and the now-dead `commitCount()` removed
- `contributing.md` (both mentions) and the PR template updated
- `pr-gate.yml` runs from the default branch (`workflow_run`), so this reaches **every open PR** immediately on merge — the ~58 currently blocked on commit count will clear on their next `regate.yml` cycle without authors doing anything

Note: `Repository config guard` untouched; this PR touches no workflow file, so it should come back fully green.