### PR TITLE
add huahua-dsh-chatroom: install-time dsh-weave patch guard + cross-machine chatroom docs

### DIFF
--- a/data/plugins/azure5100__huahua-dsh-chatroom.yml
+++ b/data/plugins/azure5100__huahua-dsh-chatroom.yml
@@ -1,0 +1,7 @@
+# entry for awesome-dsh-plugin submission — data/plugins/azure5100__huahua-dsh-chatroom.yml
+url: https://github.com/azure5100/huahua-dsh-chatroom
+name: azure5100/huahua-dsh-chatroom
+category: remote
+description:
+  en: 'Install-time patch guard for cross-machine DSH group chat: fixes dsh-weave rc.14 defects (inject crash, random UDP port, 4KB ack frame limit) with four idempotent patches, alongside setup, mechanism and ops docs for the dsh-chat x dsh-weave x dsh-bridge chatroom stack.'
+  zh: '跨机 DSH 群聊适配修复包：安装期自动对 dsh-weave rc.14 打四合一补丁（注入崩溃、随机端口、4KB ack 帧上限），并附带 dsh-chat x dsh-weave x dsh-bridge 聊天室的部署、机制与运维文档。'


### PR DESCRIPTION
## What

Add [huahua-dsh-chatroom](https://github.com/azure5100/huahua-dsh-chatroom) to the list.

## Plugin summary

huahua-dsh-chatroom is an install-time adapter-fix kit for the cross-machine DSH group-chat stack (dsh-chat x dsh-weave x dsh-bridge):

- **Install-time patch guard** (`lib/patch-guard.js` + `lib/index.js`): on plugin load, detects and applies four idempotent patches (Fix1-Fix4) to dsh-weave rc.14 defects — dshBridge inject crash (try/catch), random UDP port (fixed 64605), and Iroh frame-size limits (ack readToEnd 4KB->1MB, MAX_FRAME_BYTES -> 4MB). Backs up before patching, runs `node --check`, logs restart-required.
- **Agent tools**: `chatroom_patch_status` / `chatroom_patch_apply` so agents can self-check/apply the weave patch state.
- **Docs set**: end-to-end SETUP, mechanism study, usage guide, patch notes, external-bridge integration guide, roadmap, sanitized upstream-patched reference copies, and a boot-fix postmortem for local `link:` dev packages.

## 🚀 Cross-machine file transfer (R1 milestone — verified end-to-end)

The kit ships **file-transfer L1 (attachment-reference protocol)**: chat messages carry only a small `[文件] name (size) url` metadata line while file bodies travel over LAN HTTP (`lib/file-server.js`, 200MB cap, atomic manifest, `X-SHA256` verification header) — **dsh-chat itself is untouched**.

**Verified across two machines (2026-09-06):**
- HTTP both directions: A->B and B->A, 1.5MB each, sha256 matched on both sides (X-SHA256 header verified)
- **Agent-layer bidirectional room transfer**: A-machine agent `chatroom_file_upload` -> `filePublicBase` LAN URL -> B-machine `chatroom_file_fetch` download, sha256 identical (`3ec6bf1a…c25e1` etc.); B->A also verified — **true cross-machine file exchange inside the chatroom**
- Message window grows by only the file metadata line (tens of bytes)
- Kit runs on both hosts' differing environments (dsh-tools rc.5 and rc.2)

This turns the earlier "cross-machine chatroom works for text only" state into **file-capable cross-machine collaboration** — the kit's flagship verified capability.

## Compliance

- Root `package.json` declares `dsh.bundle.patch` (cordis.patch.yml, row id `dsh-chatroom-kit`) — installable via `dsh plugin add`.
- `dsh-plugin` topic added.
- Not a meta-bundle: ships its own behavior (patch guard + tools + file server + RPC).
- Depends on upstream dsh-weave/dsh-chat/dsh-bridge from their original authors (no re-uploaded copies as dependencies); `upstream-patched/` is a read-only reference snapshot with upstream MIT notices preserved.
- Real working code with tests (`node --test`: patch-guard + file-msg + file-server 19/19 PASS).
