### PR TITLE
Add jcaiagent7143-ui/linkdigest-mcp

### DIFF
--- a/data/plugins/jcaiagent7143-ui__linkdigest-mcp.yml
+++ b/data/plugins/jcaiagent7143-ui__linkdigest-mcp.yml
@@ -1,0 +1,6 @@
+url: https://github.com/jcaiagent7143-ui/linkdigest-mcp
+name: jcaiagent7143-ui/linkdigest-mcp
+category: tools
+description:
+  en: 'Turns a Xiaohongshu, Douyin, TikTok, YouTube or X link into text: transcript with timecodes, on-screen text, a description and OCR of every image, caption and metadata. Mounts the hosted MCP server over streamable HTTP.'
+  zh: '把小红书、抖音、TikTok、YouTube 或 X 链接转成文本：带时间戳的转写、屏幕文字、逐图描述与 OCR、正文与元数据。通过 streamable HTTP 挂载托管的 MCP 服务。'


### PR DESCRIPTION
Adds one entry file: `data/plugins/jcaiagent7143-ui__linkdigest-mcp.yml`.

**What it does.** Turns a Xiaohongshu, Douyin, TikTok, YouTube or X link into text an agent can read — transcript with timecodes, on-screen text, a description and OCR of every image, caption and metadata. It mounts a hosted MCP server over streamable HTTP through `@deepseek-ai/dsh-mcp-client`, so there is no local browser or login step.

**Against the requirements:**

- `dsh.bundle` declared in `package.json`, with `cordis.patch.yml` at the repo root — not `dsh.client` alone.
- Real code, not README-only: the patch file plus a `skills/linkdigest/SKILL.md`.
- Repo created 2026-09-03, so past the 1-day floor.
- `dsh-plugin` topic added.
- Description states what it does, no superlatives.

I ran `scripts/check-submission.mjs --base upstream/main` locally against this commit and it reports `all checked entries pass`.

Branched from current `upstream/main` rather than my fork's stale `main`, so the diff is exactly one added file and zero deletions.

One note on the `cordis.patch.yml`: `toolCallTimeoutMs` is set to 180000 rather than the default. A 17-image Xiaohongshu note measured 119 seconds end to end, so the default would time out on the content this exists to read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DpGW9DbqX9bkgv4RTETBmV