### PR TITLE
Add WongYuYe/dsh-composer-recall

### DIFF
--- a/data/plugins/WongYuYe__dsh-appshots.yml
+++ b/data/plugins/WongYuYe__dsh-appshots.yml
@@ -2,5 +2,5 @@ url: https://github.com/WongYuYe/dsh-appshots
 name: WongYuYe/dsh-appshots
 category: vision
 description:
-  en: 'Codex-style Appshots for DSH Desktop: capture the frontmost macOS window with both Command keys and attach it to the current chat.'
-  zh: 给 DSH Desktop 用的 Codex 风格 Appshots：按两边 Command 捕获当前前台窗口，并附加到当前会话。
+  en: 'Codex-style window capture for DSH Desktop: press both Command keys to grab the frontmost macOS window, attach it to the current chat, and inject available window text as hidden context.'
+  zh: 给 DSH Desktop 用的窗口截图：同时按两边 Command（或点输入框旁相机）捕获当前前台窗口，附加到会话，并读取窗口文字作为隐藏上下文。

--- a/data/plugins/WongYuYe__dsh-appshots.yml
+++ b/data/plugins/WongYuYe__dsh-appshots.yml
@@ -1,6 +1,7 @@
 url: https://github.com/WongYuYe/dsh-appshots
 name: WongYuYe/dsh-appshots
 category: vision
+tarball: https://github.com/WongYuYe/dsh-appshots/releases/latest/download/dsh-appshots.tgz
 description:
   en: 'Codex-style window capture for DSH Desktop: press both Command keys to grab the frontmost macOS window, attach it to the current chat, and inject available window text as hidden context.'
   zh: 给 DSH Desktop 用的窗口截图：同时按两边 Command（或点输入框旁相机）捕获当前前台窗口，附加到会话，并读取窗口文字作为隐藏上下文。

--- a/data/plugins/WongYuYe__dsh-composer-recall.yml
+++ b/data/plugins/WongYuYe__dsh-composer-recall.yml
@@ -1,7 +1,7 @@
-url: https://github.com/WongYuYe/pokemon-claw
-name: WongYuYe/pokemon-claw
+url: https://github.com/WongYuYe/dsh-composer-recall
+name: WongYuYe/dsh-composer-recall
 category: ui
-tarball: https://github.com/WongYuYe/pokemon-claw/releases/latest/download/dsh-composer-recall.tgz
+tarball: https://github.com/WongYuYe/dsh-composer-recall/releases/latest/download/dsh-composer-recall.tgz
 description:
   en: 'Arrow-key input history for the DSH web composer on 0.1.2-alpha.1: ↑/↓ recalls the current session user prompts through the official Lexical setDraft seam.'
   zh: DSH 0.1.2-alpha.1 Web 输入框方向键历史：↑/↓ 通过官方 Lexical setDraft 召回当前会话的用户消息。

--- a/data/plugins/WongYuYe__dsh-composer-recall.yml
+++ b/data/plugins/WongYuYe__dsh-composer-recall.yml
@@ -3,5 +3,5 @@ name: WongYuYe/dsh-composer-recall
 category: ui
 tarball: https://github.com/WongYuYe/dsh-composer-recall/releases/latest/download/dsh-composer-recall.tgz
 description:
-  en: 'Arrow-key input history for the DSH web composer on 0.1.2-alpha.1: ↑/↓ recalls the current session user prompts through the official Lexical setDraft seam.'
-  zh: DSH 0.1.2-alpha.1 Web 输入框方向键历史：↑/↓ 通过官方 Lexical setDraft 召回当前会话的用户消息。
+  en: 'Arrow-key input history for DSH 0.1.2-alpha.1: press ↑ in an empty composer to recall this session\'s prompts, ↓ to go forward, Esc to restore the draft.'
+  zh: DSH 0.1.2-alpha.1 输入框历史：空输入框按 ↑ 召回当前会话刚发过的话，↓ 前进，Esc 还原正在打的草稿。

--- a/data/plugins/WongYuYe__pokemon-claw.yml
+++ b/data/plugins/WongYuYe__pokemon-claw.yml
@@ -1,0 +1,7 @@
+url: https://github.com/WongYuYe/pokemon-claw
+name: WongYuYe/pokemon-claw
+category: ui
+tarball: https://github.com/WongYuYe/pokemon-claw/releases/latest/download/dsh-composer-recall.tgz
+description:
+  en: 'Arrow-key input history for the DSH web composer on 0.1.2-alpha.1: ↑/↓ recalls the current session user prompts through the official Lexical setDraft seam.'
+  zh: DSH 0.1.2-alpha.1 Web 输入框方向键历史：↑/↓ 通过官方 Lexical setDraft 召回当前会话的用户消息。


### PR DESCRIPTION
Adds `WongYuYe/dsh-composer-recall` under UI Enhancements.

This is the existing `pokemon-claw` repository (created 2026-03-13), renamed after being repurposed as a DSH plugin.

Arrow-key input history for DSH 0.1.2-alpha.1: press ↑ in an empty composer to recall this session's prompts, ↓ to go forward, Esc to restore the draft.

- `dsh.bundle` is declared in `package.json`
- repo created 2026-03-13 (older than 1 day)
- `dsh-plugin` topic is set
- prebuilt tarball: https://github.com/WongYuYe/dsh-composer-recall/releases/latest/download/dsh-composer-recall.tgz
