### PR TITLE
Add CJYLZS/dsh-remote-development (SSH remote development)

### DIFF
--- a/data/plugins/CJYLZS__dsh-remote-development.yml
+++ b/data/plugins/CJYLZS__dsh-remote-development.yml
@@ -1,0 +1,6 @@
+url: https://github.com/CJYLZS/dsh-remote-development
+name: CJYLZS/dsh-remote-development
+category: remote
+description:
+  en: 'Remote development over SSH: pick a directory on a registered machine as the session workspace and the file, shell, bash, and search tools run on the remote host — the agent works there with the same local tools, and no extra model-facing tools are added.'
+  zh: '基于 SSH 的远程开发：把注册机器上的目录选为会话工作区后，文件、shell、bash 与搜索工具即改在远程主机上执行——agent 用与本地相同的工具在那里工作，不新增任何面向模型的工具。'


### PR DESCRIPTION
Adds one entry: `data/plugins/CJYLZS__dsh-remote-development.yml`

- [x] I added **one file** at `data/plugins/<owner>__<repo>.yml` — that single file is the whole submission. The READMEs are regenerated on `main` after merge: don't edit them by hand, and you don't need to commit them either
- [x] My repo's `package.json` declares **`dsh.bundle`** (not just `dsh.client`) — root `package.json` declares `dsh.bundle.patch: ./cordis.patch.yml` plus `dsh.client` (`platform: web`)
- [x] My repo is at least **1 day old** — created 2026-09-04
- [x] `category` is one of the valid values — `remote` (SSH remote development: routing providers for file/subprocess/bash over SFTP and SSH exec channels)
- [x] Description states what the plugin does, no superlatives
- [x] My repo has the `dsh-plugin` topic

Recommended items:

- [ ] npm publish — not published yet; installs work from the committed `lib/` build (`dsh plugin add --profile web github:CJYLZS/dsh-remote-development`)
- [x] Official `@deepseek-ai/*` packages are declared as `peerDependencies` (^0.1.2-rc.1), `ssh2` is bundled into `lib/` at build time
- [ ] Screenshots — will add a `screenshots.json` in my own repository later

Description claims are checked against the code: the plugin replaces the filesystem, subprocess, and bash providers with routing versions (no new model-facing tools, no third-party UI plugin); the one-line description states exactly that.
