### PR TITLE
Add xchannel1987/dsh-notify-xc plugin (notify)

### DIFF
--- a/data/plugins/xchannel1987__dsh-notify-xc.yml
+++ b/data/plugins/xchannel1987__dsh-notify-xc.yml
@@ -1,0 +1,6 @@
+url: https://github.com/xchannel1987/dsh-notify-xc
+name: xchannel1987/dsh-notify-xc
+category: notify
+description:
+  en: "Browser notification plugin for DeepSeek Harness - system toasts when a task finishes, a run errors, or your input is needed (question / approval / plan review), click to open the session, per-type toggles, and no false 'done' while the main session waits on its subagents."
+  zh: "DSH 浏览器通知插件 - 任务完成 / 运行出错 / 需要你回答、批准、审阅计划时弹系统级通知，点击气泡直达会话，三类通知独立开关，主会话等子代理期间不误报完成。"


### PR DESCRIPTION
Add [xchannel1987/dsh-notify-xc](https://github.com/xchannel1987/dsh-notify-xc) to the **Notify** category. One entry, one new file - the READMEs are left to CI regeneration.

- url: https://github.com/xchannel1987/dsh-notify-xc
- category: `notify`
- description.en + description.zh included
- published on npm as `dsh-notify-xc@0.2.2` (public, prebuilt): `dsh plugin --profile web add dsh-notify-xc`
- declares `dsh.bundle.patch` in `package.json` with a root `cordis.patch.yml` - the host half is an empty `apply()`, the feature lives in the browser bundle declared via `dsh.client`
- repo created 2026-09-02, public, not archived, `dsh-plugin` topic set
- no screenshots declared (the plugin has no canvas of its own - toasts are OS chrome and the settings page is a standard `settings.section`)

What it does: system-level toasts (browser Notification API, Windows notification centre) when a session finishes a task, ends a turn with an error, or is waiting on you (question / approval / plan review). Clicking a toast focuses the page and opens that session. Three types have independent toggles, plus a settings page under Settings -> Task Alerts, an optional persistent "needs input" toast, and a [workspace] title prefix. It holds the "done" toast while a session has only yielded its turn to a background subagent, and greys itself out on mobile browsers where a local Notification cannot be shown (iOS only supports Service Worker Web Push; WebView hosts disable it).