### PR TITLE
add dsh-model-modality (model): declare third-party model image input

### DIFF
--- a/data/plugins/ct-jyjntc__dsh-model-modality.yml
+++ b/data/plugins/ct-jyjntc__dsh-model-modality.yml
@@ -1,0 +1,6 @@
+url: https://github.com/ct-jyjntc/dsh-model-modality
+name: ct-jyjntc/dsh-model-modality
+category: model
+description:
+  en: "Declare whether a configured third-party model accepts image (multimodal) input; writes the modality into the owning provider settings and verifies it through runtime model resolution."
+  zh: "声明第三方模型是否支持图像（多模态）输入，写入所属提供方设置并通过运行时模型解析校验。"


### PR DESCRIPTION
Single DSH plugin **dsh-model-modality** (source-installable, dsh.bundle): two model tools — `declare_model_multimodal(provider, model, supportsImage)` declares whether a configured third-party model accepts image input by writing the modality into the owning provider settings namespace (llm-deepseek: models[].inputModalities; llm-pi-ai: models[].input or modelOverrides[].input) and verifying it through llm.resolveModelInfo; `list_model_multimodal(provider?, model?)` lists declared input modalities. Repo: https://github.com/ct-jyjntc/dsh-model-modality · install: `dsh plugin add ct-jyjntc/dsh-model-modality`. Category: model.