### PR TITLE
Add Ox0400/dsh-vault (security): encrypted local credentials vault

### DIFF
--- a/data/plugins/Ox0400__dsh-vault.yml
+++ b/data/plugins/Ox0400__dsh-vault.yml
@@ -1,0 +1,6 @@
+url: https://github.com/Ox0400/dsh-vault
+name: Ox0400/dsh-vault
+category: security
+description:
+  en: "Encrypted local credentials vault for the Harness: a web settings page and vault_* tools to store, search and copy passwords, API keys, TOTP secrets and card data, with health audits, expiry rotation, imports/exports and read-only/ask access modes."
+  zh: "Harness 的本地加密凭据保险库：Web 设置页与 vault_* 工具，可存取与复制密码、API 密钥、TOTP 与银行卡信息，支持健康审计、到期轮换、导入导出以及只读/询问访问模式。"


### PR DESCRIPTION
## What
Add [Ox0400/dsh-vault](https://github.com/Ox0400/dsh-vault) under **security** — an encrypted **local** credentials vault (password/API-key/TOTP/card manager) with a web settings page and vault_* model tools.

This complements (does not duplicate) `tancheng33/dsh-credentials-vault`, which is a *remote* HashiCorp Vault backend over the credential seam; dsh-vault stores credentials locally, encrypted at rest (AES-256-GCM, master-password derived), and adds UI + tools.

## Checklist
- [x] Repo declares `dsh.bundle` (patch `./cordis.patch.yml`), installable — verified locally in a disposable profile via `dsh plugin --profile pt add dsh-vault@1.10.31-rc.1` + `--dump-config`.
- [x] Published to npm (`dsh-vault`, `repository` field points back to the repo) — download stats auto-link.
- [x] Repo >1 day old, actively maintained (weekly releases, 400+ tests, Playwright E2E).
- [x] `dsh-plugin` GitHub topic added.
- [x] Description is accurate and marketing-free (no counts/APIs overclaimed); category `security` matches its job.
