### PR TITLE
feat: add @botton/dsh-model-router plugin

### DIFF
--- a/data/plugins/bill277048-hash__DSH-model-router.yml
+++ b/data/plugins/bill277048-hash__DSH-model-router.yml
@@ -1,0 +1,6 @@
+url: https://github.com/bill277048-hash/DSH-model-router
+name: bill277048-hash/DSH-model-router
+category: model
+description:
+  en: Rule-based multi-provider model routing for DeepSeek Harness with pre-first-token failover, cooldown circuit-breaking, usage accounting, and a status API.
+  zh: DeepSeek Harness 多供应商模型路由插件：规则路由 + 首 token 前无感故障切换 + cooldown 熔断 + 用量记账 + 状态接口。


### PR DESCRIPTION
## 插件概要
- **仓库**：[https://github.com/bill277048-hash/DSH-model-router](https://github.com/bill277048-hash/DSH-model-router)
- **npm 包**：`@botton/dsh-model-router`（可选发布）
- **分类**：`model`（Models & Providers）
- **作者**：botton指北（GitHub owner bill277048-hash 为上架专用马甲）

## 能力
- 规则路由：四种扩展策略（explicit / same-model / same-provider / exclude-current）
- 首分片前无感故障切换（finish-chunk driven + commit-on-first-chunk）
- cooldown 三态熔断，含 v0.6.1 配额感知（QUOTA 1 次 / 600s）
- TTFT 看门狗 30s + 切换总预算 90s
- v0.7.0 模式预设（stable / balanced / fast）
- 用量记账（可视，滚动 5h/1w 窗口）+ 状态接口
- 61 项单元测试，零第三方运行时依赖

## CI 自检
- ✅ 仓库满 1 天（注册 2026-09-03 22:00）
- ✅ `dsh.bundle` manifest 声明（`./cordis.patch.yml`）
- ✅ `cordis.patch.yml` 仓库根目录存在
- ✅ `peerDependencies` 使用显式预发布分支（避免 dsh 0.1.1-rc.x ERESOLVE）
- ✅ description.en 以句号结尾；description.zh 以句号结尾
- ✅ 描述无冒号空格模式（无 YAML 解析风险）