### PR TITLE
Add dsh-github-mcp, dsh-github-mcp-hint, dsh-approval-voice

### DIFF
--- a/data/plugins/ZIye1208__dsh-approval-voice.yml
+++ b/data/plugins/ZIye1208__dsh-approval-voice.yml
@@ -1,0 +1,6 @@
+url: https://github.com/ZIye1208/dsh-approval-voice
+name: ZIye1208/dsh-approval-voice
+category: notify
+description:
+  en: "Plays a chime and speaks a Chinese voice alert when an approval, question, or plan-review popup appears in the DSH web GUI, so you never miss a request."
+  zh: "DSH Web GUI 中出现审批、提问或计划审批弹窗时，播放提示音并中文语音播报，避免漏看待处理请求。"

--- a/data/plugins/ZIye1208__dsh-github-mcp-hint.yml
+++ b/data/plugins/ZIye1208__dsh-github-mcp-hint.yml
@@ -1,0 +1,6 @@
+url: https://github.com/ZIye1208/dsh-github-mcp-hint
+name: ZIye1208/dsh-github-mcp-hint
+category: git
+description:
+  en: "GitHub MCP helper panel: shows copyable example prompts at Settings → Plugins → GitHub MCP (random 4 from a 30-example pool), visualizes a public user's repo star/fork/language, and adds the gh_repo_stats and gh_current_user model tools."
+  zh: "GitHub MCP 辅助面板：在「设置 → 插件 → GitHub MCP」展示可复制的示例提示（30 条示例池随机 4 条）、可视化公开仓库的星/fork/语言，并提供 gh_repo_stats / gh_current_user 模型工具。"

--- a/data/plugins/ZIye1208__dsh-github-mcp.yml
+++ b/data/plugins/ZIye1208__dsh-github-mcp.yml
@@ -1,0 +1,6 @@
+url: https://github.com/ZIye1208/dsh-github-mcp
+name: ZIye1208/dsh-github-mcp
+category: git
+description:
+  en: "Connects GitHub's official remote MCP server as a DSH plugin: stores the PAT in DSH's credential center (.credentials.yaml) via github_set_token, and exposes GitHub tools as mcp__github__*."
+  zh: "把 GitHub 官方远程 MCP server 封装为 DSH 插件：PAT 存入 DSH 凭据中心（.credentials.yaml），提供 github_set_token / github_token_status 模型工具，GitHub 工具以 mcp__github__* 形式可用。"


### PR DESCRIPTION
Adds three entries under `data/plugins/`, one file per plugin:

- **`ZIye1208/dsh-github-mcp`** (`git`) — Wraps GitHub's official remote MCP server as a DSH plugin. Stores the PAT in the DSH credential center (`.credentials.yaml`), exposes GitHub tools as `mcp__github__*`, and adds `github_set_token` / `github_token_status` model tools. Declares `dsh.bundle`; published to npm.
- **`ZIye1208/dsh-github-mcp-hint`** (`git`) — Companion UI panel at Settings → Plugins → GitHub MCP: a 30-example pool showing 4 random copyable prompts, a public-repo star/fork/language visualizer, plus the `gh_repo_stats` / `gh_current_user` model tools. Declares `dsh.bundle`; published to npm.
- **`ZIye1208/dsh-approval-voice`** (`notify`) — Web-GUI approval alert: plays a chime and speaks a Chinese voice message when an approval, question, or plan-review popup appears. Declares `dsh.bundle`; published to npm.

Each repository declares `dsh.bundle` in its root `package.json`, carries real working code, is >1 day old, and has the `dsh-plugin` topic.

Note: I chose `git` for both GitHub plugins since they are GitHub-tooling-centric; a maintainer may re-file `dsh-github-mcp-hint` under `ui`/`usage` if that is a better fit.