### PR TITLE
Add marcemira/dsh-theme-nier-automata

### DIFF
--- a/data/plugins/marcemira__dsh-theme-nier-automata.yml
+++ b/data/plugins/marcemira__dsh-theme-nier-automata.yml
@@ -1,0 +1,5 @@
+url: https://github.com/marcemira/dsh-theme-nier-automata
+name: marcemira/dsh-theme-nier-automata
+category: theme
+description:
+  en: NieR:Automata-inspired YoRHa theme for DSH Web with a beige palette, grid textures, CRT effects, and configurable interaction styling.


### PR DESCRIPTION
Adds the public registry entry for [marcemira/dsh-theme-nier-automata](https://github.com/marcemira/dsh-theme-nier-automata), a NieR:Automata-inspired YoRHa theme for DSH Web.

The plugin repository declares the required `dsh.bundle` manifest and includes attribution for the MIT-licensed projects that inspired its CSS and visual patterns.

This is a draft because the plugin repository must be at least 24 hours old before the registry age gate can pass.