### PR TITLE
Add loyalchiiina/dsh-skill-browser (category: ui)

### DIFF
--- a/data/plugins/loyalchiiina__dsh-skill-browser.yml
+++ b/data/plugins/loyalchiiina__dsh-skill-browser.yml
@@ -1,0 +1,6 @@
+url: https://github.com/loyalchiiina/dsh-skill-browser
+name: loyalchiiina/dsh-skill-browser
+category: ui
+description:
+  en: "Browse the DSH skill library from a floating-ball panel: categories, Chinese descriptions, instant search, full SKILL.md viewer, and an automatic skill-failure ledger driven by tools/result events."
+  zh: "悬浮球面板直接浏览 DSH 技能库：两级分类、中文简介、实时搜索、SKILL.md 全文查看；内置失效台账自动登记（监听 tools/result 事件，成功/失败自动记录），支持一键恢复悬浮球默认位置。"


### PR DESCRIPTION
## Plugin submission

- **Repo**: https://github.com/loyalchiiina/dsh-skill-browser
- **npm**: dsh-skill-browser@1.5.4 (published, public): https://www.npmjs.com/package/dsh-skill-browser
- **Category**: ui
- **dsh-plugin topic**: yes
- **Latest version**: 1.5.4 (floating-ball skill library browser: categories / Chinese descriptions / instant search / SKILL.md viewer / automatic skill-failure ledger via 	ools/result; one-click floating-ball position reset)

Install: `dsh plugin --profile web add dsh-skill-browser`

Checklist:
- [x] Plugin loads on DSH Desktop 2.x (running here)
- [x] Published to npm (
pm view dsh-skill-browser version -> 1.5.4)
- [x] data/plugins/loyalchiiina__dsh-skill-browser.yml follows the existing entry format (same as loyalchiiina__dsh-font-enhancer.yml)
- [x] No private paths / keys / personal info in repo (privacy scan passed)