### PR TITLE
docs: update dsh-archived-chats for 1.1.0

### DIFF
--- a/data/plugins/Ultronen__dsh-archived-chats.yml
+++ b/data/plugins/Ultronen__dsh-archived-chats.yml
@@ -2,5 +2,5 @@ url: https://github.com/Ultronen/dsh-archived-chats
 name: Ultronen/dsh-archived-chats
 category: session
 description:
-  en: 'Session Archive for DeepSeek Harness groups archived chats by workspace with full-text search and native read-only preview, keeps validated History versions for restore-as-copy, and adds tags, notes, ZIP backup and restore, a snapshot-protected Recycle Bin, storage accounting, preview-first retention, and read-only session lineage; all data stays local.'
-  zh: 'DeepSeek Harness 会话档案：按工作区浏览和全文搜索归档聊天，提供原生只读预览、可恢复为副本的历史版本、标签备注、ZIP 备份恢复、带保护快照的回收站、空间分账、预览优先的保留策略和只读会话血缘；所有数据留在本机。'
+  en: 'Session Archive for DeepSeek Harness safely bulk-archives eligible workspace conversations, groups archived chats by workspace with full-text search and native read-only preview, keeps validated History versions for restore-as-copy, and adds tags, notes, ZIP backup and restore, a snapshot-protected Recycle Bin, storage accounting, preview-first retention, and read-only session lineage; all data stays local.'
+  zh: 'DeepSeek Harness 会话档案：安全批量归档工作区中符合条件的会话，按工作区浏览和全文搜索归档聊天，提供原生只读预览、可恢复为副本的历史版本、标签备注、ZIP 备份恢复、带保护快照的回收站、空间分账、预览优先的保留策略和只读会话血缘；所有数据留在本机。'


### PR DESCRIPTION
## Summary

- update the existing `Ultronen/dsh-archived-chats` catalog description for the released 1.1.0 capability
- add safe bulk archiving of eligible workspace conversations in both locales
- keep every previously listed capability and the local-only data boundary unchanged
- modify only the plugin-owned YAML; generated READMEs are intentionally not committed

## Source of truth

- Release: https://github.com/Ultronen/dsh-archived-chats/releases/tag/v1.1.0
- npm: https://www.npmjs.com/package/dsh-archived-chats/v/1.1.0
- Implementation: https://github.com/Ultronen/dsh-archived-chats/pull/36

## Verification

- [x] Existing-entry update only: one file changed at `data/plugins/Ultronen__dsh-archived-chats.yml`
- [x] Plugin package declares `dsh.bundle`
- [x] Repository is older than one day
- [x] Existing `session` category remains unchanged
- [x] Descriptions are factual and contain no superlatives
- [x] Repository has the `dsh-plugin` topic
- [x] `node scripts/generate-readme.mjs --check` passed after local regeneration
- [x] `SKIP_PUBLISH_CHECKS=1 node scripts/build-site.mjs` passed for 3196 entries across two locales
- [x] `npx awesome-lint` passed; existing repository-wide spelling warnings remain warnings only

The plugin-local `screenshots.json` still declares the same eight ordered screenshot assets. No shared screenshot data is changed here.
