### PR TITLE
Add andyfan1094/dsh-devforge

### DIFF
--- a/data/plugins/andyfan1094__dsh-devforge.yml
+++ b/data/plugins/andyfan1094__dsh-devforge.yml
@@ -1,0 +1,6 @@
+url: https://github.com/andyfan1094/dsh-devforge
+name: andyfan1094/dsh-devforge
+category: dev
+description:
+  en: Spec-driven service forge and integrated operations workspace for DeepSeek Harness.
+  zh: 面向 DeepSeek Harness 的规范驱动服务工厂与本机智能体工作台。


### PR DESCRIPTION
Adds the dsh-devforge plugin to the curated registry. The repository is public, declares dsh.bundle in package.json, includes a working Cordis patch, and has dsh-plugin topic. The plugin provides a spec-driven service forge and integrated operations workspace for DeepSeek Harness. The repository also declares screenshots.json with curated GitHub-hosted screenshots.