### PR TITLE
Add evanfang0054/dsh-tailscale-console (remote)

### DIFF
--- a/data/plugins/evanfang0054__dsh-tailscale-console.yml
+++ b/data/plugins/evanfang0054__dsh-tailscale-console.yml
@@ -1,0 +1,6 @@
+url: https://github.com/evanfang0054/dsh-tailscale-console
+name: evanfang0054/dsh-tailscale-console
+category: remote
+description:
+  en: 'Tailscale remote-access operations panel for the dsh web GUI: health checks, HTTPS entry toggle via tailscale serve, macOS proxy bypass, relay server ops, and ACL snippet generation.'
+  zh: 'Tailscale 远程访问运维面板：健康检查、HTTPS 入口（tailscale serve）开关、macOS 代理绕过、中继服务器运维与 ACL 片段生成。'


### PR DESCRIPTION
## Submission / 收录

Adds `data/plugins/evanfang0054__dsh-tailscale-console.yml` — one new file only, no other entries touched. / 仅新增一个条目文件，未触碰其他条目。

### Checklist / 对照要求

- ✅ `dsh.bundle` manifest in `package.json` + `cordis.patch.yml` at repo root (installable via `dsh plugin --profile <name> add dsh-tailscale-console`)
- ✅ Published to npm (`dsh-tailscale-console@0.2.6`, latest)
- ✅ Real, working code — host half (routes on `/tsctl/api`, shell whitelist) + web client half (settings-section panel); unit-tested via `node --test` (11 cases, runs in CI)
- ✅ Repo age > 1 day (created 2026-08, active)
- ✅ `dsh-plugin` topic set on the repo
- ✅ Category `remote` — the plugin operates Tailscale remote access (serve/HTTPS/proxy/relay)
- ✅ Description states only features, matches code; `: ` quoted in YAML

### What it does / 功能

A control panel card set for operating secure remote access over Tailscale: per-device online alerts, one-click health check, HTTPS entry (tailscale serve) toggle, macOS proxy bypass repair, relay server ops over SSH, access info, and ACL snippet generation.
