### PR TITLE
ci: make the Pages deploy non-fatal on workflow_dispatch too

### DIFF
--- a/.github/workflows/build-site.yml
+++ b/.github/workflows/build-site.yml
@@ -182,7 +182,19 @@ jobs:
         # Losing that race must not abort the nightly before the two publish
         # steps below — they are the reason the run exists, and the site is
         # about to be redeployed by whichever push won anyway.
-        continue-on-error: ${{ github.event_name == 'schedule' }}
+        # workflow_dispatch is here for the same reason schedule is, and it was
+        # left out by oversight: a dispatch runs the identical probe-and-publish
+        # path, so a failed deploy costs it the identical work. On 2026-09-05 a
+        # dispatched run spent 36 minutes probing, then died here on a 403 —
+        # the App installation quota had been drained by approving a batch of
+        # queued workflow runs — and took the cache-save post-steps and both
+        # npm publish steps down with it. Nothing was banked; the probe had to
+        # be redone from scratch.
+        #
+        # Deploying is never the reason a probe run exists. Losing the deploy
+        # to a transient 403 is recoverable by the next push; losing the probe
+        # is not.
+        continue-on-error: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
 
       # The same plugins.json, published to npm — see
       # scripts/publish-catalog.mjs for why it has to exist in two places.


### PR DESCRIPTION
Extends the #3789 guard to the trigger it left out.

## What happened

#3789 made the Pages deploy non-fatal **for the nightly**, so that losing a Pages race could not take the probe cache-save and the two npm publish steps down with it. `workflow_dispatch` runs the identical probe-and-publish path — `probe-npm`, `probe-stars`, `probe-readmes`, then deploy, then `publish the catalog to npm` — but was never added to the condition.

On 2026-09-05 that gap cost a full run:

```
03:14  dispatch starts
03:50  Build finishes (36 min of probing)
03:50  actions/deploy-pages@v4 → 403 API rate limit exceeded for installation
       run fails; cache-save post-steps skipped; both npm publish steps skipped
```

The App installation quota had been drained by approving a batch of queued workflow runs, each of which fires `Submission gate`. The deploy was collateral. Nothing was banked — `data/npm-map.json` never reached the cache, so the version backfill that run existed to perform (#4361) had to be thrown away.

## The change

```diff
-        continue-on-error: ${{ github.event_name == 'schedule' }}
+        continue-on-error: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
```

Deploying is never the reason a probe run exists. A lost deploy is recovered by the next push to `main`; a lost probe is 40 minutes that has to be spent again, and in the meantime `plugins.json` keeps shipping stale data.

## Scope

`push` deliberately stays fatal. A push build's *only* job is to deploy `docs/`, so a failed deploy there is a real failure with nothing else to salvage.

## Note

`Repository config guard` will be red — it flags any PR touching `.github/`, correct for contributor submissions and unavoidable for a CI change. Same as #3832, #3789, #3956, #4113.
