### PR TITLE
Add melt502/DSH-Session-Reference-UX-Patch

### DIFF
--- a/data/plugins/melt502__DSH-Session-Reference-UX-Patch.yml
+++ b/data/plugins/melt502__DSH-Session-Reference-UX-Patch.yml
@@ -1,0 +1,6 @@
+url: https://github.com/melt502/DSH-Session-Reference-UX-Patch
+name: melt502/DSH-Session-Reference-UX-Patch
+category: ui
+description:
+  en: Durable, reversible installer that patches DSH Desktop session-reference UX — workspace-prioritized @ candidates, title-first display, two-line menu layout, and sidebar drag-to-composer session references.
+  zh: 可回滚的 DSH Desktop 会话引用体验补丁安装器——@ 菜单当前工作区优先、标题优先展示、两行布局，以及侧边栏拖拽会话到输入区形成引用。


### PR DESCRIPTION
# DSH Session Reference UX Patch

Durable, reversible installer that patches DSH Desktop session-reference UX.

## Features

- Empty `@` menu prioritizes the current workspace: only same-cwd sessions are listed, capped at 8 candidates for fast load.
- Session candidates display the dialog title as the primary line (falls back to Session ID when blank).
- `@` candidates use a two-line layout (title + subtitle with workspace path and time).
- Sidebar sessions can be dragged into the composer to form an atomic session reference chip.
- Drag-to-composer is isolated from sidebar reorder: dropping on the composer uses `dropEffect=copy` and never triggers row reordering.
- Validates canonical mention format, rejects self-reference, and enforces a maximum of 3 distinct session references.

## Requirements

- `dsh.bundle` manifest declared in `package.json` ?
- `dsh-plugin` topic added to the repo ?
- Real, working code ? (not a placeholder - ships a Node host half, a CLI installer, and 5 verified patch templates)
- Repo age: 9+ days ?