### PR TITLE
Add dsh-capability-panel

### DIFF
--- a/data/plugins/pure-craft__dsh-capability-panel.yml
+++ b/data/plugins/pure-craft__dsh-capability-panel.yml
@@ -1,0 +1,6 @@
+url: https://github.com/pure-craft/dsh-capability-panel
+name: pure-craft/dsh-capability-panel
+category: ui
+description:
+  en: See which skills and tools your agent can actually reach right now — true in-context state (loaded/truncated/evicted) and per-session switches.
+  zh: 看清 agent 此刻真正能触达哪些技能与工具——真实的在上下文状态(已加载/已截断/已挤出),并按会话开关。


### PR DESCRIPTION
Adds [pure-craft/dsh-capability-panel](https://github.com/pure-craft/dsh-capability-panel) — a DeepSeek Harness plugin that shows which skills, MCP servers, and system tools the live session can actually reach (true in-context state: loaded/truncated/evicted) and toggles them per session or per preset.

- Installs with `dsh plugin --profile web add dsh-capability-panel` (also on npm, declares `dsh.bundle`)
- MIT, actively maintained, 390+ tests with CI
- Category: ui (composer panel + settings section)