### PR TITLE
add bug-huntter/dsh-vision-plugin and bug-huntter/web-search-advanced

### DIFF
--- a/data/plugins/bug-huntter__dsh-vision-plugin.yml
+++ b/data/plugins/bug-huntter__dsh-vision-plugin.yml
@@ -1,0 +1,6 @@
+url: https://github.com/bug-huntter/dsh-vision-plugin
+name: bug-huntter/dsh-vision-plugin
+category: vision
+description:
+  en: 'Configurable image recognition for text-only DSH models: image messages are first transcribed by any OpenAI-compatible vision model (Base URL, model ID and key configured in a Settings section), then passed to the main model as text; image-input support is advertised while enabled.'
+  zh: 为纯文本 DSH 模型增加可配置识图能力：开启后图片消息先由任意 OpenAI 兼容视觉模型转写为文字描述，再交给主模型处理；设置页可配置 Base URL、Model ID 与密钥。

--- a/data/plugins/bug-huntter__web-search-advanced.yml
+++ b/data/plugins/bug-huntter__web-search-advanced.yml
@@ -1,0 +1,6 @@
+url: https://github.com/bug-huntter/web-search-advanced
+name: bug-huntter/web-search-advanced
+category: browser
+description:
+  en: 'Switchable web-search provider for DSH: native DeepSeek web search or an OpenAI-compatible custom backend, with a Settings card for provider, Base URL, model, API key and result limits.'
+  zh: 可切换的网页搜索提供方：内置 DeepSeek 原生搜索与 OpenAI 兼容自定义后端两种模式，并附设置卡片配置服务商、Base URL、模型、API Key 与搜索上限。


### PR DESCRIPTION
Two submissions, one YAML entry each, both single-plugin repos installable with `dsh plugin add`:

- `bug-huntter/dsh-vision-plugin` → category `vision`（🖼️ 视觉与多模态）
- `bug-huntter/web-search-advanced` → category `browser`（🌐 浏览器与网页）

Vision plugin: configurable image recognition for text-only DSH models, transcribing image messages through any OpenAI-compatible vision model before they reach the main model.
Web search plugin: switchable `deepseek` native search / OpenAI-compatible custom search provider with a Settings card.

Both root `package.json` files declare `dsh.bundle` with `cordis.patch.yml`; READMEs are generated on merge, so only the YAML entries are submitted.