### PR TITLE
add wjingshan/dsh-cost-gauge (usage)

### DIFF
--- a/data/plugins/wjingshan__dsh-cost-gauge.yml
+++ b/data/plugins/wjingshan__dsh-cost-gauge.yml
@@ -1,0 +1,6 @@
+url: https://github.com/wjingshan/dsh-cost-gauge
+name: wjingshan/dsh-cost-gauge
+category: usage
+description:
+  en: 'Floating cost dial for the DSH web GUI: a 24-hour rate dial with a model-colored needle, a balance ring with an alarm threshold, drag-to-resize, and a minimized status-lamp mode.'
+  zh: 'DSH Web 浮动花费表盘：24 小时费率弧 + 按模型着色的指针、带报警阈值的余额环，支持拖拽缩放与最小化状态灯模式。'


### PR DESCRIPTION
Adds **wjingshan/dsh-cost-gauge** to the `usage` category — a floating cost dial for the DSH web GUI.

What it does (verified against the code):
- 24-hour rate dial: a semicircular arc showing today's rate schedule (green = standard / yellow = peak 09:00–12:00 & 14:00–18:00 Beijing time; the whole arc is green on weekends), with a needle that tracks Beijing time (left end 06:00 → top 12:00 → right end 18:00, then wraps back to the left).
- Inner balance ring: blue-gradient fill for the remaining balance (full scale = highest balance seen), a white tick at the alarm threshold, turning red below the threshold.
- Needle colored by the current session's model tier; drag-to-resize (180–340 px); minimized status-lamp mode with countdown ring, cost/balance and a model badge; the lamps flash while the agent is running.

Compliance:
- `package.json` declares `dsh.bundle` (+ `dsh.client`) with a `cordis.patch.yml`.
- `dsh-plugin` topic added; repo older than 1 day and actively maintained.
- `screenshots.json` declares the two UI screenshots (expanded / minimized).