### PR TITLE
Add dsh-venv plugin listing

### DIFF
--- a/data/plugins/emuco__dsh-project-env.yml
+++ b/data/plugins/emuco__dsh-project-env.yml
@@ -1,6 +1,0 @@
-url: https://github.com/emuco/dsh-project-env
-name: emuco/dsh-project-env
-category: tools
-description:
-  en: 'Per-project runtime environments for DeepSeek Harness: auto-adopt or create a project-local Python venv (.venv_local/python) and wire in the toolchains and env vars for the runtimes each project uses (python venv / node / go) — python & pip always resolve to the project, never silently to system Python.'
-  zh: '为每个 DSH 工作区/项目提供独立的运行时环境：自动接管或创建项目本地 Python venv（.venv_local/python），并自动识别项目所用运行时（python venv / node / go）接入其工具链与环境变量——python / pip 永远走项目环境，绝不静默落到系统 Python。一个有则接管、无则自动建的零配置插件。'

--- a/data/plugins/emuco__dsh-project-env.yml
+++ b/data/plugins/emuco__dsh-project-env.yml
@@ -1,0 +1,6 @@
+url: https://github.com/emuco/dsh-project-env
+name: emuco/dsh-project-env
+category: tools
+description:
+  en: 'Per-project runtime environments for DeepSeek Harness: auto-adopt or create a project-local Python venv (.venv_local/python) and wire in the toolchains and env vars for the runtimes each project uses (python venv / node / go) — python & pip always resolve to the project, never silently to system Python.'
+  zh: '为每个 DSH 工作区/项目提供独立的运行时环境：自动接管或创建项目本地 Python venv（.venv_local/python），并自动识别项目所用运行时（python venv / node / go）接入其工具链与环境变量——python / pip 永远走项目环境，绝不静默落到系统 Python。一个有则接管、无则自动建的零配置插件。'

--- a/data/plugins/emuco__dsh-venv.yml
+++ b/data/plugins/emuco__dsh-venv.yml
@@ -1,0 +1,6 @@
+url: https://github.com/emuco/dsh-venv
+name: emuco/dsh-venv
+category: tools
+description:
+  en: 'Per-project runtime environments for DeepSeek Harness: auto-adopt or create a project-local Python venv (.venv_local/python) and wire in the toolchains and env vars for the runtimes each project uses (python venv / node / go) — python & pip always resolve to the project, never silently to system Python.'
+  zh: '为每个 DSH 工作区/项目提供独立的运行时环境：自动接管或创建项目本地 Python venv（.venv_local/python），并自动识别项目所用运行时（python venv / node / go）接入其工具链与环境变量——python / pip 永远走项目环境，绝不静默落到系统 Python。一个有则接管、无则自动建的零配置插件。'


### PR DESCRIPTION
Adds the [dsh-venv](https://github.com/emuco/dsh-venv) listing: per-project runtime environments for DeepSeek Harness (auto-adopt/create a project-local Python venv at .venv_local/python, wire in each runtime's toolchain/env vars). Renamed from dsh-project-env.