### PR TITLE
Add pn1024/dsh-skill-hub

### DIFF
--- a/data/plugins/pn1024__dsh-skill-hub.yml
+++ b/data/plugins/pn1024__dsh-skill-hub.yml
@@ -1,0 +1,6 @@
+url: https://github.com/pn1024/dsh-skill-hub
+name: pn1024/dsh-skill-hub
+category: skill
+description:
+  en: Skill marketplace with aggregated search across SkillHub and ClawHub, in-app README preview, one-click install and uninstall, and a chat-input skill picker.
+  zh: 技能市场插件，聚合 SkillHub 与 ClawHub 双源搜索，支持站内 README 预览、一键安装卸载与聊天栏技能选择器。


### PR DESCRIPTION
## Submission / 投稿

**Plugin / 插件**: [pn1024/dsh-skill-hub](https://github.com/pn1024/dsh-skill-hub)

Skill marketplace plugin for DeepSeek Harness.

### Checklist / 自检

- [x] Adds one entry file: `data/plugins/pn1024__dsh-skill-hub.yml` (single-entry PR / 单条目 PR)
- [x] `dsh.bundle` manifest declared in `package.json` (`dsh.bundle.patch` → `./cordis.patch.yml`, plus `dsh.client` for web UI)
- [x] Repo contains real, working code (aggregated SkillHub + ClawHub search, install/uninstall, README preview, chat-input picker)
- [x] Repo age: created 2026-09-01 (> 1 day)
- [x] Repo has the [`dsh-plugin`](https://github.com/topics/dsh-plugin) topic
- [x] Description states only what the plugin does, no marketing wording; category `skill`
- [x] Storefront screenshots declared in the plugin repo via `screenshots.json` (3 images)

### Install / 安装

```bash
dsh plugin --profile web add "github:pn1024/dsh-skill-hub"
```