### PR TITLE
Add OwnDsh team model management plugin

### DIFF
--- a/data/plugins/boe1900__owndsh--plugin-packages-bundle.yml
+++ b/data/plugins/boe1900__owndsh--plugin-packages-bundle.yml
@@ -1,0 +1,7 @@
+url: https://github.com/boe1900/owndsh/tree/main/plugin/packages/bundle
+name: boe1900/owndsh#owndsh-plugin
+category: model
+description:
+  en: Early-stage plugin connecting DeepSeek Harness to a separately deployed, self-hosted OwnDsh server for team identity, model access control, quotas, and usage auditing.
+  zh: 早期开发中的团队管理插件，将 DeepSeek Harness 接入独立部署的自托管 OwnDsh 服务端，提供团队身份、模型授权、配额与用量审计。
+tarball: https://github.com/boe1900/owndsh/releases/download/v0.1.0-beta.2/owndsh-plugin-0.1.0-beta.2.tgz


### PR DESCRIPTION
Adds [OwnDsh](https://github.com/boe1900/owndsh), an early-development plugin connecting DeepSeek Harness to a separately deployed OwnDsh server for team identity, model access control, quotas, and usage auditing.

The entry targets the monorepo's `plugin/packages/bundle` package. OwnDsh has its own Host services, login/settings UI, and runtime integration; it is not a dependency-only aggregation package.

## Installation and project stage

The `tarball` field pins the GitHub prerelease archive for `0.1.0-beta.2`. It is byte-for-byte identical to the existing npm `owndsh-plugin@0.1.0-beta.2` package and includes the built Host/Client entries and `cordis.patch.yml`. This avoids relying on a source checkout's unbuilt `lib/` files or the old npm `latest` placeholder.

Manual npm installation currently uses `owndsh-plugin@next`. The `latest` tag remains `0.0.1`, so this submission does not claim Desktop marketplace automatic-install compatibility. An independently deployed OwnDsh Server is required. This is an unofficial early-development project intended for test environments and community feedback, with known bugs and ongoing compatibility work.

## Verification

- `pnpm --filter owndsh-plugin test` from `plugin/`: 1 test file and 3 tests passed on current source.
- The published archive's SHA-512 matches npm registry integrity; built Host and Client entries pass JavaScript syntax checks.
- [Maintainer regression screenshots and project introduction](https://github.com/deepseek-ai/deepseek-harness/discussions/5693) show console management, plugin login in DSH Desktop 2.0.5, and a completed conversation.
- Four original screenshots are declared in the plugin directory's `screenshots.json` using GitHub-hosted image URLs.

## Submission checklist

- [x] Added exactly one file under `data/plugins/`; generated READMEs are untouched.
- [x] Plugin `package.json` declares `dsh.bundle` and commits its patch file.
- [x] Repository is more than one day old.
- [x] `model` matches the plugin's managed-model access and quota functionality.
- [x] Descriptions state concrete functionality without marketing claims.
- [x] Repository has the `dsh-plugin` topic.
- [x] Official Harness runtime packages are declared as peer dependencies.
- [x] A prebuilt GitHub Release tarball is provided, with an exact prerelease tag and filename.
