### PR TITLE
Add weibaohui/context-razor

### DIFF
--- a/data/plugins/weibaohui__context-razor.yml
+++ b/data/plugins/weibaohui__context-razor.yml
@@ -1,0 +1,6 @@
+url: https://github.com/weibaohui/context-razor
+name: weibaohui/context-razor
+category: memory
+description:
+  en: "Context trimmer: lists the current session's context entries with role, preview and ≈token estimate (cl100k), highlights over-threshold items, and removes selected entries exactly without LLM summarization."
+  zh: 上下文剃刀：把当前会话上下文逐条列出（角色/预览/≈token 估算），超阈值标红，勾选后不经 LLM 精确裁剪，删了什么一目了然。


### PR DESCRIPTION
Adds **weibaohui/context-razor** — surgical context trimming for the current session.

Context trimmer: lists the current session's context entries with role, preview and ≈token estimate (cl100k), highlights over-threshold items, and removes selected entries exactly without LLM summarization.

- 📦 npm: [@weibaohui/context-razor](https://www.npmjs.com/package/@weibaohui/context-razor) (v0.4.2) → `dsh plugin --profile web add @weibaohui/context-razor`
- ✅ `package.json` declares `dsh.bundle` (+ `cordis.patch.yml`), web client included
- ✅ Repo has the `dsh-plugin` topic (plus `dsh`, `deepseek-harness`)
- 🖼️ Demo GIF: https://github.com/weibaohui/context-razor/blob/main/docs/demo.gif

Checklist / 自查:

- [x] I added **one file** at `data/plugins/weibaohui__context-razor.yml` — that single file is the whole submission. The READMEs are regenerated on `main` after merge: don't edit them by hand, and you don't need to commit them either / 我新增了一个 `data/plugins/weibaohui__context-razor.yml` 文件——**这一个文件就是全部投稿**
- [x] My repo's `package.json` declares **`dsh.bundle`** (not just `dsh.client`) — [example](../blob/main/contributing.md) / 仓库 `package.json` 已声明 `dsh.bundle`
- [x] My repo is at least **1 day old** / 仓库创建满 1 天
- [x] `category` is one of the valid values ([full list](../blob/main/contributing.md)) — using `memory`
- [x] Description states what the plugin does, no superlatives / 描述只说功能，不带营销词
- [x] My repo has the `dsh-plugin` topic / 仓库已打 `dsh-plugin` topic

**Recommended (not required) / 推荐但不强制：**

- [x] 📦 Published to npm — prebuilt installs skip the `allowBuilds` approval / 已发布 npm 包
- [ ] 🔗 Official `@deepseek-ai/*` packages as `peerDependencies` — not applicable, no official runtime deps
- [ ] 🖼️ `screenshots.json` in our own repository — planned follow-up
