### PR TITLE
add MurasakiIzumi/dsh-ticker-jp (dsh-plugin)

### DIFF
--- a/data/plugins/MurasakiIzumi__dsh-ticker-jp.yml
+++ b/data/plugins/MurasakiIzumi__dsh-ticker-jp.yml
@@ -2,5 +2,5 @@ url: https://github.com/MurasakiIzumi/dsh-ticker-jp
 name: MurasakiIzumi/dsh-ticker-jp
 category: ui
 description:
-  en: A floating Japanese-stock ticker for DeepSeek Harness: real-time Nikkei 225 and TOPIX ETF quotes from Yahoo Finance, with a customizable watchlist and display-name aliases.
-  zh: DeepSeek Harness 的日股行情悬浮窗：通过 Yahoo Finance 实时显示日经225 与 TOPIX ETF 报价，支持自定义自选代码与显示别名。
+  en: 'A floating Japanese-stock ticker for DeepSeek Harness: real-time Nikkei 225 and TOPIX ETF quotes from Yahoo Finance, with a customizable watchlist and display-name aliases.'
+  zh: 'DeepSeek Harness 的日股行情悬浮窗：通过 Yahoo Finance 实时显示日经225 与 TOPIX ETF 报价，支持自定义自选代码与显示别名。'

--- a/data/plugins/MurasakiIzumi__dsh-ticker-jp.yml
+++ b/data/plugins/MurasakiIzumi__dsh-ticker-jp.yml
@@ -1,0 +1,6 @@
+url: https://github.com/MurasakiIzumi/dsh-ticker-jp
+name: MurasakiIzumi/dsh-ticker-jp
+category: ui
+description:
+  en: A floating Japanese-stock ticker for DeepSeek Harness: real-time Nikkei 225 and TOPIX ETF quotes from Yahoo Finance, with a customizable watchlist and display-name aliases.
+  zh: DeepSeek Harness 的日股行情悬浮窗：通过 Yahoo Finance 实时显示日经225 与 TOPIX ETF 报价，支持自定义自选代码与显示别名。


### PR DESCRIPTION
Adds [MurasakiIzumi/dsh-ticker-jp](https://github.com/MurasakiIzumi/dsh-ticker-jp), a Japanese-stock
ticker plugin for DeepSeek Harness.

A fork of FeiZhuNiU-INFJA/dsh-stock-ticker (already listed), adding:
- **Market**: Japanese stocks — Nikkei 225 (`^N225`) and TOPIX ETF (`1306.T`) instead of A/H-share indices
- **Data source**: Yahoo Finance chart API instead of the upstream Tencent feed
- **New features**: customizable watchlist with display-name aliases (upstream shows fixed indices only),
  market-hours-aware polling, 16 UI languages

Declares `dsh.bundle` in package.json (patch: `cordis.patch.yml`), installs via `dsh plugin add`.
Screenshots: assets/screenshotEN.png etc. in the plugin repo.