### PR TITLE
Add dsh-browser-ops: real-browser automation + record/replay flows for test data

### DIFF
--- a/data/plugins/lirui1024k__dsh-browser-ops.yml
+++ b/data/plugins/lirui1024k__dsh-browser-ops.yml
@@ -1,0 +1,6 @@
+url: https://github.com/lirui1024k/dsh-browser-ops
+name: lirui1024k/dsh-browser-ops
+category: browser
+description:
+  en: "Browser automation for DeepSeek Harness: agent-driven real-browser control (managed Chrome with an isolated persistent profile, or attach to your daily Chrome over CDP) with snapshot, click, fill and page-reading tools; records manual operation flows and replays them with variable slots to create test data on demand; ships 27 browser_* tools plus a Settings panel."
+  zh: "DeepSeek Harness 真实浏览器自动化：agent 可直接驱动真实 Chrome（独立托管档案，或附加日常 Chrome/CDP），提供页面快照、点击、填表、读表与控制台/网络诊断工具；可将手动操作录制成流程并把输入标记为变量槽，按参数自动重放来批量造测试数据；附带 27 个 browser_* 工具与设置页控制面板。"

--- a/data/plugins/lirui1024k__dsh-browser-ops.yml
+++ b/data/plugins/lirui1024k__dsh-browser-ops.yml
@@ -1,5 +1,6 @@
 url: https://github.com/lirui1024k/dsh-browser-ops
 name: lirui1024k/dsh-browser-ops
+tarball: https://github.com/lirui1024k/dsh-browser-ops/releases/latest/download/dsh-browser-ops-0.2.0.tgz
 category: browser
 description:
   en: "Browser automation for DeepSeek Harness: agent-driven real-browser control (managed Chrome with an isolated persistent profile, or attach to your daily Chrome over CDP) with snapshot, click, fill and page-reading tools; records manual operation flows and replays them with variable slots to create test data on demand; ships 27 browser_* tools plus a Settings panel."


### PR DESCRIPTION
## What

Adds **lirui1024k/dsh-browser-ops** to the `browser` category.

A local-first browser automation plugin for DeepSeek Harness:
- 27 `browser_*` agent tools: launch/manage a real Chrome (managed mode with an isolated persistent profile, or CDP attach to the user daily Chrome), snapshot/click/fill/select/read text & tables/screenshot/console+network diagnostics.
- Record manual UI operations into reusable flows (JSON), mark fill steps as variable slots, then replay flows with parameters to create test data on demand (with optional verify-text).
- Ships a Settings panel (web client) + same-origin JSON surface.

Repo requirements check: declares `dsh.bundle.patch` in package.json (+ `cordis.patch.yml`), has the `dsh-plugin` GitHub topic, MIT licensed, contains working code.

Note: the repo was created today, so the repo-age CI check may flag it; it crosses the 1-day mark shortly — happy to re-run CI / resubmit if needed.