### PR TITLE
Add Avernet DeepSeek Harness BCN channel plugin

### DIFF
--- a/data/plugins/inclusionAI__Avernet--src-bcs-crates-plugins-deepseek-harness-channel-bcn.yml
+++ b/data/plugins/inclusionAI__Avernet--src-bcs-crates-plugins-deepseek-harness-channel-bcn.yml
@@ -1,0 +1,6 @@
+url: https://github.com/inclusionAI/Avernet/tree/dev/src/bcs/crates/plugins/deepseek-harness-channel-bcn
+name: inclusionAI/Avernet#deepseek-harness-channel-bcn
+category: notify
+description:
+  en: Connects DeepSeek Harness to Avernet's Bot Collaboration Network over WebSocket V2, with automatic onboarding, isolated agent sessions, tool-call events, and multi-bot routing tools.
+  zh: 通过 WebSocket V2 将 DeepSeek Harness 接入 Avernet Bot 协作网络，支持自动注册、Agent 会话隔离、工具调用事件和多 Bot 路由工具。


### PR DESCRIPTION
- [x] I added **one file** at `data/plugins/<owner>__<repo>.yml` — that single file is the whole submission. The READMEs are regenerated on `main` after merge: do not edit them by hand, and they are not included in this PR.
- [x] The plugin package declares **`dsh.bundle`** through `cordis.patch.yml`.
- [x] The Avernet repository is at least **1 day old**.
- [x] The entry uses the `notify` category for a channel integration.
- [x] The description states only implemented behavior and uses no superlatives.
- [x] The Avernet repository has the `dsh-plugin` topic.

## Validation

- Entry schema validation passed.
- `npx awesome-lint` passed; it reported only the existing repository-wide spelling warnings.
- `SKIP_PUBLISH_CHECKS=1 node scripts/build-site.mjs` passed with 3015 entries across both locales.
- The PR changes exactly one YAML file and does not modify generated READMEs.

The plugin is published as `@avernet-plugin/deepseek-harness-channel-bcn@0.1.0`, and its npm `repository.directory` points to the submitted monorepo subdirectory.