### PR TITLE
Fix BranchMark catalog display name

### DIFF
--- a/data/plugins/zaizaizhao__dsh-branchmark--packages-bundle.yml
+++ b/data/plugins/zaizaizhao__dsh-branchmark--packages-bundle.yml
@@ -1,5 +1,5 @@
 url: https://github.com/zaizaizhao/dsh-branchmark/tree/main/packages/bundle
-name: zaizaizhao/dsh-branchmark#bundle
+name: zaizaizhao/dsh-branchmark#dsh-branchmark
 category: session
 description:
   en: While vibe coding, save an answer you may need later, use Side Chat for a question that suddenly comes up, or open a related conversation for deeper work without losing focus on the current task.


### PR DESCRIPTION
## Summary

- Change the existing BranchMark monorepo subpackage name from `zaizaizhao/dsh-branchmark#bundle` to `zaizaizhao/dsh-branchmark#dsh-branchmark`.
- Keep the repository URL, category, and descriptions unchanged.
- Leave the generated READMEs out of the commit; the catalog workflow will regenerate them after merge.

## Why

BranchMark's installable package lives under the generic internal directory `packages/bundle`, but its published npm package is `dsh-branchmark`. Storefronts such as dshmarket derive the card title from the catalog suffix after `#`, so the existing entry is displayed simply as “bundle”. Using the actual subpackage name makes the card display “dsh-branchmark” while retaining the same source URL.

## Verification

- `npm ci`
- `node scripts/generate-readme.mjs`
- `npx awesome-lint` — passed with the repository's existing non-blocking spelling warnings
- `SKIP_PUBLISH_CHECKS=1 node scripts/build-site.mjs`
- Verified the storefront display-name transformation produces `dsh-branchmark`
