### PR TITLE
Add choco9527/dsh-add-to-chat

### DIFF
--- a/data/plugins/choco9527__dsh-add-to-chat.yml
+++ b/data/plugins/choco9527__dsh-add-to-chat.yml
@@ -1,0 +1,6 @@
+url: https://github.com/choco9527/dsh-add-to-chat
+name: choco9527/dsh-add-to-chat
+category: ui
+description:
+  en: "Adds lightweight selected-text references to DSH assistant replies: selections stay outside the editor as removable draft contexts, remain marked beside the source, and render as hoverable annotations after submission."
+  zh: "为 DSH 助手回复添加轻量选中文本引用：选区以可删除的草稿上下文独立于编辑器保存，在原文旁保留标记，并在发送后显示为可悬浮查看的注释。"


### PR DESCRIPTION
## Summary

Adds choco9527/dsh-add-to-chat to the curated plugin list. The plugin lets users select text in DSH assistant replies and carry it into the next message as removable draft-context annotations, with source markers and submitted annotation previews.

## Checklist

- [x] Added one file at data/plugins/choco9527__dsh-add-to-chat.yml
- [x] The plugin declares dsh.bundle
- [x] The repository is more than one day old
- [x] Category is ui
- [x] Descriptions are factual and bilingual
- [x] The repository has the dsh-plugin topic
- [x] Screenshots are declared in the plugin repository

## Installation

    dsh plugin --profile web add github:choco9527/dsh-add-to-chat