### PR TITLE
Add weibaohui/dsh-tasks

### DIFF
--- a/data/plugins/weibaohui__dsh-tasks.yml
+++ b/data/plugins/weibaohui__dsh-tasks.yml
@@ -1,0 +1,6 @@
+url: https://github.com/weibaohui/dsh-tasks
+name: weibaohui/dsh-tasks
+category: workflow
+description:
+  en: "Scheduled tasks: run a prompt on cron schedules, each run opens a new agent session to do the work, with workspace binding, manual run, session auto-naming, and a fullscreen task management page."
+  zh: 定时任务：用 cron 表达式定时执行提示词，到点自动开一个新 agent 会话替你干活，支持绑定工作区、手动立即执行与会话自动命名。


### PR DESCRIPTION
Adds **weibaohui/dsh-tasks** — scheduled prompt execution on cron.

Scheduled tasks: run a prompt on cron schedules, each run opens a new agent session to do the work, with workspace binding, manual run, session auto-naming, and a fullscreen task management page.

- 📦 npm: [@weibaohui/dsh-tasks](https://www.npmjs.com/package/@weibaohui/dsh-tasks) (v0.4.2) → `dsh plugin --profile web add @weibaohui/dsh-tasks`
- ✅ `package.json` declares `dsh.bundle` (+ `cordis.patch.yml`), web client included
- ✅ Repo has the `dsh-plugin` topic (plus `dsh`, `deepseek-harness`)
- 🖼️ Demo GIF: https://github.com/weibaohui/dsh-tasks/blob/main/docs/demo.gif

Checklist / 自查:

- [x] I added **one file** at `data/plugins/weibaohui__dsh-tasks.yml` — that single file is the whole submission. The READMEs are regenerated on `main` after merge: don't edit them by hand, and you don't need to commit them either / 我新增了一个 `data/plugins/weibaohui__dsh-tasks.yml` 文件——**这一个文件就是全部投稿**
- [x] My repo's `package.json` declares **`dsh.bundle`** (not just `dsh.client`) — [example](../blob/main/contributing.md) / 仓库 `package.json` 已声明 `dsh.bundle`
- [x] My repo is at least **1 day old** / 仓库创建满 1 天
- [x] `category` is one of the valid values ([full list](../blob/main/contributing.md)) — using `workflow`
- [x] Description states what the plugin does, no superlatives / 描述只说功能，不带营销词
- [x] My repo has the `dsh-plugin` topic / 仓库已打 `dsh-plugin` topic

**Recommended (not required) / 推荐但不强制：**

- [x] 📦 Published to npm — prebuilt installs skip the `allowBuilds` approval / 已发布 npm 包
- [ ] 🔗 Official `@deepseek-ai/*` packages as `peerDependencies` — not applicable, no official runtime deps
- [ ] 🖼️ `screenshots.json` in our own repository — planned follow-up
