### PR TITLE
update: 3361805598-gif/dsh-usage-analytics v0.2.1

### DIFF
--- a/data/plugins/3361805598-gif__dsh-usage-analytics.yml
+++ b/data/plugins/3361805598-gif__dsh-usage-analytics.yml
@@ -1,0 +1,7 @@
+url: https://github.com/3361805598-gif/dsh-usage-analytics
+name: 3361805598-gif/dsh-usage-analytics
+category: usage
+tarball: https://github.com/3361805598-gif/dsh-usage-analytics/releases/download/v0.2.1/dsh-usage-analytics-0.2.1.tgz
+description:
+  en: Local-first personal usage insights in Settings, with 1/7/30-day token heatmaps and a 30-day calendar, token composition, model mix, and skill-call status.
+  zh: 在设置页提供本机个人用量分析：1/7/30 天 Token 热力图与 30 天日历视图、Token 构成、模型分布和技能调用状态。

--- a/data/plugins/3361805598-gif__dsh-usage-insights.yml
+++ b/data/plugins/3361805598-gif__dsh-usage-insights.yml
@@ -1,7 +1,0 @@
-url: https://github.com/3361805598-gif/dsh-usage-insights
-name: 3361805598-gif/dsh-usage-insights
-category: usage
-tarball: https://github.com/3361805598-gif/dsh-usage-insights/releases/download/v0.2.0/dsh-usage-insights-0.2.0.tgz
-description:
-  en: Local-first personal usage insights in Settings, with 1/7/30-day token heatmaps and a 30-day calendar, token composition, model mix, and skill-call status.
-  zh: 在设置页提供本机个人用量分析：1/7/30 天 Token 热力图与 30 天日历视图、Token 构成、模型分布和技能调用状态。


### PR DESCRIPTION
Rename of the entry merged in #4406: the plugin package and GitHub repo were renamed `dsh-usage-insights` → `dsh-usage-analytics` (npm already had a same-named package), so the entry file slug, `url`, and `name` follow the rename, and `tarball` bumps to the v0.2.1 release asset.

- The old repo URL 301-redirects, so the merged entry keeps working until this merges.
- `category` and both description lines are unchanged.
- v0.2.1 changelog: rename plus review fixes (dark-mode token for the cache-read tone, restored SHA-256 verification notes in README, CHANGELOG restructured, stale CODE_REVIEW.md removed). Storage domain, settings section, and local caches are unaffected.