### PR TITLE
Add HeShen-1/deepseek-whale-wallpaper (theme)

### DIFF
--- a/data/plugins/HeShen-1__deepseek-whale-wallpaper.yml
+++ b/data/plugins/HeShen-1__deepseek-whale-wallpaper.yml
@@ -1,0 +1,6 @@
+url: https://github.com/HeShen-1/deepseek-whale-wallpaper
+name: HeShen-1/deepseek-whale-wallpaper
+category: theme
+description:
+  en: 'Live dot-matrix whale wallpaper for the DSH Web UI: ~1,750 breathing WebGL2 particles with pointer liquid vortices, light/dark themes, and a Canvas2D fallback.'
+  zh: 'DSH Web 动态点阵鲸鱼壁纸：约 1,750 个呼吸的 WebGL2 粒子，指针液态涡流交互，明暗双主题，带 Canvas2D 回退。'


### PR DESCRIPTION
Adds **HeShen-1/deepseek-whale-wallpaper** — category `theme`.

- **Manifest**: `package.json` declares `dsh.bundle` (patch layer) alongside `dsh.client`; verified in-repo at [`package.json`](https://github.com/HeShen-1/deepseek-whale-wallpaper/blob/main/package.json).
- **Installable**: `dsh plugin --profile web add github:HeShen-1/deepseek-whale-wallpaper` works from git today (build artifacts are committed); the npm package `dsh-plugin-harness-whale@0.2.0` is being published in parallel, after which `dsh plugin --profile web add dsh-plugin-harness-whale` also works. A tarball is attached to the [v0.2.0 release](https://github.com/HeShen-1/deepseek-whale-wallpaper/releases/tag/v0.2.0) as a third install path.
- **Description accuracy**: one-line claim matches the README — the whale is sampled from the Harness `favicon.svg` outline, rendered as ~1,750 grid points on WebGL2 (static Canvas2D fallback), reacts to the pointer with a liquid vortex + radial glow, follows light/dark/system themes, dims on activity, pauses on hidden tabs, and cleans up fully on disable.
- One YAML file added under `data/plugins/`; generated READMEs untouched, per the contributing guide.
