### PR TITLE
Add drshy-org/lightroom-py — Adobe Lightroom Classic as native dsh tools

### DIFF
--- a/data/plugins/drshy-org__lightroom-py.yml
+++ b/data/plugins/drshy-org__lightroom-py.yml
@@ -1,0 +1,6 @@
+url: https://github.com/drshy-org/lightroom-py
+name: drshy-org/lightroom-py
+category: tools
+description:
+  en: 'Adobe Lightroom Classic as native dsh tools through the lightroom-py MCP server: read the catalog, apply develop settings and presets, export JPEG/TIFF/PSD/DNG, and write ratings, labels, keywords and IPTC — 15 tools driving the Lightroom Classic installed on the local machine, no cloud round-trip; the Python package is on PyPI and the Lightroom plugin installs with one command.'
+  zh: '通过 lightroom-py MCP 服务器把 Adobe Lightroom Classic 接入为 dsh 原生工具：读取目录、应用 develop 设置与预设、导出 JPEG/TIFF/PSD/DNG、写入星级/色标/关键词/IPTC——15 个工具，直接驱动本机安装的 Lightroom Classic，不经云端；Python 包在 PyPI 上，Lightroom 插件一条命令安装。'


### PR DESCRIPTION
One entry, category `tools`.

- Repo: https://github.com/drshy-org/lightroom-py (MIT, `dsh-plugin` topic set)
- Bundle: root `package.json` declares `dsh.bundle` → `cordis.patch.yml` (pure configuration, no build step); `dsh plugin add github:drshy-org/lightroom-py`
- What it does: mounts the `lightroom-mcp` server (PyPI `lightroom-py[mcp]` 0.6.1) as `mcp__lightroom_py__*` — 15 tools: catalog_info, catalog_stats, photos_list, develop_apply_settings, develop_apply_preset, develop_list_presets, develop_reset, library_export, metadata_add_keywords, metadata_set_rating, metadata_set_color_label, metadata_set_iptc, collections_list, collections_create, collections_add
- Verified: fresh `pip install "lightroom-py[mcp]"` + `dsh plugin add github:…` in a clean `DSH_HOME`, then a session listing all 15 tools and reading a real Lightroom Classic catalog.

Python-side prerequisite (documented in `dsh/README.md`): `pip install "lightroom-py[mcp]"` and `lightroom setup`, plus Lightroom's own Plug-in Manager enable step.