### PR TITLE
Add lokih1028/dsh-plugin-canvas-pro

### DIFF
--- a/data/plugins/lokih1028__dsh-plugin-canvas-pro.yml
+++ b/data/plugins/lokih1028__dsh-plugin-canvas-pro.yml
@@ -1,4 +1,4 @@
-﻿url: https://github.com/lokih1028/dsh-plugin-canvas-pro
+url: https://github.com/lokih1028/dsh-plugin-canvas-pro
 name: lokih1028/dsh-plugin-canvas-pro
 category: ui
 description:

--- a/data/plugins/lokih1028__dsh-plugin-canvas-pro.yml
+++ b/data/plugins/lokih1028__dsh-plugin-canvas-pro.yml
@@ -1,0 +1,6 @@
+﻿url: https://github.com/lokih1028/dsh-plugin-canvas-pro
+name: lokih1028/dsh-plugin-canvas-pro
+category: ui
+description:
+  en: Adds a Canvas drawer and eight model tools to create, patch, version, and export HTML, Markdown, Mermaid, SVG, and React artifacts.
+  zh: 为 DSH Web 增加 Canvas 抽屉与八个模型工具，用于创建、局部补丁、版本管理和导出 HTML、Markdown、Mermaid、SVG 与 React 工件。


### PR DESCRIPTION
Adds one listing for https://github.com/lokih1028/dsh-plugin-canvas-pro.

- category: ui
- package.json declares dsh.bundle.patch and dsh.client.platform web
- repo topic: dsh-plugin
- description matches the eight model tools and Canvas drawer

Note: the repository was created today. contributing.md's 1-day age check will fail until 2026-09-07. Please keep this PR open or I will push an empty commit after the bar clears.