### PR TITLE
Add dsh-chat-index plugin (ui)

### DIFF
--- a/data/plugins/kk112222__dsh-chat-index.yml
+++ b/data/plugins/kk112222__dsh-chat-index.yml
@@ -1,0 +1,6 @@
+url: https://github.com/kk112222/dsh-chat-index
+name: kk112222/dsh-chat-index
+category: ui
+description:
+  en: 'Per-session question index for the DSH Web UI: a time-proportional dot rail on the right edge and an expandable chain panel showing every user question with its time, including branch/subagent sessions; clicking a node jumps to that message and highlights it.'
+  zh: 'DSH Web UI 会话提问索引：右缘时间比例圆点窄条与可展开链面板，展示每次用户提问的问题与时间，含分支/子会话；点击节点跳转并高亮对应消息。'


### PR DESCRIPTION
Adds [dsh-chat-index](https://github.com/kk112222/dsh-chat-index) (npm: dsh-chat-index) to the ui category.

What it does: a per-session question index for the DSH Web UI — a thin, time-proportional dot rail on the right edge of the conversation plus an expandable chain panel. Each node shows the question text and its time; branch/subagent sessions render as a subtree, and clicking a node scrolls to that message and briefly highlights it.

Data source: live conversation snapshot merged with durable `session.history` pages; the host half is only the loader entry.