### PR TITLE
Add bgjobs(独立后台任务) to the plugin list

### DIFF
--- a/data/plugins/bitsmug__dsh-bgjobs.yml
+++ b/data/plugins/bitsmug__dsh-bgjobs.yml
@@ -2,5 +2,5 @@ url: https://github.com/bitsmug/dsh-bgjobs
 name: bitsmug/dsh-bgjobs
 category: tools
 description:
-  en: Runs commands as background jobs that keep executing when DSH exits, with an optional sandbox to constrain file effects, plus a live web panel and offline CLI/GUI management.
-  zh: 将命令提交为独立于 DSH 进程的后台任务（可选沙箱），关闭 DSH 也不影响运行，并提供实时网页面板与离线 CLI/GUI 管理。
+  en: 'Runs commands as background jobs that keep executing when DSH exits, with an optional sandbox to constrain file effects, plus a live web panel and offline CLI/GUI management. Windows only for now.'
+  zh: '将命令提交为独立于 DSH 进程的后台任务（可选沙箱），关闭 DSH 也不影响运行，并提供实时网页面板与离线 CLI/GUI 管理。当前仅支持Windows系统。'

--- a/data/plugins/bitsmug__dsh-bgjobs.yml
+++ b/data/plugins/bitsmug__dsh-bgjobs.yml
@@ -1,0 +1,6 @@
+url: https://github.com/bitsmug/dsh-bgjobs
+name: bitsmug/dsh-bgjobs
+category: tools
+description:
+  en: Runs commands as background jobs that keep executing when DSH exits, with a live web panel and offline CLI/GUI management.
+  zh: 将命令提交为独立于 DSH 进程的后台任务，关闭 DSH 也不影响运行，并提供实时网页面板与离线 CLI/GUI 管理。

--- a/data/plugins/bitsmug__dsh-bgjobs.yml
+++ b/data/plugins/bitsmug__dsh-bgjobs.yml
@@ -2,5 +2,5 @@ url: https://github.com/bitsmug/dsh-bgjobs
 name: bitsmug/dsh-bgjobs
 category: tools
 description:
-  en: Runs commands as background jobs that keep executing when DSH exits, with a live web panel and offline CLI/GUI management.
-  zh: 将命令提交为独立于 DSH 进程的后台任务，关闭 DSH 也不影响运行，并提供实时网页面板与离线 CLI/GUI 管理。
+  en: Runs commands as background jobs that keep executing when DSH exits, with an optional sandbox to constrain file effects, plus a live web panel and offline CLI/GUI management.
+  zh: 将命令提交为独立于 DSH 进程的后台任务（可选沙箱），关闭 DSH 也不影响运行，并提供实时网页面板与离线 CLI/GUI 管理。


### PR DESCRIPTION
bgjobs runs commands as **Windows background jobs that keep executing when DSH exits** —
a job handed to the Windows Task Scheduler service keeps running even when you close DSH,
the web page, or the terminal that started it:

- Submit a command with the bat or PowerShell engine → it runs on its own; live output
  streams to the web panel, and an optional toast / agent notify fires on exit.
- Recover after restarts: jobs that finished while DSH was offline are picked up again —
  nothing is lost; the optional dsh sandbox (read-only / workspace-write) constrains
  background file effects instead of always running full-access.
- Manage everything offline too: a standalone CLI/GUI (list / status / log / submit /
  kill / cleanup) works without DSH, and the cleanup age cutoff is adjustable.
- Panel copy follows the DSH UI language; the offline GUI and toast follow the Windows UI
  language. **Windows only for now.**

npm: `bgjobs` — `latest` 0.1.41（v0.1.42 auto-publishes via CI）

___

**补充说明 / Update**: the listing description now also mentions the optional sandbox and
the Windows-only scope; the repo keeps shipping through npm.

- en: “Runs commands as background jobs … with an optional sandbox to constrain file
  effects … Windows only for now.”
- zh: 将命令提交为独立于 DSH 进程的后台任务（可选沙箱），关闭 DSH 也不影响运行，并
  提供实时网页面板与离线 CLI/GUI 管理。当前仅支持 Windows 系统。

___

<!-- Checklist -->

- [x] One file added: `data/plugins/bitsmug__dsh-bgjobs.yml`（READMEs regenerate on merge）
- [x] `package.json` declares `dsh.bundle`（patch `cordis.patch.yml`）
- [x] Repo > 1 day old · `category: tools` · `dsh-plugin` topic set
- [x] Description factual, no superlatives

Recommended:
- [x] Published to npm（`bgjobs` latest 0.1.41；v0.1.42 via CI）
- [x] Official `@deepseek-ai/*` via peerDependencies
- [ ] Screenshots（`screenshots.json` later, no new PR needed）