### PR TITLE
Add YiRan0/dsh-bangumi (anime subscription manager)

### DIFF
--- a/data/plugins/YiRan0__dsh-bangumi.yml
+++ b/data/plugins/YiRan0__dsh-bangumi.yml
@@ -1,0 +1,6 @@
+url: https://github.com/YiRan0/dsh-bangumi
+name: YiRan0/dsh-bangumi
+category: tools
+description:
+  en: 'Anime subscription manager for DeepSeek Harness: Bangumi metadata lookup, nyaa/dmhy torrent search, qBittorrent auto-download with RSS-based new-episode polling, local media-library dedup, and a calendar/progress sidebar GUI with 11 LLM tools (bangumi_lookup / bangumi_search / bangumi_subscribe / bangumi_unsubscribe / bangumi_list / bangumi_progress / bangumi_calendar / qb_status / qb_configure / qb_add_torrent / library_scan).'
+  zh: 'DSH 追番订阅管理器：Bangumi 查番、nyaa/dmhy 搜种、qBittorrent 自动下载（RSS 判新轮询）、本地媒体库查重，附日历/进度侧边栏 GUI 与 11 个 LLM 工具（bangumi_lookup / bangumi_search / bangumi_subscribe / bangumi_unsubscribe / bangumi_list / bangumi_progress / bangumi_calendar / qb_status / qb_configure / qb_add_torrent / library_scan）。'


### PR DESCRIPTION
Adds [YiRan0/dsh-bangumi](https://github.com/YiRan0/dsh-bangumi), an anime subscription manager for DeepSeek Harness:

- Bangumi subject lookup (metadata card, season/sequel convergence)
- nyaa/dmhy torrent search with scoring/ranking and auto-subscribe
- qBittorrent integration: RSS new-episode polling (configurable window), auto-categorised downloads, whole-season packs for finished shows
- Local media-library dedup against already-downloaded episodes
- Calendar & progress sidebar GUI (sidebar entry + full page, DOM-panel form)
- 11 agent-facing tools (bangumi_lookup/search/subscribe/unsubscribe/list/progress/calendar, qb_status/configure/add_torrent, library_scan)

Declares `dsh.bundle` (cordis.patch.yml) at the repo root — installable via `dsh plugin --profile web add github:YiRan0/dsh-bangumi` — with a web client (`dsh.client`). Repo is public, tagged `dsh-plugin`, created 2026-09-04. No existing entry covers anime subscription/torrent management.