### PR TITLE
Add NattoCB/dsh-safe-delete (security)

### DIFF
--- a/data/plugins/NattoCB__dsh-safe-delete.yml
+++ b/data/plugins/NattoCB__dsh-safe-delete.yml
@@ -1,0 +1,6 @@
+url: https://github.com/NattoCB/dsh-safe-delete
+name: NattoCB/dsh-safe-delete
+category: security
+description:
+  en: Tools guard that moves agent-issued `rm` targets to the macOS Trash instead of deleting, with a shell-aware lexer covering compound and disguised commands; a switch in Settings → General turns it off.
+  zh: 工具守卫将 agent 执行的 rm 目标移入 macOS 废纸篓而非直接删除，shell 感知词法器覆盖复合与伪装命令；设置页通用设置中可随时关闭。


### PR DESCRIPTION
Adds `data/plugins/NattoCB__dsh-safe-delete.yml`.

**What it does:** a host-side tools guard that moves agent-issued `rm` targets to the macOS Trash instead of deleting them — one guard covers GUI sessions, automation runs, headless bridges, and subagents. Shell-aware lexer catches `sudo rm`, absolute-path `rm`, `xargs rm`, and env-prefix forms inside compound commands; constructs that could hide an `rm` (subshells, `$(...)`, heredocs, `eval`, nested `sh -c`) are denied with guidance instead of executed. A switch in the web GUI (Settings → General) toggles the guard; disabled, commands run with native DSH behavior. State persists at `$DSH_HOME/storages/safe-delete.json`.

**Submission checks**
- `dsh.bundle` manifest: yes — `dsh.bundle.patch` + a web client half (the settings row); `scripts/check-submission.mjs --base 279ea98` passes locally ("all checked entries pass")
- Repo age: created 2026-09-01 (> 1 day)
- `dsh-plugin` topic: yes (dsh-plugin, deepseek-harness, safe-delete, trash, macos)
- Description factual: interception report format, scope table (covered vs. not covered: `find -delete`, `unlink`, `git clean`, language file APIs), and the switch behavior are all in the README and match the source; zero runtime dependencies; 36 `node --test` tests pass.