### PR TITLE
Add RoutineKit to workflow plugins

### DIFF
--- a/data/plugins/sjh9714__routinekit.yml
+++ b/data/plugins/sjh9714__routinekit.yml
@@ -1,0 +1,5 @@
+url: https://github.com/sjh9714/routinekit
+name: sjh9714/routinekit
+category: workflow
+description:
+  en: Capture selected DSH, local MCP, or native WebMCP calls as reviewed, parameterized routines, expose typed tools, and replay with fresh approval.


### PR DESCRIPTION
Add one workflow entry for https://github.com/sjh9714/routinekit.

RoutineKit captures selected successful DSH, local MCP, or native WebMCP tool calls, lets the user review and parameterize the sequence, exposes typed tools, and requires fresh approval for replay. It is not a general autonomous-task benchmark or an endorsement of every MCP client.

The repository contains working code, a dsh.bundle patch, the dsh-plugin topic, and screenshots.json pointing to docs/workbench.png. It was created on 2026-09-05 and is older than one day. npm routinekit 0.2.0 is published with prebuilt files.

On 2026-09-07, the unversioned official command `dsh plugin --profile web add routinekit` installed 0.2.0 from the npm registry in a fresh temporary web profile, using official DSH 0.1.2-rc.1 and pnpm 11.24.0. The effective 1440-minute release-age policy was preserved, strict mode was enabled only for the test, and user/global configuration was unchanged. The installed manifest, pnpm list, composed config and removal were checked. This install check is not a claim of autonomous model success.

Only data/plugins/sjh9714__routinekit.yml is added; no generated README or unrelated entry changes. The entry validates with the repository entry validator.