### PR TITLE
Add HaoyueQin/dsh-git-review to git

### DIFF
--- a/data/plugins/HaoyueQin__dsh-git-review.yml
+++ b/data/plugins/HaoyueQin__dsh-git-review.yml
@@ -1,0 +1,6 @@
+url: https://github.com/HaoyueQin/dsh-git-review
+name: HaoyueQin/dsh-git-review
+category: git
+description:
+  en: 'Review tab for DeepSeek Harness sessions: workspace changes versus HEAD or any two refs as a filterable file tree with side-by-side diffs, a lane commit graph with blame and file history, three-scope search, line comments back to the composer, and guarded stage/commit/branch/tag/stash/conflict operations.'
+  zh: 'DeepSeek Harness 会话审查标签页：工作区相对 HEAD 或任意两 ref 的变更，以可过滤文件树加双列差异呈现；泳道提交图带逐行追溯与单文件历史；三范围搜索；行内评论回写对话输入框；暂存、提交、分支、标签、贮藏与冲突操作全部设防。'


### PR DESCRIPTION
Review tab plus fenced git workbench for DeepSeek Harness sessions (v0.1.0 published on npm and GitHub Releases). Requirement checklist: dsh.bundle manifest + cordis.patch.yml at repo root, real working code, repo created 2026-09-05 (>1 day), dsh-plugin topic set, screenshots declared in the plugin repo (screenshots.json, 2 images), yml-only submission (READMEs regenerate on main). Differentiation from nearby entries: yangzhe1991/dsh-code-review renders single conversation diffs on a standalone page, while this reviews the whole workspace as a session tab with any-two-ref compare; Wongzexu/dsh-git-status is a status/branch drawer, while this adds three-scope search, the review-to-composer comment loop, Viewed markers, file previews, stash and conflict flows in the same tab.