### PR TITLE
Update dsh-paste-to-path description

### DIFF
--- a/data/plugins/Johnny-xuan__dsh-paste-to-path.yml
+++ b/data/plugins/Johnny-xuan__dsh-paste-to-path.yml
@@ -2,5 +2,5 @@ url: https://github.com/Johnny-xuan/dsh-paste-to-path
 name: Johnny-xuan/dsh-paste-to-path
 category: tools
 description:
-  en: Adds a path-backed attachment dock for images, documents, archives, code, and other files, leaving file reading to the Agent's available tools.
-  zh: 为图片、文档、压缩包、代码及其他文件提供路径附件 Dock，文件读取交由 Agent 的当前可用工具完成。
+  en: Adds a path-backed Dock for pasted, dropped, or selected files, Host paths, and long text, leaving content reading to Agent tools.
+  zh: 把粘贴、拖入或选择的文件、Host 路径与长文本放进路径附件 Dock，由 Agent 工具读取内容。

--- a/data/plugins/Johnny-xuan__dsh-paste-to-path.yml
+++ b/data/plugins/Johnny-xuan__dsh-paste-to-path.yml
@@ -2,5 +2,5 @@ url: https://github.com/Johnny-xuan/dsh-paste-to-path
 name: Johnny-xuan/dsh-paste-to-path
 category: tools
 description:
-  en: Paste, drop, or choose images, documents, archives, code, and other files in DSH, then review and manage them before sending them to the Agent.
-  zh: 在 DSH 中粘贴、拖入或选择图片、文档、压缩包、代码等文件，发送前统一查看和管理，再交给 Agent 处理。
+  en: 'A lightweight, general-purpose attachment Dock for DSH: paste, drop, or choose images, PDFs, documents, archives, code, and other files, review and manage them before sending, then pass them to the Agent as local paths. It gives non-image files a consistent attachment entry point.'
+  zh: 一个轻量、通用的 DSH 附件 Dock：支持粘贴、拖入或选择图片、PDF、文档、压缩包、代码等文件，发送前统一查看和管理，再以本地路径交给 Agent；解决非图片文件缺少统一附件入口的问题。

--- a/data/plugins/Johnny-xuan__dsh-paste-to-path.yml
+++ b/data/plugins/Johnny-xuan__dsh-paste-to-path.yml
@@ -2,5 +2,5 @@ url: https://github.com/Johnny-xuan/dsh-paste-to-path
 name: Johnny-xuan/dsh-paste-to-path
 category: tools
 description:
-  en: Adds a path-backed Dock for pasted, dropped, or selected files, Host paths, and long text, leaving content reading to Agent tools.
-  zh: 把粘贴、拖入或选择的文件、Host 路径与长文本放进路径附件 Dock，由 Agent 工具读取内容。
+  en: Paste, drop, or choose images, documents, archives, code, and other files in DSH, then review and manage them before sending them to the Agent.
+  zh: 在 DSH 中粘贴、拖入或选择图片、文档、压缩包、代码等文件，发送前统一查看和管理，再交给 Agent 处理。


### PR DESCRIPTION
## Summary

- update the English and Chinese card descriptions for `Johnny-xuan/dsh-paste-to-path`
- reflect the current pasted/dropped/selected file, Host-path, and long-text intake behavior
- leave generated README files unchanged, as required by the contribution guide

## Validation

- parsed the entry as YAML and checked both locale endings
- ran `npm ci --ignore-scripts`
- ran `node scripts/generate-readme.mjs` and verified both generated lines
- restored generated files so the PR changes only this plugin entry