### PR TITLE
docs: update web-search-advanced npm package

### DIFF
--- a/data/plugins/bug-huntter__web-search-advanced.yml
+++ b/data/plugins/bug-huntter__web-search-advanced.yml
@@ -2,5 +2,5 @@ url: https://github.com/bug-huntter/web-search-advanced
 name: bug-huntter/web-search-advanced
 category: browser
 description:
-  en: 'Switchable web-search provider for DSH: native DeepSeek web search or an OpenAI-compatible custom backend, with a Settings card for provider, Base URL, model, API key and result limits.'
-  zh: 可切换的网页搜索提供方：内置 DeepSeek 原生搜索与 OpenAI 兼容自定义后端两种模式，并附设置卡片配置服务商、Base URL、模型、API Key 与搜索上限。
+  en: 'Switchable web-search provider for DSH: native DeepSeek web search or an OpenAI-compatible custom backend, with a Settings card for provider, Base URL, model, API key and result limits. Published on npm as @lp181818/web-search-advanced@0.1.1.'
+  zh: 可切换的网页搜索提供方：内置 DeepSeek 原生搜索与 OpenAI 兼容自定义后端两种模式，并附设置卡片配置服务商、Base URL、模型、API Key 与搜索上限。已发布为 npm 包 @lp181818/web-search-advanced@0.1.1。


### PR DESCRIPTION
Update the existing `bug-huntter/web-search-advanced` catalog entry with its published npm package:

- `@lp181818/web-search-advanced@0.1.1`
- The GitHub source repository and plugin description remain unchanged.

The original submission was merged in #4421. This follow-up records the now-available npm installation source after the plugin was rebuilt and published.