### PR TITLE
Fix StrataGate marketplace repository URL

### DIFF
--- a/data/plugins/diqierjia__StrataGate-AgentMemory.yml
+++ b/data/plugins/diqierjia__StrataGate-AgentMemory.yml
@@ -1,4 +1,4 @@
-url: https://github.com/diqierjia/StrataGate-AgentMemory/tree/main/integrations/deepseek-harness
+url: https://github.com/diqierjia/StrataGate-AgentMemory
 tarball: https://github.com/diqierjia/StrataGate-AgentMemory/releases/latest/download/stratagate-dsh.tgz
 name: diqierjia/StrataGate-AgentMemory
 category: memory


### PR DESCRIPTION
## Summary

- update the StrataGate entry to point at the repository root after the DSH plugin moved out of `integrations/deepseek-harness`
- rename the entry file to match the root repository URL
- allow the marketplace screenshot probe to discover the root-level `screenshots.json`

## Why

The old subdirectory no longer exists, so the marketplace's GitHub link returns 404 and screenshot discovery probes the wrong directory. The repository root now contains the DSH package and its `screenshots.json`.