### PR TITLE
收录 dsh-theme-black-hole 黑洞主题

### DIFF
--- a/data/plugins/wxj783428795__dsh-plugins--dsh-theme-black-hole.yml
+++ b/data/plugins/wxj783428795__dsh-plugins--dsh-theme-black-hole.yml
@@ -1,0 +1,7 @@
+url: https://github.com/wxj783428795/dsh-plugins/tree/main/dsh-theme-black-hole
+name: wxj783428795/dsh-plugins#dsh-theme-black-hole
+category: theme
+description:
+  en: 'A switchable WebGPU black-hole theme for the DeepSeek Harness Web UI that retains the built-in Dark palette and animates only the new-session background.'
+  zh: '适用于 DeepSeek Harness Web UI 的可切换 WebGPU 黑洞主题：沿用内置深色配色，仅在新会话页面显示动态背景。'
+tarball: https://github.com/wxj783428795/dsh-plugins/releases/latest/download/dsh-theme-black-hole.tgz


### PR DESCRIPTION
## 概要

- 收录 `dsh-plugins` 父仓库中的 `dsh-theme-black-hole` 子插件。
- 归类为 `theme`，沿用 DeepSeek Harness 内置深色配色，仅为新会话页增加可切换的 WebGPU 黑洞动态背景。
- 使用 GitHub Release 中稳定命名的预构建 `.tgz`，并由插件仓库内的 `screenshots.json` 提供效果图。

## 本地校验

- YAML 解析及字段检查通过。
- 仓库公开、创建已满 1 天，并带有 `dsh-plugin` Topic。
- 子插件声明了 `dsh.bundle`，Release 安装包可用。