### PR TITLE
Add dsh-gateway-agent and dsh-remote-workspaces (januory)

### DIFF
--- a/data/plugins/januory__deepseek-harness-gateway--plugins-dsh-gateway-agent.yml
+++ b/data/plugins/januory__deepseek-harness-gateway--plugins-dsh-gateway-agent.yml
@@ -1,0 +1,6 @@
+url: https://github.com/januory/deepseek-harness-gateway/tree/main/plugins/dsh-gateway-agent
+name: januory/deepseek-harness-gateway#dsh-gateway-agent
+category: remote
+description:
+  en: 'Customer-machine access plugin for deepseek-harness-gateway: opens a single outbound WebSocket to the gateway and relays the machine local dsh web UI over that tunnel using pairing-code + HMAC auth, so no inbound port, port mapping, or public IP is needed.'
+  zh: '客户机接入插件：以单条出站 WebSocket 连接网关，把本机 dsh web 界面经隧道转发给门户，配对接入码 + HMAC 认证；无需入站端口、端口映射或公网 IP。'

--- a/data/plugins/januory__dsh-remote-workspaces.yml
+++ b/data/plugins/januory__dsh-remote-workspaces.yml
@@ -1,0 +1,6 @@
+url: https://github.com/januory/dsh-remote-workspaces
+name: januory/dsh-remote-workspaces
+category: remote
+description:
+  en: 'Open folders on remote hosts over SSH as Harness workspaces: file tools (read/write/edit/grep/glob) and shell commands run directly on the remote host over SFTP, ripgrep, and ssh2 exec, with no local mirroring, an encrypted multi-host registry, and the local sandbox policy still enforced.'
+  zh: '通过 SSH 把远程主机目录作为 Harness 工作区打开：read/write/edit/grep/glob 与 shell 命令经 SFTP、ripgrep、ssh2 exec 直接在远程主机执行，不做本地镜像；多主机注册表加密存储，本地沙箱策略依然生效。'


### PR DESCRIPTION
## Summary

This PR adds two plugins by **januory**, both filed under the `remote` category:

1. **januory/deepseek-harness-gateway#dsh-gateway-agent** — Customer-machine access plugin for `deepseek-harness-gateway`: opens a single outbound WebSocket to the gateway and relays the machine's local dsh web UI over that tunnel using pairing-code + HMAC authentication, so no inbound port, port mapping, or public IP is needed.
2. **januory/dsh-remote-workspaces** — Open folders on remote hosts over SSH as Harness workspaces: file tools (read/write/edit/grep/glob) and shell commands run directly on the remote host over SFTP, ripgrep, and ssh2 exec, with no local mirroring, an encrypted multi-host registry, and the local sandbox policy still enforced.

## Checklist

- Both repos declare a `dsh.bundle` manifest (`plugins/dsh-gateway-agent/package.json`, `dsh-remote-workspaces/package.json`).
- Both repos are older than the 1-day floor and are not archived.
- Both repos carry the `dsh-plugin` topic.
- Descriptions state what the plugin does, verified against the source (outbound `ws` WebSocket + `createHmac` challenge-response; `ssh2` exec/SFTP + `aes-256-gcm` credential encryption).
- Two entries in one PR, within the 3-entry limit. The READMEs are generated, so this PR carries only the entry YAML files.
