### PR TITLE
Add Jonah-Wu23/dsh-bg-carousel

### DIFF
--- a/data/plugins/Jonah-Wu23__dsh-bg-carousel.yml
+++ b/data/plugins/Jonah-Wu23__dsh-bg-carousel.yml
@@ -1,0 +1,7 @@
+url: https://github.com/Jonah-Wu23/dsh-bg-carousel
+name: Jonah-Wu23/dsh-bg-carousel
+category: theme
+description:
+  en: Rotates images and videos from a media folder as the DSH UI background, with panel controls for the rotation interval and UI opacity.
+  zh: 把媒体目录中的图片与视频自动轮换为 DSH 界面背景，面板可调轮播间隔与界面透明度。
+tarball: https://github.com/Jonah-Wu23/dsh-bg-carousel/releases/download/v0.3.0/jonahwu-dsh-bg-carousel-0.3.0.tgz


### PR DESCRIPTION
Add Jonah-Wu23/dsh-bg-carousel to the theme category. The plugin rotates images and videos from a media folder as the DSH UI background, with panel controls for the rotation interval and UI opacity; it installs via dsh plugin add and is published on npm as @jonahwu/dsh-bg-carousel.

投稿 Jonah-Wu23/dsh-bg-carousel，分类 theme。插件把媒体目录中的图片与视频自动轮换为 DSH 界面背景，面板可调轮播间隔与界面透明度；可从 GitHub 或 npm 安装。

<!-- Thanks for contributing! Quick checklist / 提交前快速自查 -->

- [x] I added **one file** at `data/plugins/Jonah-Wu23__dsh-bg-carousel.yml` — that single file is the whole submission. The READMEs are regenerated on `main` after merge: don't edit them by hand, and you don't need to commit them either / 我新增了一个 `data/plugins/Jonah-Wu23__dsh-bg-carousel.yml` 文件——**这一个文件就是全部投稿**。README 会在合并后由 `main` 自动重新生成：不要手工编辑，也不需要提交
- [x] My repo's `package.json` declares **`dsh.bundle`** (not just `dsh.client`) — [example](../blob/main/contributing.md) / 仓库 `package.json` 已声明 `dsh.bundle`（只有 `dsh.client` 无法安装）
- [x] My repo is at least **1 day old** (created 2026-08-19) / 仓库创建满 1 天（2026-08-19 创建）
- [x] `category` is one of `agi ui usage theme model identity session memory tools wsl browser vision voice docs skill workflow git notify dev security remote market fun` ([full list with descriptions](../blob/main/contributing.md)), and themes/skins go under `theme` (this entry: theme) / `category` 取值正确（完整清单见 contributing.md），主题/皮肤类请用 `theme`（本条目已用 `theme`）
- [x] Description states what the plugin does, no superlatives / 描述只说功能，不带营销词（内容见上文条目描述）
- [x] My repo has the `dsh-plugin` topic / 仓库已打 `dsh-plugin` topic

**Recommended (not required) / 推荐但不强制：**

- [x] 📦 Publish to npm — npm installs are prebuilt and skip the `allowBuilds` approval, so users get a one-command install / 发布 npm 包：预构建产物免 `allowBuilds` 授权，用户一条命令装好
- [ ] 🔗 Declare official `@deepseek-ai/*` packages as `peerDependencies` (not `dependencies`) — avoids duplicate runtimes inside the profile / 官方 `@deepseek-ai/*` 包用 `peerDependencies` 声明（而非 `dependencies`），避免 profile 里出现重复运行时
- [x] 🖼️ Screenshots go in **your own repository** now: a `screenshots.json` beside your `package.json`, listing image paths. Nothing to add here, and you can change them later without another pull request ([how](../blob/main/contributing.md#screenshots--截图optional-recommended--可选推荐)) / 截图现在放在**你自己的仓库**里：在 `package.json` 旁边放一个 `screenshots.json`，列出图片路径。这个 PR 里不用加任何东西，以后想换也不必再提 PR（[说明](../blob/main/contributing.md#screenshots--截图optional-recommended--可选推荐)）

Notes / 备注：

- npm package is `@jonahwu/dsh-bg-carousel@0.3.0`; its `repository` field points at this repo / 已发布 npm 包 `@jonahwu/dsh-bg-carousel@0.3.0`，`repository` 字段指向本仓库
- The plugin ships zero runtime dependencies, so the peerDependencies guidance does not apply / 插件运行时零依赖，peerDependencies 这条不适用
- `screenshots.json` sits in the repo root and lists `docs/readme-panel.png` and `docs/readme-sidebar.png` / 仓库根已有 `screenshots.json`，指向 `docs/readme-panel.png` 与 `docs/readme-sidebar.png`
- The entry pins a prebuilt tarball from the v0.3.0 GitHub release / 条目附 v0.3.0 Release 预构建 tarball（钉住 tag）