### PR TITLE
Add cndn/dsh-d1 (Cloudflare D1 tools)

### DIFF
--- a/data/plugins/cndn__dsh-d1.yml
+++ b/data/plugins/cndn__dsh-d1.yml
@@ -1,0 +1,6 @@
+url: https://github.com/cndn/dsh-d1
+name: cndn/dsh-d1
+category: tools
+description:
+  en: 'Cloudflare D1 tools for agents: d1_list/query/exec/schema/stats/health over the D1 HTTP API, read-only by default with a SQLite-accurate lexical guard, LIMIT row cap, CSV/JSON query output and an approval-gated write path.'
+  zh: 'Cloudflare D1 数据库工具：d1_list/query/exec/schema/stats/health，通过 D1 HTTP API 访问，默认只读（SQLite 语义的词法级只读保护）、LIMIT 行数上限、CSV/JSON 查询输出与写审批门。'


### PR DESCRIPTION
Adds `data/plugins/cndn__dsh-d1.yml` (category: `tools`).

Repo: https://github.com/cndn/dsh-d1 — Cloudflare D1 tools for the DeepSeek Harness: `d1_list/query/exec/schema/stats/health` over the D1 HTTP API, read-only by default with a SQLite-accurate lexical guard, a LIMIT row cap, CSV/JSON output and an approval-gated write path. Zero runtime dependencies, MIT, CI green. Published to npm as `dsh-d1` with provenance.

- [x] I added **one file** at `data/plugins/<owner>__<repo>.yml`
- [ ] I ran `node scripts/generate-readme.mjs` — left the READMEs untouched on purpose; PR check accepts that and regenerates them on main after merge
- [x] My repo's `package.json` declares **`dsh.bundle`** (`dsh.bundle.patch` → `cordis.patch.yml`)
- [ ] My repo is at least **1 day old** with **10+ commits** — 13 commits; created 2026-09-02T16:50Z, so the age rule clears at 16:50 UTC today and the re-check will pick it up
- [x] `category` is `tools`
- [x] Description states what the plugin does, no superlatives
- [x] My repo has the `dsh-plugin` topic

🤖 Generated with [Claude Code](https://claude.com/claude-code)
