### PR TITLE
Use GitHub sources for MDR-EX1000 plugins

### DIFF
--- a/data/plugins/MDR-EX1000__dsh-desktop-kit.yml
+++ b/data/plugins/MDR-EX1000__dsh-desktop-kit.yml
@@ -1,7 +1,6 @@
 url: https://github.com/MDR-EX1000/dsh-desktop-kit
 name: MDR-EX1000/dsh-desktop-kit
 category: ui
-tarball: https://github.com/MDR-EX1000/dsh-desktop-kit/releases/latest/download/dsh-desktop-kit.tgz
 description:
   en: 'macOS desktop shell for the DSH web UI: a plugin plus a small Tauri/WKWebView window over the loopback web surface — real macOS fullscreen, single instance, external links delegated to the system browser, and browser-style zoom.'
   zh: '把 DSH Web UI 装进原生 macOS 桌面窗口：插件 + 轻量 Tauri/WKWebView 外壳跑在同一个 loopback 地址上——真 macOS 全屏、单实例、外链交给系统浏览器、类浏览器页面缩放。'

--- a/data/plugins/MDR-EX1000__dsh-rw.yml
+++ b/data/plugins/MDR-EX1000__dsh-rw.yml
@@ -1,7 +1,6 @@
 url: https://github.com/MDR-EX1000/dsh-rw
 name: MDR-EX1000/dsh-rw
 category: remote
-tarball: https://github.com/MDR-EX1000/dsh-rw/releases/latest/download/dsh-rw.tgz
 description:
   en: 'Remote-SSH-style workspaces: turn an SSH host and a remote directory into a native DSH workspace; the agent operates the remote filesystem directly via 12 rw_* tools (SFTP/exec), with workspace-confined paths and known_hosts verification.'
   zh: 'Remote-SSH 风格工作区：把 SSH 主机上的远程目录变成原生 DSH 工作区，agent 通过 12 个 rw_* 工具（SFTP/exec）直接操作远程文件，路径限定在工作区内并校验 known_hosts。'


### PR DESCRIPTION
The two MDR-EX1000 plugin entries currently force Release tarball URLs, so DSH shows the full `.tgz` URL as the installed source and returns to that source after reinstalling from Market. Removing `tarball` lets Market use the entries' GitHub repositories directly, yielding `github:MDR-EX1000/dsh-rw` and `github:MDR-EX1000/dsh-desktop-kit`.

Both repositories track the build artifacts required for direct GitHub installation:

- `dsh-rw` tracks its compiled `lib/` bundle.
- `dsh-desktop-kit` tracks its compiled `lib/` bundle, native `bin/` launchers, and `app/` installer assets.

Validated locally by installing both through their GitHub sources in DSH Market. `dsh-rw` 0.4.3 and `dsh-desktop-kit` 0.2.6 both activate with `bundle: true`, `hot: true`, and `state: live`.

Local repository checks also passed: README generation, `awesome-lint`, and `SKIP_PUBLISH_CHECKS=1 node scripts/build-site.mjs`.
