### PR TITLE
Add countossbot/dsh-skill-injector (skill)

### DIFF
--- a/data/plugins/countossbot__dsh-skill-injector.yml
+++ b/data/plugins/countossbot__dsh-skill-injector.yml
@@ -1,0 +1,6 @@
+url: https://github.com/countossbot/dsh-skill-injector
+name: countossbot/dsh-skill-injector
+category: skill
+description:
+  en: 'Auto-injects user-chosen skills into every DSH session, per prompt or once at session start, with a settings page, a composer indicator, and log-deduplicated session-start stamps; verified against DSH 0.1.3 source.'
+  zh: 自动把所选技能注入每个 DSH 会话：每轮提示或仅在会话开始时注入一次，带设置页与输入区指示条；会话开始盖戳按会话日志去重，API 对照 DSH 0.1.3 源码验证。


### PR DESCRIPTION
## Entry

- **Repo**: https://github.com/countossbot/dsh-skill-injector
- **Category**: `skill`
- **File**: `data/plugins/countossbot__dsh-skill-injector.yml` (single new file, no other entries touched)

## What the plugin does

Auto-injects user-chosen skills (`~/.agents/skills/*`) into every DSH session — either as a `systemPrompt.section` re-rendered per request (`each-prompt`), or as one durable `agent.inject()` message stamped at `agent/session-start` (`start-only`), deduplicated against the session log via the official `skill-invocation` message source. Ships a settings page (`settings.section` slot) and a composer indicator line (`conversation.composer.dock` slot).

## Checklist (per contributing.md)

- [x] `dsh.bundle` manifest declared in `package.json` (with `cordis.patch.yml` beside it) — installable via `dsh plugin add`
- [x] Real, working code — host half, browser half, esbuild build, 8 node:test unit tests, all green
- [x] Repo created 2026-09-06T04:14Z (UTC) — **note**: submitted within ~9h of creation; if CI's 1-day bar rejects on age, I will resubmit after the bar passes (per the guide: finishing work and resubmitting is expected, nothing held against it)
- [x] `dsh-plugin` topic added to the repo
- [x] Description states function only, no marketing; every claim matches the code (two injection modes, settings page, composer indicator, log-dedup, DSH 0.1.3 verification)
- [x] Category `skill` matches what the plugin does (skill injection/management)
- [x] GitHub install works: committed `lib/` products + a git-install-safe `prepare` script (builds when devDeps available, falls back to committed products otherwise); verified end-to-end via fresh clone → npm install → prepare → tests

## Relation to existing entries

The list already carries `Zenjibad/skill-injector-plugin` (the upstream blueprint). This fork-relation plugin was rewritten against the running DSH source because the upstream depends on npm `@deepseek-ai/dsh-skill@0.0.1-rc.1` / a renamed `dsh-client-runtime` that no longer match current API. Differences: zero `@deepseek-ai/*` runtime deps in the host half (inlined, byte-identical rendering), settings writes via the official `settingsScope` transport instead of a custom REST PUT route, and per-source-verified API facts. Happy to withdraw if maintainers judge it a duplicate without enough added value.