### PR TITLE
Bump dsh-code-quote tarball to v0.3.3

### DIFF
--- a/data/plugins/hanrr92__dsh-code-quote.yml
+++ b/data/plugins/hanrr92__dsh-code-quote.yml
@@ -4,4 +4,4 @@ category: ui
 description:
   en: 'Composer code-quote collapse for the DSH Web UI: pasting a `path:line` header followed by code folds the input into one compact inline quote token (Ctrl+Z reverses it), and at send time the `agent/pre-step` hook injects the full pasted snapshot to the model as a separate context message.'
   zh: '输入框代码引用折叠：粘贴「路径:行号 + 代码」时自动折叠为一行紧凑的引用 token（Ctrl+Z 可还原），发送时由 agent/pre-step 钩子将完整代码快照作为独立上下文消息注入给模型。'
-tarball: https://github.com/hanrr92/dsh-code-quote/releases/download/v0.2.0/dsh-code-quote-0.2.0.tgz
+tarball: https://github.com/hanrr92/dsh-code-quote/releases/download/v0.3.3/dsh-code-quote-0.3.3.tgz


### PR DESCRIPTION
Update the tarball URL for hanrr92/dsh-code-quote from v0.2.0 to the current release v0.3.3.

- v0.3.3 ships real reference chips by default for folded quotes, plus fold-failure toasts and threshold config
- npm dist-tag latest is also 0.3.3
- release asset verified: dsh-code-quote-0.3.3.tgz (13724B)
- no other listing fields changed