### PR TITLE
docs: add xgone/dsh-netshell

### DIFF
--- a/data/plugins/xgone__dsh-netshell.yml
+++ b/data/plugins/xgone__dsh-netshell.yml
@@ -1,0 +1,6 @@
+url: https://github.com/xgone/dsh-netshell
+name: xgone/dsh-netshell
+category: remote
+description:
+  en: 'Local and remote SSH terminals for DeepSeek Harness Web with three permission levels, human approval for risky AI commands, and encrypted credential storage.'
+  zh: 'DeepSeek Harness Web 的本地与远程 SSH 终端：提供三级权限，危险 AI 命令需真人确认，凭据加密存储。'


### PR DESCRIPTION
## Summary

Add `xgone/dsh-netshell` to the `remote` category.

The plugin provides local and remote SSH terminals for DeepSeek Harness Web, three permission levels, human approval for risky AI commands, and encrypted credential storage.

## Submission checks

- The repository is public, older than one day, and has the `dsh-plugin` topic.
- `package.json` declares `dsh.bundle` with a committed patch file.
- `@xgone/dsh-netshell@0.6.0` is published to npm.
- `pnpm test` passes in the plugin repository.
- This PR adds only `data/plugins/xgone__dsh-netshell.yml`; generated READMEs are untouched.
