### PR TITLE
Add Harzva/dsh-pr-guardian

### DIFF
--- a/data/plugins/Harzva__dsh-pr-guardian.yml
+++ b/data/plugins/Harzva__dsh-pr-guardian.yml
@@ -1,0 +1,7 @@
+url: https://github.com/Harzva/dsh-pr-guardian
+name: Harzva/dsh-pr-guardian
+category: git
+description:
+  en: 'Authored pull request feedback inbox with paginated GitHub collection, priority favorites, and version-bound local progress shared by the DSH panel and CLI.'
+  zh: '聚合本人创建的 PR 反馈，分页采集 GitHub 评论与审查，支持重点标记和 DSH 面板、CLI 共用的版本化本地处理进度。'
+tarball: https://github.com/Harzva/dsh-pr-guardian/releases/download/v0.2.0-alpha.1/dsh-pr-guardian-0.2.0-alpha.1.tgz


### PR DESCRIPTION
Adds a Git-category authored PR feedback inbox. It provides paginated GitHub feedback collection, a DSH sidebar panel, favorites and version-bound local progress shared with its CLI. GitHub collection is read-only; the general repair/publish workflow remains planned.

- [x] One YAML entry only; README generation preview produced exactly one added line per README and zero removals.
- [x] Repository declares dsh.bundle, dsh.client and the dsh-plugin topic.
- [x] Factual description and category git.
- [ ] Repository is at least one day old: **created today; the age gate is expected to fail until 24 hours have elapsed.** Please treat this as a preview submission pending that gate and maintainer review.

Prebuilt prerelease: https://github.com/Harzva/dsh-pr-guardian/releases/tag/v0.2.0-alpha.1

Validation: 78 tests, artifact preflight, exact tarball offline isolated DSH 0.1.1-rc.2 Web boot, actual strict RPC, restart persistence, removal, and real UI/authenticated feedback sync. Official runtime packages are peers with matching development dependencies. The entry links the tested versioned Release tarball; GitHub source-shortcut installation is unverified.
