### PR TITLE
Add roclee2692/dsh-model-groups

### DIFF
--- a/data/plugins/roclee2692__dsh-model-groups.yml
+++ b/data/plugins/roclee2692__dsh-model-groups.yml
@@ -1,0 +1,6 @@
+url: https://github.com/roclee2692/dsh-model-groups
+name: roclee2692/dsh-model-groups
+category: model
+description:
+  en: 'Grouped provider and manufacturer model selector for DeepSeek Harness, preserving provider/model routes and reasoning levels.'
+  zh: 'DeepSeek Harness 的平台与厂家折叠模型选择器，保留 provider/model 路由与思考等级。'


### PR DESCRIPTION
Adds the model selector plugin `roclee2692/dsh-model-groups` to the Model Providers category.

The selector groups models first by API provider and then by model manufacturer, while keeping the original provider/model route and the reasoning options exposed by each model.

Validation: MIT license; installable `dsh.bundle` manifest and patch; repository older than one day; `dsh-plugin` topic present; both included tests pass. The public source was checked for credentials and personal runtime configuration before submission. This PR adds only the listing YAML.
