### PR TITLE
feat: add 3 Desktop-Ultra plugins (split 1/2 of #4390)

### DIFF
--- a/data/plugins/ijry__DeepSeek-Harness-Desktop-Ultra--plugins-dsh-plugin-canvas.yml
+++ b/data/plugins/ijry__DeepSeek-Harness-Desktop-Ultra--plugins-dsh-plugin-canvas.yml
@@ -1,0 +1,6 @@
+url: https://github.com/ijry/DeepSeek-Harness-Desktop-Ultra/tree/main/plugins/dsh-plugin-canvas
+name: ijry/DeepSeek-Harness-Desktop-Ultra#dsh-plugin-canvas
+category: session
+description:
+  en: Infinite canvas for sessions, with regions bound to workspaces and agent presets, pinned session cards, sticky notes and alignment guides.
+  zh: 无限会话画布，区域绑定工作区与智能体预设，可钉住会话卡片、放置便签，带对齐参考线。

--- a/data/plugins/ijry__DeepSeek-Harness-Desktop-Ultra--plugins-dsh-plugin-mobile-bridge.yml
+++ b/data/plugins/ijry__DeepSeek-Harness-Desktop-Ultra--plugins-dsh-plugin-mobile-bridge.yml
@@ -1,0 +1,6 @@
+url: https://github.com/ijry/DeepSeek-Harness-Desktop-Ultra/tree/main/plugins/dsh-plugin-mobile-bridge
+name: ijry/DeepSeek-Harness-Desktop-Ultra#dsh-plugin-mobile-bridge
+category: remote
+description:
+  en: Token-authenticated REST and SSE bridge with QR pairing, so a phone app can read sessions, send messages and approve tool calls.
+  zh: 带令牌鉴权的 REST 与 SSE 接口，扫码配对后可在手机 App 上看会话、发消息、批准工具调用。

--- a/data/plugins/ijry__DeepSeek-Harness-Desktop-Ultra--plugins-dsh-plugin-repopanel.yml
+++ b/data/plugins/ijry__DeepSeek-Harness-Desktop-Ultra--plugins-dsh-plugin-repopanel.yml
@@ -2,5 +2,5 @@ url: https://github.com/ijry/DeepSeek-Harness-Desktop-Ultra/tree/main/plugins/ds
 name: ijry/DeepSeek-Harness-Desktop-Ultra#dsh-plugin-repopanel
 category: git
 description:
-  en: Browse the GitHub issues and pull requests of a workspace's origin remote, filter and comment, close or reopen, and hand one to an agent as a task.
-  zh: 浏览工作区 origin 远端对应的 GitHub issue 与 pull request，筛选、评论、关闭或重开，并可交给 agent 变成任务。
+  en: Browse the GitHub issues and pull requests of a workspace's origin remote, filter and comment, close or reopen, and file one as a task on dsh-plugin-taskboard for an agent to claim.
+  zh: 浏览工作区 origin 远端对应的 GitHub issue 与 pull request，筛选、评论、关闭或重开，并可转成任务写到 dsh-plugin-taskboard 的看板上等 agent 领取。

--- a/data/plugins/ijry__DeepSeek-Harness-Desktop-Ultra--plugins-dsh-plugin-repopanel.yml
+++ b/data/plugins/ijry__DeepSeek-Harness-Desktop-Ultra--plugins-dsh-plugin-repopanel.yml
@@ -1,0 +1,6 @@
+url: https://github.com/ijry/DeepSeek-Harness-Desktop-Ultra/tree/main/plugins/dsh-plugin-repopanel
+name: ijry/DeepSeek-Harness-Desktop-Ultra#dsh-plugin-repopanel
+category: git
+description:
+  en: Browse the GitHub issues and pull requests of a workspace's origin remote, filter and comment, close or reopen, and hand one to an agent as a task.
+  zh: 浏览工作区 origin 远端对应的 GitHub issue 与 pull request，筛选、评论、关闭或重开，并可交给 agent 变成任务。


### PR DESCRIPTION
Split of #4390 as asked in review — 3 entries here, `dsh-plugin-taskboard` in #4426. / 按评审要求拆开 #4390：这条 3 个条目,`dsh-plugin-taskboard` 在 #4426。

Both branches are cut fresh from `main` (`9b2c190`) and each contains only its own entry files. Neither branch's history adds, modifies or deletes the other's entry, so they cannot revert each other under merge, squash or rebase-and-merge.

Three subpackages of the [DeepSeek-Harness-Desktop-Ultra](https://github.com/ijry/DeepSeek-Harness-Desktop-Ultra) monorepo:

- **dsh-plugin-canvas** (`session`) — infinite session canvas: regions bound to workspaces and agent presets, pinned session cards, sticky notes, alignment guides. GUI only: it registers no tools and does not touch the system prompt.
- **dsh-plugin-mobile-bridge** (`remote`) — token-authenticated REST + SSE surface over dsh's own `/api`, with a QR pairing panel, so a phone app can read sessions, send messages and approve tool calls. To be upfront: the phone client itself is a separate closed-source app, so what is listed here is the bridge, not the app.
- **dsh-plugin-repopanel** (`git`) — browse the issues and pull requests of the repository a workspace's `origin` points at: filter and page, read and post comments, close/reopen, and file one as a task on dsh-plugin-taskboard.

One description is tightened relative to #4390: repopanel's said "hand one to an agent as a task", but `POST /start` composes a prompt and calls dsh-plugin-taskboard's `POST /tasks` — it starts no agent and creates no session — so the entry now says it files a task for an agent to claim, and names the plugin it needs for that.

Checklist / 自查：

- [x] One file per entry under `data/plugins/`; the READMEs are untouched and not regenerated here.
- [x] Each subpackage's `package.json` declares `dsh.bundle` (with a `cordis.patch.yml` beside it), not just `dsh.client`.
- [x] Repo created 2026-09-03, not archived, `dsh-plugin` topic present.
- [x] Categories are from the list; `zh` descriptions included.
- 📦 All three are published to npm at `0.1.0`.
