### PR TITLE
Add seeingrain/dsh-session-todos (session)

### DIFF
--- a/data/plugins/seeingrain__dsh-session-todos.yml
+++ b/data/plugins/seeingrain__dsh-session-todos.yml
@@ -1,0 +1,6 @@
+url: https://github.com/seeingrain/dsh-session-todos
+name: seeingrain/dsh-session-todos
+category: session
+description:
+  en: Floating todo panel for DSH sessions with server-side cross-device persistence and pending-task badges in the session list.
+  zh: 会话内悬浮待办面板，支持服务器端跨设备持久化及会话列表未完成任务图标。


### PR DESCRIPTION
Adds `seeingrain/dsh-session-todos` to the **session** category.

Floating todo panel for DSH sessions with server-side cross-device persistence and pending-task badges in the session list.

- Repo: https://github.com/seeingrain/dsh-session-todos
- Has `dsh.bundle` manifest ✅
- `dsh-plugin` topic added ✅