### PR TITLE
add 3 insurance expert plugins (ops/company/product)

### DIFF
--- a/data/plugins/kevinchu1981__dsh-insurance-experts--packages-insurance-company-analyst.yml
+++ b/data/plugins/kevinchu1981__dsh-insurance-experts--packages-insurance-company-analyst.yml
@@ -1,0 +1,6 @@
+url: https://github.com/kevinchu1981/dsh-insurance-experts/tree/main/packages/insurance-company-analyst
+name: kevinchu1981/dsh-insurance-experts#insurance-company-analyst
+category: tools
+description:
+  en: Insurance company financial & operating analyst — solvency, financials, investment, distribution channels and peer comparison with real calculations.
+  zh: 保险公司财务经营分析专家，真跑偿付能力、财务报表、投资、渠道与同业对标测算。

--- a/data/plugins/kevinchu1981__dsh-insurance-experts--packages-insurance-ops-analyst.yml
+++ b/data/plugins/kevinchu1981__dsh-insurance-experts--packages-insurance-ops-analyst.yml
@@ -1,0 +1,6 @@
+url: https://github.com/kevinchu1981/dsh-insurance-experts/tree/main/packages/insurance-ops-analyst
+name: kevinchu1981/dsh-insurance-experts#insurance-ops-analyst
+category: tools
+description:
+  en: Insurance company operations analyst — runs real solvency, profitability, embedded value (EV), investment risk and regulatory compliance calculations, not just text explanations.
+  zh: 保险公司经营分析专家（盈安），真跑偿付能力、盈利能力、内含价值(EV)、投资风险与监管合规五维测算。

--- a/data/plugins/kevinchu1981__dsh-insurance-experts--packages-insurance-product-analyst.yml
+++ b/data/plugins/kevinchu1981__dsh-insurance-experts--packages-insurance-product-analyst.yml
@@ -1,0 +1,6 @@
+url: https://github.com/kevinchu1981/dsh-insurance-experts/tree/main/packages/insurance-product-analyst
+name: kevinchu1981/dsh-insurance-experts#insurance-product-analyst
+category: tools
+description:
+  en: Insurance product comparison & proposal expert — clause analysis, cost-effectiveness, coverage planning, generates verifiable client-facing PDF proposals.
+  zh: 保险产品对比与建议书专家（险析君），条款拆解、性价比测算、保障规划，生成可自核 PDF 建议书。


### PR DESCRIPTION
Adds 3 insurance expert DSH plugins from kevinchu1981/dsh-insurance-experts (ops / company / product subpackages). Each is a standalone installable package with dsh.bundle. Submitted as data/plugins/*.yml per the generator-based listing format (no README edits).