### PR TITLE
Add DSH Connect

### DIFF
--- a/data/plugins/Canary-Builds__dhs-connect.yml
+++ b/data/plugins/Canary-Builds__dhs-connect.yml
@@ -1,0 +1,5 @@
+url: https://github.com/Canary-Builds/dhs-connect
+name: Canary-Builds/dhs-connect
+category: model
+description:
+  en: Connects DeepSeek Harness to ChatGPT models through OAuth sign-in using the official Codex app-server, without requiring an OpenAI API key.


### PR DESCRIPTION
Adds DSH Connect under model providers. It uses ChatGPT OAuth sign-in through the installed official Codex app-server, with model discovery, streaming, and a DSH tool-call bridge.

- Repository: https://github.com/Canary-Builds/dhs-connect (the `dhs-connect` repository spelling is intentional).
- Install: `dsh plugin --profile web add @canary-builds/dsh-connect`
- Root `package.json` declares `dsh.bundle`, pointing at the included `cordis.patch.yml`. MIT licensed; published npm release 0.3.3; `dsh-plugin` topic present.
- Requires the official Codex CLI and an eligible ChatGPT account. Prompts and tool results are sent to OpenAI through that authenticated process. Tested with DSH 0.1.1-rc.2; text-only bridge.

**Draft for the repository-age requirement:** the repository was created 2026-09-05 23:52:50 UTC and reaches the required one day on 2026-09-06 23:52:50 UTC. Please hold review until then. No exception to the age requirement is requested.

Only the entry YAML is changed.
