### PR TITLE
Add BitDG reference library and music player

### DIFF
--- a/data/plugins/BitDG__dsh-plugins--plugins-music-player.yml
+++ b/data/plugins/BitDG__dsh-plugins--plugins-music-player.yml
@@ -1,0 +1,7 @@
+url: https://github.com/BitDG/dsh-plugins/tree/main/plugins/music-player
+name: BitDG/dsh-plugins#music-player
+category: fun
+tarball: https://github.com/BitDG/dsh-plugins/releases/download/music-player-v0.4.2/dship-music-player-0.4.2.tgz
+description:
+  en: 'Adds a sidebar music browser with multiple public sources, persistent background playback, queue advancement, and reviewed MusicFree-compatible source extensions.'
+  zh: '提供多公共音源的侧栏音乐浏览、持续后台播放、队列续播，以及经审核安装的 MusicFree 兼容音源扩展。'

--- a/data/plugins/BitDG__dsh-plugins--plugins-reference-library.yml
+++ b/data/plugins/BitDG__dsh-plugins--plugins-reference-library.yml
@@ -1,0 +1,7 @@
+url: https://github.com/BitDG/dsh-plugins/tree/main/plugins/reference-library
+name: BitDG/dsh-plugins#reference-library
+category: browser
+tarball: https://github.com/BitDG/dsh-plugins/releases/download/reference-library-v0.6.8/dship-reference-library-0.6.8.tgz
+description:
+  en: 'Adds CodePen, Pinterest, Z-Library, and GitHub data cards to the native @ reference menu, with Pinterest pagination and Z-Library sorting.'
+  zh: '在原生 @ 引用菜单中提供 CodePen、Pinterest、Z-Library 与 GitHub 数据卡片，并支持 Pinterest 分页和 Z-Library 排序。'


### PR DESCRIPTION
## Summary

Adds two separately installable plugins from the `BitDG/dsh-plugins` monorepo:

- `reference-library`: native `@` reference tabs for CodePen, Pinterest, Z-Library, and GitHub.
- `music-player`: sidebar music browser with background playback and MusicFree-compatible source extensions.

Both entries point to version-pinned GitHub release tarballs. Each subpackage declares `dsh.bundle`, includes screenshots beside its package manifest, and was installed and booted from the exact release tarball in an isolated DeepSeek Harness profile.

## Checklist

- [x] Added only the two monorepo subpackage entry files under `data/plugins/`.
- [x] Both subpackages declare `dsh.bundle`.
- [x] Repository is more than one day old.
- [x] Categories are valid (`browser`, `fun`).
- [x] Descriptions are factual and contain no superlatives.
- [x] Repository has the `dsh-plugin` topic.
- [x] `npm ci`, README generation preview, YAML validation, and `git diff --check` passed locally.
- [x] Both release tarball URLs resolve successfully.