### PR TITLE
data: add l2685209197/dsh-pdf-translate

### DIFF
--- a/data/plugins/l2685209197__dsh-pdf-translate.yml
+++ b/data/plugins/l2685209197__dsh-pdf-translate.yml
@@ -1,0 +1,6 @@
+url: https://github.com/l2685209197/dsh-pdf-translate
+name: l2685209197/dsh-pdf-translate
+category: tools
+description:
+  en: "Translate text-based PDFs via DeepSeek or OpenAI-compatible APIs while preserving layout, fonts, images and links, with editable output."
+  zh: "用 DeepSeek 或兼容 API 翻译文本型 PDF，保留版式、字体、图片与链接，输出可编辑 PDF。"


### PR DESCRIPTION
## Summary

Adds [`l2685209197/dsh-pdf-translate`](https://github.com/l2685209197/dsh-pdf-translate) to the DeepSeek Harness plugin list.

## What it does

DSH plugin that translates text-based PDFs via DeepSeek or any OpenAI-compatible API. It performs paragraph-level translation and rebuilds an editable PDF with original layout, fonts, images and links preserved (original text is removed, not covered). Pages are processed in configurable ranges (≤50 per task), with resume-friendly translation caching, termbase support, a bilingual zh/en settings card, and a Python (PyMuPDF) worker.

## Verification

- Manifest: `package.json` declares `dsh.bundle.patch: cordis.patch.yml` (committed in the same repo).
- The npm package `dsh-pdf-translate@0.1.0` is published.
- Tests run by the author: `python -m pytest worker/tests -q` (41 passed) and `pnpm exec vitest run` (73 passed) and `pnpm exec tsc -p tsconfig.json --noEmit` (exit 0).
