### PR TITLE
Add delock/dsh-whats-up

### DIFF
--- a/data/plugins/delock__dsh-whats-up.yml
+++ b/data/plugins/delock__dsh-whats-up.yml
@@ -1,0 +1,6 @@
+url: https://github.com/delock/dsh-whats-up
+name: delock/dsh-whats-up
+category: session
+description:
+  en: What's up - a zero-maintenance status board for your sessions. Scans every conversation on the host, extracts a goal + one-line status per session (multi-provider LLM, fingerprint-cached), surfaces half-done, unanswered and recent work in a sidebar panel, and jumps you back into any session with one click.
+  zh: What's up · 在忙啥——零维护的会话动态看板:host 端扫描全部会话,为每个会话提取「目标 + 一句话现状」(多 provider LLM、按指纹缓存),自动发现做到一半、问了没回、近期在推进的事,点卡片一键跳回会话。


### PR DESCRIPTION
Adds **delock/dsh-whats-up** to the `session` category.

**What it is:** a zero-maintenance status board for your DSH sessions. The host side scans `~/.dsh/sessions` (multi-frame zstd jsonl, incremental by file fingerprint), classifies every conversation by rules (half-done / unanswered / recent / active / automation / done), and extracts a **goal + one-line status** per session via LLM (multi-provider: follows agent-default-model, credentials resolved from env / ~/.dsh/.credentials.yaml, endpoints from the pi-ai registry — nothing hardcoded). Sidebar widget + fullscreen panel; click any card to jump straight back into that session. Archived sessions are respected (registry-based), marked-done cards sink, and board-born sessions taken over by a human are reclassified.

- Installs with `dsh plugin --profile web add` via a `link:`/`file:` dependency (dsh.bundle manifest declared) ✅
- Repo is 1+ day old, 33 commits, actively maintained ✅
- Single entry file only (`data/plugins/delock__dsh-whats-up.yml`); READMEs untouched ✅
- No secrets in history (audited), no external runtime deps ✅