### PR TITLE
Add weibaohui/dsh-settings-ui

### DIFF
--- a/data/plugins/weibaohui__dsh-settings-ui.yml
+++ b/data/plugins/weibaohui__dsh-settings-ui.yml
@@ -1,0 +1,6 @@
+url: https://github.com/weibaohui/dsh-settings-ui
+name: weibaohui/dsh-settings-ui
+category: ui
+description:
+  en: "Customizes the native settings window: preset or custom window sizes, fullscreen, background transparency, and theme, solid-color, or image backgrounds, with a floating ball for quick access; saved in the local browser."
+  zh: 设置界面自定义：调整原生设置窗口大小（全屏/预置大尺寸/自定义宽高）、背景透明度与背景（主题/自定义颜色/图片），悬浮球即开即调，存本机浏览器。


### PR DESCRIPTION
Adds **weibaohui/dsh-settings-ui** — settings-window customization for the DeepSeek Harness web UI.

Customizes the native settings window: preset or custom window sizes, fullscreen, background transparency, and theme, solid-color, or image backgrounds, with a floating ball for quick access. Light and dark themes store separate colors; saved in the local browser.

- 📦 npm: [@weibaohui/dsh-settings-ui](https://www.npmjs.com/package/@weibaohui/dsh-settings-ui) (v0.2.0) → `dsh plugin --profile web add @weibaohui/dsh-settings-ui`
- ✅ `package.json` declares `dsh.bundle` (+ `cordis.patch.yml`), web client included
- ✅ Repo has the `dsh-plugin` topic (plus `dsh`, `deepseek-harness`)
- 🖼️ Demo GIF: https://github.com/weibaohui/dsh-settings-ui/blob/main/docs/demo.gif

Checklist / 自查:

- [x] I added **one file** at `data/plugins/weibaohui__dsh-settings-ui.yml` — that single file is the whole submission. The READMEs are regenerated on `main` after merge: don't edit them by hand, and you don't need to commit them either / 我新增了一个 `data/plugins/weibaohui__dsh-settings-ui.yml` 文件——**这一个文件就是全部投稿**
- [x] My repo's `package.json` declares **`dsh.bundle`** (not just `dsh.client`) — [example](../blob/main/contributing.md) / 仓库 `package.json` 已声明 `dsh.bundle`
- [x] My repo is at least **1 day old** / 仓库创建满 1 天
- [x] `category` is one of the valid values ([full list](../blob/main/contributing.md)) — using `ui`
- [x] Description states what the plugin does, no superlatives / 描述只说功能，不带营销词
- [x] My repo has the `dsh-plugin` topic / 仓库已打 `dsh-plugin` topic

**Recommended (not required) / 推荐但不强制：**

- [x] 📦 Published to npm — prebuilt installs skip the `allowBuilds` approval / 已发布 npm 包
- [ ] 🔗 Official `@deepseek-ai/*` packages as `peerDependencies` — not applicable, no official runtime deps
- [ ] 🖼️ `screenshots.json` in our own repository — planned follow-up
