### PR TITLE
add: 3361805598-gif/dsh-usage-analytics

### DIFF
--- a/data/plugins/3361805598-gif__dsh-usage-insights.yml
+++ b/data/plugins/3361805598-gif__dsh-usage-insights.yml
@@ -1,0 +1,7 @@
+url: https://github.com/3361805598-gif/dsh-usage-insights
+name: 3361805598-gif/dsh-usage-insights
+category: usage
+tarball: https://github.com/3361805598-gif/dsh-usage-insights/releases/download/v0.2.0/dsh-usage-insights-0.2.0.tgz
+description:
+  en: Local-first personal usage insights in Settings, with 1/7/30-day token heatmaps and a 30-day calendar, token composition, model mix, and skill-call status.
+  zh: 在设置页提供本机个人用量分析：1/7/30 天 Token 热力图与 30 天日历视图、Token 构成、模型分布和技能调用状态。


### PR DESCRIPTION
- [x] I added **one file** at `data/plugins/3361805598-gif__dsh-usage-insights.yml` — that single file is the whole submission. The READMEs are regenerated on `main` after merge: don't edit them by hand, and you don't need to commit them either
- [x] My repo's `package.json` declares **`dsh.bundle`** (not just `dsh.client`)
- [x] My repo is at least **1 day old**
- [x] `category` is one of `agi ui usage theme model identity session memory tools wsl browser vision voice docs skill workflow git notify dev security remote market fun`, and themes/skins go under `theme` → `usage`
- [x] Description states what the plugin does, no superlatives
- [x] My repo has the `dsh-plugin` topic

**Recommended (not required):**
- Release tarball provided: the entry's `tarball` field pins the v0.2.0 GitHub Release asset (`dsh-usage-insights-0.2.0.tgz`).

Plugin: local-first personal usage insights for the dsh web client. Adds a Settings section with 1/7/30-day token heatmaps and a 30-day calendar, token composition (input/output/cache read/cache write/reasoning), model distribution, and skill-call status. Stores only a derived 90-day index in its own storage domain (no prompts, replies, tool payloads, or secrets); "rebuild cache" re-derives from original sessions and never deletes them. All API routes sit behind the host trust fence, same-origin only.