### PR TITLE
add tiphareth0/dsh-hardssh — run your existing DSH plugins on remote servers, across any number of machines

### DIFF
--- a/data/plugins/tiphareth0__dsh-hardssh--packages-dsh-hardssh.yml
+++ b/data/plugins/tiphareth0__dsh-hardssh--packages-dsh-hardssh.yml
@@ -1,0 +1,6 @@
+url: https://github.com/tiphareth0/dsh-hardssh/tree/master/packages/dsh-hardssh
+name: tiphareth0/dsh-hardssh#dsh-hardssh
+category: remote
+description:
+  en: 'SSH workspace and operations for DeepSeek Harness: bind a server directory as a workspace whose fs/subprocess calls route to the remote host via cordis seam replacement, plus web terminal, file transfers, tunnels, cluster runs and host management.'
+  zh: '为 DeepSeek Harness 提供 SSH 工作区与运维：把服务器目录绑定为工作区，fs/命令经 cordis seam 替换透明路由到远端主机，并带 Web 终端、文件传输、隧道、集群执行与主机管理。'


### PR DESCRIPTION
dsh-hardssh binds any folder on your servers into a DSH workspace — and the
whole point is that **your existing plugins don't know the difference**:

- Pick a server, bind a directory → open it like a local project.
- Every tool that works on a local project works here too — your usual file
  editing, search, agent commands now run **on the server** instead.
- Manage any number of machines from one panel: web terminal, file transfer,
  tunnels, cluster runs, host CRUD and `~/.ssh/config` import.
- Install on any dsh core version; passwords never saved (enter once per
  session), first-connect host-key confirmation included.

npm: `@tiphareth/dsh-hardssh` — `latest` 0.1.2 / alpha 0.1.2-alpha

<!-- Thanks for contributing! Quick checklist / 提交前快速自查 -->

- [x] I added **one file** at `data/plugins/<owner>__<repo>.yml` — that single file is the whole submission. The READMEs are regenerated on `main` after merge: don't edit them by hand, and you don't need to commit them either / 我新增了一个 `data/plugins/<owner>__<repo>.yml` 文件——**这一个文件就是全部投稿**。README 会在合并后由 `main` 自动重新生成：不要手工编辑，也不需要提交
- [x] My repo's `package.json` declares **`dsh.bundle`** (not just `dsh.client`) — [example](../blob/main/contributing.md) / 仓库 `package.json` 已声明 `dsh.bundle`（只有 `dsh.client` 无法安装）
- [x] My repo is at least **1 day old** / 仓库创建满 1 天
- [x] `category` is one of `agi ui usage theme model identity session memory tools wsl browser vision voice docs skill workflow git notify dev security remote market fun` ([full list with descriptions](../blob/main/contributing.md)), and themes/skins go under `theme` / `category` 取值正确（完整清单见 contributing.md），主题/皮肤类请用 `theme`
- [x] Description states what the plugin does, no superlatives / 描述只说功能，不带营销词
- [x] My repo has the `dsh-plugin` topic / 仓库已打 `dsh-plugin` topic

**Recommended (not required) / 推荐但不强制：**

- 📦 Publish to npm — npm installs are prebuilt and skip the `allowBuilds` approval, so users get a one-command install / 发布 npm 包：预构建产物免 `allowBuilds` 授权，用户一条命令装好
- 🔗 Declare official `@deepseek-ai/*` packages as `peerDependencies` (not `dependencies`) — avoids duplicate runtimes inside the profile / 官方 `@deepseek-ai/*` 包用 `peerDependencies` 声明（而非 `dependencies`），避免 profile 里出现重复运行时
- 🖼️ Screenshots go in **your own repository** now: a `screenshots.json` beside your `package.json`, listing image paths. Nothing to add here, and you can change them later without another pull request ([how](../blob/main/contributing.md#screenshots--截图optional-recommended--可选推荐)) / 截图现在放在**你自己的仓库**里：在 `package.json` 旁边放一个 `screenshots.json`，列出图片路径。这个 PR 里不用加任何东西，以后想换也不必再提 PR（[说明](../blob/main/contributing.md#screenshots--截图optional-recommended--可选推荐)）
