### PR TITLE
Add YEYEYEYESHIFU/dsh-split-screen (split-screen workspace)

### DIFF
--- a/data/plugins/YEYEYEYESHIFU__dsh-split-screen.yml
+++ b/data/plugins/YEYEYEYESHIFU__dsh-split-screen.yml
@@ -1,0 +1,6 @@
+url: https://github.com/YEYEYEYESHIFU/dsh-split-screen
+name: YEYEYEYESHIFU/dsh-split-screen
+category: ui
+description:
+  en: Split-screen workspace for the DeepSeek Harness web GUI - chat with several agents side by side in panes that look and behave exactly like the stock conversation, with a compact TUI composer mode (Alt+T) and pane-focus shortcuts.
+  zh: DeepSeek Harness 网页端分屏工作区 - 多个会话并排聊天，面板观感与原生对话完全一致，支持 Alt+T 切换紧凑 TUI 输入模式与面板焦点快捷键。


### PR DESCRIPTION
## Add dsh-split-screen

- Repo: https://github.com/YEYEYEYESHIFU/dsh-split-screen
- npm: https://www.npmjs.com/package/dsh-split-screen (v1.0.0, published)
- Category: `ui`

Split-screen workspace for the DeepSeek Harness web GUI - chat with several agents side by side in panes that look and behave exactly like the stock conversation.

### Highlights

- Always-on split workspace - a single pane renders without any chrome, exactly like the stock view
- Drag a conversation from the sidebar onto a pane edge to split; center drop swaps the pane's conversation
- Native look in light & dark - stock styles, theme variables and primitives in every pane
- Fully interactive panes: streaming, Enter/Shift+Enter, /commands, Stop, queued messages, todos
- Image paste & drag-drop attachments
- Compact TUI composer mode (Alt+T) with identical width and button positions
- Built-in shortcuts: Alt+T (composer mode), Alt+Shift+Arrows (pane focus)

Published on npm as [`dsh-split-screen@1.0.0`](https://www.npmjs.com/package/dsh-split-screen).
