### PR TITLE
Add lengzhanbao/dsh-raiden-theme, update lengzhanbao/dsh-taffy-theme tarball

### DIFF
--- a/data/plugins/lengzhanbao__dsh-raiden-theme.yml
+++ b/data/plugins/lengzhanbao__dsh-raiden-theme.yml
@@ -1,0 +1,7 @@
+url: https://github.com/lengzhanbao/dsh-raiden-theme
+name: lengzhanbao/dsh-raiden-theme
+category: theme
+tarball: https://github.com/lengzhanbao/dsh-raiden-theme/releases/download/v0.1.0/dsh-external-dsh-raiden-theme-0.1.0.tgz
+description:
+  en: Violet-gold acrylic DSH Web theme with light and dark stage art, framed chat, workspace mascot, and an optional Raiden agent preset.
+  zh: 紫金亚克力 DSH Web 主题，含浅色与深色舞台背景、描边对话框、工作区吉祥物与可选 Raiden Agent 预设。

--- a/data/plugins/lengzhanbao__dsh-taffy-theme.yml
+++ b/data/plugins/lengzhanbao__dsh-taffy-theme.yml
@@ -1,7 +1,7 @@
 url: https://github.com/lengzhanbao/dsh-taffy-theme
 name: lengzhanbao/dsh-taffy-theme
 category: theme
-tarball: https://github.com/lengzhanbao/dsh-taffy-theme/releases/download/v0.1.2/dsh-external-dsh-taffy-theme-0.1.2.tgz
+tarball: https://github.com/lengzhanbao/dsh-taffy-theme/releases/download/v0.1.3/dsh-external-dsh-taffy-theme-0.1.3.tgz
 description:
   en: Candy-pink acrylic DSH Web theme with light conservatory and dark stage art, gold-pink chat frame, Taffy character overlays, and an optional agent preset.
   zh: 粉金亚克力 DSH Web 主题，含浅色花房与深色舞台背景、粉金对话框、塔菲立绘装饰与可选 Agent 预设。


### PR DESCRIPTION
## Changes (2 entries)

- **Update** `lengzhanbao/dsh-taffy-theme`: tarball pinned to v0.1.3 release asset (v0.1.2 asset superseded by latest release).
- **Add** `lengzhanbao/dsh-raiden-theme` under Themes & Appearance (category: theme) with pinned v0.1.0 tarball.

## Manifest / checks

- Both repos declare `dsh.bundle` + `cordis.patch.yml` + Web client inject, both carry the `dsh-plugin` topic, both repos > 1 day old.
- Tarballs are pinned `releases/download/<tag>/...` URLs (verified HTTP 200), no `latest/download` filename rot.
- Screenshots: both repos now ship repo-local `screenshots.json` (preview/light.webp + preview/dark.webp), so no `data/screenshots.json` change needed.

Related: #2653 (taffy, already merged). This PR adds raiden and refreshes the taffy tarball.