### PR TITLE
Add mokuyoaxis/dsh-iris — media and vision workspace for DeepSeek Harness

### DIFF
--- a/data/plugins/mokuyoaxis__dsh-iris.yml
+++ b/data/plugins/mokuyoaxis__dsh-iris.yml
@@ -1,0 +1,6 @@
+url: https://github.com/mokuyoaxis/dsh-iris
+name: mokuyoaxis/dsh-iris
+category: tools
+description:
+  en: 'Media and vision workspace for DeepSeek Harness: image, video and speech generation, image Q&A and element locating, long-image OCR, pixel diff, HTML-screenshot verification and video summarization, with DashScope and OpenAI-compatible providers, model pools and a workbench client.'
+  zh: '面向 DeepSeek Harness 的媒体与视觉工作台：文生图、图/文生视频、语音合成与转写、图像问答与元素定位、长图 OCR、像素比对、HTML 截图验证、视频摘要；支持 DashScope 与 OpenAI 兼容供应商，含模型池与工作台客户端。'


### PR DESCRIPTION
Add mokuyoaxis/dsh-iris.

- Repo: https://github.com/mokuyoaxis/dsh-iris (created 2026-09-04, actively maintained)
- npm: @mokuyoaxis/dsh-iris 0.1.1 published; `repository` points back at the listed repo
- `dsh.bundle` declared at repo root (`{"patch": "./cordis.patch.yml"}`), installable via `dsh plugin add`
- Category `tools`: generation + vision + voice under one workspace; re-file freely if `vision` fits better
- Description verified against source; no marketing wording