### PR TITLE
docs: refine dsh-session-manager description

### DIFF
--- a/data/plugins/hkkz9522__dsh-session-manager.yml
+++ b/data/plugins/hkkz9522__dsh-session-manager.yml
@@ -2,5 +2,4 @@ url: https://github.com/hkkz9522/dsh-session-manager
 name: hkkz9522/dsh-session-manager
 category: session
 description:
-  en: Delete, archive, move conversations across workspaces, and migrate a session's Agent preset — with confirmation dialogs — in the DeepSeek Harness web UI.
-  zh: 在 DeepSeek Harness Web 中删除、归档、跨工作区移动会话，以及迁移单条会话的 Agent 预设，全部带二次确认。
+  en: '用于在 DeepSeek Harness（DSH）Web 中进行会话管理，包括：删除会话、归档会话、跨工作区移动会话、迁移会话的 Agent 预设。欢迎至 GitHub 提意见。'

--- a/data/plugins/hkkz9522__dsh-session-manager.yml
+++ b/data/plugins/hkkz9522__dsh-session-manager.yml
@@ -2,4 +2,5 @@ url: https://github.com/hkkz9522/dsh-session-manager
 name: hkkz9522/dsh-session-manager
 category: session
 description:
-  en: '用于在 DeepSeek Harness（DSH）Web 中进行会话管理，包括：删除会话、归档会话、跨工作区移动会话、迁移会话的 Agent 预设。欢迎至 GitHub 提意见。'
+  en: 'Conversation manager for the DeepSeek Harness Web UI: delete conversations, archive conversations, move conversations across workspaces, and migrate a conversation’s Agent preset. Suggestions are welcome on GitHub.'
+  zh: '用于在 DeepSeek Harness（DSH）Web 中进行会话管理，包括：删除会话、归档会话、跨工作区移动会话、迁移会话的 Agent 预设。欢迎至 GitHub 提意见。'


### PR DESCRIPTION
Replace the previous single-line Chinese entry with a proper bilingual description that mirrors the README summary:

- description.en — English sentence covering delete / archive / cross-workspace move / Agent preset migration.
- description.zh — Chinese sentence matching the README.

The category and the other fields are unchanged.