### PR TITLE
Add WongYuYe/dsh-appshots

### DIFF
--- a/data/plugins/WongYuYe__dsh-appshots.yml
+++ b/data/plugins/WongYuYe__dsh-appshots.yml
@@ -1,0 +1,6 @@
+url: https://github.com/WongYuYe/dsh-appshots
+name: WongYuYe/dsh-appshots
+category: vision
+description:
+  en: 'Codex-style Appshots for DSH Desktop: capture the frontmost macOS window with both Command keys and attach it to the current chat.'
+  zh: 给 DSH Desktop 用的 Codex 风格 Appshots：按两边 Command 捕获当前前台窗口，并附加到当前会话。


### PR DESCRIPTION
Add `WongYuYe/dsh-appshots`.

Codex-style Appshots for DSH Desktop on macOS: press both Command keys (or the composer camera button) to capture the frontmost window and attach it to the current chat. Window text is injected as hidden model context.

- Repo: https://github.com/WongYuYe/dsh-appshots
- Category: vision
- Declares `dsh.bundle` + `dsh.client.platform: web`
- Topic: `dsh-plugin`

The listing repo is brand new, so the 1-day age check may fail until tomorrow. Please keep this PR open or I will ping after the age bar clears.
