### PR TITLE
feat: add aipx toolkit (dsh-plugin) — hub console + skills

### DIFF
--- a/data/plugins/zhangliang0115__ai-plugin--dsh-plugin.yml
+++ b/data/plugins/zhangliang0115__ai-plugin--dsh-plugin.yml
@@ -1,0 +1,6 @@
+url: https://github.com/zhangliang0115/ai-plugin/tree/main/dsh-plugin
+name: zhangliang0115/ai-plugin#dsh-plugin
+category: ui
+description:
+  en: 'Aipx toolkit: skills plus a Hub Console that fronts every MCP server with ~4 meta tools — server pool health, per-tool enable/disable, a tool catalog, and a search playground showing exactly what mcp_search hands the model.'
+  zh: 'aipx 工具包：技能之外还有 Hub Console 控制台——用约 4 个元工具代理全部 MCP 服务器，含服务器池健康、工具级启停、工具目录，以及直观展示 mcp_search 返回结果的搜索试验场。'


### PR DESCRIPTION
## Submission

- **Repo**: https://github.com/zhangliang0115/ai-plugin/tree/main/dsh-plugin
- **Install**: `dsh plugin --profile web add "github:zhangliang0115/ai-plugin#path:/dsh-plugin"`
- **Category**: `ui`
- **dsh.bundle**: declared in `dsh-plugin/package.json` (the repo also declares `dsh.client`, contributing the Hub Console web panel)

## What it is

The aipx toolkit: six cross-agent skills plus a **Hub Console** — an MCP management panel that fronts every downstream MCP server with ~4 meta tools (`mcp_search` / `mcp_call` / `mcp_status` / `mcp_refresh`), so context stays flat no matter how many servers are registered.

Console features: server pool with live health, add/remove servers, per-tool enable/disable, the full tool catalog with filtering, a search engine selector (lexical / zvec full-text / zero-config local hybrid via a small auto-downloaded embedding model), and a search playground that shows exactly what `mcp_search` hands the model.

## Checklist

- [x] `package.json` declares `dsh.bundle` (subpackage `dsh-plugin/`)
- [x] Install line verified on a real machine: `dsh plugin --profile web add "github:zhangliang0115/ai-plugin#path:/dsh-plugin"`
- [x] description.en ends with a period; zh provided