### PR TITLE
Add weibaohui/user-management

### DIFF
--- a/data/plugins/weibaohui__user-management.yml
+++ b/data/plugins/weibaohui__user-management.yml
@@ -1,0 +1,6 @@
+url: https://github.com/weibaohui/user-management
+name: weibaohui/user-management
+category: security
+description:
+  en: "Login gate for the dsh web UI: unauthenticated visitors get a login/register page and the first registrant becomes admin; includes user and role management plus login and access audit logs."
+  zh: 用户管理：给 dsh web 加登录门禁，未登录访问弹登录/注册页，首个注册者自动成为管理员；管理员可管理用户/角色，带登录与访问审计。


### PR DESCRIPTION
Adds **weibaohui/user-management** — a login gate for the dsh web UI.

Login gate for the dsh web UI: unauthenticated visitors get a login/register page and the first registrant becomes admin; includes user and role management plus login and access audit logs.

- 📦 npm: [@weibaohui/user-management](https://www.npmjs.com/package/@weibaohui/user-management) (v0.6.1) → `dsh plugin --profile web add @weibaohui/user-management`
- ✅ `package.json` declares `dsh.bundle` (+ `cordis.patch.yml`), web client included
- ✅ Repo has the `dsh-plugin` topic (plus `dsh`, `deepseek-harness`)
- 🖼️ Demo GIF: https://github.com/weibaohui/user-management/blob/main/docs/demo.gif

Checklist / 自查:

- [x] I added **one file** at `data/plugins/weibaohui__user-management.yml` — that single file is the whole submission. The READMEs are regenerated on `main` after merge: don't edit them by hand, and you don't need to commit them either / 我新增了一个 `data/plugins/weibaohui__user-management.yml` 文件——**这一个文件就是全部投稿**
- [x] My repo's `package.json` declares **`dsh.bundle`** (not just `dsh.client`) — [example](../blob/main/contributing.md) / 仓库 `package.json` 已声明 `dsh.bundle`
- [x] My repo is at least **1 day old** / 仓库创建满 1 天
- [x] `category` is one of the valid values ([full list](../blob/main/contributing.md)) — using `security`
- [x] Description states what the plugin does, no superlatives / 描述只说功能，不带营销词
- [x] My repo has the `dsh-plugin` topic / 仓库已打 `dsh-plugin` topic

**Recommended (not required) / 推荐但不强制：**

- [x] 📦 Published to npm — prebuilt installs skip the `allowBuilds` approval / 已发布 npm 包
- [ ] 🔗 Official `@deepseek-ai/*` packages as `peerDependencies` — not applicable, no official runtime deps
- [ ] 🖼️ `screenshots.json` in our own repository — planned follow-up
