### PR TITLE
add wangtie-os entry

### DIFF
--- a/data/plugins/wangtie-010101__wangtie-os.yml
+++ b/data/plugins/wangtie-010101__wangtie-os.yml
@@ -1,0 +1,6 @@
+url: https://github.com/wangtie-010101/wangtie-os
+name: wangtie-010101/wangtie-os
+category: dev
+description:
+  en: "Fullscreen business-app framework for DeepSeek Harness Web with a dark-sidebar workbench bundling a database connectivity tester and SQL query panel, a two-level knowledge base (bill and accounting) with local search and Word document ingestion, metadata environment comparison with alter-SQL generation, a data dictionary, agent log-search report demos, a system test-case runner, Evernote-style notes, developer utilities, and mini-games."
+  zh: "构建在 DeepSeek Harness Web 之上的全屏业务应用框架：深色侧边栏工作台，集成数据库连通测试与 SQL 查询、票据/会计二级知识库（本地检索与 Word 文档投喂）、元数据环境比对与变更 SQL 生成、数据字典、Agent 日志检索报告演示、系统测试用例执行、印象笔记风格记事本、常用开发工具与小游戏。"


### PR DESCRIPTION
## What

Add one entry for my plugin **wangtie-os** — a fullscreen business-app framework for DeepSeek Harness Web.

- Entry file: `data/plugins/wangtie-010101__wangtie-os.yml` (one file, the whole submission)
- Repo: https://github.com/wangtie-010101/wangtie-os
- The repo's `package.json` declares `dsh.bundle` with `cordis.patch.yml` and ships built output in `lib/` and `client/`, so it installs via `dsh plugin --profile web add https://github.com/wangtie-010101/wangtie-os`.
- Repo topic `dsh-plugin` is set.

> Note: the repo was created just now, so the automated 1-day repo-age check will report red until <created_at + 1 day>. Per the contributing guide I'll re-trigger CI once the bar clears; no new PR needed.

## Checklist

- [x] One file at `data/plugins/wangtie-010101__wangtie-os.yml`
- [x] `package.json` declares `dsh.bundle` (not only `dsh.client`)
- [ ] Repo at least 1 day old (currently under the bar; will pass automatically)
- [x] `category` is a valid value (`dev`)
- [x] Description states what the plugin does, no superlatives
- [x] Repo has the `dsh-plugin` topic
