### PR TITLE
Update dsh-conversation-archive tarball URL

### DIFF
--- a/data/plugins/yxv1203-collab__dsh-conversation-archive.yml
+++ b/data/plugins/yxv1203-collab__dsh-conversation-archive.yml
@@ -4,4 +4,4 @@ category: session
 description:
   en: Manage archived DSH sessions on Windows with search, batch restore and deletion, AI-assisted file retention, and verified local or network-directory backups.
   zh: 在 Windows 上管理 DSH 已归档会话，支持搜索、批量取消归档与删除、AI 辅助文件保留，以及经过校验的本地或网络目录备份。
-tarball: https://github.com/yxv1203-collab/dsh-conversation-archive/releases/download/v1.0.0/dsh-conversation-archive-1.0.0.tgz
+tarball: https://github.com/yxv1203-collab/dsh-conversation-archive/releases/latest/download/dsh-conversation-archive.tgz


### PR DESCRIPTION
Use a version-independent latest-release asset for dsh-conversation-archive so future plugin releases do not require listing changes.

The stable URL currently resolves to the verified v1.0.1 tarball.