### PR TITLE
Update dsh-llm-mlx to v0.4.0

### DIFF
--- a/data/plugins/robbywang25__dsh-llm-mlx.yml
+++ b/data/plugins/robbywang25__dsh-llm-mlx.yml
@@ -4,4 +4,4 @@ category: model
 description:
   en: Use local MLX-LM or MLX-VLM models in DeepSeek Harness through a loopback OpenAI-compatible provider, with optional DSH-owned server startup.
   zh: 通过回环 OpenAI-compatible 提供方在 DeepSeek Harness 中使用本机 MLX-LM 或 MLX-VLM 模型，并可选由 DSH 托管模型服务进程。
-tarball: https://github.com/robbywang25/dsh-llm-mlx/releases/download/v0.3.0/dsh-llm-mlx-0.3.0.tgz
+tarball: https://github.com/robbywang25/dsh-llm-mlx/releases/download/v0.4.0/dsh-llm-mlx-0.4.0.tgz


### PR DESCRIPTION
Update the existing `robbywang25/dsh-llm-mlx` entry to the compiled [v0.4.0 release](https://github.com/robbywang25/dsh-llm-mlx/releases/tag/v0.4.0), which adds model-identity checks, bounded proxy waits/SSE buffering, and malformed-request isolation.

Only the tarball URL in the existing YAML changes. The current submission checker passes for exactly this one entry; README generation is in sync and the local site build produces the v0.4.0 installation command in the catalog and both detail-page locales. The release has 69 passing tests and [Node 22/24 CI](https://github.com/robbywang25/dsh-llm-mlx/actions/runs/34009584385).

The independently downloaded tarball is 22,721 bytes with SHA-256 `6576168cc341bf0dd848779f8d1f87b2ff39746e471c3288fe98770025f9240a`; all 10 files match release commit `f61219ece704331e85ff54ad26f6cd317b03dfad`.
