### PR TITLE
Add DSH Mobile UI

### DIFF
--- a/data/plugins/Canary-Builds__dsh-mobile-ui.yml
+++ b/data/plugins/Canary-Builds__dsh-mobile-ui.yml
@@ -1,0 +1,5 @@
+url: https://github.com/Canary-Builds/dsh-mobile-ui
+name: Canary-Builds/dsh-mobile-ui
+category: ui
+description:
+  en: Adds touch-friendly navigation, layout refinements, and standalone PWA styling to the existing DeepSeek Harness web interface.


### PR DESCRIPTION
Adds DSH Mobile UI under UI enhancements. It improves touch navigation and standalone PWA layouts inside the existing DSH web interface.

- Source and MIT license: https://github.com/Canary-Builds/dsh-mobile-ui
- Install: `dsh plugin --profile web add @canary-builds/dsh-mobile-ui`
- Root `package.json` declares `dsh.bundle`; `cordis.patch.yml` mounts the host/client plugin.
- Published npm release: 1.1.2. Repository has the `dsh-plugin` topic and predates the one-day minimum.
- Targets DSH 0.1.1-rc.x; UI selectors can require updates for later DSH versions.

Only the entry YAML is changed, as requested by the contribution guide.
