### PR TITLE
Add Player-MINEPIG/dsh-tavern to Fun

### DIFF
--- a/data/plugins/Player-MINEPIG__dsh-tavern.yml
+++ b/data/plugins/Player-MINEPIG__dsh-tavern.yml
@@ -1,0 +1,6 @@
+url: https://github.com/Player-MINEPIG/dsh-tavern
+name: Player-MINEPIG/dsh-tavern
+category: fun
+description:
+  en: 'SillyTavern-compatible roleplay with character cards, presets, world books, and swipe branches that restore their continuations alongside native DSH conversations.'
+  zh: '为 DSH 提供兼容 SillyTavern 的角色扮演，支持角色卡、预设、世界书及保留后续对话的 swipe 分支，并可切回原生会话视图。'


### PR DESCRIPTION
## Summary

Add [pmp-dsh-tavern](https://github.com/Player-MINEPIG/dsh-tavern), a SillyTavern-compatible roleplay framework for DeepSeek Harness, under `fun`. Its primary purpose is character-driven storytelling, not productivity.

The entry covers character cards, presets, world books, and branching RP. Switching an earlier swipe restores that branch's later user messages and replies instead of discarding the continuation. Users can switch between the RP display and native DSH conversations; DSH remains the authoritative owner of session history.

Native tool and subagent workflows remain available subject to DSH permissions and Tavern's RP safety overlay. The screenshot gallery demonstrates three real subagents exploring story routes, with display-only regex keeping the final narrative in RP while native Chat retains the underlying records. This is a compatibility framework, not a claim of full SillyTavern feature parity or unrestricted tool execution.

## Compatibility and installation

- Version: [`v2.1.0`](https://github.com/Player-MINEPIG/dsh-tavern/tree/v2.1.0), commit `d9fedf7`.
- Supports only DSH `0.1.2-rc.1`. Earlier interfaces are incompatible; later versions are unverified and compatibility is not promised.
- Install from GitHub using the command below. No npm package or Release tarball is required for this entry.

```sh
dsh plugin --profile web add github:Player-MINEPIG/dsh-tavern
```

The [installation guide](https://github.com/Player-MINEPIG/dsh-tavern/blob/v2.1.0/docs/INSTALLATION_en.md) explains exact DSH-provided runtime peers, startup resolution, and pnpm's static missing-peer warning. Tavern data lives outside the package and survives ordinary removal; native DSH history remains readable.

## Verification and screenshots

- A fresh isolated DSH `0.1.2-rc.1` profile on macOS / Node `22.23.1` installed the GitHub candidate at `a2e2566`. Host API reads and the installed prompt bridge's UUID call passed; peers resolved from DSH. `d9fedf7` changes only version metadata and documentation from that tested commit.
- RP interaction, locale switching, initial credential onboarding, API error notices, and all seven screenshots passed acceptance. See the [acceptance record](https://github.com/Player-MINEPIG/dsh-tavern/blob/v2.1.0/docs/PLAY_REVIEW_en.md).
- [Screenshot manifest](https://github.com/Player-MINEPIG/dsh-tavern/blob/v2.1.0/screenshots.json) and [annotated gallery](https://github.com/Player-MINEPIG/dsh-tavern/blob/v2.1.0/docs/assets/market/README.md#gallery).

## Submission checklist

- [x] Add only `data/plugins/Player-MINEPIG__dsh-tavern.yml` to this PR; leave generated READMEs and other entries unchanged, following the current contributing guide.
- [x] The public repository contains working code and declares `dsh.bundle` with its patch file.
- [x] The repository is over one day old, is not archived, and has the `dsh-plugin` topic.
- [x] Category `fun` matches the plugin's purpose; both descriptions state implemented behavior without superlatives.
- [x] Official runtime packages are exact required peers; screenshots are declared in the plugin repository.

Local submission validation: `npm ci --ignore-scripts` and the Market repository's `validateEntries(readEntries())` passed; the commit adds exactly one YAML file, matching the maintainer-approved draft. Generated READMEs are intentionally omitted.
