### PR TITLE
Add Kayungko/dsh-plugin-task-coordinator (session)

### DIFF
--- a/data/plugins/Kayungko__dsh-plugin-task-coordinator.yml
+++ b/data/plugins/Kayungko__dsh-plugin-task-coordinator.yml
@@ -1,0 +1,6 @@
+url: https://github.com/Kayungko/dsh-plugin-task-coordinator
+name: Kayungko/dsh-plugin-task-coordinator
+category: session
+description:
+  en: Cross-task coordination for DeepSeek Harness - list, inspect, spawn, message and steer top-level sessions from a supervisor agent.
+  zh: 跨任务协调：在监督代理中列出、查看、派生、发消息并引导顶层会话。


### PR DESCRIPTION
One new entry: Kayungko/dsh-plugin-task-coordinator.

- Declares dsh.bundle (patch: ./cordis.patch.yml) plus a web client; real code, tests and docs in-repo.
- Cross-task coordination for DSH: list, inspect, spawn, message and steer top-level sessions from a supervisor agent; ships the task-coordination supervisor skill.
- Repo carries the dsh-plugin topic and is >1 day old.
- Single entry; no existing entries touched.