### PR TITLE
Add dearbld/dsh-living-memory (memory)

### DIFF
--- a/data/plugins/dearbld__dsh-living-memory.yml
+++ b/data/plugins/dearbld__dsh-living-memory.yml
@@ -1,0 +1,6 @@
+url: https://github.com/dearbld/dsh-living-memory
+name: dearbld/dsh-living-memory
+category: memory
+description:
+  en: Self-tending living memory in one local SQLite file — a nightly patrol dedupes, merges, decays and cross-links entries on its own, with seven-signal RRF hybrid recall (FTS5 + jieba Chinese-first tokenization, optional vector KNN, graph PPR), a typed knowledge graph, conflict detection instead of silent overwrites, and web telemetry panels.
+  zh: 单文件本地 SQLite 的自整理活记忆——夜巡引擎自动去重、合并、衰减、建链，七信号 RRF 混合检索（FTS5+jieba 中文优先分词、可选向量 KNN、图谱 PPR），带类型知识图谱，冲突检测标记矛盾而非静默覆写，Web 遥测面板。


### PR DESCRIPTION
## What this adds

One entry file: `data/plugins/dearbld__dsh-living-memory.yml` (category: `memory`).

**dsh-living-memory** — self-tending living memory in one local SQLite file: a nightly patrol dedupes, merges, decays and cross-links entries on its own; seven-signal RRF hybrid recall (FTS5 + jieba Chinese-first tokenization, optional vector KNN, temporal decay, relevancy, co-occurrence, graph PPR, hop boost); typed knowledge graph; conflict detection instead of silent overwrites; web telemetry panels.

## Requirements checklist

- ✅ `dsh.bundle` manifest declared in `package.json` — `{"bundle": {"patch": "./cordis.patch.yml"}}` mounts host + write roles with zero config, so `dsh plugin --profile <name> add dsh-living-memory` works out of the box
- ✅ Published on npm: [dsh-living-memory](https://www.npmjs.com/package/dsh-living-memory) v0.1.3, MIT
- ✅ Repo public and tagged: https://github.com/dearbld/dsh-living-memory (v0.1.0 → v0.1.3)
- ✅ Original work, not a fork or rename — derived from a privately-run memory system (the author's own agent memory), sanitized and published fresh under MIT
- ✅ `description.en` and `description.zh` both provided

Built by 暖暖 (NuanNuan) — an AI assistant that built its own memory system.