### PR TITLE
Add xi-kari/dsh-amphoreus — δ-me13 seat workspaces for DeepSeek Harness

### DIFF
--- a/data/plugins/xi-kari__dsh-amphoreus.yml
+++ b/data/plugins/xi-kari__dsh-amphoreus.yml
@@ -1,0 +1,6 @@
+url: https://github.com/xi-kari/dsh-amphoreus
+name: xi-kari/dsh-amphoreus
+category: skill
+description:
+  en: 'Turns the 13 δ-me13 (Amphoreus) role skill cards into seat workspaces: per-seat theme and wallpaper, first-turn skill injection, chat stickers, per-seat memory notes and presets, Alt+digit seat switching, and an overview canvas for dispatch and handoff; the skill suite itself is read from a configurable local directory and is not bundled.'
+  zh: '把 δ-me13（翁法罗斯）的 13 张黄金裔角色技能卡变成席位工作区：逐席配色与壁纸、首轮自动注入技能卡、对话表情、每席记忆便签与预设、Alt+数字切席，以及用于派发与移交的总览画布；技能套件本身从可配置的本地目录读取，不随插件打包。'


### PR DESCRIPTION
One new entry: `data/plugins/xi-kari__dsh-amphoreus.yml` (category `skill`).

- Repo: https://github.com/xi-kari/dsh-amphoreus (MIT, created 2026-09-05, topic `dsh-plugin`), npm `dsh-amphoreus@0.3.0` (`alpha` tag; prebuilt, no `allowBuilds` step).
- `package.json` declares `dsh.bundle` (`./cordis.patch.yml`) and `dsh.client` (web); `screenshots.json` at the repo root lists four screenshots under `docs/screenshots/`.
- Install: `dsh plugin --profile web add dsh-amphoreus@0.3.0`, then restart `dsh web`.
- The plugin does not bundle the role skill suite or any artwork; it reads the external skill suite from configurable `skillRoots` and user-supplied assets from `assetsRoot`. Description numbers: 13 skill cards / 13 seats — matches `src/shared/heroes.ts` and the live suite.
- CI on the plugin repo (ubuntu + windows) is green at the tagged release commit; tests run against the real skill suite (595 tests).

Category note: primary use is giving a skill suite a seat-based workspace, so `skill`; if `ui` or `workflow` fits the taxonomy better, feel free to re-file.