### PR TITLE
Add dsh-git-graph: Git view for DeepSeek Harness

### DIFF
--- a/data/plugins/enoughpower__dsh-git-graph.yml
+++ b/data/plugins/enoughpower__dsh-git-graph.yml
@@ -1,0 +1,6 @@
+url: https://github.com/enoughpower/dsh-git-graph
+name: dsh-git-graph
+category: git
+description:
+  en: 'Git view for DeepSeek Harness: status, commit graph, branches, diff, staging/commit, push/pull and blame.'
+  zh: 'DeepSeek Harness 的 Git 视图：状态、提交图、分支、差异、暂存提交、推送拉取与逐行溯源。'


### PR DESCRIPTION
## Plugin

`dsh-git-graph` — a Git view for DeepSeek Harness: status, commit graph, branches, diff, staging/commit, push/pull and blame.

- **Category:** git
- **Repo:** https://github.com/enoughpower/dsh-git-graph
- **npm:** [`dsh-git-graph`](https://www.npmjs.com/package/dsh-git-graph) (with provenance)
- Installable via `dsh plugin add` — the repo declares a `dsh.bundle` manifest in `package.json`.

## Checklist

- [x] Single file: `data/plugins/enoughpower__dsh-git-graph.yml`
- [x] Repo declares `dsh.bundle` in `package.json`
- [x] Repo is 1+ day old (created 2026-09-02) with 10+ commits (35)
- [x] `description.en` included (ends with a period)
- [x] Category `git` is a valid value
- [x] One file, one plugin — no unrelated edits

English + Chinese descriptions included.