### PR TITLE
Add Jonah-Wu23/dsh-agy-safe (model)

### DIFF
--- a/data/plugins/Jonah-Wu23__dsh-agy-safe.yml
+++ b/data/plugins/Jonah-Wu23__dsh-agy-safe.yml
@@ -1,0 +1,6 @@
+url: https://github.com/Jonah-Wu23/dsh-agy-safe
+name: Jonah-Wu23/dsh-agy-safe
+category: model
+description:
+  en: "Compliantly use your own Antigravity quota in dsh: bridges your local logged-in official Antigravity CLI (agy) session as the chat and subagent model provider."
+  zh: "合规地在 dsh 中使用你自己的 Antigravity 额度：将本机已登录的官方 Antigravity CLI（agy）会话桥接为主对话与子代理模型提供方。"


### PR DESCRIPTION
新增条目 `Jonah-Wu23/dsh-agy-safe`，分类 `model`。

## 插件做什么
把本机已登录的官方 Antigravity CLI（agy）无头会话（stream-json）桥接为 dsh 的一级模型提供方（`LlmAdapter` 实现）。主对话与子代理模型通用：工具调用经结构化标记双向转换，历史用指纹链检测分叉并按需重放，用量按会话基线差分核算。

## 与 LiZhenNet/dsh-antigravity 的区别
两者目标相近，实现机制不同：

- `LiZhenNet/dsh-antigravity` 自带 Web OAuth 登录，作为 Antigravity / Cloud Code Assist 的 API 直接提供商。
- 本插件不实现任何 OAuth，也不直连任何 API 端点：以子进程方式运行官方 `agy` 二进制的无头会话，经 stdin/stdout 管道收发事件，复用用户本机的 CLI 登录态。

## 合规性（重点）
桥接的是官方 CLI 本体：请求由官方二进制发出，账号是用户自己在本机登录的本人账号，无共享账号、无第三方中转。因此这是合规地在 dsh 中使用自己的 Antigravity 额度，相比绕过官方客户端、直连内部接口的方式，封号风险大大降低。

---

<!-- Thanks for contributing! Quick checklist / 提交前快速自查 -->

- [x] I added **one file** at `data/plugins/Jonah-Wu23__dsh-agy-safe.yml` — that single file is the whole submission. The READMEs are regenerated on `main` after merge: don't edit them by hand, and you don't need to commit them either / 我新增了一个 `data/plugins/Jonah-Wu23__dsh-agy-safe.yml` 文件——**这一个文件就是全部投稿**。README 会在合并后由 `main` 自动重新生成：不要手工编辑，也不需要提交
- [x] My repo's `package.json` declares **`dsh.bundle`** (not just `dsh.client`) — [example](../blob/main/contributing.md) / 仓库 `package.json` 已声明 `dsh.bundle`（只有 `dsh.client` 无法安装）
- [x] My repo is at least **1 day old** / 仓库创建满 1 天
- [x] `category` is one of `agi ui usage theme model identity session memory tools wsl browser vision voice docs skill workflow git notify dev security remote market fun` ([full list with descriptions](../blob/main/contributing.md)), and themes/skins go under `theme` / `category` 取值正确（完整清单见 contributing.md），主题/皮肤类请用 `theme`
- [x] Description states what the plugin does, no superlatives / 描述只说功能，不带营销词
- [x] My repo has the `dsh-plugin` topic / 仓库已打 `dsh-plugin` topic

**Recommended (not required) / 推荐但不强制：**

- 📦 Published to npm as `dsh-agy-safe@0.1.6`, `repository` field points back to this repo / 已发布 npm，`repository` 字段指回本仓库
- 🔗 `@deepseek-ai/cordis`、`@deepseek-ai/dsh-llm` 均声明在 `peerDependencies`（非 `dependencies`）
- 🖼️ `screenshots.json` 已放在本仓库 `package.json` 旁（3 张图在 `assets/`，README 同步展示）