### PR TITLE
Add HOWILLMAKEIT/dsh-model-context-catalog (model)

### DIFF
--- a/data/plugins/HOWILLMAKEIT__dsh-model-context-catalog.yml
+++ b/data/plugins/HOWILLMAKEIT__dsh-model-context-catalog.yml
@@ -1,0 +1,6 @@
+url: https://github.com/HOWILLMAKEIT/dsh-model-context-catalog
+name: HOWILLMAKEIT/dsh-model-context-catalog
+category: model
+description:
+  en: 'Route-level contextWindow catalog for llm-pi-ai models: a Settings page lists configured routes, stores the real window per route, and syncs it through the public Settings API so long sessions are no longer misjudged as context overflow.'
+  zh: '为 llm-pi-ai 模型维护路由级 contextWindow：设置页列出已配置路由、按路由保存真实窗口值，并经公开 Settings API 同步，避免长会话被误判为上下文溢出。'


### PR DESCRIPTION
Adds one entry file: `data/plugins/HOWILLMAKEIT__dsh-model-context-catalog.yml`

**What the plugin does:** maintains accurate route-level `contextWindow` values for `llm-pi-ai` models in DeepSeek Harness. Custom routes that don't declare a window fall back to a 262,144-token guess, which misclassifies successful long responses as context overflow (breaking final answers and `/compact`). The plugin adds a **Settings → Context Window** page that lists configured `llm-pi-ai` routes, stores the real window per route, and syncs it through the public DSH Settings API — no patches to DSH/pi-ai internals.

**Submission checklist:**
- [x] One YAML file in `data/plugins/`, READMEs left for regeneration
- [x] `package.json` declares `dsh.bundle` (`cordis.patch.yml` at repo root) — installs via `dsh plugin --profile web add dsh-model-context-catalog` (also on npm)
- [x] Repo created 2026-09-01 (> 1 day), actively maintained, real working code
- [x] `dsh-plugin` topic present
- [x] Category `model`: it manages per-route model context-window metadata
- [x] Description matches the code; both `en` and `zh` provided

Happy to adjust the category or wording if a maintainer sees a better fit.