### PR TITLE
Add BrianHIO-x/dsh-think-expand

### DIFF
--- a/data/plugins/BrianHIO-x__dsh-think-expand.yml
+++ b/data/plugins/BrianHIO-x__dsh-think-expand.yml
@@ -1,0 +1,6 @@
+url: https://github.com/BrianHIO-x/dsh-think-expand
+name: BrianHIO-x/dsh-think-expand
+category: ui
+description:
+  en: Auto-expands every Think row after switching sessions, with a header switch to turn it on or off.
+  zh: 切换会话后也会自动展开全部 Think 行，标题栏有开关可以打开或关闭。


### PR DESCRIPTION
Adds [BrianHIO-x/dsh-think-expand](https://github.com/BrianHIO-x/dsh-think-expand) to the catalog.

- Installs with `dsh plugin --profile web add github:BrianHIO-x/dsh-think-expand`
- Declares `dsh.bundle` plus `cordis.patch.yml`
- Client UI registers a Think switch on the session header
- Topic: `dsh-plugin`
- Category: `ui`
