### PR TITLE
Update JanEickholt/dsh-inline-diff (ui): mention git diff

### DIFF
--- a/data/plugins/JanEickholt__dsh-inline-diff.yml
+++ b/data/plugins/JanEickholt__dsh-inline-diff.yml
@@ -2,5 +2,5 @@ url: https://github.com/JanEickholt/dsh-inline-diff
 name: JanEickholt/dsh-inline-diff
 category: ui
 description:
-  en: "Renders edit and write tool calls as always-expanded side-by-side diffs, with optional syntax coloring and word-level highlighting."
-  zh: "将编辑与写入工具调用渲染为常开的双栏 diff，可选语法配色与词级高亮。"
+  en: "Renders edit and write tool calls as always-expanded side-by-side diffs styled like git diff, with optional syntax coloring and word-level highlighting."
+  zh: "将编辑与写入工具调用渲染为常开的双栏 diff，样式类似 git diff，可选语法配色与词级高亮。"


### PR DESCRIPTION
The site search matches card text only, and this entry's card never said git, so searching "git" or "git diff" returned nothing. The plugin renders side-by-side diffs styled after git diff: additions in green, deletions in red, word-level highlighting, colored edge bar per changed line.

The new wording is factual, borrowed from what the plugin does per its README. Only this entry is touched.