### PR TITLE
Update pan17/dsh-minimax-usage description

### DIFF
--- a/data/plugins/pan17__dsh-minimax-usage.yml
+++ b/data/plugins/pan17__dsh-minimax-usage.yml
@@ -2,5 +2,5 @@ url: https://github.com/pan17/dsh-minimax-usage
 name: pan17/dsh-minimax-usage
 category: usage
 description:
-  en: Draggable floating bubble in the DSH Web UI showing MiniMax Token Plan usage — 5h and weekly windows with reset countdowns, CN and global panels, click-to-refresh, idle-15s trigger plus 2min→24h heartbeat with auto endpoint fallback. Reuses the subscription key already configured under Settings → 模型; auto-hides the panel for any region whose key is not set. 36 unit tests, MIT.
-  zh: 在 DSH Web UI 右下角以可拖动悬浮气泡展示 MiniMax Token Plan 用量：5 小时 / 周窗口重置倒计时、国内与国际双面板、点击刷新、空闲 15 秒触发 + 心跳 2 分钟起步每次翻倍到 24 小时上限、端点失败自动回退；密钥复用「设置 → 模型」已配置的订阅 Key，未配置的区域静默跳过。36 个单元测试，MIT。
+  en: Shows MiniMax Token Plan usage beside the DSH Web UI model selector with compact 5h/7d bars, click-to-refresh, automatic idle and heartbeat refreshes, and endpoint fallback. Reuses subscription keys configured under Settings → Model and appears only for MiniMax Token Plan providers.
+  zh: 在 DSH Web UI 模型选择器旁显示 MiniMax Token Plan 用量，以紧凑的 5h/7d 进度条展示，支持点击刷新、空闲与心跳自动刷新及接口回退；复用「设置 → 模型」中的订阅 Key，且仅在 MiniMax Token Plan provider 下显示。


### PR DESCRIPTION
## Summary
- update the dsh-minimax-usage catalog description to match v0.1.7
- describe the inline 5h/7d indicator beside the model selector
- clarify that it appears only for MiniMax Token Plan providers

Only the plugin's own catalog entry is changed.