### PR TITLE
Add CAI-MH/dsh-reply-language, CAI-MH/dsh-feishu-task-recorder, CAI-MH/dsh-quality-review

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 <!-- BEGIN PLUGINS -->
 ### AGI Architecture Exploration
 
+- [CAI-MH/dsh-quality-review](https://github.com/CAI-MH/dsh-quality-review) - Audit each finished assistant turn with an independent reviewer model and steer the agent to fix failed output, with at most 2 review rounds per turn.
 - [FuRongJun-1999/dsh-memory](https://github.com/FuRongJun-1999/dsh-memory) - White-box AGI architecture exploration: metacognition (self-cognition loop), continual learning (knowledge flywheel), world model (condition space, spatiotemporal memory graph), self-improvement (bootstrap discipline), zero-LLM white-box pipeline, and auditable trust guardrails.
 - [Jonah-Wu23/dsh-gungnir#dsh-plugin](https://github.com/Jonah-Wu23/dsh-gungnir/tree/main/packages/dsh-plugin) - Evidence-driven goal verification plugin for DeepSeek Harness. Locks goals via /ultragoal and verifies completion against command exit codes and generated artifacts, preventing the model from falsely reporting task completion.
 
@@ -1046,6 +1047,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 ### Identity & Communication
 
 - [AgentConnect/dsh-awiki](https://github.com/AgentConnect/dsh-awiki) - Provides DeepSeek Harness agents with native identities based on the open Agent Network Protocol (ANP), plus identity-based direct, group, mail, and Agent-to-Agent communication.
+- [CAI-MH/dsh-reply-language](https://github.com/CAI-MH/dsh-reply-language) - Force the model to write all replies in a chosen language (Simplified Chinese by default) via a system-prompt section, switchable anytime with a tool.
 - [chenbin-dev/dsh-auth-everying](https://github.com/chenbin-dev/dsh-auth-everying) - Import local Claude, Codex, Grok, Gemini, Copilot, OpenCode, and CC Switch config into DeepSeek Harness with OAuth login for supported providers.
 - [Freakz2z/dsh-catgirl-plugin](https://github.com/Freakz2z/dsh-catgirl-plugin) - Token-efficient persona runtime for DeepSeek Harness with local catgirl rendering and progressive tool-schema disclosure.
 - [lw-storm/dsh-plugin-masterprompt](https://github.com/lw-storm/dsh-plugin-masterprompt) - Per-conversation persona / master prompt plugin: create, edit, switch and delete persona templates from the composer toolbar, with highest-priority system-prompt injection, fixed interaction guardrails, subagent inheritance, new-conversation default, and local JSON persistence.
@@ -2594,6 +2596,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 - [bobleer/dsh-acp-for-bitfun](https://github.com/bobleer/dsh-acp-for-bitfun) - ACP bridge between BitFun and DSH.
 - [BolunHan/cc-monitor#dsh-cc-monitor](https://github.com/BolunHan/cc-monitor/tree/main/dsh-cc-monitor) - Reports DeepSeek Harness session activity to a self-hosted cc-monitor server, which surfaces Claude Code and DSH sessions as color-coded state cards in one web dashboard and pings your browser and Android app when a session needs attention.
 - [br1nosense/dsh-wxauto-plugin](https://github.com/br1nosense/dsh-wxauto-plugin) - WeChat automation for DSH: push task progress to WeChat, listen for messages with keyword auto-reply, and a WeChat ↔ DSH two-way bridge controllable from the settings page, built on wxauto4.
+- [CAI-MH/dsh-feishu-task-recorder](https://github.com/CAI-MH/dsh-feishu-task-recorder) - Poll Feishu (Lark) chats through lark-cli, extract candidate tasks with a review workflow, and two-way sync them with the task-board plugin, with a floating browser panel.
 - [caoxiaohu7745-bot/kongmu-im-bridge](https://github.com/caoxiaohu7745-bot/kongmu-im-bridge) - Feishu bridge for DeepSeek Harness (derived from dsh-im-bridge): WebSocket long connection, approval cards, group @-mention-only replies, streaming card updates, /stop command.
 - [cdxiaodong/dsh-island](https://github.com/cdxiaodong/dsh-island) - Bridge DSH agent sessions, tool calls, and approvals to the CodeIsland macOS notch panel over a Unix socket, with in-panel allow/deny.
 - [cerebrixos-org/tuning-engines-cli#tuningengines-dsh-plugin](https://github.com/cerebrixos-org/tuning-engines-cli/tree/main/packages/tuningengines-dsh-plugin) - Exports metadata-only DSH turn, model, tool, approval, retry, and error events to Tuning Engines for governed traces, policy evaluation, cost analysis, and Work Session review, with a disk-backed retry queue.

--- a/README.zh.md
+++ b/README.zh.md
@@ -80,6 +80,7 @@ dsh plugin --profile web add dshmarket
 <!-- BEGIN PLUGINS -->
 ### 🧭 AGI 架构探索
 
+- [CAI-MH/dsh-quality-review](https://github.com/CAI-MH/dsh-quality-review) — 每轮回复结束时用独立审查模型审核输出，判定不合格则引导 agent 修复，每轮最多追问 2 次。
 - [FuRongJun-1999/dsh-memory](https://github.com/FuRongJun-1999/dsh-memory) — 白箱AGI架构探索：元认知（自我认知循环）、持续学习（知识飞轮）、世界模型（条件空间+语义时空图）、自我改进（自举纪律）、零LLM白箱管线与可审计信任护栏。
 - [Jonah-Wu23/dsh-gungnir#dsh-plugin](https://github.com/Jonah-Wu23/dsh-gungnir/tree/main/packages/dsh-plugin) — 面向 DeepSeek Harness 的证据驱动目标校验插件。通过 /ultragoal 锁定目标，并依据命令退出码与生成产物验证完成状态，防止模型虚报任务完成。
 
@@ -1046,6 +1047,7 @@ dsh plugin --profile web add dshmarket
 ### 🆔 身份与通信
 
 - [AgentConnect/dsh-awiki](https://github.com/AgentConnect/dsh-awiki) — 为 DeepSeek Harness 智能体提供基于开放协议ANP的原生身份，以及基于该身份的私聊、群聊、邮件和智能体间通信能力。
+- [CAI-MH/dsh-reply-language](https://github.com/CAI-MH/dsh-reply-language) — 通过系统提示词强制模型全程使用指定语言回复（默认中文简体），可用工具随时切换。
 - [chenbin-dev/dsh-auth-everying](https://github.com/chenbin-dev/dsh-auth-everying) — 把本机的 Claude、Codex、Grok、Gemini、Copilot、OpenCode 与 CC Switch 配置导入 DeepSeek Harness，支持的提供方可直接 OAuth 登录。
 - [Freakz2z/dsh-catgirl-plugin](https://github.com/Freakz2z/dsh-catgirl-plugin) — DeepSeek Harness 的省 token 人格运行时：本地渲染猫娘风味，并支持渐进式工具 schema 披露。
 - [lw-storm/dsh-plugin-masterprompt](https://github.com/lw-storm/dsh-plugin-masterprompt) — 每对话独立的人设 / 主提示词插件：在输入框工具栏创建、编辑、切换和删除人设模板，最高优先级系统提示注入，附带固定交互护栏、子代理继承、新对话默认继承与本地 JSON 持久化。
@@ -2594,6 +2596,7 @@ dsh plugin --profile web add dshmarket
 - [bobleer/dsh-acp-for-bitfun](https://github.com/bobleer/dsh-acp-for-bitfun) — BitFun 与 DSH 的 ACP 交互对接。
 - [BolunHan/cc-monitor#dsh-cc-monitor](https://github.com/BolunHan/cc-monitor/tree/main/dsh-cc-monitor) — 将 DeepSeek Harness 会话活动上报到自托管的 cc-monitor 服务器：Claude Code 与 DSH 会话以彩色状态卡片出现在同一个 Web 仪表盘中，会话需要关注时通过浏览器与 Android 应用通知你。
 - [br1nosense/dsh-wxauto-plugin](https://github.com/br1nosense/dsh-wxauto-plugin) — 基于 wxauto4 的微信自动化插件：任务进度微信推送、消息监听（关键词自动回复）、微信⇄DSH 双向桥，设置页开关与配置。
+- [CAI-MH/dsh-feishu-task-recorder](https://github.com/CAI-MH/dsh-feishu-task-recorder) — 通过 lark-cli 轮询飞书会话，提取候选任务并逐条审核，与任务看板插件双向同步，含悬浮面板。
 - [caoxiaohu7745-bot/kongmu-im-bridge](https://github.com/caoxiaohu7745-bot/kongmu-im-bridge) — DeepSeek Harness 飞书桥（衍生自 dsh-im-bridge）：长连接免公网、审批卡片、群聊仅 @ 回复、流式卡片打字机回显、/stop 中断任务。
 - [cdxiaodong/dsh-island](https://github.com/cdxiaodong/dsh-island) — 通过 Unix socket 把 DSH agent 的会话、工具调用与审批实时桥接到 CodeIsland macOS 刘海面板，可直接在面板上批准/拒绝。
 - [cerebrixos-org/tuning-engines-cli#tuningengines-dsh-plugin](https://github.com/cerebrixos-org/tuning-engines-cli/tree/main/packages/tuningengines-dsh-plugin) — 将不含原始内容的 DSH 回合、模型、工具、审批、重试和错误事件导出到 Tuning Engines，用于受治理的追踪、策略评估、成本分析和 Work Session 审阅，并提供磁盘持久化重试队列。

--- a/data/plugins/CAI-MH__dsh-feishu-task-recorder.yml
+++ b/data/plugins/CAI-MH__dsh-feishu-task-recorder.yml
@@ -1,0 +1,6 @@
+url: https://github.com/CAI-MH/dsh-feishu-task-recorder
+name: CAI-MH/dsh-feishu-task-recorder
+category: notify
+description:
+  en: 'Poll Feishu (Lark) chats through lark-cli, extract candidate tasks with a review workflow, and two-way sync them with the task-board plugin, with a floating browser panel.'
+  zh: '通过 lark-cli 轮询飞书会话，提取候选任务并逐条审核，与任务看板插件双向同步，含悬浮面板。'

--- a/data/plugins/CAI-MH__dsh-quality-review.yml
+++ b/data/plugins/CAI-MH__dsh-quality-review.yml
@@ -1,0 +1,6 @@
+url: https://github.com/CAI-MH/dsh-quality-review
+name: CAI-MH/dsh-quality-review
+category: agi
+description:
+  en: 'Audit each finished assistant turn with an independent reviewer model and steer the agent to fix failed output, with at most 2 review rounds per turn.'
+  zh: '每轮回复结束时用独立审查模型审核输出，判定不合格则引导 agent 修复，每轮最多追问 2 次。'

--- a/data/plugins/CAI-MH__dsh-reply-language.yml
+++ b/data/plugins/CAI-MH__dsh-reply-language.yml
@@ -1,0 +1,6 @@
+url: https://github.com/CAI-MH/dsh-reply-language
+name: CAI-MH/dsh-reply-language
+category: identity
+description:
+  en: 'Force the model to write all replies in a chosen language (Simplified Chinese by default) via a system-prompt section, switchable anytime with a tool.'
+  zh: '通过系统提示词强制模型全程使用指定语言回复（默认中文简体），可用工具随时切换。'


### PR DESCRIPTION
Adds three plugin entries, one file each under `data/plugins/`:

- **CAI-MH/dsh-reply-language** (`identity`) — forces the model to write all replies in a chosen language (Simplified Chinese by default) via a system-prompt section, switchable anytime with the `reply_language_set` tool.
- **CAI-MH/dsh-feishu-task-recorder** (`notify`) — polls Feishu (Lark) chats through `lark-cli`, extracts candidate tasks with a review workflow (pending → ai/manual/rejected → done), two-way syncs them with `@linxin666/dsh-client-ui-task-board`, and ships a floating browser panel.
- **CAI-MH/dsh-quality-review** (`agi`) — audits each finished assistant turn with an independent reviewer model on `agent/turn-stopping` and steers the agent to fix failed output, at most 2 review rounds per turn (hard loop guard).

All three repos declare a complete `dsh.bundle` manifest (`bundle.patch` + `cordis.patch.yml` at the root; the feishu plugin also declares `dsh.client` for its panel), contain real working code, carry the `dsh-plugin` topic, and are MIT-licensed.

**Note on the repo-age check:** the three repos were created on 2026-09-04, so the 1-day-old CI gate will fail until 2026-09-05. Happy for CI to be re-run once they pass the mark — nothing else about the submissions depends on it.
