### PR TITLE
Add Andor-Z/dsh-turn-outline

### DIFF
--- a/data/plugins/Andor-Z__dsh-turn-outline.yml
+++ b/data/plugins/Andor-Z__dsh-turn-outline.yml
@@ -1,0 +1,6 @@
+url: https://github.com/Andor-Z/dsh-turn-outline
+name: Andor-Z/dsh-turn-outline
+category: ui
+description:
+  en: Adds a sidebar tab that folds a session into user turns (input, tool steps, output) with one-click jump back into the conversation.
+  zh: 在侧边栏按用户轮次折叠会话（输入、工具步骤、输出），一键跳回对话原位。


### PR DESCRIPTION
Adds [Andor-Z/dsh-turn-outline](https://github.com/Andor-Z/dsh-turn-outline) to **UI Enhancements / UI 增强**.

A sidebar tab for dsh-better-sidebar that folds a session into user turns (input + tool steps + output) with one-click jump back into the conversation. Read-only, zero-LLM.

- **npm**: [dsh-turn-outline](https://www.npmjs.com/package/dsh-turn-outline) — published (v0.2.7), `repository` field points back to this repo
- **Manifest**: `dsh.bundle` declared in `package.json` (`bundle.patch: ./cordis.patch.yml`, entry `turn-outline`), plus `dsh.client` for the web sidebar tab
- **Topics**: `dsh-plugin`, `deepseek-harness`, `dsh`, `dsh-better-sidebar`, `sidebar`
- **Repo**: created 2026-09-03, actively maintained

---

收录 Andor-Z/dsh-turn-outline 到 **UI 增强** 分类：DSH 轮次轨迹侧边栏插件，按用户轮次折叠会话（输入+工具步骤+输出），一键跳回对话原位。零 AI、只读。已发布 npm，`package.json` 已声明 `dsh.bundle` manifest，仓库已加 `dsh-plugin` topic。