### PR TITLE
Add po-et/dsh-http-probe (tools)

### DIFF
--- a/data/plugins/po-et__dsh-http-probe.yml
+++ b/data/plugins/po-et__dsh-http-probe.yml
@@ -1,0 +1,6 @@
+url: https://github.com/po-et/dsh-http-probe
+name: po-et/dsh-http-probe
+category: tools
+description:
+  en: 'Adds an http_probe tool for endpoint health checks: status code, latency and key response headers, using HEAD with GET fallback; response bodies are never downloaded.'
+  zh: 为 agent 增加 http_probe 工具：探测 HTTP(S) 端点的状态码、延迟与关键响应头，HEAD 被拒时自动降级 GET，不下载响应体。


### PR DESCRIPTION
One entry file per the contributing guide: `data/plugins/po-et__dsh-http-probe.yml`.

- `dsh.bundle` manifest with `cordis.patch.yml` at repo root — installs via `dsh plugin add` (github: source with a self-contained `prepare`; npm release planned)
- Real, tested code (TypeScript, typed `defineTool` registration), bilingual README, MIT
- `dsh-plugin` topic set; repo is over a week old
- Ran `node scripts/generate-readme.mjs` locally to preview the line; generated files left untouched per the guide

🤖 Generated with [Claude Code](https://claude.com/claude-code)