### PR TITLE
Update curated store screenshots for dsh-wallpaper-engine (v0.7 UI)

### DIFF
--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -1166,13 +1166,12 @@
   "https://raw.githubusercontent.com/liustack/modlens/main/assets/demo-codex-chart.jpg",
   "https://raw.githubusercontent.com/liustack/modlens/main/assets/demo-codex-app.jpg"
  ],
- "https://github.com/elysia395/dsh-wallpaper-engine": [
-  "https://raw.githubusercontent.com/elysia395/dsh-wallpaper-engine/main/docs/images/showcase.png",
-  "https://raw.githubusercontent.com/elysia395/dsh-wallpaper-engine/main/docs/images/wallpaper-library.png",
-  "https://raw.githubusercontent.com/elysia395/dsh-wallpaper-engine/main/docs/images/liquid-glass-window.png",
-  "https://raw.githubusercontent.com/elysia395/dsh-wallpaper-engine/main/docs/images/features.png",
-  "https://raw.githubusercontent.com/elysia395/dsh-wallpaper-engine/main/docs/images/compact-wallpaper-library.png",
-  "https://raw.githubusercontent.com/elysia395/dsh-wallpaper-engine/main/docs/images/better-sidebar.png"
+  "https://github.com/elysia395/dsh-wallpaper-engine": [
+  "https://raw.githubusercontent.com/elysia395/dsh-wallpaper-engine/main/docs/images/main-interface.gif",
+  "https://raw.githubusercontent.com/elysia395/dsh-wallpaper-engine/main/docs/images/settings-ui.gif",
+  "https://raw.githubusercontent.com/elysia395/dsh-wallpaper-engine/main/docs/images/wallpaper-library.gif",
+  "https://raw.githubusercontent.com/elysia395/dsh-wallpaper-engine/main/docs/images/mascot-drawer.png",
+  "https://raw.githubusercontent.com/elysia395/dsh-wallpaper-engine/main/docs/images/better-sidebar-font.png"
  ],
  "https://github.com/dami9527/dsh-image-pathify": [
   "https://raw.githubusercontent.com/dami9527/dsh-image-pathify/master/assets/example.png",


### PR DESCRIPTION
Updates the `data/screenshots.json` entry for [elysia395/dsh-wallpaper-engine](https://github.com/elysia395/dsh-wallpaper-engine) — replaces the six pre-0.7 screenshots with the current 0.7 interface recordings, so dsh-market shows the latest UI:

- `main-interface.gif` — hero: wallpaper + iOS-style liquid glass rendered behind the DSH chat
- `settings-ui.gif` — the new six-tab settings page (壁纸 / 外观 / 字体 / 吉祥物 / 效果 / 高级)
- `wallpaper-library.gif` — the wallpaper picker modal (batch hide / restore)
- `mascot-drawer.png` — the mascot pull-cord wallpaper-repo drawer
- `better-sidebar-font.png` — dsh-better-sidebar glass adaptation + custom typography

No YAML/description changes, so no README regeneration is needed. All five URLs point to files already on the plugin repo's `main` branch (verified via the contents API).