### PR TITLE
chore(plugin): update kenny2077/dsh-web-search-zai

### DIFF
--- a/data/plugins/kenny2077__dsh-web-search-zai.yml
+++ b/data/plugins/kenny2077__dsh-web-search-zai.yml
@@ -1,6 +1,6 @@
 url: https://github.com/kenny2077/dsh-web-search-zai
 name: kenny2077/dsh-web-search-zai
-category: browser
+category: tools
 description:
-  en: 'Single-key web search for the DeepSeek Harness: swaps the built-in web_search backend to the Z.ai (GLM) standalone Web Search API and reuses your existing ZAI_API_KEY for both chat and search.'
-  zh: '单密钥模式的 DeepSeek Harness 网页搜索：把内置 web_search 的后端切换为 Z.ai（智谱/GLM）独立 Web 搜索 API，复用你已有的 ZAI_API_KEY，聊天与搜索共用一把密钥。'
+  en: "Web search for DeepSeek Harness through Z.ai or Zhipu, with Coding Plan MCP quota and REST API billing modes, a native bilingual settings card, and support for reusing an existing ZAI_API_KEY."
+  zh: "DeepSeek Harness 的 Z.ai / 智谱网页搜索插件，支持 Coding Plan MCP 套餐额度和 REST API 余额两种计费模式，提供原生中英文设置卡片，可复用现有 ZAI_API_KEY。"


### PR DESCRIPTION
### Description

Update catalog description for `kenny2077/dsh-web-search-zai` to reflect v0.2.0 features:

- **Coding Plan MCP quota** is now the default billing mode (subscription-based search via Streamable HTTP MCP).
- **REST API billing** remains available as an explicit choice.
- **Native bilingual settings card** (English / Chinese) for billing mode, key management, and endpoint selection.
- Category changed from `browser` to `tools` to better reflect the plugin's role as a search provider backend.

The plugin's README on `main` already documents these changes. This PR updates only the catalog one-line description stored in `data/plugins/kenny2077__dsh-web-search-zai.yml`.

### Checklist

- [x] Modified existing YAML entry in `data/plugins/kenny2077__dsh-web-search-zai.yml`
- [x] Did NOT manually edit `README.md` or `README.zh-CN.md`
- [x] English description ends with a period (`.`)
- [x] Chinese description ends with a period (`。`)
- [x] Verified strings with `: ` are properly quoted
- [x] Tested plugin installation and functionality