### PR TITLE
feat: add four plugins from ijry/DeepSeek-Harness-Desktop-Ultra

### DIFF
--- a/data/plugins/ijry__DeepSeek-Harness-Desktop-Ultra--plugins-dsh-plugin-canvas.yml
+++ b/data/plugins/ijry__DeepSeek-Harness-Desktop-Ultra--plugins-dsh-plugin-canvas.yml
@@ -1,0 +1,6 @@
+url: https://github.com/ijry/DeepSeek-Harness-Desktop-Ultra/tree/main/plugins/dsh-plugin-canvas
+name: ijry/DeepSeek-Harness-Desktop-Ultra#dsh-plugin-canvas
+category: session
+description:
+  en: Infinite canvas for sessions, with regions bound to workspaces and agent presets, pinned session cards, sticky notes and alignment guides.
+  zh: 无限会话画布，区域绑定工作区与智能体预设，可钉住会话卡片、放置便签，带对齐参考线。

--- a/data/plugins/ijry__DeepSeek-Harness-Desktop-Ultra--plugins-dsh-plugin-mobile-bridge.yml
+++ b/data/plugins/ijry__DeepSeek-Harness-Desktop-Ultra--plugins-dsh-plugin-mobile-bridge.yml
@@ -1,0 +1,6 @@
+url: https://github.com/ijry/DeepSeek-Harness-Desktop-Ultra/tree/main/plugins/dsh-plugin-mobile-bridge
+name: ijry/DeepSeek-Harness-Desktop-Ultra#dsh-plugin-mobile-bridge
+category: remote
+description:
+  en: Token-authenticated REST and SSE bridge with QR pairing, so a phone app can read sessions, send messages and approve tool calls.
+  zh: 带令牌鉴权的 REST 与 SSE 接口，扫码配对后可在手机 App 上看会话、发消息、批准工具调用。

--- a/data/plugins/ijry__DeepSeek-Harness-Desktop-Ultra--plugins-dsh-plugin-repopanel.yml
+++ b/data/plugins/ijry__DeepSeek-Harness-Desktop-Ultra--plugins-dsh-plugin-repopanel.yml
@@ -1,0 +1,6 @@
+url: https://github.com/ijry/DeepSeek-Harness-Desktop-Ultra/tree/main/plugins/dsh-plugin-repopanel
+name: ijry/DeepSeek-Harness-Desktop-Ultra#dsh-plugin-repopanel
+category: git
+description:
+  en: Browse the GitHub issues and pull requests of a workspace's origin remote, filter and comment, close or reopen, and hand one to an agent as a task.
+  zh: 浏览工作区 origin 远端对应的 GitHub issue 与 pull request，筛选、评论、关闭或重开，并可交给 agent 变成任务。

--- a/data/plugins/ijry__DeepSeek-Harness-Desktop-Ultra--plugins-dsh-plugin-taskboard.yml
+++ b/data/plugins/ijry__DeepSeek-Harness-Desktop-Ultra--plugins-dsh-plugin-taskboard.yml
@@ -1,0 +1,6 @@
+url: https://github.com/ijry/DeepSeek-Harness-Desktop-Ultra/tree/main/plugins/dsh-plugin-taskboard
+name: ijry/DeepSeek-Harness-Desktop-Ultra#dsh-plugin-taskboard
+category: workflow
+description:
+  en: Task kanban where agents claim and hand off work through taskboard_* tools; acceptance and rework stay human-only.
+  zh: 任务看板，agent 通过 taskboard_* 工具领活与交接，验收和退回只由人操作。


### PR DESCRIPTION
Adds four plugins from the DeepSeek-Harness-Desktop-Ultra monorepo:

- **dsh-plugin-taskboard** (workflow): Task kanban where agents claim and hand off work through taskboard_* tools
- **dsh-plugin-canvas** (session): Infinite canvas for sessions, with regions bound to workspaces and agent presets
- **dsh-plugin-mobile-bridge** (remote): Token-authenticated REST and SSE bridge for phone app integration
- **dsh-plugin-repopanel** (git): Browse GitHub issues and PRs of workspace origin, filter, comment, and hand to agents

All plugins:
- Published to npm (0.1.0)
- Support dark mode
- Part of https://github.com/ijry/DeepSeek-Harness-Desktop-Ultra
- Repository created: 2026-09-03 (2 days old)
- Added dsh-plugin topic

Each entry follows the monorepo subpackage naming convention.