### PR TITLE
 update dsh-auto-memory description to 2.1.2

### DIFF
--- a/data/plugins/Aik358__dsh-auto-memory.yml
+++ b/data/plugins/Aik358__dsh-auto-memory.yml
@@ -2,5 +2,5 @@ url: https://github.com/Aik358/dsh-auto-memory
 name: Aik358/dsh-auto-memory
 category: memory
 description:
-  en: 'Proactive associative memory for DSH: memories recall themselves without the model ever calling a tool. Host-side middleware watches the conversation, runs dual-track retrieval (NLP keywords + vector similarity), and injects at fixed boundaries — prefix-cache friendly. Three-layer auto-consolidation, a welcome tour with per-feature switches, recall review with full evidence, unattended mode for long batch jobs, AI greetings & daily reflections, calendar reminders, and cross-tool memory inheritance. Backends are user-selectable: built-in JS semantic tier (e5-small, ~130MB, default) or optional Python BGE-M3 int8 sidecar — lexical BM25 always-on as the 0GB floor.'
-  zh: 主动联想记忆插件：记忆不靠模型调用，自己被唤回——Host 观察情境，NLP 关键词 + 向量化双轨检索，固定边界注入不破坏前缀缓存。三层记忆自动沉淀、欢迎向导（每项功能当场开关）、唤起回顾（全证据可打分）、无人值守模式、AI 问候与每日反思、日历提醒、跨工具记忆继承。语义后端可自选：内置 JS 档（e5-small ~130MB，默认）或可选 Python BGE-M3 int8 sidecar，词法 BM25 0GB 永远兜底。
+  en: 'Proactive associative memory for DSH: zero-prompt recall injected at a fixed boundary, three-layer auto-consolidation, skill crystallization, and Astra-style context management - handoff ledgers and a PLAN whiteboard that survive context-window switches, water-level sensing with an auto-detected model window. Local Markdown storage, model-agnostic, zero deps; lexical 0GB floor with optional semantic tiers.'
+  zh: 主动联想记忆 + Astra 式上下文管理：自动唤回（固定边界注入，前缀缓存友好）/自动沉淀/技能固化/交接账本与 PLAN 白板跨窗口续命/水位感知（窗口自动适配当前模型）。本地 Markdown 存储，模型无关，零依赖；词法 0GB 兜底，可选语义档。


### PR DESCRIPTION
Refresh the existing dsh-auto-memory entry for the published 2.1.2 release.

Release: https://github.com/Aik358/dsh-auto-memory/releases/tag/v2.1.2
npm: `@a9i5k4/dsh-auto-memory@2.1.2`

Adds experimental Astra-style context management to the existing proactive-recall feature set: four-part handoff ledgers and a PLAN.md whiteboard that survive context-window switches, water-level sensing with an auto-detected model window (from `settings.yaml` contextWindow), and `memory_recall` scopes (`all`/`handoff`/`sessions`). The handoff feature is off by default (Settings → Automation). Existing capabilities — fixed-boundary proactive recall, three-layer auto-consolidation, skill crystallization, cross-tool memory inheritance, unattended mode — are unchanged.

Maintenance follow-up to the existing `Aik358__dsh-auto-memory.yml` entry. Only that one YAML entry changes; no duplicate entry or unrelated modification. Description matches the npm `description` for 2.1.2.