### PR TITLE
Add Busabase knowledge and structured-data plugin

### DIFF
--- a/data/plugins/busabase__busabase-dsh-plugin.yml
+++ b/data/plugins/busabase__busabase-dsh-plugin.yml
@@ -1,0 +1,6 @@
+url: https://github.com/busabase/busabase-dsh-plugin
+name: busabase/busabase-dsh-plugin
+category: memory
+description:
+  en: 'Connects DeepSeek Harness to Busabase: search workspace knowledge, work with structured records and apps, submit writes as reviewable ChangeRequests, and inspect results in live cards.'
+  zh: '把 DeepSeek Harness 接入 Busabase：检索工作区知识、操作结构化记录与应用、将写入提交为可审阅的 ChangeRequest，并在实时卡片中查看结果。'


### PR DESCRIPTION
Adds `busabase/busabase-dsh-plugin` to the Memory category.

- Connects DeepSeek Harness to Busabase workspace knowledge, structured records, and apps.
- Writes are submitted as reviewable ChangeRequests rather than silently becoming canonical data.
- Results render as conversation cards with a live Inspector.
- Declares `dsh.bundle`, is published on npm as `@busabase/dsh-plugin`, and carries the `dsh-plugin` topic.
- Only `data/plugins/busabase__busabase-dsh-plugin.yml` is added; generated READMEs are left to the repository workflow.

Disclosure: I work on Busabase.