### PR TITLE
Add WMXS-A/dsh-utility-plugins (skill cheatsheet, bootcheck)

### DIFF
--- a/data/plugins/WMXS-A__dsh-utility-plugins--packages-dsh-bootcheck.yml
+++ b/data/plugins/WMXS-A__dsh-utility-plugins--packages-dsh-bootcheck.yml
@@ -1,6 +1,0 @@
-url: https://github.com/WMXS-A/dsh-utility-plugins/tree/main/packages/dsh-bootcheck
-name: WMXS-A/dsh-utility-plugins#dsh-bootcheck
-category: usage
-description:
-  en: 'Quiet session-start check that verifies every installed skill is catalogued in the skill dictionary, showing a report card only when something is missing.'
-  zh: '会话启动时静默体检：核对已安装的每个技能是否都已录入技能词典，仅在发现遗漏时弹出体检简报。'

--- a/data/plugins/WMXS-A__dsh-utility-plugins--packages-dsh-bootcheck.yml
+++ b/data/plugins/WMXS-A__dsh-utility-plugins--packages-dsh-bootcheck.yml
@@ -1,0 +1,6 @@
+url: https://github.com/WMXS-A/dsh-utility-plugins/tree/main/packages/dsh-bootcheck
+name: WMXS-A/dsh-utility-plugins#dsh-bootcheck
+category: usage
+description:
+  en: 'Quiet session-start check that verifies every installed skill is catalogued in the skill dictionary, showing a report card only when something is missing.'
+  zh: '会话启动时静默体检：核对已安装的每个技能是否都已录入技能词典，仅在发现遗漏时弹出体检简报。'

--- a/data/plugins/WMXS-A__dsh-utility-plugins--packages-dsh-skill-cheatsheet.yml
+++ b/data/plugins/WMXS-A__dsh-utility-plugins--packages-dsh-skill-cheatsheet.yml
@@ -2,5 +2,5 @@ url: https://github.com/WMXS-A/dsh-utility-plugins/tree/main/packages/dsh-skill-
 name: WMXS-A/dsh-utility-plugins#dsh-skill-cheatsheet
 category: ui
 description:
-  en: 'Composer 🧩 button that opens a panel listing every skill available to the current session, with Chinese titles, purposes, usage examples and a notice for newly installed skills that are not catalogued yet.'
-  zh: '在输入框工具栏提供 🧩 按钮，一键打开技能面板，列出当前会话的全部技能（中文标题、用途与例句），并提示尚未录入词典的新技能。'
+  en: 'Composer button that opens a panel listing every skill available to the current session with Chinese titles, purposes and usage examples, and lets you catalogue newly installed skills in one click (saved locally).'
+  zh: '在输入框工具栏提供一个按钮，一键打开技能面板，列出当前会话的全部技能（中文标题、用途与例句），并可一键收录新安装但尚未录入词典的技能（保存在本机）。'

--- a/data/plugins/WMXS-A__dsh-utility-plugins--packages-dsh-skill-cheatsheet.yml
+++ b/data/plugins/WMXS-A__dsh-utility-plugins--packages-dsh-skill-cheatsheet.yml
@@ -1,0 +1,6 @@
+url: https://github.com/WMXS-A/dsh-utility-plugins/tree/main/packages/dsh-skill-cheatsheet
+name: WMXS-A/dsh-utility-plugins#dsh-skill-cheatsheet
+category: ui
+description:
+  en: 'Composer 🧩 button that opens a panel listing every skill available to the current session, with Chinese titles, purposes, usage examples and a notice for newly installed skills that are not catalogued yet.'
+  zh: '在输入框工具栏提供 🧩 按钮，一键打开技能面板，列出当前会话的全部技能（中文标题、用途与例句），并提示尚未录入词典的新技能。'


### PR DESCRIPTION
Add two client plugins from the dsh-utility-plugins monorepo: dsh-skill-cheatsheet (ui) and dsh-bootcheck (usage). Both declare dsh.bundle manifests and ship real client code.