### PR TITLE
feat: add dsh-plugin-taskboard (split 2/2 of #4390)

### DIFF
--- a/data/plugins/ijry__DeepSeek-Harness-Desktop-Ultra--plugins-dsh-plugin-taskboard.yml
+++ b/data/plugins/ijry__DeepSeek-Harness-Desktop-Ultra--plugins-dsh-plugin-taskboard.yml
@@ -1,0 +1,6 @@
+url: https://github.com/ijry/DeepSeek-Harness-Desktop-Ultra/tree/main/plugins/dsh-plugin-taskboard
+name: ijry/DeepSeek-Harness-Desktop-Ultra#dsh-plugin-taskboard
+category: workflow
+description:
+  en: Task kanban where agents claim and hand off work through taskboard_* tools; acceptance and rework stay human-only.
+  zh: 任务看板，agent 通过 taskboard_* 工具领活与交接，验收和退回只由人操作。

--- a/data/plugins/ijry__DeepSeek-Harness-Desktop-Ultra--plugins-dsh-plugin-taskboard.yml
+++ b/data/plugins/ijry__DeepSeek-Harness-Desktop-Ultra--plugins-dsh-plugin-taskboard.yml
@@ -2,5 +2,5 @@ url: https://github.com/ijry/DeepSeek-Harness-Desktop-Ultra/tree/main/plugins/ds
 name: ijry/DeepSeek-Harness-Desktop-Ultra#dsh-plugin-taskboard
 category: workflow
 description:
-  en: Task kanban where agents claim and hand off work through taskboard_* tools; acceptance and rework stay human-only.
-  zh: 任务看板，agent 通过 taskboard_* 工具领活与交接，验收和退回只由人操作。
+  en: Task kanban where agents claim and hand off work through taskboard_* tools, which cannot move a task to done or canceled — acceptance stays with a human.
+  zh: 任务看板，agent 通过 taskboard_* 工具领活与交接；这些工具无法把任务移到 done 或 canceled，验收由人来做。


### PR DESCRIPTION
Split of #4390 as asked in review — this is the fourth entry; the other three are in #4424. / 按评审要求拆开 #4390：这条是第四个条目,另外三个在 #4424。

This branch is cut fresh from `main` (`9b2c190`) and contains only this one entry file. Neither branch's history adds, modifies or deletes the other's entry, so they cannot revert each other under merge, squash or rebase-and-merge.

- **dsh-plugin-taskboard** (`workflow`) — task kanban in the dsh web GUI, four columns (`todo` / `inProgress` / `attention` / `done`) with a live SSE board view. Agents claim and hand off work through six `taskboard_*` tools (`list`, `get`, `create`, `update`, `move`, `comment`); `taskboard_move` cannot target `done` or `canceled`, enforced in the parameter enum, in a pre-check and again against the live record inside the mutation, so acceptance stays with a human.

Part of the [DeepSeek-Harness-Desktop-Ultra](https://github.com/ijry/DeepSeek-Harness-Desktop-Ultra) monorepo.

The description is tightened relative to #4390: it said "acceptance and rework stay human-only", but an agent may move a task out of `review` back to `running` or `todo` (`AGENT_TRANSITIONS.review`), so only acceptance is human-only, and the entry now says only that.

Checklist / 自查：

- [x] One file under `data/plugins/`; the READMEs are untouched and not regenerated here.
- [x] `plugins/dsh-plugin-taskboard/package.json` declares `dsh.bundle` (with a `cordis.patch.yml` beside it), not just `dsh.client`.
- [x] Repo created 2026-09-03, not archived, `dsh-plugin` topic present.
- [x] Category is from the list; `zh` description included.
- 📦 Published to npm at `0.1.0`.
