### PR TITLE
docs: add soul-md and tdai-memory plugins

### DIFF
--- a/data/plugins/Scorp1o117__dsh-soul-md.yml
+++ b/data/plugins/Scorp1o117__dsh-soul-md.yml
@@ -1,0 +1,6 @@
+url: https://github.com/Scorp1o117/dsh-soul-md
+name: Scorp1o117/dsh-soul-md
+category: memory
+description:
+  en: Manage soul.md persona cards and long-term memory, with workspace and session persona selection and tools to read and update them.
+  zh: 管理 soul.md 人设卡与长期记忆，支持按工作区和会话选择人设，并提供读取和更新工具。

--- a/data/plugins/Scorp1o117__dsh-tdai-memory.yml
+++ b/data/plugins/Scorp1o117__dsh-tdai-memory.yml
@@ -1,0 +1,6 @@
+url: https://github.com/Scorp1o117/dsh-tdai-memory
+name: Scorp1o117/dsh-tdai-memory
+category: memory
+description:
+  en: TencentDB Agent Memory integration with conversation capture, structured memory extraction, automatic recall, and memory and conversation search tools.
+  zh: 集成 TencentDB Agent Memory，支持对话捕获、结构化记忆提取、自动召回，以及记忆和对话搜索工具。


### PR DESCRIPTION
Adds two independently installable memory plugins, each as a bilingual YAML entry:

- `Scorp1o117/dsh-soul-md`: persona cards, workspace/session selection, and long-term memory tools.
- `Scorp1o117/dsh-tdai-memory`: conversation capture, memory extraction, recall, and search.

This is the two-entry memory batch replacing part of #822, created directly from upstream main. The other batch contains marketplace, vision, and reasoning-options. Neither branch includes or removes entries from the other. The CLI-only `dsh-enhancement-suite` is omitted because it does not declare `dsh.bundle`.

Validation: the upstream submission gate checked and passed both entries; bilingual README generation and the site build passed. Descriptions were checked against current source. Only the two YAML files are committed; generated READMEs are left to the main-branch workflow. No new DSH runtime compatibility claim is made by this directory-only change.
