### PR TITLE
feat: add dsh-workspace-monitor

### DIFF
--- a/data/plugins/Rainier-Z__dsh-workspace-monitor.yml
+++ b/data/plugins/Rainier-Z__dsh-workspace-monitor.yml
@@ -1,0 +1,6 @@
+url: https://github.com/Rainier-Z/dsh-workspace-monitor
+name: Rainier-Z/dsh-workspace-monitor
+category: workflow
+description:
+  en: A DeepSeek Harness plugin that periodically detects added, modified, and deleted files in a workspace and reports the changes.
+  zh: 一个适配 DeepSeek Harness 的工作区监测插件，按周期检测并报告文件的新增、修改和删除。


### PR DESCRIPTION
## Submission

Adds `Rainier-Z/dsh-workspace-monitor` to the DSH plugin list.

- Declares a `dsh.bundle` manifest and ships `cordis.patch.yml`.
- Publishes the installable package as `dsh-workspace-monitor` on npm.
- Uses the `workflow` category.
- The entry contains only the required repository metadata and bilingual descriptions.