### PR TITLE
Add dsh-super-pm plugin entry

### DIFF
--- a/data/plugins/Lohaslee__dsh-super-pm.yml
+++ b/data/plugins/Lohaslee__dsh-super-pm.yml
@@ -2,5 +2,5 @@ url: https://github.com/Lohaslee/dsh-super-pm
 name: Lohaslee/dsh-super-pm
 category: skill
 description:
-  en: Super PM product-thinking skill packaged as a DeepSeek Harness plugin.
-  zh: 将 Super PM 产品思考技能打包为 DeepSeek Harness 插件。
+  en: "Product-thinking companion for DeepSeek Harness: clarifies negative boundaries first, separates facts from assumptions, routes through seven product lenses, and persists confirmed decisions to project memory."
+  zh: "DeepSeek Harness 的产品思考助手：先明确负向边界，拆开事实与假设，经七套产品视角讨论取舍，并将确认的决策沉淀到项目记忆中。"

--- a/data/plugins/Lohaslee__dsh-super-pm.yml
+++ b/data/plugins/Lohaslee__dsh-super-pm.yml
@@ -1,0 +1,6 @@
+url: https://github.com/Lohaslee/dsh-super-pm
+name: Lohaslee/dsh-super-pm
+category: skill
+description:
+  en: Super PM product-thinking skill packaged as a DeepSeek Harness plugin.
+  zh: 将 Super PM 产品思考技能打包为 DeepSeek Harness 插件。


### PR DESCRIPTION
## Summary

Add [dsh-super-pm](https://github.com/Lohaslee/dsh-super-pm) to the plugin list.

**What it does:** Packages the Super PM product-thinking skill as a DeepSeek Harness plugin. Provides seven product lenses, negative-boundary-first discovery, fact/assumption separation, and decision persistence via DSH tools.

**Category:** `skill`

**Verification:**
- `dsh.bundle` manifest present in `package.json`
- `cordis.patch.yml` present
- 14 commits, repo created 2026-09-01 (meets 1-day / 10-commit bar)
- `dsh-plugin` topic declared in `package.json` keywords
- npm package `dsh-super-pm` published; `repository` field points back to this repo