### PR TITLE
Add Nicercz007-cloud/schedule

### DIFF
--- a/data/plugins/Nicercz007-cloud__schedule.yml
+++ b/data/plugins/Nicercz007-cloud__schedule.yml
@@ -1,0 +1,6 @@
+url: https://github.com/Nicercz007-cloud/schedule
+name: Nicercz007-cloud/schedule
+category: ui
+description:
+  en: Three draggable, resizable, auto-positioning floating desktop widgets for DSH Desktop — daily schedule, goals tracker, and calendar planner.
+  zh: DSH Desktop 的三个可拖动、可缩放、自动记忆位置的悬浮桌面小组件：每日时间安排、目标设置与日期规划。

--- a/data/plugins/Nicercz007-cloud__schedule.yml
+++ b/data/plugins/Nicercz007-cloud__schedule.yml
@@ -1,4 +1,5 @@
 url: https://github.com/Nicercz007-cloud/schedule
+tarball: https://github.com/Nicercz007-cloud/schedule/releases/download/v0.16.6/schedule.tgz
 name: Nicercz007-cloud/schedule
 category: ui
 description:

--- a/data/plugins/Nicercz007-cloud__schedule.yml
+++ b/data/plugins/Nicercz007-cloud__schedule.yml
@@ -1,5 +1,5 @@
 url: https://github.com/Nicercz007-cloud/schedule
-tarball: https://github.com/Nicercz007-cloud/schedule/releases/download/v0.16.6/schedule.tgz
+tarball: https://github.com/Nicercz007-cloud/schedule/releases/download/v0.16.7/schedule.tgz
 name: Nicercz007-cloud/schedule
 category: ui
 description:


### PR DESCRIPTION
Add the `schedule` desktop-widgets plugin for DSH Desktop: three draggable, resizable, auto-positioning floating widgets (daily schedule, goals tracker, calendar planner). Declares a `dsh.bundle` manifest; repo carries the `dsh-plugin` topic.