### PR TITLE
feat: add sduwall/dsh-wall-mcp-manager plugin

### DIFF
--- a/data/plugins/sduwall__dsh-wall-mcp-manager.yml
+++ b/data/plugins/sduwall__dsh-wall-mcp-manager.yml
@@ -1,0 +1,6 @@
+url: https://github.com/sduwall/dsh-wall-mcp-manager
+name: sduwall/dsh-wall-mcp-manager
+category: Tools & Capabilities
+description:
+  en: A plugin for managing MCP servers in DeepSeek Harness.
+  zh: 在DeepSeek Harness内管理MCP服务的插件。

--- a/data/plugins/sduwall__dsh-wall-mcp-manager.yml
+++ b/data/plugins/sduwall__dsh-wall-mcp-manager.yml
@@ -1,6 +1,6 @@
 url: https://github.com/sduwall/dsh-wall-mcp-manager
 name: sduwall/dsh-wall-mcp-manager
-category: Tools & Capabilities
+category: tools
 description:
   en: A plugin for managing MCP servers in DeepSeek Harness.
   zh: 在DeepSeek Harness内管理MCP服务的插件。


### PR DESCRIPTION
## 新增插件
仓库地址：https://github.com/sduwall/dsh-wall-mcp-manager
功能：MCP服务管理插件
> 本插件不发布npm包，使用github方式安装
自检清单：
- ✅ 仓库已添加dsh-plugin topic
- ✅ cordis.patch.yml配置dsh.bundle
- ✅ lib预构建产物提交到仓库
- ✅ dsh plugin add github:sduwall/dsh-wall-mcp-manager 本地可正常安装
