### PR TITLE
feat: add dsh-about

### DIFF
--- a/data/plugins/1010n111__dsh-about.yml
+++ b/data/plugins/1010n111__dsh-about.yml
@@ -1,0 +1,6 @@
+url: https://github.com/1010n111/dsh-about
+name: 1010n111/dsh-about
+category: ui
+description:
+  en: Adds an "About" settings page to the DeepSeek Harness web interface, showing the running DSH version and recent release notes.
+  zh: 为 DeepSeek Harness Web 设置面板添加“关于”页，展示运行中的 DSH 版本与最近更新日志。


### PR DESCRIPTION
## What this PR does

Adds one entry: `data/plugins/1010n111__dsh-about.yml`.

- Repo: [1010n111/dsh-about](https://github.com/1010n111/dsh-about)
- `dsh.bundle` declared in `package.json` with `cordis.patch.yml` (installable via `dsh plugin add`)
- Category: `ui`
- Action: adds an "About" settings page to the DeepSeek Harness web UI (running DSH version + recent release notes)

Rules checked: 1 entry, repo > 1 day old, `dsh-plugin` topic added, description matches the code.
