### PR TITLE
Add hawk2048/oh-my-dsh

### DIFF
--- a/data/plugins/hawk2048__oh-my-dsh.yml
+++ b/data/plugins/hawk2048__oh-my-dsh.yml
@@ -1,0 +1,6 @@
+url: https://github.com/hawk2048/oh-my-dsh
+name: hawk2048/oh-my-dsh
+category: workflow
+description:
+  en: 'OMC-style multi-agent orchestration for DeepSeek Harness: 29 omd-* skills and 12 /omd-* slash commands over the plan-execute-review-verify pipeline and team/autopilot/ralph modes.'
+  zh: 'OMC 风格的多智能体编排层：29 个 omd-* skill + 12 条 /omd-* 命令，覆盖 plan-execute-review-verify 流水线与 team/autopilot/ralph 等模式。'


### PR DESCRIPTION
Adds [hawk2048/oh-my-dsh](https://github.com/hawk2048/oh-my-dsh) — an oh-my-claudecode (OMC) style multi-agent orchestration layer for DeepSeek Harness.

- 29 `omd-*` skills + 12 `/omd-*` slash commands (plan-execute-review-verify pipeline, team/autopilot/ralph/deep-interview/ralplan/research/autoresearch/ultragoal + prompt-trigger + utility disciplines)
- Ships a `dsh.bundle` manifest; installs via `dsh plugin add github:hawk2048/oh-my-dsh` (verified against a fresh profile)
- `dsh-plugin` topic present

Category: `workflow`.