### PR TITLE
Add Crosery/dsh-drop

### DIFF
--- a/data/plugins/Crosery__dsh-drop.yml
+++ b/data/plugins/Crosery__dsh-drop.yml
@@ -1,0 +1,7 @@
+url: https://github.com/Crosery/dsh-drop
+name: Crosery/dsh-drop
+category: ui
+description:
+  en: 'Drag or paste files into the Web composer with one image-and-file preview rail; native PNG/JPEG/WebP/GIF keep the image attachment path, while other files reuse a matching local path or stream to Host staging and become @ references only at send time. Includes browser media/PDF and bounded text previews; Office and archives show identity cards, and unsent file entries are page-local.'
+  zh: '把文件拖入或粘贴进 Web 输入框，图片与文件共用预览栏；PNG/JPEG/WebP/GIF 保留出厂图片通道，其他文件优先引用匹配的本地路径，否则流式暂存到 Host，发送时才追加 @ 引用。提供浏览器媒体/PDF 和限长文本预览；Office 与压缩包显示身份卡，未发送文件清单仅保存在页面内。'
+tarball: https://github.com/Crosery/dsh-drop/releases/latest/download/dsh-drop.tgz


### PR DESCRIPTION
## Add Crosery/dsh-drop

A standalone MIT distribution of the existing drag-and-paste plugin, following the repository/documentation/release conventions of [DSH Viewer](https://github.com/Crosery/dsh-viewer) (listed via #3954).

- Adds only `data/plugins/Crosery__dsh-drop.yml`; no generated README or existing entry edits.
- Package: `@crosery/dsh-drop` with `dsh.bundle.patch` and a Web client entry.
- Source: https://github.com/Crosery/dsh-drop
- Verified release: https://github.com/Crosery/dsh-drop/releases/tag/v0.1.0
- Stable prebuilt asset: https://github.com/Crosery/dsh-drop/releases/latest/download/dsh-drop.tgz
- CI (Node 22.19 and 24): https://github.com/Crosery/dsh-drop/actions/runs/33958010809
- Release build: https://github.com/Crosery/dsh-drop/actions/runs/33958052346

### Validation

103 tests; separate host/client/test typechecks; lazy-CJS/module-table and tarball-content gates; deliberate negative checks for a bad peer range and foreign browser require. Installed the prebuilt package in an isolated DSH home and verified its composition layer. Tested a refreshed existing DSH Web instance with synthetic files: pure image intake, mixed file drop, clean draft, text lightbox/Escape, file paste, removal and narrow layout. Screenshots are declared in the plugin repository.

The description intentionally does not claim Office rendering, universal codec support, persistent unsent file entries, or a new model content block. Those limits and the capture-phase submit-key tradeoffs are documented in both READMEs.

### Repository age

This independent repository was created at **2026-09-05 08:57:21 UTC**, extracted from an existing local plugin rather than padded with empty commits. It reaches the one-day age floor at **2026-09-06 08:57:21 UTC**. I expect the age gate to reject it until then; please defer/rerun the gate after eligibility (or advise resubmission). No exception or backdated history is requested. This PR is a submission for review, not a claim that the plugin is already listed.
