### PR TITLE
Add ice5kysl/dsh-workspace-kit and ice5kysl/dsh-file-explorer-kit (ui)

### DIFF
--- a/data/plugins/ice5kysl__dsh-file-explorer-kit.yml
+++ b/data/plugins/ice5kysl__dsh-file-explorer-kit.yml
@@ -1,0 +1,6 @@
+url: https://github.com/ice5kysl/dsh-file-explorer-kit
+name: ice5kysl/dsh-file-explorer-kit
+category: ui
+description:
+  en: In-session "Files" tab (conversation.view, order 20) for dsh Web that browses the active session's workspace directory with breadcrumbs and previews files inline — sanitized Markdown (marked + DOMPurify), images, line-numbered text and PDF — served by read-only /dsh-files host routes registered on ctx.webServer; no write endpoints. Bilingual zh/en.
+  zh: dsh Web 会话内「文件」页签（conversation.view，order 20）：以当前会话工作区为根的面包屑目录浏览，内联预览消毒渲染的 Markdown（marked + DOMPurify）、图片、带行号文本与 PDF；目录与读取全部经 ctx.webServer 注册的只读 /dsh-files 宿主路由，无任何写端点（中英双语）。

--- a/data/plugins/ice5kysl__dsh-workspace-kit.yml
+++ b/data/plugins/ice5kysl__dsh-workspace-kit.yml
@@ -1,0 +1,6 @@
+url: https://github.com/ice5kysl/dsh-workspace-kit
+name: ice5kysl/dsh-workspace-kit
+category: ui
+description:
+  en: Workspace-first enhanced sidebar for dsh Web that shadows the built-in workspace browser at low priority (one-click toggle back to the official one) and adds soft workspace archive/restore, per-workspace SVG icons and accent colors, drag reorder and title/path/session-content search, plus a ⌘K Spotlight palette fuzzy-searching workspaces and sessions; the host half ships read-only workspace_find/workspace_list model tools and /workspace-find /workspace-list slash commands. Bilingual zh/en.
+  zh: 面向 dsh Web 的工作区优先增强侧栏：以低优先级 shadow 内置工作区浏览器（可一键切回官方版），提供软归档/恢复、每工作区 SVG 图标与强调色、拖拽排序与标题/路径/会话内容搜索；另提供 ⌘K Spotlight 面板模糊搜索工作区/会话；宿主侧附带只读 workspace_find/workspace_list 工具与 /workspace-find /workspace-list 斜杠命令（中英双语）。


### PR DESCRIPTION
## Add two plugins (ui) — ice5kysl/dsh-workspace-kit + ice5kysl/dsh-file-explorer-kit

Both are standard Cordis "bundle" plugins for DeepSeek Harness (dsh Web GUI), MIT, bilingual zh/en, targeting `@deepseek-ai/dsh` ≥ 0.1.1-rc.2.

1. **ice5kysl/dsh-workspace-kit** — workspace-first enhanced sidebar that shadows the built-in workspace browser (`sidebar.workspaces`, priority −1, one-click toggle back) and adds soft workspace archive/restore, per-workspace SVG icons + accent colors, drag reorder and title/path/session-content search, plus a ⌘K Spotlight palette on the official `shell.overlay` slot; the host half registers read-only `workspace_find`/`workspace_list` tools and slash commands. Known limitations documented in the repo.
2. **ice5kysl/dsh-file-explorer-kit** — in-session "Files" tab (`conversation.view`, order 20) browsing the active session's workspace with breadcrumbs and inline previews of sanitized Markdown, images, line-numbered text and PDF, served by read-only `/dsh-files` host routes on `ctx.webServer`; no write endpoints; coexists with dsh-workspace-kit.

Both repos declare a `dsh.bundle` manifest (committed `cordis.patch.yml`) and carry the `dsh-plugin` topic.

Checklist:
- [x] Added one YAML per plugin under `data/plugins/` (2 files, ≤3 per PR)
- [x] Did not edit the generated READMEs
- [x] Descriptions factual (en + zh), no invented features

中文说明：两个标准 Cordis bundle 插件（MIT、中英双语、目标 dsh ≥ 0.1.1-rc.2），分别提供工作区侧栏增强 + ⌘K Spotlight（workspace-kit）与会话内「文件」页签只读预览（file-explorer-kit），均已提交 `dsh.bundle` manifest 与 `dsh-plugin` topic。
