### PR TITLE
Move ruisenbai/dsh-annotation to Sessions & Messages

### DIFF
--- a/data/plugins/ruisenbai__dsh-annotation.yml
+++ b/data/plugins/ruisenbai__dsh-annotation.yml
@@ -1,7 +1,7 @@
 url: https://github.com/ruisenbai/dsh-annotation
 name: ruisenbai/dsh-annotation
-category: ui
+category: session
 description:
-  en: 'Select text in a finished assistant reply to add numbered annotations beside the quote; drafts submit with composer text and images as one user message, and the model replies to each annotation in order.'
-  zh: '在已完成的助手回复中选中原文，在引文旁添加编号注解；草稿与输入框文字、图片合并为一条用户消息发送，模型按注解逐条回复。'
+  en: 'Requires DSH 0.1.2-rc.1. Annotate selected text in finished assistant messages, then submit multiple drafts with official composer text and images as one Session user message; the model answers each annotation in order with hoverable reply chips.'
+  zh: '需要 DSH 0.1.2-rc.1。在已完成的助手消息中选中原文并添加多条注解，再与官方输入框文字和图片合并为一条会话用户消息；模型按顺序逐条回答，并用可悬浮的回复芯片关联原文。'
 tarball: https://github.com/ruisenbai/dsh-annotation/releases/latest/download/dsh-annotation.tgz


### PR DESCRIPTION
## Summary

- move the existing `ruisenbai/dsh-annotation` entry from `ui` to `session` (**Sessions & Messages**)
- update both descriptions to state the exact DSH `0.1.2-rc.1` host requirement and the current Session-message workflow
- preserve the existing stable GitHub Release tarball alias, now serving v0.5.2

## Why `session`

The UI is the authoring surface, but the owned behavior is a message lifecycle: annotations are kept per Session, composer text and images become one standard user message, and queued/sent state is reconciled from Session data. Reply chips link the assistant response back to those annotations.

This project is GitHub-Release-only, so discovery has no npm manifest to query. The catalog copy therefore states the exact host requirement; the install artifact also declares `engines.dsh: 0.1.2-rc.1` and matching lockstep DSH peers. The repository now owns five storefront images through `screenshots.json`.

## Validation

- `npm ci`
- `node scripts/generate-readme.mjs` (local preview only; generated READMEs restored)
- `npx awesome-lint`
- `SKIP_PUBLISH_CHECKS=1 node scripts/build-site.mjs`
- final diff contains only `data/plugins/ruisenbai__dsh-annotation.yml`
