### PR TITLE
Add kagurazakayashi/dsh-startup-command (workflow)

### DIFF
--- a/data/plugins/kagurazakayashi__dsh-startup-command.yml
+++ b/data/plugins/kagurazakayashi__dsh-startup-command.yml
@@ -1,0 +1,6 @@
+url: https://github.com/kagurazakayashi/dsh-startup-command
+name: kagurazakayashi/dsh-startup-command
+category: workflow
+description:
+  en: A DeepSeek Harness Web plugin that runs a user-defined command after the web profile has started successfully.
+  zh: 在 dsh web 启动成功后运行用户自定义命令的 DeepSeek Harness Web 插件。


### PR DESCRIPTION
## Summary

Adds the **dsh-startup-command** plugin.

Runs a user-defined command after the dsh web profile finishes booting — for
example launching a Chromium-family browser with custom flags — with
`{url}` / `{home}` / `{browser}` placeholder substitution.

## Checklist

- [x] Declares a `dsh.bundle` manifest (`dsh.bundle.patch` → `cordis.patch.yml`) and installs via `dsh plugin add`
- [x] Published to npm: `@kagurazakayashi/dsh-startup-command` (its `repository` field points back to this repository)
- [x] `dsh-plugin` topic added to the repository
- [x] Dual-face plugin: a host half runs the command at startup; a browser half registers a settings card under Settings → Plugins → Plugin configuration