### PR TITLE
Add dsh-gungnir

### DIFF
--- a/data/plugins/Jonah-Wu23__dsh-gungnir--packages-dsh-plugin.yml
+++ b/data/plugins/Jonah-Wu23__dsh-gungnir--packages-dsh-plugin.yml
@@ -2,5 +2,5 @@ url: https://github.com/Jonah-Wu23/dsh-gungnir/tree/main/packages/dsh-plugin
 name: Jonah-Wu23/dsh-gungnir#dsh-plugin
 category: agi
 description:
-  en: 'Locks goals via /ultragoal and verifies completion against command exit codes and generated artifacts, preventing the model from falsely reporting task completion.'
-  zh: '通过 /ultragoal 锁定目标，并依据命令退出码与生成产物验证完成状态，防止模型虚报任务完成。'
+  en: 'Evidence-driven goal verification plugin for DeepSeek Harness. Locks goals via /ultragoal and verifies completion against command exit codes and generated artifacts, preventing the model from falsely reporting task completion.'
+  zh: '面向 DeepSeek Harness 的证据驱动目标校验插件。通过 /ultragoal 锁定目标，并依据命令退出码与生成产物验证完成状态，防止模型虚报任务完成。'

--- a/data/plugins/Jonah-Wu23__dsh-gungnir--packages-dsh-plugin.yml
+++ b/data/plugins/Jonah-Wu23__dsh-gungnir--packages-dsh-plugin.yml
@@ -2,5 +2,5 @@ url: https://github.com/Jonah-Wu23/dsh-gungnir/tree/main/packages/dsh-plugin
 name: Jonah-Wu23/dsh-gungnir#dsh-plugin
 category: agi
 description:
-  en: 'Evidence-driven goal verification for DeepSeek Harness. /ultragoal locks versioned goal specs, tool results are captured into an append-only evidence ledger, exit-code and artifact verifiers judge completion claims against evidence, and the reconcile loop intercedes only on evidence conflicts. Installs from npm as dsh-gungnir.'
-  zh: '面向 DeepSeek Harness 的证据驱动目标校验插件。/ultragoal 锁定版本化目标规格，工具结果进入追加式证据账本，退出码与工件验证器对照证据裁决完成声明，对账循环只在证据冲突时介入。npm 包名 dsh-gungnir。'
+  en: 'Locks goals via /ultragoal and verifies completion against command exit codes and generated artifacts, preventing the model from falsely reporting task completion.'
+  zh: '通过 /ultragoal 锁定目标，并依据命令退出码与生成产物验证完成状态，防止模型虚报任务完成。'

--- a/data/plugins/Jonah-Wu23__dsh-gungnir--packages-dsh-plugin.yml
+++ b/data/plugins/Jonah-Wu23__dsh-gungnir--packages-dsh-plugin.yml
@@ -1,0 +1,6 @@
+url: https://github.com/Jonah-Wu23/dsh-gungnir/tree/main/packages/dsh-plugin
+name: Jonah-Wu23/dsh-gungnir#dsh-plugin
+category: agi
+description:
+  en: 'Evidence-driven goal verification for DeepSeek Harness. /ultragoal locks versioned goal specs, tool results are captured into an append-only evidence ledger, exit-code and artifact verifiers judge completion claims against evidence, and the reconcile loop intercedes only on evidence conflicts. Installs from npm as dsh-gungnir.'
+  zh: '面向 DeepSeek Harness 的证据驱动目标校验插件。/ultragoal 锁定版本化目标规格，工具结果进入追加式证据账本，退出码与工件验证器对照证据裁决完成声明，对账循环只在证据冲突时介入。npm 包名 dsh-gungnir。'


### PR DESCRIPTION
Adds one entry for dsh-gungnir, an evidence-driven goal verification plugin for DeepSeek Harness. The manifest is declared in the `packages/dsh-plugin` subpackage and the package is published on npm as `dsh-gungnir` (0.1.3).

新增 dsh-gungnir 条目，面向 DeepSeek Harness 的证据驱动目标校验插件。manifest 声明于 `packages/dsh-plugin` 子包，npm 包 `dsh-gungnir` 已发布（0.1.3）。

<!-- Thanks for contributing! Quick checklist / 提交前快速自查 -->

- [x] I added **one file** at `data/plugins/Jonah-Wu23__dsh-gungnir--packages-dsh-plugin.yml` — that single file is the whole submission. The READMEs are regenerated on `main` after merge: don't edit them by hand, and you don't need to commit them either / 我新增了一个 `data/plugins/Jonah-Wu23__dsh-gungnir--packages-dsh-plugin.yml` 文件——**这一个文件就是全部投稿**。README 会在合并后由 `main` 自动重新生成：不要手工编辑，也不需要提交
- [x] My repo's `package.json` declares **`dsh.bundle`** (not just `dsh.client`) — [example](../blob/main/contributing.md) / 仓库 `package.json` 已声明 `dsh.bundle`（只有 `dsh.client` 无法安装）
- [x] My repo is at least **1 day old** / 仓库创建满 1 天
- [x] `category` is one of `agi ui usage theme model identity session memory tools wsl browser vision voice docs skill workflow git notify dev security remote market fun` ([full list with descriptions](../blob/main/contributing.md)), and themes/skins go under `theme` / `category` 取值正确（完整清单见 contributing.md），主题/皮肤类请用 `theme`
- [x] Description states what the plugin does, no superlatives / 描述只说功能，不带营销词
- [x] My repo has the `dsh-plugin` topic / 仓库已打 `dsh-plugin` topic

**Recommended (not required) / 推荐但不强制：**

- [x] 📦 Publish to npm — npm installs are prebuilt and skip the `allowBuilds` approval, so users get a one-command install / 发布 npm 包：预构建产物免 `allowBuilds` 授权，用户一条命令装好
- [x] 🔗 Declare official `@deepseek-ai/*` packages as `peerDependencies` (not `dependencies`) — avoids duplicate runtimes inside the profile / 官方 `@deepseek-ai/*` 包用 `peerDependencies` 声明（而非 `dependencies`），避免 profile 里出现重复运行时
- [ ] 🖼️ Screenshots go in **your own repository** now: a `screenshots.json` beside your `package.json`, listing image paths. Nothing to add here, and you can change them later without another pull request ([how](../blob/main/contributing.md#screenshots--截图optional-recommended--可选推荐)) / 截图现在放在**你自己的仓库**里：在 `package.json` 旁边放一个 `screenshots.json`，列出图片路径。这个 PR 里不用加任何东西，以后想换也不必再提 PR（[说明](../blob/main/contributing.md#screenshots--截图optional-recommended--可选推荐)）