### PR TITLE
Add sunzhentao/dsh--prompt--enhance

### DIFF
--- a/data/plugins/sunzhentao__dsh--prompt--enhance.yml
+++ b/data/plugins/sunzhentao__dsh--prompt--enhance.yml
@@ -1,0 +1,6 @@
+url: https://github.com/sunzhentao/dsh--prompt--enhance
+name: sunzhentao/dsh--prompt--enhance
+category: usage
+description:
+  en: 'Prompt enhancer for the DSH web UI with basic/standard/expert modes: standard/expert modes rewrite drafts with project context and recent session history, retry gracefully when gateways reject reasoning-effort settings, and show a before/after review with undo.'
+  zh: 'DSH Web 界面提示词增强插件：基础/标准/专家三档模式，标准/专家模式结合项目上下文与最近会话历史重写草稿；网关拒绝推理档位参数时自动去参重试；增强结果支持对比确认与撤回。'


### PR DESCRIPTION
## Summary

Adds [sunzhentao/dsh--prompt--enhance](https://github.com/sunzhentao/dsh--prompt--enhance) to the `usage` category.

- `package.json` declares the `dsh.bundle` manifest (`dsh.bundle.patch: ./cordis.patch.yml`), plus a web `dsh.client` entry.
- The repo carries the `dsh-plugin` topic and contains real, working Host + browser code with tests.
- The one-line description was drafted from the plugin's actual feature surface: basic/standard/expert modes, project-context and session-history-aware rewriting in the standard/expert modes, automatic retry without reasoning-effort settings when a gateway rejects them, and confirm-before-apply with undo.

## Checklist

- [x] One new file only: `data/plugins/sunzhentao__dsh--prompt--enhance.yml`
- [x] READMEs not edited by hand
