### PR TITLE
Add dsboylw/LazyNoobsCockloft#dsh-session-notes

### DIFF
--- a/data/plugins/dsboylw__LazyNoobsCockloft--dsh-session-notes.yml
+++ b/data/plugins/dsboylw__LazyNoobsCockloft--dsh-session-notes.yml
@@ -1,0 +1,6 @@
+url: https://github.com/dsboylw/LazyNoobsCockloft/tree/main/dsh-session-notes
+name: dsboylw/LazyNoobsCockloft#dsh-session-notes
+category: session
+description:
+  en: 'Per-session notes: header-button editor popover with autosave and five color flags, an all-notes overview with one-click session jump and prompt copy, and a persistent bottom bar (workspace badge, title, 20-char preview, toggle) — truncation everywhere, copy always takes the full text.'
+  zh: '会话备注插件：头部按钮弹层编辑（防抖自动保存、五色标记），全部备注总览（显示工作区徽标与标题，点击直达会话、一键复制提示词），输入框上方常驻备注条（可开关）——长文本按位置截断显示，复制始终取全文。'


### PR DESCRIPTION
Adds one plugin: **dsboylw/LazyNoobsCockloft#dsh-session-notes** (monorepo subdirectory entry).

### What it does
Per-session notes for DSH Desktop / Web:
- Header-button editor popover with debounced autosave, five color flags, copy buttons
- All-notes overview: workspace badge + session title + note preview per row; click a row to jump to that session; one-click copy of the full note (e.g. a reused prompt)
- Persistent bottom bar above the composer (color dot, workspace badge, session title, 20-char preview, toggle)
- Long text is truncated per surface (5/8/15/20 chars) with ellipsis; hover shows the full text; **copy always takes the full content**

### Manifest
The subdirectory `dsh-session-notes/` declares a `dsh.bundle` in its `package.json` (`patch: ./cordis.patch.yml`) plus `dsh.client` (platform web), so it is installable via `dsh plugin add`.

### Compatibility
Built and tested on DSH Desktop 0.7.1; verified working on 0.7.2.

### Category
`session` — the plugin attaches notes to sessions and navigates between them.