### PR TITLE
add shlouai/dsh-debate (tools): adversarial multi-agent debate orchestrator

### DIFF
--- a/data/plugins/shlouai__dsh-debate.yml
+++ b/data/plugins/shlouai__dsh-debate.yml
@@ -1,0 +1,6 @@
+url: https://github.com/shlouai/dsh-debate
+name: shlouai/dsh-debate
+category: tools
+description:
+  en: 'Answers hard questions by staging a formal debate: two adversarial subagents argue opposite sides with research, then the main agent rules on the transcript through the debate_open, debate_round, and debate_verdict tools.'
+  zh: '通过一场正式辩论来回答难题：两个对抗性子代理各自调研并论证对立立场，最后由主代理依据辩论记录作出裁决，提供 debate_open、debate_round、debate_verdict 三个工具。'


### PR DESCRIPTION
Add [shlouai/dsh-debate](https://github.com/shlouai/dsh-debate) to the **Tools & Capabilities** category.

- url: https://github.com/shlouai/dsh-debate
- category: `tools`
- description.en + description.zh included
- Repo declares `dsh.bundle` manifest (`cordis.patch.yml`), published on npm as `@shlouai/dsh-debate@0.1.0` (public) and installable via `dsh plugin add @shlouai/dsh-debate`
- `dsh-plugin` topic on repo — verified
- Repo is > 1 day old (created 2026-09-02) — verified

Three tools (`debate_open` / `debate_round` / `debate_verdict`) stage a formal debate: two adversarial subagents argue opposite sides with research, then the main agent rules on the transcript.