### PR TITLE
Add weibaohui/hermes-loop

### DIFF
--- a/data/plugins/weibaohui__hermes-loop.yml
+++ b/data/plugins/weibaohui__hermes-loop.yml
@@ -1,0 +1,6 @@
+url: https://github.com/weibaohui/hermes-loop
+name: weibaohui/hermes-loop
+category: memory
+description:
+  en: "Automatic session retrospective: after a conversation wraps up, distills useful experience into reusable skills stored in the skill library for the model to call, with signal-accelerated triggers, manual runs, an approval mode, and skill-library governance (archive/restore, never deletes directly)."
+  zh: 自动复盘：对话收尾后自动把有价值的经验蒸馏成可复用的技能（skill）存入技能库，支持信号加速触发、手动立即复盘、审批模式与技能库治理（归档/恢复，永不直接删除）。


### PR DESCRIPTION
Adds **weibaohui/hermes-loop** — automatic session retrospective for DeepSeek Harness.

After a conversation wraps up, the plugin distills useful experience into reusable skills stored in the skill library for the model to call, with signal-accelerated triggers, manual runs, an approval mode, and skill-library governance (archive/restore, never deletes directly).

- 📦 npm: [@weibaohui/hermes-loop](https://www.npmjs.com/package/@weibaohui/hermes-loop) (v0.1.4) → `dsh plugin --profile web add @weibaohui/hermes-loop`
- ✅ `package.json` declares `dsh.bundle` (+ `cordis.patch.yml`), web client included
- ✅ Repo has the `dsh-plugin` topic (plus `dsh`, `deepseek-harness`)
- 🖼️ Demo GIF: https://github.com/weibaohui/hermes-loop/blob/main/docs/demo.gif

Checklist / 自查:

- [x] I added **one file** at `data/plugins/weibaohui__hermes-loop.yml` — that single file is the whole submission. The READMEs are regenerated on `main` after merge: don't edit them by hand, and you don't need to commit them either / 我新增了一个 `data/plugins/weibaohui__hermes-loop.yml` 文件——**这一个文件就是全部投稿**
- [x] My repo's `package.json` declares **`dsh.bundle`** (not just `dsh.client`) — [example](../blob/main/contributing.md) / 仓库 `package.json` 已声明 `dsh.bundle`
- [x] My repo is at least **1 day old** / 仓库创建满 1 天
- [x] `category` is one of the valid values ([full list](../blob/main/contributing.md)) — using `memory`
- [x] Description states what the plugin does, no superlatives / 描述只说功能，不带营销词
- [x] My repo has the `dsh-plugin` topic / 仓库已打 `dsh-plugin` topic

**Recommended (not required) / 推荐但不强制：**

- [x] 📦 Published to npm — prebuilt installs skip the `allowBuilds` approval / 已发布 npm 包
- [ ] 🔗 Official `@deepseek-ai/*` packages as `peerDependencies` — not applicable, no official runtime deps
- [ ] 🖼️ `screenshots.json` in our own repository — planned follow-up
