### PR TITLE
Add bainianlaoyao/dsh-session-robustness

### DIFF
--- a/data/plugins/bainianlaoyao__dsh-session-robustness.yml
+++ b/data/plugins/bainianlaoyao__dsh-session-robustness.yml
@@ -1,0 +1,6 @@
+url: https://github.com/bainianlaoyao/dsh-session-robustness
+name: bainianlaoyao/dsh-session-robustness
+category: session
+description:
+  en: 'After official llm-retry (n/5) gives up, keep retrying transient API failures (timeout, transport, rate-limit, 5xx, dropped SSE) on the same open step until success, cancel, or pause; AUTH, QUOTA, and user Stop are never retried.'
+  zh: 官方 llm-retry（n/5）耗尽后，对超时/传输/限流/5xx/SSE 断流等瞬时失败在同一打开 step 上继续重试直到成功、取消或暂停；认证失败、额度耗尽和用户停止不会重试。


### PR DESCRIPTION
## Add plugin

- **Repo:** https://github.com/bainianlaoyao/dsh-session-robustness
- **npm:** `dsh-session-robustness@0.1.4`
- **Install:** `dsh plugin --profile web add dsh-session-robustness`
- **Category:** session
- **dsh.bundle.patch** + **dsh.client** declared
- **`dsh-plugin` topic** set

After official `@deepseek-ai/dsh-llm-retry` (UI `n/5`) gives up, this plugin keeps retrying transient API failures (timeout, transport, rate-limit, 5xx, dropped SSE, Codex overloaded) on the same open step until success, cancel, or pause. AUTH, QUOTA, context overflow, and user Stop are never retried.

Note: the repo was created today, so the 1-day age check may fail until tomorrow. Happy to wait for that gate.