### PR TITLE
Add dsh-clearview (Vinzelles/dsh-clearview)

### DIFF
--- a/data/plugins/Vinzelles__dsh-clearview.yml
+++ b/data/plugins/Vinzelles__dsh-clearview.yml
@@ -4,3 +4,4 @@ category: ui
 description:
   en: 'Adds a Reading tab to the DSH web client that shows process steps and live reasoning in source order, collapses successful turns to the final answer, and keeps the original tabs, composer, and tooling intact.'
   zh: '为 DSH Web 客户端新增「阅读」页签：按源顺序呈现过程步骤与实时思考，成功轮次收起只留最终回答，原有页签、输入框与工具保持不变。'
+tarball: https://github.com/Vinzelles/dsh-clearview/releases/download/v0.1.6/dsh-clearview-0.1.6.tgz

--- a/data/plugins/Vinzelles__dsh-clearview.yml
+++ b/data/plugins/Vinzelles__dsh-clearview.yml
@@ -1,0 +1,6 @@
+url: https://github.com/Vinzelles/dsh-clearview
+name: Vinzelles/dsh-clearview
+category: ui
+description:
+  en: 'Adds a Reading tab to the DSH web client that shows process steps and live reasoning in source order, collapses successful turns to the final answer, and keeps the original tabs, composer, and tooling intact.'
+  zh: '为 DSH Web 客户端新增「阅读」页签：按源顺序呈现过程步骤与实时思考，成功轮次收起只留最终回答，原有页签、输入框与工具保持不变。'


### PR DESCRIPTION
Adds an entry for dsh-clearview: a Reading tab for the DSH web client (native process details, live reasoning in source order, successful turns collapsed to the final answer).

- dsh.bundle manifest declared in the repo package.json (bundle patch + web client plugin)
- dsh-plugin topic added to the repo
- description verified against the plugin README
