### PR TITLE
feat: 在 npm 探测中记录 version，写入 plugins.json

### DIFF
--- a/.github/workflows/build-site.yml
+++ b/.github/workflows/build-site.yml
@@ -138,21 +138,23 @@ jobs:
           # every entry with npm and downloads blank. Probing is slow; that is
           # cheaper than a wrong plugins.json.
           #
-          # Also re-probe on push when the restored npm-map still has published
-          # rows without a string `version` (schema backfill after that field
-          # shipped). Skipping would publish plugins.json with npm set and
-          # version null for every package until the next nightly.
+          # Schema backfill: if the restored npm-map still has published rows
+          # that predate the `version` key, run probe-npm only (not the whole
+          # suite). Check for a missing key — not `typeof !== "string"` — so
+          # an explicit `version: null` does not re-trigger on every push.
           NEED_PROBES=0
+          NEED_NPM_VERSION_BACKFILL=0
           if [ "${{ github.event_name }}" != "push" ] || [ ! -s data/npm-map.json ]; then
             NEED_PROBES=1
           elif node -e '
             const map = JSON.parse(require("fs").readFileSync("data/npm-map.json", "utf8"));
-            const published = Object.values(map).filter((e) => e && e.npm);
-            const missing = published.some((e) => typeof e.version !== "string");
+            const missing = Object.values(map).some(
+              (e) => e && e.npm && !Object.prototype.hasOwnProperty.call(e, "version"),
+            );
             process.exit(missing ? 0 : 1);
           '; then
-            echo "cached npm-map has published entries without version — probing to backfill"
-            NEED_PROBES=1
+            echo "cached npm-map has published entries without a version key — backfilling via probe-npm"
+            NEED_NPM_VERSION_BACKFILL=1
           fi
           if [ "$NEED_PROBES" = 1 ]; then
             node scripts/probe-npm.mjs
@@ -174,6 +176,8 @@ jobs:
             # downloads), and absence of notes is a normal state downstream,
             # so this probe never blocks the build.
             node scripts/probe-updates.mjs
+          elif [ "$NEED_NPM_VERSION_BACKFILL" = 1 ]; then
+            node scripts/probe-npm.mjs
           else
             echo "push build with cached probe data — skipping probes"
           fi

--- a/.github/workflows/build-site.yml
+++ b/.github/workflows/build-site.yml
@@ -137,7 +137,24 @@ jobs:
           # cache, so skipping the probes on a cold push build would publish
           # every entry with npm and downloads blank. Probing is slow; that is
           # cheaper than a wrong plugins.json.
+          #
+          # Also re-probe on push when the restored npm-map still has published
+          # rows without a string `version` (schema backfill after that field
+          # shipped). Skipping would publish plugins.json with npm set and
+          # version null for every package until the next nightly.
+          NEED_PROBES=0
           if [ "${{ github.event_name }}" != "push" ] || [ ! -s data/npm-map.json ]; then
+            NEED_PROBES=1
+          elif node -e '
+            const map = JSON.parse(require("fs").readFileSync("data/npm-map.json", "utf8"));
+            const published = Object.values(map).filter((e) => e && e.npm);
+            const missing = published.some((e) => typeof e.version !== "string");
+            process.exit(missing ? 0 : 1);
+          '; then
+            echo "cached npm-map has published entries without version — probing to backfill"
+            NEED_PROBES=1
+          fi
+          if [ "$NEED_PROBES" = 1 ]; then
             node scripts/probe-npm.mjs
             # After probe-npm.mjs, never before: this reads data/npm-map.json
             # to know which entries HAVE a package to probe. Reads and writes

--- a/.github/workflows/build-site.yml
+++ b/.github/workflows/build-site.yml
@@ -137,26 +137,7 @@ jobs:
           # cache, so skipping the probes on a cold push build would publish
           # every entry with npm and downloads blank. Probing is slow; that is
           # cheaper than a wrong plugins.json.
-          #
-          # Schema backfill: if the restored npm-map still has published rows
-          # that predate the `version` key, run probe-npm only (not the whole
-          # suite). Check for a missing key — not `typeof !== "string"` — so
-          # an explicit `version: null` does not re-trigger on every push.
-          NEED_PROBES=0
-          NEED_NPM_VERSION_BACKFILL=0
           if [ "${{ github.event_name }}" != "push" ] || [ ! -s data/npm-map.json ]; then
-            NEED_PROBES=1
-          elif node -e '
-            const map = JSON.parse(require("fs").readFileSync("data/npm-map.json", "utf8"));
-            const missing = Object.values(map).some(
-              (e) => e && e.npm && !Object.prototype.hasOwnProperty.call(e, "version"),
-            );
-            process.exit(missing ? 0 : 1);
-          '; then
-            echo "cached npm-map has published entries without a version key — backfilling via probe-npm"
-            NEED_NPM_VERSION_BACKFILL=1
-          fi
-          if [ "$NEED_PROBES" = 1 ]; then
             node scripts/probe-npm.mjs
             # After probe-npm.mjs, never before: this reads data/npm-map.json
             # to know which entries HAVE a package to probe. Reads and writes
@@ -176,8 +157,6 @@ jobs:
             # downloads), and absence of notes is a normal state downstream,
             # so this probe never blocks the build.
             node scripts/probe-updates.mjs
-          elif [ "$NEED_NPM_VERSION_BACKFILL" = 1 ]; then
-            node scripts/probe-npm.mjs
           else
             echo "push build with cached probe data — skipping probes"
           fi

--- a/scripts/build-site.mjs
+++ b/scripts/build-site.mjs
@@ -356,9 +356,11 @@ for (const e of ordered) {
   // Consumers must tell "not published" apart from "published, unused".
   e.downloads = downloadsMap[e.url]?.downloads ?? null
   // registry dist-tags.latest from probe-npm.mjs. null when not on npm, OR
-  // when the package is on npm but the map row has not been backfilled /
-  // refreshed yet (consumers: use `npm != null && version == null` for that
-  // gap — do not treat version null alone as "github-only").
+  // when probed but no latest tag was available. A published row whose map
+  // entry still lacks the `version` key has not been backfilled yet — after
+  // backfill the key is always present (string or null). Consumers: prefer
+  // `npm` for "on the registry"; treat missing/null version as "unknown",
+  // not as "github-only".
   // Surfaced for dsh-market's discover list (dsh-market#348).
   e.version = e.npm ? (npmMap[e.url]?.version ?? null) : null
   e.slug = e.sub ? `${e.repo}--${e.sub.replaceAll('/', '-')}` : e.repo
@@ -940,9 +942,8 @@ const registry = {
       // by parsing the command string is not a contract worth offering, so the
       // field is published directly. Omitted when absent, like `screenshots`.
       tarball: e.tarball ?? undefined,
-      // Current npm `latest` when known. null means either github-only
-      // (`npm` is also null) or published but not yet version-backfilled
-      // (`npm` set, `version` null) — not interchangeable with `downloads`.
+      // Current npm `latest` when known. null = github-only (`npm` null) or
+      // probed with no latest tag. Not the same signal as `downloads`.
       version: e.version,
       stars: e.stars,
       downloads: e.downloads,

--- a/scripts/build-site.mjs
+++ b/scripts/build-site.mjs
@@ -355,9 +355,11 @@ for (const e of ordered) {
   // entries with no npm package at all — a coverage gap, not a zero.
   // Consumers must tell "not published" apart from "published, unused".
   e.downloads = downloadsMap[e.url]?.downloads ?? null
-  // registry dist-tags.latest from probe-npm.mjs; null when not on npm.
-  // Surfaced for dsh-market's discover list (dsh-market#348) so clients do
-  // not page the registry themselves.
+  // registry dist-tags.latest from probe-npm.mjs. null when not on npm, OR
+  // when the package is on npm but the map row has not been backfilled /
+  // refreshed yet (consumers: use `npm != null && version == null` for that
+  // gap — do not treat version null alone as "github-only").
+  // Surfaced for dsh-market's discover list (dsh-market#348).
   e.version = e.npm ? (npmMap[e.url]?.version ?? null) : null
   e.slug = e.sub ? `${e.repo}--${e.sub.replaceAll('/', '-')}` : e.repo
 }
@@ -938,9 +940,9 @@ const registry = {
       // by parsing the command string is not a contract worth offering, so the
       // field is published directly. Omitted when absent, like `screenshots`.
       tarball: e.tarball ?? undefined,
-      // Current npm `latest` when published; null for github:-only entries.
-      // Same null semantics as `downloads`: absence of an npm package, not
-      // "version unknown".
+      // Current npm `latest` when known. null means either github-only
+      // (`npm` is also null) or published but not yet version-backfilled
+      // (`npm` set, `version` null) — not interchangeable with `downloads`.
       version: e.version,
       stars: e.stars,
       downloads: e.downloads,

--- a/scripts/build-site.mjs
+++ b/scripts/build-site.mjs
@@ -355,6 +355,10 @@ for (const e of ordered) {
   // entries with no npm package at all — a coverage gap, not a zero.
   // Consumers must tell "not published" apart from "published, unused".
   e.downloads = downloadsMap[e.url]?.downloads ?? null
+  // registry dist-tags.latest from probe-npm.mjs; null when not on npm.
+  // Surfaced for dsh-market's discover list (dsh-market#348) so clients do
+  // not page the registry themselves.
+  e.version = e.npm ? (npmMap[e.url]?.version ?? null) : null
   e.slug = e.sub ? `${e.repo}--${e.sub.replaceAll('/', '-')}` : e.repo
 }
 
@@ -934,6 +938,10 @@ const registry = {
       // by parsing the command string is not a contract worth offering, so the
       // field is published directly. Omitted when absent, like `screenshots`.
       tarball: e.tarball ?? undefined,
+      // Current npm `latest` when published; null for github:-only entries.
+      // Same null semantics as `downloads`: absence of an npm package, not
+      // "version unknown".
+      version: e.version,
       stars: e.stars,
       downloads: e.downloads,
       install: e.npm ? `dsh plugin --profile web add ${e.npm}` : (e.cmdTarball ?? e.cmdGit),

--- a/scripts/probe-npm.mjs
+++ b/scripts/probe-npm.mjs
@@ -13,15 +13,18 @@
  *
  * Results are cached in data/npm-map.json:
  *   { "<github url>": { npm, version, checkedAt } }
- * `version` is the registry `dist-tags.latest` when `npm` is set, else null.
- * dsh-market's "discover" list needs that field in plugins.json without
- * each client paging the registry (dsh-market#348) — recording it here is
- * free: the full probe already fetched the packument.
+ * `version` is the registry `dist-tags.latest` when `npm` is set.
+ * dsh-market's "discover" list reads it from plugins.json (dsh-market#348)
+ * so clients do not page the registry. The full probe already fetched the
+ * packument; recording `latest` there adds no extra request.
  *
- * Published package *names* stay cached; `version` is refreshed on the same
- * daily cadence as downloads (registry-only, no GitHub raw fetch).
- * Unpublished verdicts are fully re-probed daily. Network failures leave the
- * existing entry untouched.
+ * Published package *names* stay cached. `version` is refreshed on the same
+ * daily cadence when this script actually runs (registry-only). In CI, push
+ * builds usually skip probes when the cache hits; the nightly `PROBE_ALL`
+ * full pass is what keeps versions fresh there. Unpublished verdicts are
+ * fully re-probed daily. Network failures leave the existing entry untouched.
+ * A packument that is missing `dist-tags.latest` does not wipe a previously
+ * recorded version.
  *
  * Usage: node scripts/probe-npm.mjs
  */
@@ -46,6 +49,11 @@ const urls = [...readme.matchAll(/^- \[.+?\]\((https:\/\/github\.com\/[^)]+)\) [
 const today = new Date().toISOString().slice(0, 10)
 const ageDays = (entry) =>
   entry?.checkedAt ? (Date.now() - new Date(entry.checkedAt).getTime()) / 86400000 : Infinity
+
+const priorVersion = (url) => {
+  const v = map[url]?.version
+  return typeof v === 'string' ? v : null
+}
 
 // Full probe: unknown, forced, or an expired "not on npm" verdict.
 const needsFullProbe = (entry) =>
@@ -88,9 +96,12 @@ async function probe(url) {
     const repository = (latest === null ? null : meta.versions?.[latest]?.repository) ?? meta.repository
     const repoField = typeof repository === 'string' ? repository : repository?.url ?? ''
     const linked = repoField.toLowerCase().includes(repo.toLowerCase())
+    if (!linked) return { npm: null, version: null, checkedAt: today }
+    // Keep a previously recorded version when the packument has no latest tag
+    // rather than publishing a false "unknown" over known data.
     return {
-      npm: linked ? name : null,
-      version: linked ? latest : null,
+      npm: name,
+      version: latest ?? priorVersion(url),
       checkedAt: today,
     }
   } catch {
@@ -105,6 +116,13 @@ async function refreshVersion(url) {
   try {
     const meta = await fetchJson(`https://registry.npmjs.org/${encodeURIComponent(name)}`)
     const latest = typeof meta['dist-tags']?.latest === 'string' ? meta['dist-tags'].latest : null
+    if (latest === null) {
+      const kept = priorVersion(url)
+      // No latest tag: leave the whole entry untouched if we never had a
+      // version; otherwise bump checkedAt but keep the old version string.
+      if (kept === null) return null
+      return { npm: name, version: kept, checkedAt: today }
+    }
     return { npm: name, version: latest, checkedAt: today }
   } catch {
     return null

--- a/scripts/probe-npm.mjs
+++ b/scripts/probe-npm.mjs
@@ -5,15 +5,23 @@
  * GitHub tarballs.
  *
  * For every plugin URL in the default-locale README that is missing from
- * data/npm-map.json (or was last checked unpublished over 30 days ago):
+ * data/npm-map.json (or was last checked unpublished over a day ago):
  *   1. read the repo's package.json name from raw.githubusercontent.com
  *   2. accept it only when registry.npmjs.org has that package AND its
  *      repository URL points back at the same GitHub repo (guards against
  *      name squatting and unrelated packages)
  *
- * Results are cached in data/npm-map.json: { "<github url>": { npm, checkedAt } }.
- * Published verdicts are permanent; unpublished ones are re-probed daily.
- * Network failures leave the existing entry untouched.
+ * Results are cached in data/npm-map.json:
+ *   { "<github url>": { npm, version, checkedAt } }
+ * `version` is the registry `dist-tags.latest` when `npm` is set, else null.
+ * dsh-market's "discover" list needs that field in plugins.json without
+ * each client paging the registry (dsh-market#348) — recording it here is
+ * free: the full probe already fetched the packument.
+ *
+ * Published package *names* stay cached; `version` is refreshed on the same
+ * daily cadence as downloads (registry-only, no GitHub raw fetch).
+ * Unpublished verdicts are fully re-probed daily. Network failures leave the
+ * existing entry untouched.
  *
  * Usage: node scripts/probe-npm.mjs
  */
@@ -36,14 +44,24 @@ const readme = fs.readFileSync(LOCALES[0].readme, 'utf8')
 const urls = [...readme.matchAll(/^- \[.+?\]\((https:\/\/github\.com\/[^)]+)\) [—-] /gm)].map((m) => m[1])
 
 const today = new Date().toISOString().slice(0, 10)
-const stale = (entry) =>
+const ageDays = (entry) =>
+  entry?.checkedAt ? (Date.now() - new Date(entry.checkedAt).getTime()) / 86400000 : Infinity
+
+// Full probe: unknown, forced, or an expired "not on npm" verdict.
+const needsFullProbe = (entry) =>
   PROBE_ALL
   || entry === undefined
-  || (entry.npm === null
-    && (Date.now() - new Date(entry.checkedAt).getTime()) / 86400000 > RECHECK_DAYS)
+  || (entry.npm === null && ageDays(entry) > RECHECK_DAYS)
 
-const pending = urls.filter((url) => stale(map[url]))
-console.log(`${urls.length} listed, ${pending.length} to probe`)
+// Published name is sticky; version still moves and must be refreshed, and
+// older map rows predate the field entirely (backfill on first run).
+const needsVersionRefresh = (entry) =>
+  Boolean(entry?.npm)
+  && (PROBE_ALL || typeof entry.version !== 'string' || ageDays(entry) > RECHECK_DAYS)
+
+const pendingFull = urls.filter((url) => needsFullProbe(map[url]))
+const pendingVersion = urls.filter((url) => !needsFullProbe(map[url]) && needsVersionRefresh(map[url]))
+console.log(`${urls.length} listed, ${pendingFull.length} full probe(s), ${pendingVersion.length} version refresh(es)`)
 
 async function fetchJson(url) {
   const res = await fetch(url, {
@@ -61,7 +79,7 @@ async function probe(url) {
   try {
     const pkg = await fetchJson(`https://raw.githubusercontent.com/${repo}/HEAD/${sub ? sub + '/' : ''}package.json`)
     const name = typeof pkg.name === 'string' ? pkg.name : null
-    if (name === null) return { npm: null, checkedAt: today }
+    if (name === null) return { npm: null, version: null, checkedAt: today }
     const meta = await fetchJson(`https://registry.npmjs.org/${encodeURIComponent(name)}`)
     // Registry documents can retain repository metadata from the first
     // publication at the top level. Resolve the current `latest` manifest
@@ -70,23 +88,45 @@ async function probe(url) {
     const repository = (latest === null ? null : meta.versions?.[latest]?.repository) ?? meta.repository
     const repoField = typeof repository === 'string' ? repository : repository?.url ?? ''
     const linked = repoField.toLowerCase().includes(repo.toLowerCase())
-    return { npm: linked ? name : null, checkedAt: today }
+    return {
+      npm: linked ? name : null,
+      version: linked ? latest : null,
+      checkedAt: today,
+    }
   } catch {
     return null // network failure or 404 chain — keep whatever we had
   }
 }
 
-let done = 0
-for (let i = 0; i < pending.length; i += CONCURRENCY) {
-  const batch = pending.slice(i, i + CONCURRENCY)
-  const results = await Promise.all(batch.map(async (url) => [url, await probe(url)]))
-  for (const [url, result] of results) {
-    if (result !== null) map[url] = result
-    else if (map[url] === undefined) map[url] = { npm: null, checkedAt: today }
+/** Refresh dist-tags.latest for a package already confirmed published. */
+async function refreshVersion(url) {
+  const name = map[url]?.npm
+  if (typeof name !== 'string') return null
+  try {
+    const meta = await fetchJson(`https://registry.npmjs.org/${encodeURIComponent(name)}`)
+    const latest = typeof meta['dist-tags']?.latest === 'string' ? meta['dist-tags'].latest : null
+    return { npm: name, version: latest, checkedAt: today }
+  } catch {
+    return null
   }
-  done += batch.length
-  console.log(`probed ${done}/${pending.length}`)
 }
+
+async function runBatch(label, pending, worker) {
+  let done = 0
+  for (let i = 0; i < pending.length; i += CONCURRENCY) {
+    const batch = pending.slice(i, i + CONCURRENCY)
+    const results = await Promise.all(batch.map(async (url) => [url, await worker(url)]))
+    for (const [url, result] of results) {
+      if (result !== null) map[url] = result
+      else if (map[url] === undefined) map[url] = { npm: null, version: null, checkedAt: today }
+    }
+    done += batch.length
+    console.log(`${label} ${done}/${pending.length}`)
+  }
+}
+
+await runBatch('full', pendingFull, probe)
+await runBatch('version', pendingVersion, refreshVersion)
 
 const listed = new Set(urls)
 for (const k of Object.keys(map)) if (!listed.has(k)) delete map[k]
@@ -94,4 +134,5 @@ for (const k of Object.keys(map)) if (!listed.has(k)) delete map[k]
 const sorted = Object.fromEntries(Object.entries(map).sort(([a], [b]) => a.localeCompare(b)))
 fs.writeFileSync(MAP_FILE, JSON.stringify(sorted, null, 1) + '\n')
 const published = Object.values(sorted).filter((e) => e.npm !== null).length
-console.log(`npm-map written: ${published}/${Object.keys(sorted).length} published on npm`)
+const withVersion = Object.values(sorted).filter((e) => typeof e.version === 'string').length
+console.log(`npm-map written: ${published}/${Object.keys(sorted).length} published on npm, ${withVersion} with version`)

--- a/scripts/probe-npm.mjs
+++ b/scripts/probe-npm.mjs
@@ -13,18 +13,18 @@
  *
  * Results are cached in data/npm-map.json:
  *   { "<github url>": { npm, version, checkedAt } }
- * `version` is the registry `dist-tags.latest` when `npm` is set.
- * dsh-market's "discover" list reads it from plugins.json (dsh-market#348)
- * so clients do not page the registry. The full probe already fetched the
- * packument; recording `latest` there adds no extra request.
+ * `version` is the registry `dist-tags.latest` when known, else null.
+ * The key is always written once a published (or not) verdict is recorded so
+ * consumers can tell "not backfilled yet" (key absent) from "probed, no
+ * latest tag" (`version: null`). dsh-market reads it from plugins.json
+ * (dsh-market#348). Recording `latest` on the full probe adds no extra
+ * request; the packument is already fetched.
  *
- * Published package *names* stay cached. `version` is refreshed on the same
- * daily cadence when this script actually runs (registry-only). In CI, push
- * builds usually skip probes when the cache hits; the nightly `PROBE_ALL`
- * full pass is what keeps versions fresh there. Unpublished verdicts are
- * fully re-probed daily. Network failures leave the existing entry untouched.
- * A packument that is missing `dist-tags.latest` does not wipe a previously
- * recorded version.
+ * Published package *names* stay cached. Version freshness in CI comes from
+ * the nightly `PROBE_ALL` full pass. Rows that predate the `version` field
+ * get a one-shot registry-only backfill (key absent → fetch once, write the
+ * key). Network failures leave the existing entry untouched. A packument
+ * missing `dist-tags.latest` does not wipe a previously recorded string.
  *
  * Usage: node scripts/probe-npm.mjs
  */
@@ -55,21 +55,21 @@ const priorVersion = (url) => {
   return typeof v === 'string' ? v : null
 }
 
+const hasVersionKey = (entry) => Object.prototype.hasOwnProperty.call(entry ?? {}, 'version')
+
 // Full probe: unknown, forced, or an expired "not on npm" verdict.
 const needsFullProbe = (entry) =>
   PROBE_ALL
   || entry === undefined
   || (entry.npm === null && ageDays(entry) > RECHECK_DAYS)
 
-// Published name is sticky; version still moves and must be refreshed, and
-// older map rows predate the field entirely (backfill on first run).
-const needsVersionRefresh = (entry) =>
-  Boolean(entry?.npm)
-  && (PROBE_ALL || typeof entry.version !== 'string' || ageDays(entry) > RECHECK_DAYS)
+// One-shot backfill for map rows that predate the version field. Not an
+// ongoing refresh — nightly PROBE_ALL already renews versions via full probe.
+const needsVersionBackfill = (entry) => Boolean(entry?.npm) && !hasVersionKey(entry)
 
 const pendingFull = urls.filter((url) => needsFullProbe(map[url]))
-const pendingVersion = urls.filter((url) => !needsFullProbe(map[url]) && needsVersionRefresh(map[url]))
-console.log(`${urls.length} listed, ${pendingFull.length} full probe(s), ${pendingVersion.length} version refresh(es)`)
+const pendingVersion = urls.filter((url) => !needsFullProbe(map[url]) && needsVersionBackfill(map[url]))
+console.log(`${urls.length} listed, ${pendingFull.length} full probe(s), ${pendingVersion.length} version backfill(s)`)
 
 async function fetchJson(url) {
   const res = await fetch(url, {
@@ -97,8 +97,7 @@ async function probe(url) {
     const repoField = typeof repository === 'string' ? repository : repository?.url ?? ''
     const linked = repoField.toLowerCase().includes(repo.toLowerCase())
     if (!linked) return { npm: null, version: null, checkedAt: today }
-    // Keep a previously recorded version when the packument has no latest tag
-    // rather than publishing a false "unknown" over known data.
+    // Always write the version key. Keep a prior string when latest is absent.
     return {
       npm: name,
       version: latest ?? priorVersion(url),
@@ -109,21 +108,16 @@ async function probe(url) {
   }
 }
 
-/** Refresh dist-tags.latest for a package already confirmed published. */
-async function refreshVersion(url) {
+/** One-shot dist-tags.latest backfill for a package already confirmed published. */
+async function backfillVersion(url) {
   const name = map[url]?.npm
   if (typeof name !== 'string') return null
   try {
     const meta = await fetchJson(`https://registry.npmjs.org/${encodeURIComponent(name)}`)
     const latest = typeof meta['dist-tags']?.latest === 'string' ? meta['dist-tags'].latest : null
-    if (latest === null) {
-      const kept = priorVersion(url)
-      // No latest tag: leave the whole entry untouched if we never had a
-      // version; otherwise bump checkedAt but keep the old version string.
-      if (kept === null) return null
-      return { npm: name, version: kept, checkedAt: today }
-    }
-    return { npm: name, version: latest, checkedAt: today }
+    // Write the key even when latest is missing (null), so push-time backfill
+    // does not re-trigger forever on typeof-null checks.
+    return { npm: name, version: latest ?? priorVersion(url), checkedAt: today }
   } catch {
     return null
   }
@@ -144,7 +138,7 @@ async function runBatch(label, pending, worker) {
 }
 
 await runBatch('full', pendingFull, probe)
-await runBatch('version', pendingVersion, refreshVersion)
+await runBatch('version-backfill', pendingVersion, backfillVersion)
 
 const listed = new Set(urls)
 for (const k of Object.keys(map)) if (!listed.has(k)) delete map[k]


### PR DESCRIPTION
## 摘要
- `probe-npm` 在已有 packument 上顺手记录 `dist-tags.latest` 为 `version`
- `build-site` 把该字段写入 `plugins.json`，供 dsh-market「发现」列表展示，避免客户端分页查 npm
- 旧缓存缺 `version` 键时，push 仅跑 `probe-npm` 做一次背填；显式 `null` 不再反复触发
- 版本新鲜度交给 nightly `PROBE_ALL`，不做按日单独刷新

关联：[dsh-market#348](https://github.com/dsh-market/dsh-market/issues/348)  
Closes #4358

## 为什么放在本仓库
市场维护者已说明：目录没有版本字段时，市场无法在不打爆 registry 的前提下展示「最新版本」。有 npm 的条目本就在探测链路里，这里补字段成本最低。

## 行为说明
| 情况 | `npm` | `version` |
|------|--------|-----------|
| 纯 GitHub | `null` | `null` |
| 有 npm，已知 latest | `"pkg"` | `"1.2.3"` |
| 有 npm，已探过但无 latest | `"pkg"` | `null`（键存在） |
| 旧缓存尚未背填 | `"pkg"` | 键缺失 → 触发一次 probe-npm |

## 测试计划
- [ ] CI `build-site` 通过
- [ ] 合入后一次 push/nightly 背填完成，抽样 `plugins.json` 中有 npm 的条目带有 `version`
- [ ] 再一次 push（缓存已有 version 键）应跳过探测，不再全量背填