### PR TITLE
Add liaoyuqing/dsh-llm-error-retry

### DIFF
--- a/data/plugins/liaoyuqing__dsh-llm-error-retry.yml
+++ b/data/plugins/liaoyuqing__dsh-llm-error-retry.yml
@@ -1,0 +1,7 @@
+url: https://github.com/liaoyuqing/dsh-llm-error-retry
+name: liaoyuqing/dsh-llm-error-retry
+category: model
+tarball: https://github.com/liaoyuqing/dsh-llm-error-retry/releases/latest/download/dsh-llm-error-retry.tgz
+description:
+  en: "LLM request retry plugin for DeepSeek Harness: when a model request fails with a configured HTTP status code, machine code, or provider field=value match, it sleeps for the per-rule delay and re-issues the request automatically, so subscription quota and rate-limit errors (429 / insufficient_quota) do not interrupt a run."
+  zh: "大模型请求重试插件：命中配置的 HTTP 状态码、机器码或 provider 返回字段=值时，按该条规则独立配置的时长休眠后自动重新请求，让订阅套餐的限额、限流报错（429 / insufficient_quota）不打断运行。"


### PR DESCRIPTION
## liaoyuqing/dsh-llm-error-retry

?????????:???? plan ?????????,?????

- Repo: https://github.com/liaoyuqing/dsh-llm-error-retry (11 commits, MIT, v0.7.0 tag; v0.6.0-v1.x ????)
- Install: `dsh plugin --profile web add github:liaoyuqing/dsh-llm-error-retry` - verified locally on a throwaway profile (`dsh plugin --profile test-lre add ...`, then `--dump-config` showed the inserted `llm-error-retry` host row; test profile removed afterwards)
- `dsh.bundle` manifest: `package.json` declares `dsh.bundle.patch: ./cordis.patch.yml` (patch file at the repo root); `dsh.client` declares the browser half (Settings-page section via the dual-face client package convention)
- Tarball asset name is version-free (`dsh-llm-error-retry.tgz`), so the entry's `latest/download` URL does not rot on the next release; the release workflow attaches it automatically on tags
- No build step, zero runtime dependencies - no `allowBuilds` needed for git installs
- Per-rule retry cap configurable 0..1000 (raised from 0..100 in v0.7.0)
- Description claims match the code: HTTP status / machine code / `field=value` rule forms, per-rule `delayMs` + `maxRetries`, in-conversation retry card (`llm/retry` + `llm/retry-started`), rules editable live in the Settings page
- Repo topic `dsh-plugin`: being added via the web UI (the PAT used for automation lacks repo-admin scope)

Note on CI: the repo was created 2026-09-02 - the repo-age check turns green once the repo is 1 day old; a re-run of that check after that passes. Happy to retrigger if needed.