### PR TITLE
Add dsh-wechat

### DIFF
--- a/data/plugins/PerryLink__dsh-wechat.yml
+++ b/data/plugins/PerryLink__dsh-wechat.yml
@@ -1,0 +1,6 @@
+url: https://github.com/PerryLink/dsh-wechat
+name: PerryLink/dsh-wechat
+category: remote
+description:
+  en: Bridges WeChat private messages to DSH with two-way text, image, file, and media transfer, aiming to restore the native DSH experience in WeChat.
+  zh: 将微信私聊消息桥接到 DSH，支持文本、图片、文件与音视频双向传输，在微信端还原 DSH 原生体验。


### PR DESCRIPTION
Adds PerryLink/dsh-wechat, a maintained fork of pan17/dsh-wechat rebuilt for the current harness: bridges WeChat private messages to DSH with two-way text, image, file, and media transfer. Declares the dsh.bundle manifest and carries the dsh-plugin topic.