### PR TITLE
Add KhaosGx/dsh-stop-service — service control panel for DSH Web settings

### DIFF
--- a/data/plugins/KhaosGx__dsh-stop-service.yml
+++ b/data/plugins/KhaosGx__dsh-stop-service.yml
@@ -1,0 +1,6 @@
+url: https://github.com/KhaosGx/dsh-stop-service
+name: KhaosGx/dsh-stop-service
+category: dev
+description:
+  en: 'Service control panel in DSH Web settings: live host info (PID, versions, uptime, memory/CPU trends, active sessions), npm update banner, and a confirm-guarded graceful stop that warns when tasks are running and can wait for them to finish.'
+  zh: 'DSH Web 设置页的服务控制面板：实时宿主信息（PID、版本、运行时长、内存/CPU 趋势、活跃会话）、npm 更新提醒，以及带确认的优雅停止——任务运行时发出警告，也可等待任务结束后自动停止。'


### PR DESCRIPTION
Adds one entry file: `data/plugins/KhaosGx__dsh-stop-service.yml`.

- **What it does**: a Service section in DSH Web settings with live host info (PID, host/Node/plugin versions, uptime, memory/CPU sparklines, active sessions incl. running-task count), an npm dist-tags update banner (browser-side), and a confirm-guarded graceful stop — the confirmation escalates when sessions have tasks running, and a drain-then-stop action waits for running tasks to finish before stopping.
- **Installable**: `package.json` declares `dsh.bundle.patch` with a root `cordis.patch.yml`; published on npm as `dsh-stop-service` (latest 0.6.0), so `dsh plugin --profile web add dsh-stop-service` installs prebuilt.
- **Repo**: created 2026-09-04, real code, actively maintained, `dsh-plugin` topic set.
- Every claim in the description maps to a route or component in the source (`/api/dsh-stop-service/info` carries the session/running figures; the drain button renders from `runningSessions`).