### PR TITLE
docs: update web-search-advanced to npm 0.1.3

### DIFF
--- a/data/plugins/bug-huntter__web-search-advanced.yml
+++ b/data/plugins/bug-huntter__web-search-advanced.yml
@@ -2,5 +2,5 @@ url: https://github.com/bug-huntter/web-search-advanced
 name: bug-huntter/web-search-advanced
 category: browser
 description:
-  en: 'Switchable web-search provider for DSH: native DeepSeek web search or an OpenAI-compatible custom backend, with a Settings card for provider, Base URL, model, API key and result limits. Published on npm as @lp181818/web-search-advanced@0.1.1.'
-  zh: 可切换的网页搜索提供方：内置 DeepSeek 原生搜索与 OpenAI 兼容自定义后端两种模式，并附设置卡片配置服务商、Base URL、模型、API Key 与搜索上限。已发布为 npm 包 @lp181818/web-search-advanced@0.1.1。
+  en: 'Switchable web-search provider for DSH: native DeepSeek web search or an OpenAI-compatible custom backend. Installation automatically routes DSH web searches to the plugin; only provider, API key and model are required. Published on npm as @lp181818/web-search-advanced@0.1.3.'
+  zh: 安装后自动将 DSH 网页搜索路由到本插件；只需配置服务商、API Key 和模型即可使用。支持 DeepSeek 原生搜索与 OpenAI 兼容自定义后端，已发布为 npm 包 @lp181818/web-search-advanced@0.1.3。


### PR DESCRIPTION
Update the catalog entry for `bug-huntter/web-search-advanced`.

- Update the published npm package from `@lp181818/web-search-advanced@0.1.1` to `@lp181818/web-search-advanced@0.1.3`.
- Document that installation automatically routes DSH web searches to this plugin.
- Only the provider, API key, and model are required after installation.

The previous catalog update was merged in #4515.