### PR TITLE
Add kobenfang BigTimer skill plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1937,6 +1937,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 - [kobenfang/BigLead](https://github.com/kobenfang/BigLead) - B2B lead generation skill: search target companies by industry/product/region, cross-validate and extract contacts.
 - [kobenfang/BigPlan](https://github.com/kobenfang/BigPlan) - Product research skill: analyze market, technology and supply chain, then output three-tier product spec proposals.
 - [kobenfang/BigSeedSkill](https://github.com/kobenfang/BigSeedSkill) - Life-story skill: capture moments and fragments, build a user profile and generate novels, scripts or autobiographies.
+- [kobenfang/BigTimer](https://github.com/kobenfang/BigTimer) - Scheduled tasks and message push manager: cron scheduling with auto push to Feishu and multi-channel, dual-env (OpenClaw/DSH).
 - [kobenfang/Eyes](https://github.com/kobenfang/Eyes) - Global news monitoring skill: track world events and analyze impact across industries, currencies and commodities.
 - [kobenfang/FruitPi](https://github.com/kobenfang/FruitPi) - Fruit price tracking skill: collect and query global wholesale fruit prices with RMB/kg conversion.
 - [kobenfang/ListForm](https://github.com/kobenfang/ListForm) - Smart form skill: structured record-keeping for bills, ledgers and logs with auto-categorization and periodic reports.

--- a/README.zh.md
+++ b/README.zh.md
@@ -1937,6 +1937,7 @@ dsh plugin --profile web add dshmarket
 - [kobenfang/BigLead](https://github.com/kobenfang/BigLead) — 精准客户线索挖掘技能：按行业/产品/地区搜索目标公司，多渠道验证并提取联系方式。
 - [kobenfang/BigPlan](https://github.com/kobenfang/BigPlan) — AI产品调研技能：分析市场、技术与供应链，输出高中低三套产品规格方案。
 - [kobenfang/BigSeedSkill](https://github.com/kobenfang/BigSeedSkill) — 闪念记录与人生拼图技能：捕捉生活点滴，构建画像并生成小说、剧本或自传。
+- [kobenfang/BigTimer](https://github.com/kobenfang/BigTimer) — 定时任务与消息推送管家：统一管理 cron 调度，自动推送飞书/多端，兼容 OpenClaw 与 DSH 双环境。
 - [kobenfang/Eyes](https://github.com/kobenfang/Eyes) — 全球热点监控技能：追踪全球事件，按行业、汇率与大宗商品链路分析影响。
 - [kobenfang/FruitPi](https://github.com/kobenfang/FruitPi) — 全球水果价格追踪技能：采集与查询国内外水果批发价，支持人民币/公斤换算。
 - [kobenfang/ListForm](https://github.com/kobenfang/ListForm) — 智能表单技能：支出账单、台账与日志的结构化记录，自动归类并生成周期报表。

--- a/data/plugins/kobenfang__BigTimer.yml
+++ b/data/plugins/kobenfang__BigTimer.yml
@@ -1,0 +1,6 @@
+url: https://github.com/kobenfang/BigTimer
+name: kobenfang/BigTimer
+category: skill
+description:
+  en: 'Scheduled tasks and message push manager: cron scheduling with auto push to Feishu and multi-channel, dual-env (OpenClaw/DSH).'
+  zh: '定时任务与消息推送管家：统一管理 cron 调度，自动推送飞书/多端，兼容 OpenClaw 与 DSH 双环境。'


### PR DESCRIPTION
<!-- Thanks for contributing! Quick checklist / 提交前快速自查 -->

- [ ] I added **one file** at `data/plugins/<owner>__<repo>.yml` — that single file is the whole submission. The READMEs are regenerated on `main` after merge: don't edit them by hand, and you don't need to commit them either / 我新增了一个 `data/plugins/<owner>__<repo>.yml` 文件——**这一个文件就是全部投稿**。README 会在合并后由 `main` 自动重新生成：不要手工编辑，也不需要提交
- [ ] My repo's `package.json` declares **`dsh.bundle`** (not just `dsh.client`) — [example](../blob/main/contributing.md) / 仓库 `package.json` 已声明 `dsh.bundle`（只有 `dsh.client` 无法安装）
- [ ] My repo is at least **1 day old** / 仓库创建满 1 天
- [ ] `category` is one of `agi ui usage theme model identity session memory tools wsl browser vision voice docs skill workflow git notify dev security remote market fun` ([full list with descriptions](../blob/main/contributing.md)), and themes/skins go under `theme` / `category` 取值正确（完整清单见 contributing.md），主题/皮肤类请用 `theme`
- [ ] Description states what the plugin does, no superlatives / 描述只说功能，不带营销词
- [ ] My repo has the `dsh-plugin` topic / 仓库已打 `dsh-plugin` topic

**Recommended (not required) / 推荐但不强制：**

- 📦 Publish to npm — npm installs are prebuilt and skip the `allowBuilds` approval, so users get a one-command install / 发布 npm 包：预构建产物免 `allowBuilds` 授权，用户一条命令装好
- 🔗 Declare official `@deepseek-ai/*` packages as `peerDependencies` (not `dependencies`) — avoids duplicate runtimes inside the profile / 官方 `@deepseek-ai/*` 包用 `peerDependencies` 声明（而非 `dependencies`），避免 profile 里出现重复运行时
- 🖼️ Screenshots go in **your own repository** now: a `screenshots.json` beside your `package.json`, listing image paths. Nothing to add here, and you can change them later without another pull request ([how](../blob/main/contributing.md#screenshots--截图optional-recommended--可选推荐)) / 截图现在放在**你自己的仓库**里：在 `package.json` 旁边放一个 `screenshots.json`，列出图片路径。这个 PR 里不用加任何东西，以后想换也不必再提 PR（[说明](../blob/main/contributing.md#screenshots--截图optional-recommended--可选推荐)）
