### PR TITLE
Add songofhawk/dsh-alpha

### DIFF
--- a/data/plugins/songofhawk__dsh-alpha.yml
+++ b/data/plugins/songofhawk__dsh-alpha.yml
@@ -1,0 +1,6 @@
+url: https://github.com/songofhawk/dsh-alpha
+name: songofhawk/dsh-alpha
+category: remote
+description:
+  en: "Multi-machine, multi-agent orchestration and control plane for DSH: discovers Agents and workspaces across devices, routes tasks by machine, repository, capability, and load to local or remote Agent runtimes, streams progress and results, forwards approvals, and recovers durable tasks after disconnections."
+  zh: "DSH 的多机多 Agent 编排与控制平台：发现各设备上的 Agent 与工作区，按机器、仓库、能力和负载将任务路由到本地或远程 Agent Runtime，统一回传进度、审批与结果，并在断线后恢复持久任务。"


### PR DESCRIPTION
Adds `songofhawk/dsh-alpha` to the `remote` category. The entry describes its multi-machine agent orchestration, workspace-aware routing, streamed progress, approval forwarding, and task recovery.

- [x] Added exactly one file at `data/plugins/songofhawk__dsh-alpha.yml`; generated READMEs are unchanged.
- [x] The repository declares `dsh.bundle` in `package.json`.
- [x] The repository is more than one day old.
- [x] `remote` is a valid and fitting category.
- [x] The descriptions are factual and contain no superlatives.
- [x] The repository has the `dsh-plugin` topic.