### PR TITLE
Add weibaohui/dsh-continue

### DIFF
--- a/data/plugins/weibaohui__dsh-continue.yml
+++ b/data/plugins/weibaohui__dsh-continue.yml
@@ -1,0 +1,6 @@
+url: https://github.com/weibaohui/dsh-continue
+name: weibaohui/dsh-continue
+category: session
+description:
+  en: "Auto-resume for interrupted agent sessions: an ordered rule table routes by failure type (rate limit, quota, auth, context overflow, crashed orphan) to automatic backoff retry, model switch, resume after context compaction, or a stop-loss notification, with a visual rule editor and a full activity log."
+  zh: 自动续跑：agent 会话中断后自动续上，规则表按失败类型（限流/额度/鉴权/上下文超限/崩溃孤儿）路由——自动退避重试、换模型继续、压缩上下文后继续或止损通知，规则可视化编辑，全程活动日志。


### PR DESCRIPTION
Adds **weibaohui/dsh-continue** — auto-resume for interrupted agent sessions.

An ordered rule table routes by failure type (rate limit, quota, auth, context overflow, crashed orphan) to automatic backoff retry, model switch, resume after context compaction, or a stop-loss notification — no more typing "continue" by hand. Rules are editable visually, with a full activity log.

- 📦 npm: [@weibaohui/dsh-continue](https://www.npmjs.com/package/@weibaohui/dsh-continue) (v0.3.0) → `dsh plugin --profile web add @weibaohui/dsh-continue`
- ✅ `package.json` declares `dsh.bundle` (+ `cordis.patch.yml`), web client included
- ✅ Repo has the `dsh-plugin` topic (plus `dsh`, `deepseek-harness`)
- 🖼️ Demo GIF: https://github.com/weibaohui/dsh-continue/blob/main/docs/demo.gif

Checklist / 自查:

- [x] I added **one file** at `data/plugins/weibaohui__dsh-continue.yml` — that single file is the whole submission. The READMEs are regenerated on `main` after merge: don't edit them by hand, and you don't need to commit them either / 我新增了一个 `data/plugins/weibaohui__dsh-continue.yml` 文件——**这一个文件就是全部投稿**
- [x] My repo's `package.json` declares **`dsh.bundle`** (not just `dsh.client`) — [example](../blob/main/contributing.md) / 仓库 `package.json` 已声明 `dsh.bundle`
- [x] My repo is at least **1 day old** / 仓库创建满 1 天
- [x] `category` is one of the valid values ([full list](../blob/main/contributing.md)) — using `session`
- [x] Description states what the plugin does, no superlatives / 描述只说功能，不带营销词
- [x] My repo has the `dsh-plugin` topic / 仓库已打 `dsh-plugin` topic

**Recommended (not required) / 推荐但不强制：**

- [x] 📦 Published to npm — prebuilt installs skip the `allowBuilds` approval / 已发布 npm 包
- [ ] 🔗 Official `@deepseek-ai/*` packages as `peerDependencies` — not applicable, no official runtime deps
- [ ] 🖼️ `screenshots.json` in our own repository — planned follow-up
