### PR TITLE
fix: install dsh-agent-team-gui from the v1.0.1 prebuilt release

### DIFF
--- a/data/plugins/toolclub__dsh-agent-team-gui.yml
+++ b/data/plugins/toolclub__dsh-agent-team-gui.yml
@@ -4,3 +4,4 @@ category: workflow
 description:
   en: Persistent multi-model squads configured in Settings and selected in the Composer, with per-member model/tool policies; the main Agent dynamically plans each send as a bounded DAG with bounded reviewer/repair loops, while Run Center tracks retries and per-member tokens from official Harness usage events.
   zh: 持久化多模型小队在 Settings 中配置、从 Composer 选择，并支持逐成员模型与工具策略；主 Agent 为每次发送动态规划有界 DAG，并可执行有界的审阅/修复质量回路；Run Center 展示重试和基于 Harness 官方 usage 事件的逐成员 token 用量。
+tarball: https://github.com/toolclub/dsh-agent-team-gui/releases/download/v1.0.1/dsh-agent-team-gui-1.0.1.tgz


### PR DESCRIPTION
Add the existing `toolclub/dsh-agent-team-gui` entry's supported `tarball` field, pinned to the published [v1.0.1 prebuilt package](https://github.com/toolclub/dsh-agent-team-gui/releases/tag/v1.0.1). The generated catalog and downstream storefronts can then offer the compiled release package for this entry, addressing the Git-source installation path reported in [toolclub/dsh-agent-team-gui#27](https://github.com/toolclub/dsh-agent-team-gui/issues/27).

Validation:

- All 3,186 entries pass the repository's entry validator.
- Both generated READMEs pass `node scripts/generate-readme.mjs --check`.
- `awesome-lint` passes with 74 existing spelling warnings in the unchanged README.
- `SKIP_PUBLISH_CHECKS=1 node scripts/build-site.mjs` passes; the generated `plugins.json` contains the pinned tarball and the matching install command.
- The release asset responds to a one-byte ranged GET with HTTP 206.
- `git diff --check` passes.
