### PR TITLE
Update SuCriss/dsh-version-update listing for v1.0.7

### DIFF
--- a/data/plugins/SuCriss__dsh-version-update.yml
+++ b/data/plugins/SuCriss__dsh-version-update.yml
@@ -3,5 +3,5 @@ name: SuCriss/dsh-version-update
 category: dev
 tarball: https://github.com/SuCriss/dsh-version-update/releases/latest/download/dsh-version-update.tgz
 description:
-  zh: "DeepSeek Harness 版本管理：对照各 npm 通道或版本线查看已装版本，一键安装或降级，从本地快照秒级回滚，用策略引擎（静默自动更新、执行时间窗、每日检查）托管整个流程，检查到新版本时弹窗确认是否立即更新，保存策略即时提示成功或失败，安装后自动重启宿主，遇到 registry 不可达时自动回退到镜像。"
-  en: "Version management for dsh: inspect the installed version against every npm channel or version line, install or downgrade in one click, roll back instantly from local snapshots, automate the cycle with a policy engine (silent auto-update, execution windows, daily checks), confirm before installing a found update, report policy-save success or failure, auto-restart the host after install, and fall back to a mirror when the primary registry is unreachable."
+  zh: "DeepSeek Harness 版本管理：对照各 npm 通道或版本线查看已装版本，一键安装或降级，安装日志实时流出（回滚快照复制进度、npm 提取进度、已运行时长），从本地快照秒级回滚，用策略引擎（静默自动更新、执行时间窗、每日检查）托管整个流程，检查到新版本时弹窗确认是否立即更新，保存策略即时提示成功或失败，安装后自动重启宿主，遇到 registry 不可达时自动回退到镜像。"
+  en: "Version management for dsh: inspect the installed version against every npm channel or version line, install or downgrade in one click, stream the install log live (rollback-snapshot copy progress, npm extraction progress, elapsed time), roll back instantly from local snapshots, automate the cycle with a policy engine (silent auto-update, execution windows, daily checks), confirm before installing a found update, report policy-save success or failure, auto-restart the host after install, and fall back to a mirror when the primary registry is unreachable."


### PR DESCRIPTION
## What changed / 改了什么

Updates **my own entry only** (`data/plugins/SuCriss__dsh-version-update.yml`, both description lines) to cover what the plugin actually does since v1.0.7:

- **Live install log from the first second.** Previously the rollback snapshot ran synchronously inside the install route — a full copy of the installation blocked the host event loop, so the panel sat with an empty log for tens of seconds. The snapshot now runs async and reports copied-bytes progress, npm extraction progress and an elapsed clock stream into the log while npm runs.
- **The rollback snapshot store works again.** Snapshots were keyed by the install target while validity/restore/recovery compare the copied manifest against the directory name, so every fresh snapshot was pruned as damaged immediately. Snapshots are now keyed by the version of the tree they copy.

## Why this claim is checkable / 描述可核对

- Live progress lines: `lib/updater.js` (`watchExtraction`, the `[installing] … extracted` lines) and `lib/snapshot.js` (`createSnapshotAsync` with the `onProgress` callback), streamed through the `beforeSpawn(version, report)` hook wired in `lib/index.js`.
- Snapshot fix: `lib/index.js` keys the snapshot by `readInstalled(installDir).installed`.
- Panel side: 800 ms polling and the elapsed clock in `lib/client.js`.
- Shipped as `dsh-version-update@1.0.7` on npm (https://registry.npmjs.org/dsh-version-update/-/dsh-version-update-1.0.7.tgz), changelog under the `## [1.0.7]` heading in the repo.
- The `tarball:` field is unchanged and still resolves (the release asset `dsh-version-update.tgz` was verified with a HEAD request before this PR).

No other entries touched; the READMEs are left to the generator.