### PR TITLE
Add meyaomiao/dsh-graphmemory

### DIFF
--- a/data/plugins/meyaomiao__dsh-graphmemory.yml
+++ b/data/plugins/meyaomiao__dsh-graphmemory.yml
@@ -1,0 +1,6 @@
+url: https://github.com/meyaomiao/dsh-graphmemory
+name: meyaomiao/dsh-graphmemory
+category: memory
+description:
+  en: 'DSH knowledge-graph memory with a better-sidebar tab and a standalone /graph-memory/app dashboard: extracts TASK/SKILL/EVENT nodes, recalls across sessions, and ships as the npm package dsh-graphmemory.'
+  zh: 'DSH 知识图谱记忆：better-sidebar「记忆图谱」页签与独立看板 /graph-memory/app；抽取任务/技能/事件节点并跨会话召回，npm 包名为 dsh-graphmemory。'


### PR DESCRIPTION
Add [meyaomiao/dsh-graphmemory](https://github.com/meyaomiao/dsh-graphmemory) under **memory**.

This is a maintained DSH fork of [adoresever/graph-memory](https://github.com/adoresever/graph-memory) (already listed). It adds a better-sidebar tab, a standalone dashboard at `/graph-memory/app`, extraction-queue overview, and publishes as npm \`dsh-graphmemory\` (0.1.0).

## Checklist vs contributing.md

- One file only: \`data/plugins/meyaomiao__dsh-graphmemory.yml\` (READMEs not edited)
- \`dsh.bundle.patch\` present in root \`package.json\` + \`cordis.patch.yml\`
- Repo older than 1 day (created 2026-09-04)
- Topic \`dsh-plugin\` set
- npm \`dsh-graphmemory@0.1.0\`; \`repository\` points at this GitHub repo
- \`screenshots.json\` in the plugin repo (\`screenshots/01-overview.png\`, \`02-graph.png\`)
- Description states what it does; no superlatives
- Category: \`memory\` (same family as the upstream entry; this fork adds the DSH dashboard)

Not a meta-package. Working code, not a placeholder.