### PR TITLE
Add dsh-vision-pro-bridge

### DIFF
--- a/data/plugins/ShaineDemo__dsh-vision-pro-bridge.yml
+++ b/data/plugins/ShaineDemo__dsh-vision-pro-bridge.yml
@@ -1,0 +1,6 @@
+url: https://github.com/ShaineDemo/dsh-vision-pro-bridge
+name: ShaineDemo/dsh-vision-pro-bridge
+category: vision
+description:
+  en: Vision bridge for text-only DeepSeek models: transcribes attached images with deepseek-v4-flash-vision-exp before they reach deepseek-v4-pro, with no third-party dependencies.
+  zh: 视觉桥：贴图先经 deepseek-v4-flash-vision-exp 转写为文字，再交给纯文本的 deepseek-v4-pro 回答，零第三方依赖。

--- a/data/plugins/ShaineDemo__dsh-vision-pro-bridge.yml
+++ b/data/plugins/ShaineDemo__dsh-vision-pro-bridge.yml
@@ -2,5 +2,5 @@ url: https://github.com/ShaineDemo/dsh-vision-pro-bridge
 name: ShaineDemo/dsh-vision-pro-bridge
 category: vision
 description:
-  en: Vision bridge for text-only DeepSeek models: transcribes attached images with deepseek-v4-flash-vision-exp before they reach deepseek-v4-pro, with no third-party dependencies.
-  zh: 视觉桥：贴图先经 deepseek-v4-flash-vision-exp 转写为文字，再交给纯文本的 deepseek-v4-pro 回答，零第三方依赖。
+  en: 'Vision bridge for text-only DeepSeek models: transcribes attached images with deepseek-v4-flash-vision-exp before they reach deepseek-v4-pro, with no third-party dependencies.'
+  zh: '视觉桥：贴图先经 deepseek-v4-flash-vision-exp 转写为文字，再交给纯文本的 deepseek-v4-pro 回答，零第三方依赖。'


### PR DESCRIPTION
Adds a vision bridge plugin for text-only DeepSeek models.

- **Repo:** https://github.com/ShaineDemo/dsh-vision-pro-bridge
- **What it does:** registers a `deepseek-vision-pro` provider route; attached images are transcribed to text by `deepseek-v4-flash-vision-exp` (reusing the existing `DEEPSEEK_API_KEY`), then the text-only `deepseek-v4-pro` answers.
- **Category:** `vision`
- **Dependencies:** zero third-party dependencies (reuses `@deepseek-ai/dsh-llm` + `@deepseek-ai/dsh-llm-deepseek` from the harness).
- Declares a `dsh.bundle` manifest; installable via `dsh plugin --profile web add dsh-vision-pro-bridge`.

Note: this repository was created today, so it is under the 1-day repo-age check — resubmitting after 24h if CI flags it.