### PR TITLE
Add dsh-git-panel, dsh-chat-toc, and dsh-smart-reminder

### DIFF
--- a/data/plugins/a792883583__dsh-chat-toc.yml
+++ b/data/plugins/a792883583__dsh-chat-toc.yml
@@ -1,0 +1,6 @@
+url: https://github.com/a792883583/dsh-chat-toc
+name: a792883583/dsh-chat-toc
+category: ui
+description:
+  en: "Interactive chat table of contents with bookmarks, turn pinning, global shortcuts, and heading extraction."
+  zh: "对话大纲目录导航：支持书签标记、轮次置顶钉住、全局快捷键与智能标题提取。"

--- a/data/plugins/a792883583__dsh-git-panel.yml
+++ b/data/plugins/a792883583__dsh-git-panel.yml
@@ -1,0 +1,6 @@
+url: https://github.com/a792883583/dsh-git-panel
+name: a792883583/dsh-git-panel
+category: git
+description:
+  en: "Git sidebar panel with commit graphs, ahead/behind tracking, branch operations, and one-click chat context injection."
+  zh: "Git 侧边栏面板：提交图谱、超前/落后跟踪、分支操作及改动 Diff 一键带入对话。"

--- a/data/plugins/a792883583__dsh-smart-reminder.yml
+++ b/data/plugins/a792883583__dsh-smart-reminder.yml
@@ -1,0 +1,6 @@
+url: https://github.com/a792883583/dsh-smart-reminder
+name: a792883583/dsh-smart-reminder
+category: notify
+description:
+  en: "Smart calendar and checklist assistant with lunar dates, macOS/Windows native notifications, and WeCom push."
+  zh: "智能日程与待办助手：农历节气、macOS/Windows 原生桌面弹窗、企微多平台推送与拖拽改期。"


### PR DESCRIPTION
This PR adds 3 maintained DSH plugins:

- **dsh-git-panel** (`git`): Git sidebar panel with commit graphs, ahead/behind tracking, branch operations, and one-click chat context injection.
- **dsh-chat-toc** (`ui`): Interactive chat table of contents with bookmarks, turn pinning, global shortcuts, and heading extraction.
- **dsh-smart-reminder** (`notify`): Smart calendar and checklist assistant with lunar dates, macOS/Windows native notifications, and WeCom push.

All plugins declare `dsh.bundle` manifests, are published to npm with prebuilts, and have `dsh-plugin` topics added.