### PR TITLE
docs: add marketplace, vision and reasoning-options plugins

### DIFF
--- a/data/plugins/Scorp1o117__dsh-plugin-marketplace.yml
+++ b/data/plugins/Scorp1o117__dsh-plugin-marketplace.yml
@@ -1,0 +1,6 @@
+url: https://github.com/Scorp1o117/dsh-plugin-marketplace
+name: Scorp1o117/dsh-plugin-marketplace
+category: market
+description:
+  en: Browse and search GitHub dsh-plugin repositories from Web UI Settings, sort by stars, and install plugins through the DSH CLI.
+  zh: 在 Web UI 设置页浏览和搜索 GitHub dsh-plugin 仓库，按 Star 排序，并通过 DSH CLI 安装插件。

--- a/data/plugins/Scorp1o117__dsh-reasoning-options.yml
+++ b/data/plugins/Scorp1o117__dsh-reasoning-options.yml
@@ -1,0 +1,6 @@
+url: https://github.com/Scorp1o117/dsh-reasoning-options
+name: Scorp1o117/dsh-reasoning-options
+category: model
+description:
+  en: Add missing reasoning-effort declarations to custom pi-ai models through DSH settings, enabling the native effort picker and handling models added later.
+  zh: 通过 DSH 设置为自定义 pi-ai 模型补充缺失的推理强度声明，启用原生强度选择器，并自动处理后续添加的模型。

--- a/data/plugins/Scorp1o117__dsh-tool-vision.yml
+++ b/data/plugins/Scorp1o117__dsh-tool-vision.yml
@@ -1,0 +1,6 @@
+url: https://github.com/Scorp1o117/dsh-tool-vision
+name: Scorp1o117/dsh-tool-vision
+category: vision
+description:
+  en: Send local images or HTTP(S) image URLs to a configured OpenAI-compatible vision endpoint with the inspect_image tool and return its text response to the conversation.
+  zh: 通过 inspect_image 工具将本地图片或 HTTP(S) 图片链接发送至配置的 OpenAI 兼容视觉端点，并将文字结果带回对话。


### PR DESCRIPTION
Adds three independently installable plugins as bilingual YAML entries:

- `Scorp1o117/dsh-plugin-marketplace` under `market`.
- `Scorp1o117/dsh-tool-vision` under `vision`.
- `Scorp1o117/dsh-reasoning-options` under `model` (new submission): adds missing effort declarations for custom pi-ai models so the native picker can display them. Supported effort levels still depend on the model/provider.

This is the three-entry batch replacing part of #822, created directly from upstream main. The separate memory batch contains soul-md and tdai-memory. Neither branch includes or removes entries from the other. The CLI-only `dsh-enhancement-suite` is omitted because it does not declare `dsh.bundle`.

Validation: the upstream submission gate checked and passed all three entries; bilingual README generation and the site build passed. All three repositories have the `dsh-plugin` topic. Descriptions were checked against current source. Only the three YAML files are committed; generated READMEs are left to the main-branch workflow. No new DSH runtime compatibility claim is made by this directory-only change.
