### PR TITLE
Update huaweicloud/huaweicloud-devkit description

### DIFF
--- a/data/plugins/huaweicloud__huaweicloud-devkit.yml
+++ b/data/plugins/huaweicloud__huaweicloud-devkit.yml
@@ -2,5 +2,5 @@
 name: huaweicloud/huaweicloud-devkit
 category: dev
 description:
-  en: Huawei Cloud DevKit -- MCP server, 30+ skills, safety hooks, and sandbox deployment for coding agents.
-  zh: 为 AI 编码助手提供操作华为云所需的知识、工具与安全护栏，让 Agent 安全、准确地使用华为云。
+  en: 'Huawei Cloud DevKit -- MCP server, 30+ skills, safety hooks, and sandbox deployment for coding agents.'
+  zh: '为 AI 编码助手提供操作华为云所需的知识、工具与安全护栏，让 Agent 安全、准确地使用华为云。'

--- a/data/plugins/huaweicloud__huaweicloud-devkit.yml
+++ b/data/plugins/huaweicloud__huaweicloud-devkit.yml
@@ -1,6 +1,6 @@
-﻿url: https://github.com/huaweicloud/huaweicloud-devkit
+url: https://github.com/huaweicloud/huaweicloud-devkit
 name: huaweicloud/huaweicloud-devkit
 category: dev
 description:
-  en: 'Huawei Cloud DevKit -- MCP server, 30+ skills, safety hooks, and sandbox deployment for coding agents.'
-  zh: '为 AI 编码助手提供操作华为云所需的知识、工具与安全护栏，让 Agent 安全、准确地使用华为云。'
+  en: Huawei Cloud DevKit -- MCP server, 30+ skills, safety hooks, and sandbox deployment for coding agents.
+  zh: 为 AI 编码助手提供操作华为云所需的知识、工具与安全护栏，让 Agent 安全、准确地使用华为云。

--- a/data/plugins/huaweicloud__huaweicloud-devkit.yml
+++ b/data/plugins/huaweicloud__huaweicloud-devkit.yml
@@ -3,4 +3,4 @@ name: huaweicloud/huaweicloud-devkit
 category: dev
 description:
   en: Huawei Cloud DevKit -- MCP server, 30+ skills, safety hooks, and sandbox deployment for coding agents.
-  zh: 华为云开发工具包 -- MCP 服务器，30+ Agent Skills，安全护栏和沙箱部署，专为编码 Agent 打造。
+  zh: 为 AI 编码助手提供操作华为云所需的知识、工具与安全护栏，让 Agent 安全、准确地使用华为云。

--- a/data/plugins/huaweicloud__huaweicloud-devkit.yml
+++ b/data/plugins/huaweicloud__huaweicloud-devkit.yml
@@ -1,6 +1,6 @@
-url: https://github.com/huaweicloud/huaweicloud-devkit
+ï»¿url: https://github.com/huaweicloud/huaweicloud-devkit
 name: huaweicloud/huaweicloud-devkit
 category: dev
 description:
-  en: Huawei Cloud DevKit ¡ª MCP server, 30+ skills, safety hooks, and sandbox deployment for coding agents.
-  zh: »ªÎªÔÆ¿ª·¢¹¤¾ß°ü¡ª¡ªMCP ·şÎñÆ÷¡¢30+ Agent Skills¡¢°²È«»¤À¸ÓëÉ³Ïä²¿Êğ£¬ÃæÏò±à³ÌÖÇÄÜÌå¡£
+  en: Huawei Cloud DevKit -- MCP server, 30+ skills, safety hooks, and sandbox deployment for coding agents.
+  zh: åä¸ºäº‘å¼€å‘å·¥å…·åŒ… -- MCP æœåŠ¡å™¨ï¼Œ30+ Agent Skillsï¼Œå®‰å…¨æŠ¤æ å’Œæ²™ç®±éƒ¨ç½²ï¼Œä¸“ä¸ºç¼–ç  Agent æ‰“é€ ã€‚

--- a/data/plugins/huaweicloud__huaweicloud-devkit.yml
+++ b/data/plugins/huaweicloud__huaweicloud-devkit.yml
@@ -2,5 +2,5 @@ url: https://github.com/huaweicloud/huaweicloud-devkit
 name: huaweicloud/huaweicloud-devkit
 category: dev
 description:
-  en: Huawei Cloud DevKit -- MCP server, 30+ skills, safety hooks, and sandbox deployment for coding agents.
-  zh: 为 AI 编码助手提供操作华为云所需的知识、工具与安全护栏，让 Agent 安全、准确地使用华为云。
+  en: HuaweiCloud DevKit gives AI agents complete command of Huawei Cloud — build, deploy, operate, always governed, always secure.
+  zh: 让 AI 智能体掌握华为云全流程操作——构建、部署、运维全程受控，助您轻松安全上云。


### PR DESCRIPTION
The \zh\ description for huaweicloud-devkit was saved with incorrect encoding, causing garbled text display in DSH plugin list:

- Fixed \zh\ field encoding to proper UTF-8
- Replaced \—\ (em dash) with \--\ in both \en\ and \zh\ to avoid potential encoding issues