### PR TITLE
Add SunshineR04/dsh-session-manager (archived session manager: restore / permanent delete)

### DIFF
--- a/data/plugins/SunshineR04__dsh-session-manager.yml
+++ b/data/plugins/SunshineR04__dsh-session-manager.yml
@@ -1,0 +1,6 @@
+url: https://github.com/SunshineR04/dsh-session-manager
+name: SunshineR04/dsh-session-manager
+category: session
+description:
+  en: 'Settings-page manager for archived DeepSeek Harness sessions: restore an archived session to its previous workspace position or permanently delete it (direct physical deletion), with a red permanently-delete item in the session context menu, /sessions slash commands and three agent tools. Deleting an open session works immediately; the leftover in-memory copy is hidden behind an archive tombstone until the next restart.'
+  zh: '在设置页管理已归档会话：恢复或彻底删除（直接物理删除），会话菜单新增红色彻底删除项，附 /sessions 斜杠命令与三个 agent 工具。已打开的会话也能立即删除，残留内存副本以归档墓碑隐藏、重启后自动清理。'

--- a/data/plugins/SunshineR04__dsh-session-manager.yml
+++ b/data/plugins/SunshineR04__dsh-session-manager.yml
@@ -2,5 +2,5 @@ url: https://github.com/SunshineR04/dsh-session-manager
 name: SunshineR04/dsh-session-manager
 category: session
 description:
-  en: 'Settings-page manager for archived DeepSeek Harness sessions: restore an archived session to its previous workspace position or permanently delete it (direct physical deletion), with a red permanently-delete item in the session context menu, /sessions slash commands and three agent tools. Deleting an open session works immediately; the leftover in-memory copy is hidden behind an archive tombstone until the next restart.'
-  zh: '在设置页管理已归档会话：恢复或彻底删除（直接物理删除），会话菜单新增红色彻底删除项，附 /sessions 斜杠命令与三个 agent 工具。已打开的会话也能立即删除，残留内存副本以归档墓碑隐藏、重启后自动清理。'
+  en: 'Settings-page manager for archived DeepSeek Harness sessions: restore an archived session to its previous workspace position or permanently delete it (direct physical deletion, no backup layer). Adds a red permanently-delete item to the session context menu and three agent tools. Deleting an open session works immediately; the leftover in-memory copy is hidden behind an archive tombstone until the next restart.'
+  zh: '在设置页管理已归档会话：恢复或彻底删除（直接物理删除，无备份层）。会话菜单新增红色彻底删除项，附三个 agent 工具。已打开的会话也能立即删除，残留内存副本以归档墓碑隐藏、重启后自动清理。'

--- a/data/plugins/SunshineR04__dsh-session-manager.yml
+++ b/data/plugins/SunshineR04__dsh-session-manager.yml
@@ -1,6 +1,7 @@
 url: https://github.com/SunshineR04/dsh-session-manager
 name: SunshineR04/dsh-session-manager
 category: session
+tarball: https://github.com/SunshineR04/dsh-session-manager/releases/download/v0.3.0/dsh-session-manager-0.3.0.tgz
 description:
   en: 'Settings-page manager for archived DeepSeek Harness sessions: restore an archived session to its previous workspace position or permanently delete it (direct physical deletion, no backup layer). Adds a red permanently-delete item to the session context menu and three agent tools. Deleting an open session works immediately; the leftover in-memory copy is hidden behind an archive tombstone until the next restart.'
   zh: '在设置页管理已归档会话：恢复或彻底删除（直接物理删除，无备份层）。会话菜单新增红色彻底删除项，附三个 agent 工具。已打开的会话也能立即删除，残留内存副本以归档墓碑隐藏、重启后自动清理。'


### PR DESCRIPTION
## Plugin

[dsh-session-manager](https://github.com/SunshineR04/dsh-session-manager) — a DeepSeek Harness plugin that manages archived sessions from a first-class Settings page.

## What it does

- **Settings page** (Settings → Session Manager): lists every archived session (title, owning workspace, project directory, update time, running state) with **Restore** and **Delete permanently** per row, plus a pending-deletion banner
- **Session context menu**: a red **Delete permanently** item below the built-in Rename / Fork / Archive items
- **Three agent tools**: `session_list_archived`, `session_restore_archived`, `session_delete_permanently` (requires `confirm: true`, refuses running sessions)
- Deleting an **open** session works immediately: registry accounting and files are removed at once, the lingering in-memory summary is hidden via an archive-set tombstone and cleaned up at the next restart

## Compliance

- Declares a `dsh.bundle` manifest (`dsh.bundle.patch: ./cordis.patch.yml`) with the patch file at the repository root; `dsh.client.platform: web` + the `@deepseek-ai/dsh-client-*` inject list
- MIT licensed, repository created 2026-09-05 (older than 1 day at submission time)
- Actively maintained: v0.3.0, 19 unit + render tests, changelog-quality commits
- Description states only what the code does; category `session`