### PR TITLE
Add ffseika0304/code-ownership-audit

### DIFF
--- a/data/plugins/ffseika0304__code-ownership-audit.yml
+++ b/data/plugins/ffseika0304__code-ownership-audit.yml
@@ -1,0 +1,6 @@
+url: https://github.com/ffseika0304/code-ownership-audit
+name: ffseika0304/code-ownership-audit
+category: skill
+description:
+  en: 'Decides whether Python code is original or a derivative work: reports the longest identical expression span against an upstream tree, an exemption rationale per finding, and a risk list. Pure stdlib `ast` analysis — offline, no model calls.'
+  zh: '判定 Python 代码是原创还是演绎作品：给出与上游最长相同表达片段、逐条豁免依据和风险清单。纯标准库 `ast` 分析——离线运行，不调用模型。'


### PR DESCRIPTION
Adds one entry: `ffseika0304/code-ownership-audit`.

Decides whether Python code is original or a derivative work, reporting the longest
identical expression span against an upstream tree, an exemption rationale per finding,
and a risk list.

**Checklist**

- `package.json` declares `dsh.bundle` (`{"dsh":{"bundle":{"patch":"./cordis.patch.yml"}}}`), with `cordis.patch.yml` at the repo root.
- The `dsh-plugin` topic is on the repo.
- Real working code: the audit engine is 741 lines of Python with 31 tests.
- The plugin layer is plain ESM JavaScript with **zero runtime dependencies and no build step**, so installing it does not hit the pnpm `allowBuilds` prompt.
- Not a meta-package — it ships the audit engine itself, not a dependency list.
- One entry, one file. No existing entries touched, and the generated READMEs are untouched.

**On the description being accurate**

The claim "pure stdlib `ast` analysis, offline, no model calls" is checkable: `audit.py`
imports only `argparse`, `ast`, `difflib`, `hashlib`, `json`, `re`, `sys`, `datetime` and
`pathlib` — all standard library. The audit path makes no network or model calls.

**One thing I should flag myself:** the repository was created earlier today, so the
1-day age check may not have elapsed yet depending on when CI runs. If it fails on age,
I'll push to this same branch tomorrow rather than opening a new PR — happy to wait.
