### PR TITLE
Add Foggy Java data-analysis integration

### DIFF
--- a/data/plugins/foggy-projects__foggy-deepseek-harness-plugin.yml
+++ b/data/plugins/foggy-projects__foggy-deepseek-harness-plugin.yml
@@ -1,0 +1,6 @@
+url: https://github.com/foggy-projects/foggy-deepseek-harness-plugin
+name: foggy-projects/foggy-deepseek-harness-plugin
+category: tools
+description:
+  en: Foggy Java data-analysis integration for DeepSeek Harness with a managed Runtime, CLI, Launcher, onboarding Skills, and semantic-layer workflows.
+  zh: 在 DeepSeek Harness 中管理 Foggy Java 数据分析 Runtime、CLI、Launcher 与 onboarding/语义查询 Skill，支持数据库接入和语义层建模。


### PR DESCRIPTION
## Foggy Java data-analysis integration

This PR adds the public Foggy plugin repository to the curated DeepSeek Harness plugin list.

- Repository: https://github.com/foggy-projects/foggy-deepseek-harness-plugin
- Install: `dsh plugin --profile web add --workspace-root @foggy-projects/deepseek-harness-plugin@rc`
- The repository declares a `dsh.bundle` manifest and ships working Runtime/CLI/Launcher/onboarding Skill integration.
- The project is published to npm and its public README documents compatibility, update behavior, diagnostics, and local development scope.

The entry description is intentionally factual and avoids claiming official DeepSeek endorsement.