### PR TITLE
Add pavangupta352/stalegreen#dsh-plugin-stalegreen

### DIFF
--- a/data/plugins/pavangupta352__stalegreen--dsh-plugin-stalegreen.yml
+++ b/data/plugins/pavangupta352__stalegreen--dsh-plugin-stalegreen.yml
@@ -1,0 +1,6 @@
+url: https://github.com/pavangupta352/stalegreen/tree/main/dsh-plugin-stalegreen
+name: pavangupta352/stalegreen#dsh-plugin-stalegreen
+category: dev
+description:
+  en: 'Freshness gate for the agent''s test, typecheck, lint and build claims: each verification run becomes a receipt on tools/post-execute, file edits are tracked, and on agent/turn-stopping a claim whose latest receipt is stale, failed or has no readable result steers one more step naming the receipt and the files edited since.'
+  zh: '为智能体的测试、类型检查、lint 与构建结论提供新鲜度检查：每次验证运行在 tools/post-execute 上记录为凭据，文件修改被跟踪；在 agent/turn-stopping 时，若结论对应的最新凭据已过期、失败或没有可读结果，则引导再走一步，并指出凭据与其后被修改的文件。'


### PR DESCRIPTION
This adds one entry file for the DeepSeek Harness plugin that lives in my stalegreen repository:
`data/plugins/pavangupta352__stalegreen--dsh-plugin-stalegreen.yml`.

The subpackage is at https://github.com/pavangupta352/stalegreen/tree/main/dsh-plugin-stalegreen.
Its `package.json` declares `dsh.bundle` pointing at `cordis.patch.yml` next to it, and it is
published on npm as `dsh-plugin-stalegreen`, so `dsh plugin add dsh-plugin-stalegreen` installs
prebuilt code with no build approval step. I checked that end to end in a scratch profile: the
bundle installs, `--dump-config` shows the layer, and the module loads inside the profile.

What the plugin does: it listens on `tools/pre-execute`, `tools/post-execute` and
`agent/turn-stopping`. A verification command (test, typecheck, lint or build) gets a receipt
from its output on `tools/post-execute`, edits from `edit`, `write` and `str_replace_editor` are
tracked, and on `agent/turn-stopping` a claim such as "all tests pass" whose latest receipt is
stale, failed or left no readable result steers one more step, naming the receipt and the files
edited since it ran. It never rewrites a tool call, since the pre-execute waterfall cannot; in
strict mode it denies a verification command whose result would be hidden.

Category `dev`. The repository carries the `dsh-plugin` topic. Happy to change the wording or the
category if something reads wrong.
