### PR TITLE
Add JNNarrator/dsh-deckseek (UI enhancement)

### DIFF
--- a/data/plugins/JNNarrator__dsh-deckseek.yml
+++ b/data/plugins/JNNarrator__dsh-deckseek.yml
@@ -1,6 +1,7 @@
 url: https://github.com/JNNarrator/dsh-deckseek
 name: JNNarrator/dsh-deckseek
 category: ui
+tarball: https://github.com/JNNarrator/dsh-deckseek/releases/download/v0.4.5/dsh-deckseek-0.4.5.tgz
 description:
   en: A calmer reading view for DeepSeek Harness with auto-collapsing process, a minimap-style message navigation rail, in-page search, unified failure cards, and generative MCP Apps (SEP-1865) in sandboxed iframes.
   zh: 阅读视图增强插件——执行过程自动收起、右缘消息导航导轨、页内查找、统一失败卡片，支持生成式 MCP Apps（SEP-1865）沙箱交互。

--- a/data/plugins/JNNarrator__dsh-deckseek.yml
+++ b/data/plugins/JNNarrator__dsh-deckseek.yml
@@ -1,0 +1,6 @@
+url: https://github.com/JNNarrator/dsh-deckseek
+name: JNNarrator/dsh-deckseek
+category: ui
+description:
+  en: A calmer reading view for DeepSeek Harness with auto-collapsing process, a minimap-style message navigation rail, in-page search, unified failure cards, and generative MCP Apps (SEP-1865) in sandboxed iframes.
+  zh: 阅读视图增强插件——执行过程自动收起、右缘消息导航导轨、页内查找、统一失败卡片，支持生成式 MCP Apps（SEP-1865）沙箱交互。


### PR DESCRIPTION
收录 [JNNarrator/dsh-deckseek](https://github.com/JNNarrator/dsh-deckseek)（`ui` 分类），v0.4.5。

## 插件简介

DSH 阅读视图增强插件：执行过程自动收起、右缘消息导航导轨（minimap 风格悬停气泡与平滑跳转）、页内实时查找、统一失败卡片（失败原因 / 退出码 / 可展开原始记录）、生成式 MCP Apps（SEP-1865）沙箱交互、双语 UI（中 / EN）。

- fork 自 [aa2246740/dsh-better-display](https://github.com/aa2246740/dsh-better-display)（MIT），README 与 THIRD_PARTY_NOTICES.md 均已署名原仓库；在原仓库基础上新增消息导轨、页内查找、会话阅读位置记忆、失败卡片、Write/Edit 变更统计、双语 i18n 等，75 项单元测试（`npm test` 全部通过）。

## 收录要求自查

- [x] `package.json` 声明 `dsh.bundle`（`patch: ./cordis.patch.yml`），另有 `dsh.client`（web）
- [x] 仓库创建满 1 天（2026-09-06），提交数 ≥ 10（24 commits）
- [x] 已添加 `dsh-plugin` topic
- [x] 未发布 npm，`tarball` 字段指向 GitHub Release v0.4.5 预构建包（已验证包含 `dsh.bundle` manifest）
- [x] 一个插件一个文件 `data/plugins/JNNarrator__dsh-deckseek.yml`，未手工编辑 README