### PR TITLE
Add fengb3/dsh-theme-macintosh (Themes)

### DIFF
--- a/data/plugins/fengb3__dsh-theme-macintosh.yml
+++ b/data/plugins/fengb3__dsh-theme-macintosh.yml
@@ -1,0 +1,6 @@
+url: https://github.com/fengb3/dsh-theme-macintosh
+name: fengb3/dsh-theme-macintosh
+category: theme
+description:
+  en: 'Classic Macintosh (System 7) pixel theme: desktop pattern canvas, Finder sidebar, monochrome buttons and dialogs, light/dark support.'
+  zh: '经典麦金塔 System 7 像素风主题：桌面网点画布、Finder 侧栏、黑白按钮与弹窗，深浅色随官方外观切换。'


### PR DESCRIPTION
Adds one plugin entry:

- **fengb3/dsh-theme-macintosh** (Themes) — Classic Macintosh (System 7) pixel theme for the DSH Web UI: desktop pattern canvas, Finder-style session sidebar, monochrome buttons and dialogs, light/dark following the official appearance toggle.

Details:

- `data/plugins/fengb3__dsh-theme-macintosh.yml` — new entry, `category: theme`, bilingual description. No other files touched.
- Screenshots follow the new convention: declared as `screenshots.json` in the plugin repository (no `data/screenshots.json` change in this PR).
- Repo bar: created 2026-08-28, MIT license, `dsh.bundle` manifest with `cordis.patch.yml` at repo root, `dsh-plugin` topic set, published to npm as `dsh-theme-macintosh@0.1.1` with the `repository` field pointing back at the repo.
- GitHub-source install verified end to end: `dsh plugin --profile web add github:fengb3/dsh-theme-macintosh` installs, registers in `dsh.profile.bundles`, and the theme is live after a Web UI restart.