### PR TITLE
Move Kayungko/dsh-plugin-task-coordinator from session to workflow (+ description refresh)

### DIFF
--- a/data/plugins/Kayungko__dsh-plugin-task-coordinator.yml
+++ b/data/plugins/Kayungko__dsh-plugin-task-coordinator.yml
@@ -1,6 +1,6 @@
 url: https://github.com/Kayungko/dsh-plugin-task-coordinator
 name: Kayungko/dsh-plugin-task-coordinator
-category: session
+category: workflow
 description:
-  en: Cross-task coordination for DeepSeek Harness - list, inspect, spawn, message and steer top-level sessions from a supervisor agent.
-  zh: 跨任务协调：在监督代理中列出、查看、派生、发消息并引导顶层会话。
+  en: 'Supervisor-style workflow orchestration over top-level sessions: confirmation-gated batch dispatch, team workstreams, steering running tasks, idle-wait collection and live model-route discovery across 11 task_* tools plus a /tasks slash command.'
+  zh: '总控式工作流编排：确认闸门批量派发、团队编组、向运行中任务纠偏、等待收口与模型路线发现——11 个 task_* 工具加 /tasks 斜杠命令。'


### PR DESCRIPTION
## What

Moves our own entry `data/plugins/Kayungko__dsh-plugin-task-coordinator.yml` from `category: session` to `category: workflow`, and refreshes both descriptions to match the plugin's current, verifiable feature set. No other entry is touched; README regeneration is left to the pipeline per the contributing guide.

## Why `workflow`

Per the review note - "the category that matches what the plugin does": this plugin is supervisor-driven automation, not a session/message surface tool. Its loop is decompose, `task_confirm` dispatch-confirmation gate, `task_spawn_batch` fan-out, `team` workstream grouping, steering/waiting on running tasks, report-back, with recursion-depth governance on top. Sessions are the substrate it orchestrates, not the UX it enhances. Its natural neighbors in Workflow & Automation are `apheli0os/deepseek-harness-orchestrate` (task orchestration) and `82c86b8z86-stack/dsh-engineering-workflow` (gated phases), while Sessions & Messages collects session/message UX (undo/rewind, inline images, archives, copy, record-replay).

## Description refresh (accuracy only)

The old line described the early five verbs (list/inspect/spawn/message/steer). The plugin has since grown to 11 `task_*` tools - dispatch confirmation cards, multi-select partial dispatch, workspace migration, per-child model selection and live model-route discovery - plus the `/tasks` slash command, all verifiable in the repo README and tool registry (`tools.mjs`). No superlatives or marketing terms added; en stays one sentence with a trailing period, and both strings are quoted because en contains ': '.

Happy to be refiled if maintainers read the fit differently - per the contributing notes, category is the maintainers' call.