### PR TITLE
Add plugin metadata for dsh-readme-writer

### DIFF
--- a/data/plugins/wenbuer__dsh-readme-writer.yml
+++ b/data/plugins/wenbuer__dsh-readme-writer.yml
@@ -1,0 +1,6 @@
+url: https://github.com/wenbuer/dsh-readme-writer
+name: wenbuer/dsh-readme-writer
+category: skill
+description:
+  en: 'Adaptive GitHub README writer for DeepSeek Harness: detects image-capture capability (web browser or console/CLI terminal screenshot), then writes/optimizes README.md with relative-path screenshots and captions.'
+  zh: 'DeepSeek Harness 的自适应 GitHub README 撰写技能：先探测截图能力（网页或控制台/CLI 终端截屏），再写或优化 README.md，配相对路径截图与说明。'


### PR DESCRIPTION
Add [wenbuer/dsh-readme-writer](https://github.com/wenbuer/dsh-readme-writer) to the **Skill** category.

- url: https://github.com/wenbuer/dsh-readme-writer
- category: `skill`
- description.en + description.zh included
- Repo declares `dsh.bundle` manifest, installable via `dsh plugin add wenbuer/dsh-readme-writer`
- `dsh-plugin` topic on repo
- Repo is > 1 day old
- Screenshots declared in the repo's own `screenshots.json` (verify + terminal)