### PR TITLE
Add choco9527/dsh-product-preview

### DIFF
--- a/data/plugins/choco9527__dsh-product-preview.yml
+++ b/data/plugins/choco9527__dsh-product-preview.yml
@@ -1,0 +1,7 @@
+url: https://github.com/choco9527/dsh-product-preview
+name: choco9527/dsh-product-preview
+category: ui
+description:
+  en: Browse local image, video, and SVGA artifacts from conversation nodes in a Finder-style column view.
+  zh: 以访达式分栏浏览对话节点中的本地图片、视频与 SVGA 产物。
+tarball: https://github.com/choco9527/dsh-product-preview/releases/latest/download/dsh-product-preview.tgz


### PR DESCRIPTION
## Plugin

Adds https://github.com/choco9527/dsh-product-preview under UI enhancements.

The plugin discovers supported local media paths in successful tool results and assistant messages, and displays conversation nodes, original directories/files, and image/video/SVGA previews in Finder-style columns. Previews are limited to explicitly configured `allowedRoots`, which default to empty.

## Distribution

- Declares `dsh.bundle` with `cordis.patch.yml` and a Web client entry.
- Prebuilt release: https://github.com/choco9527/dsh-product-preview/releases/tag/v0.1.0
- The `tarball` uses a version-free asset name under `releases/latest/download/`.
- The repository declares `screenshots.json` and the `dsh-plugin` topic.
- Targets DSH host packages `0.1.2-alpha.3`; compatibility with other host versions is not claimed. Native file actions require a supporting Desktop host.

## Verification

- Frozen-lockfile install in an isolated directory using public registry dependencies, with no sibling Desktop checkout.
- 19 tests passed; host/client build and declaration generation passed; peer dependency check passed.
- Final tarball installed in an empty directory with scripts disabled; packed Host import, browser module factory, default-deny configuration, and portable dependency declarations checked.
- Only this plugin's YAML entry is changed. Generated READMEs are untouched.

No full Desktop-profile restart or new browser UI acceptance test was performed during this packaging-only submission.
