### PR TITLE
Add UnknowCao/dsh-dock (one-click desktop launcher)

### DIFF
--- a/data/plugins/UnknowCao__dsh-dock.yml
+++ b/data/plugins/UnknowCao__dsh-dock.yml
@@ -1,0 +1,6 @@
+url: https://github.com/UnknowCao/dsh-dock
+name: UnknowCao/dsh-dock
+category: tools
+description:
+  en: 'One-click desktop launcher: a prebuilt whale exe opens the DSH Web UI as a fullscreen Edge app (token health gate, cold-start card), and a sidebar More menu adds Settings/Reload/Full Exit that stops the server and closes the window.'
+  zh: '一键桌面启动器：预编译鲸鱼 exe 双击即全屏打开 DSH Web UI（token 健康闸、冷启动呼吸卡）；侧栏「更多」菜单提供 设置/重启/完全退出，退出自动关窗并停止服务器。'


### PR DESCRIPTION
Adds [UnknowCao/dsh-dock](https://github.com/UnknowCao/dsh-dock) — a one-click desktop launcher for DSH Harness on Windows.

- Declares `dsh.bundle` in package.json; installs with `dsh plugin --profile web add github:UnknowCao/dsh-dock#v0.3.2`
- Repo carries the `dsh-plugin` topic, 10 commits, first release [v0.3.2](https://github.com/UnknowCao/dsh-dock/releases/tag/v0.3.2) out
- What it does: a prebuilt native whale exe lands on the desktop on activation (no build, no lifecycle scripts); double-click opens the Web UI as a fullscreen Edge app (token health gate, cold-start breathing card), and a sidebar More menu adds Settings/Reload/Full Exit — Full Exit stops the server and auto-closes the window
- Category: tools (desktop launcher utility)