### PR TITLE
add Luisarg03/dsh-memory-vault memory-mcp and memory-auto

### DIFF
--- a/data/plugins/Luisarg03__dsh-memory-vault--packages-memory-auto.yml
+++ b/data/plugins/Luisarg03__dsh-memory-vault--packages-memory-auto.yml
@@ -1,0 +1,5 @@
+url: https://github.com/Luisarg03/dsh-memory-vault/tree/main/packages/memory-auto
+name: Luisarg03/dsh-memory-vault#memory-auto
+category: memory
+description:
+  en: 'Session-memory autopilot: watches DSH sessions and digests transcripts into the OKF vault at idle, commit and compaction checkpoints, spawning a configurable LLM digest script (uv + opencode CLI).'

--- a/data/plugins/Luisarg03__dsh-memory-vault--packages-memory-auto.yml
+++ b/data/plugins/Luisarg03__dsh-memory-vault--packages-memory-auto.yml
@@ -2,4 +2,4 @@ url: https://github.com/Luisarg03/dsh-memory-vault/tree/main/packages/memory-aut
 name: Luisarg03/dsh-memory-vault#memory-auto
 category: memory
 description:
-  en: 'Session-memory autopilot: watches DSH sessions and digests transcripts into the OKF vault at idle, commit and compaction checkpoints, spawning a configurable LLM digest script (uv + opencode CLI).'
+  en: 'Session-memory autopilot: watches DSH sessions and extracts OKF entries in-process through the harness LLM (ctx.llm, deepseek-official by default) at idle, commit, compaction and end checkpoints, storing them via the vault MCP server.'

--- a/data/plugins/Luisarg03__dsh-memory-vault--packages-memory-mcp.yml
+++ b/data/plugins/Luisarg03__dsh-memory-vault--packages-memory-mcp.yml
@@ -1,0 +1,5 @@
+url: https://github.com/Luisarg03/dsh-memory-vault/tree/main/packages/memory-mcp
+name: Luisarg03/dsh-memory-vault#memory-mcp
+category: memory
+description:
+  en: 'Bridges the agent to a persistent OKF memory vault over MCP stdio: a Python server (SQLite FTS5 + Markdown) with 10 tools for searching and storing decisions, facts, learnings, conventions, profiles and sources.'


### PR DESCRIPTION
## Adds

- [Luisarg03/dsh-memory-vault#memory-mcp](https://github.com/Luisarg03/dsh-memory-vault/tree/main/packages/memory-mcp) — category: `memory`
- [Luisarg03/dsh-memory-vault#memory-auto](https://github.com/Luisarg03/dsh-memory-vault/tree/main/packages/memory-auto) — category: `memory`

## Notes

- Both subpackages declare `dsh.bundle` (with `cordis.patch.yml`) and install via
  `dsh plugin --profile <name> add <package>` (verified locally: profile boot,
  `--dump-config` layer composition, MCP stdio handshake with the vault server).
- `memory-mcp` mounts `@deepseek-ai/dsh-mcp-client` pointed at the Python vault
  server (SQLite FTS5 + Markdown OKF, 10 tools) over stdio via `uv run`.
- `memory-auto` watches session checkpoints (idle, git commit, compaction,
  session end) and digests transcripts into OKF entries through an external LLM
  CLI (`opencode`); no credentials stored by the plugin.
- Repository has the `dsh-plugin` topic and passes the manifest/commit checks
  (age gate will pass after the repository is 1 day old).
- YAML only: the READMEs regenerate on main after merge.
