### PR TITLE
add dsh-mattpocock-skills

### DIFF
--- a/data/plugins/addie-ace__dsh-mattpocock-skills.yml
+++ b/data/plugins/addie-ace__dsh-mattpocock-skills.yml
@@ -1,0 +1,7 @@
+url: https://github.com/addie-ace/dsh-mattpocock-skills
+name: addie-ace/dsh-mattpocock-skills
+category: skill
+tarball: https://github.com/addie-ace/dsh-mattpocock-skills/releases/download/v0.2.0/dsh-mattpocock-skills-0.2.0.tgz
+description:
+  en: 'Skill pack plugin: the 25 promoted skills from mattpocock/skills (engineering and productivity), translated to Chinese, registered as a bundled DSH skill provider.'
+  zh: '技能包插件：把 mattpocock/skills 的 25 个 promoted 技能（工程与效率）全文汉化，注册为 DSH 捆绑技能 provider，经技能系统发现与调用。'


### PR DESCRIPTION
收录技能包插件 dsh-mattpocock-skills。

- 仓库：https://github.com/addie-ace/dsh-mattpocock-skills
- 功能：把 mattpocock/skills 的 25 个 promoted 技能（engineering 18 + productivity 7）全文汉化后打包为 DSH 捆绑技能 provider（rank 600），经 ctx.skills 注册；14 个用户调用技能 + 11 个模型可调用技能。
- 原出处：https://github.com/mattpocock/skills （Matt Pocock，MIT License），仓库 README 与 LICENSE 已注明。
- 仓库已声明 dsh.bundle manifest 与 dsh-plugin topic；Release v0.2.0 附预构建 tgz。

注：目标仓库创建于 2026-09-05，提交时尚未满 1 天年龄门槛；CI 的 repo-age 检查预期失败，将于 2026-09-06 满足后重推本分支触发。