### PR TITLE
docs: refine dsh-session-manager description (v0.4.4)

### DIFF
--- a/data/plugins/hkkz9522__dsh-session-manager.yml
+++ b/data/plugins/hkkz9522__dsh-session-manager.yml
@@ -2,5 +2,5 @@ url: https://github.com/hkkz9522/dsh-session-manager
 name: hkkz9522/dsh-session-manager
 category: session
 description:
-  en: 'Conversation manager for the DeepSeek Harness Web UI: delete conversations, archive conversations, move conversations across workspaces, and migrate a conversation’s Agent preset. Suggestions are welcome on GitHub.'
+  en: 'Session manager for the DeepSeek Harness Web UI: delete sessions, archive sessions, move sessions across workspaces, and migrate a session’s Agent preset. Suggestions are welcome on GitHub.'
   zh: '用于在 DeepSeek Harness（DSH）Web 中进行会话管理，包括：删除会话、归档会话、跨工作区移动会话、迁移会话的 Agent 预设。欢迎至 GitHub 提意见。'


### PR DESCRIPTION
Use "Session manager" / "sessions" instead of "Conversation manager" / "conversations" so the wording matches the plugin name (dsh-session-manager), the bilingual README, the GitHub repository description, and the existing Chinese description.

This is a follow-up to #4255.