### PR TITLE
Add dsh-plugin-execution-graph

### DIFF
--- a/data/plugins/liqiGeGe__dsh-plugin-execution-graph.yml
+++ b/data/plugins/liqiGeGe__dsh-plugin-execution-graph.yml
@@ -1,0 +1,6 @@
+url: https://github.com/liqiGeGe/dsh-plugin-execution-graph
+name: liqiGeGe/dsh-plugin-execution-graph
+category: ui
+description:
+  en: Adds an Execution graph conversation-view tab that renders each turn's prompts, replies, and tool calls/results as a foldable timeline with a detail panel and PNG export.
+  zh: 在会话视图中新增「执行图」标签页，把每个轮次的提问、模型回复与工具调用/结果渲染为可折叠的时间轴，并带详情面板与 PNG 导出。


### PR DESCRIPTION
  Adds the execution-graph conversation-view plugin.

  - `dsh.bundle` + `dsh.client` manifest: installable via `dsh plugin add`
  - Published to npm: `dsh-plugin-execution-graph`
  - Category `ui`: a conversation-view tab rendering per-turn activity as a foldable timeline