### PR TITLE
Add dsh-cron-panel and dsh-message-gateway

### DIFF
--- a/data/plugins/a792883583__dsh-cron-panel.yml
+++ b/data/plugins/a792883583__dsh-cron-panel.yml
@@ -1,0 +1,6 @@
+url: https://github.com/a792883583/dsh-cron-panel
+name: a792883583/dsh-cron-panel
+category: workflow
+description:
+  en: "Scheduled tasks panel for managing DSH agent and system crontabs with natural language input and execution logs."
+  zh: "定时任务面板：分区管理 DSH 与系统 crontab、自然语言生成表达式、执行日志与完成后消息推送。"

--- a/data/plugins/a792883583__dsh-message-gateway.yml
+++ b/data/plugins/a792883583__dsh-message-gateway.yml
@@ -1,0 +1,6 @@
+url: https://github.com/a792883583/dsh-message-gateway
+name: a792883583/dsh-message-gateway
+category: notify
+description:
+  en: "Multi-platform message gateway and WeCom AI bot bridge with session context compression and smartsheet creation."
+  zh: "多平台消息网关与企微智能机器人桥接：会话自动压缩持久化与智能表格一键创建。"


### PR DESCRIPTION
This PR adds 2 maintained DSH plugins:

- **dsh-cron-panel** (`workflow`): Scheduled tasks panel for managing DSH agent and system crontabs with natural language input and execution logs.
- **dsh-message-gateway** (`notify`): Multi-platform message gateway and WeCom AI bot bridge with session context compression and smartsheet creation.

Both plugins declare `dsh.bundle` manifests, are published to npm with prebuilts, and have `dsh-plugin` topics added.