### PR TITLE
Add TheGoodMorty/chat-pace

### DIFF
--- a/data/plugins/TheGoodMorty__chat-pace.yml
+++ b/data/plugins/TheGoodMorty__chat-pace.yml
@@ -1,0 +1,6 @@
+url: https://github.com/TheGoodMorty/chat-pace
+name: TheGoodMorty/chat-pace
+category: ui
+description:
+  en: 'Configurable chat auto-scroll — paced section-by-section reading with size-proportional pauses, smooth follow, step and hold modes, hotkeys, and per-session open positions.'
+  zh: '可配置的聊天自动滚动——按节定速阅读（停顿时长与篇幅成比例）、平滑跟随、单步与固定模式，支持快捷键与按会话记忆打开位置。'


### PR DESCRIPTION
Adds TheGoodMorty/chat-pace - configurable chat auto-scroll for the DSH web UI.

- Five scroll modes: Follow (shipped default), Smooth glide, Paced section-by-section reading (pauses proportional to section size, clamped up to 80 s), Step, and Hold
- Reading follows tool output live between text sections and holds still while text streams, so unread text never scrolls past
- On-screen controls (composer row, dock status line with progress bar, session header), global hotkeys with a recorder, and a full settings page
- Per-session open position (Top / Bottom / Where I left it) with always-on position tracking per session
- dsh.bundle manifest + cordis.patch.yml at the repo root; dsh-plugin topic set
- Screenshots declared via screenshots.json in the plugin repo

The repo was created today, so the 1-day age check may need a re-run once it passes the bar.