### PR TITLE
Add guhanfei-ai/dsh-grafana and guhanfei-ai/dsh-mindmap

### DIFF
--- a/data/plugins/guhanfei-ai__dsh-grafana.yml
+++ b/data/plugins/guhanfei-ai__dsh-grafana.yml
@@ -1,0 +1,6 @@
+url: https://github.com/guhanfei-ai/dsh-grafana
+name: guhanfei-ai/dsh-grafana
+category: tools
+description:
+  en: 'Grafana dashboard editor: paste a dashboard URL, edit the JSON through conversation, and push it back over the HTTP API.'
+  zh: 'Grafana 大盘编辑器：粘贴大盘 URL，通过对话修改 JSON，再经 HTTP API 推回 Grafana。'

--- a/data/plugins/guhanfei-ai__dsh-mindmap.yml
+++ b/data/plugins/guhanfei-ai__dsh-mindmap.yml
@@ -1,0 +1,6 @@
+url: https://github.com/guhanfei-ai/dsh-mindmap
+name: guhanfei-ai/dsh-mindmap
+category: ui
+description:
+  en: 'Markdown mindmap panel: a plain markdown file in the working directory is the mindmap; the chat edits it step by step and the side panel follows live.'
+  zh: 'Markdown 思维脑图面板：工作目录里一个普通 md 文件就是脑图，对话逐步编辑，侧栏面板实时跟随。'


### PR DESCRIPTION
Two plugins: dsh-grafana (tools, Grafana dashboard editor) and dsh-mindmap (ui, markdown mindmap panel). Both declare dsh.bundle manifests, publish npm packages pointing back at these repos, and carry the dsh-plugin topic. Both are adapted to dsh 0.1.2-rc.1.