### PR TITLE
Add F1star/dsh-research

### DIFF
--- a/data/plugins/F1star__dsh-research.yml
+++ b/data/plugins/F1star__dsh-research.yml
@@ -1,0 +1,7 @@
+url: https://github.com/F1star/dsh-research
+name: F1star/dsh-research
+category: tools
+description:
+  en: 'Adds local PDF reading, a durable paper library, traceable evidence records, and cross-paper comparison and synthesis tools.'
+  zh: '提供本地 PDF 阅读、持久论文库、可追溯证据记录，以及跨论文比较与综合工具。'
+tarball: https://github.com/F1star/dsh-research/releases/latest/download/dsh-research.tgz


### PR DESCRIPTION
Adds `F1star/dsh-research` to the tools catalog. It provides local PDF reading, a durable paper library, traceable evidence records, and cross-paper comparison and synthesis tools. The entry uses a version-independent prebuilt tarball from the latest GitHub Release.

- [x] I added **one file** at `data/plugins/<owner>__<repo>.yml` — that single file is the whole submission. The READMEs are regenerated on `main` after merge: don't edit them by hand, and you don't need to commit them either / 我新增了一个 `data/plugins/<owner>__<repo>.yml` 文件——**这一个文件就是全部投稿**。README 会在合并后由 `main` 自动重新生成：不要手工编辑，也不需要提交
- [x] My repo's `package.json` declares **`dsh.bundle`** (not just `dsh.client`) — [example](../blob/main/contributing.md) / 仓库 `package.json` 已声明 `dsh.bundle`（只有 `dsh.client` 无法安装）
- [x] My repo is at least **1 day old** / 仓库创建满 1 天
- [x] `category` is one of `agi ui usage theme model identity session memory tools wsl browser vision voice docs skill workflow git notify dev security remote market fun` ([full list with descriptions](../blob/main/contributing.md)), and themes/skins go under `theme` / `category` 取值正确（完整清单见 contributing.md），主题/皮肤类请用 `theme`
- [x] Description states what the plugin does, no superlatives / 描述只说功能，不带营销词
- [x] My repo has the `dsh-plugin` topic / 仓库已打 `dsh-plugin` topic

**Recommended (not required) / 推荐但不强制：**

- 📦 A version-independent prebuilt tarball is attached to the latest GitHub Release.
- 🔗 Official `@deepseek-ai/*` packages are declared as `peerDependencies`.
- 🖼️ No screenshots are submitted.