### PR TITLE
dsh-conversation-navigator: note host version requirement

### DIFF
--- a/data/plugins/gjj-star__dsh-conversation-navigator.yml
+++ b/data/plugins/gjj-star__dsh-conversation-navigator.yml
@@ -2,5 +2,5 @@ url: https://github.com/gjj-star/dsh-conversation-navigator
 name: gjj-star/dsh-conversation-navigator
 category: ui
 description:
-  en: 'Conversation navigator panel: turn-folded outline of the current session with per-step kind badges (assistant, tool, command, compaction, error), a hover bubble showing the full user question, a minimal mode that hides turn numbers for an all-badge view, keyword filter over user questions and assistant replies, click-to-jump with reading-position tracking, and load-earlier/load-all history paging.'
-  zh: 会话导航面板：按轮折叠的当前会话大纲与步次类型徽标（助手/工具/命令/压缩/出错），悬停气泡显示用户提问全文，可隐藏轮次号的极简徽标视图，仅检索提问与助手回复的关键词过滤，点击跳转与阅读位置跟踪，支持加载更早/加载全部历史分页。
+  en: 'Conversation navigator panel: turn-folded outline of the current session with per-step kind badges (assistant, tool, command, compaction, error), a hover bubble showing the full user question, a minimal mode that hides turn numbers for an all-badge view, keyword filter over user questions and assistant replies, click-to-jump with reading-position tracking, and load-earlier/load-all history paging. Host >= 0.1.2-rc.1; legacy hosts install @legacy/0.2.5.'
+  zh: 会话导航面板：按轮折叠的当前会话大纲与步次类型徽标（助手/工具/命令/压缩/出错），悬停气泡显示用户提问全文，可隐藏轮次号的极简徽标视图，仅检索提问与助手回复的关键词过滤，点击跳转与阅读位置跟踪，支持加载更早/加载全部历史分页。宿主 ≥ 0.1.2-rc.1，旧宿主装 @legacy/0.2.5。


### PR DESCRIPTION
Update the dsh-conversation-navigator entry to note its host-version requirement, so users on different DSH host versions can pick the matching plugin version.

DSH v0.1.2-rc.1 made a breaking change to the conversation data layer, so the plugin forks by host:

- Host `dsh-client-ui-conversation` >= 0.1.2-rc.1  ->  plugin 0.2.6+ (npm `latest`)
- Host <= 0.1.1-rc.2  ->  plugin 0.2.5 and earlier (npm `legacy`)

The npm `peerDependencies` range is already declared as `>=0.1.2-rc.1 <0.2.0` on 0.2.8, and the `legacy` dist-tag points at 0.2.5.