### PR TITLE
Add djs326/dsh-plugin-width-slider to ui plugins

### DIFF
--- a/data/plugins/djs326__dsh-plugin-width-slider.yml
+++ b/data/plugins/djs326__dsh-plugin-width-slider.yml
@@ -1,0 +1,6 @@
+url: https://github.com/djs326/dsh-plugin-width-slider
+name: djs326/dsh-plugin-width-slider
+category: ui
+description:
+  en: 'All-in-one UI plugin for DSH Desktop (Windows): conversation-width slider with fullscreen preview and follow-window mode, thinking-block enhancements (forced Chinese, expand/collapse, Markdown rendering), an Open With header button, UI label localization, a resizable settings dialog, session delete, and workspace tabs.'
+  zh: 'DSH 桌面版多功能 UI 插件：对话宽度滑块（按下全屏预览、跟随窗口宽度）、思考块增强（思考/回复强制中文、展开收起、Markdown 渲染）、Open With 头部打开按钮、界面英文标签中文化、设置弹窗窗口化、会话删除与工作区分页。'


### PR DESCRIPTION
## What

Adds [djs326/dsh-plugin-width-slider](https://github.com/djs326/dsh-plugin-width-slider) to the `ui` category.

One file: `data/plugins/djs326__dsh-plugin-width-slider.yml` — no generated README edits.

## Plugin

A multi-feature UI plugin for DSH Desktop (Windows), every feature behind its own toggle:

- conversation-width slider (press-to-preview fullscreen, drag to resize, follow-window mode, persisted)
- thinking-block enhancements: forced-Chinese prompt injection, expand/collapse, Markdown rendering
- Open With header button (launch VS Code / terminal / explorer at the current workspace)
- UI label localization (hardcoded English labels to Chinese)
- resizable settings dialog (windowed patch)
- session delete from the row context menu
- workspace tabs in the sidebar (named tabs + assign-workspace)

The package declares `dsh.bundle.patch` (`cordis.patch.yml`), is installable via `dsh plugin add dsh-plugin-width-slider`, and the repo has the `dsh-plugin` topic.