### PR TITLE
Add lovezi0/dsh-model-extension

### DIFF
--- a/data/plugins/lovezi0__dsh-model-extension.yml
+++ b/data/plugins/lovezi0__dsh-model-extension.yml
@@ -1,0 +1,6 @@
+url: https://github.com/lovezi0/dsh-model-extension
+name: lovezi0/dsh-model-extension
+category: model
+description:
+  en: 'Models+ settings page for the DSH web UI: per-model reasoning-effort tables, input modalities and compat flags saved through the official settings pipeline, with models.dev metadata prefill and API key management.'
+  zh: '模型+ 设置页:按模型声明推理挡位、输入模态与兼容参数(走官方 settings 管线保存),支持 models.dev 元数据预填与 API 密钥管理。'


### PR DESCRIPTION
- [x] I added **one file** at `data/plugins/<owner>__<repo>.yml` — that single file is the whole submission. The READMEs are regenerated on `main` after merge: don't edit them by hand, and you don't need to commit them either / 我新增了一个 `data/plugins/<owner>__<repo>.yml` 文件——**这一个文件就是全部投稿**。README 会在合并后由 `main` 自动重新生成：不要手工编辑，也不需要提交
- [x] My repo's `package.json` declares **`dsh.bundle`** (not just `dsh.client`) / 仓库 `package.json` 已声明 `dsh.bundle`（只有 `dsh.client` 无法安装）
- [x] My repo is at least **1 day old** / 仓库创建满 1 天
- [x] `category` is one of `agi ui usage theme model identity session memory tools wsl browser vision voice docs skill workflow git notify dev security remote market fun` / `category` 取值正确
- [x] Description states what the plugin does, no superlatives / 描述只说功能，不带营销词
- [x] My repo has the `dsh-plugin` topic / 仓库已打 `dsh-plugin` topic

**Recommended / 推荐项：**

- [x] 📦 Published to npm as `dsh-model-extension` (v1.0.0, `repository` field points back at this repo) / 已发布 npm（repository 字段回指本仓库）
- [x] 🔗 All official `@deepseek-ai/*` packages are declared as `peerDependencies` with an explicit prerelease branch / 官方包全部 `peerDependencies`，范围带显式预发布分支
- [x] 🖼️ `screenshots.json` in the repo (2 UI screenshots) / 仓库已含 `screenshots.json`（2 张界面截图）

---

Adds [lovezi0/dsh-model-extension](https://github.com/lovezi0/dsh-model-extension) (v1.0.0, MIT) — a fully plugin-owned **Models+ settings page** for the DSH web UI:

- Per-model reasoning-effort tables, input modalities and compat flags, saved **through the official settings pipeline** (the host logic modules — store / operations / schema-operations — are vendored verbatim; the write path is the untouched `settings.mutate` wire with revision fencing)
- `models.dev` metadata prefill: a manual download button caches the flat `models.json` next to `settings.yaml`; quick-load matches model ids (case-insensitive, max 10 candidates)
- The official Models page is disabled via a bundle-patch id override, so this page is the only model settings page

Repo is self-contained (build needs no host checkout); tests/audits run in CI of the plugin repo itself.
