### PR TITLE
Add yingjian666/dsh-zh-thinking

### DIFF
--- a/data/plugins/yingjian666__dsh-zh-thinking.yml
+++ b/data/plugins/yingjian666__dsh-zh-thinking.yml
@@ -1,0 +1,6 @@
+url: https://github.com/yingjian666/dsh-zh-thinking
+name: yingjian666/dsh-zh-thinking
+category: session
+description:
+  en: Injects one system-prompt section so the agent's chain-of-thought, planning and tool-invocation reasoning stay in Simplified Chinese. Zero external dependencies - clone and link-install from any local directory, no npm build or publish required.
+  zh: 注入一条系统提示词段落，让 Agent 的思维链、规划与工具调用推理全程使用简体中文；零外部依赖，git clone 后可从任意本地目录 link 安装，无需 npm 构建或发布。


### PR DESCRIPTION
Add plugin: dsh-zh-thinking — force the agent's chain-of-thought / planning /
tool-invocation reasoning to stay in Simplified Chinese.

Differences from similar plugins on the list:
- Zero external dependencies: it only consumes the ctx services that cordis
  injects (systemPrompt, logger, effect). No import of any npm package.
- Installable without npm: git clone then dsh plugin add link:<path> works from
  any local directory. No npm publish, no build step, no dependency resolution.
- Fixes a real failure mode: when a plugin is mounted via link: from a
  directory outside the profile/app node_modules tree, plugins that import
  third-party packages cannot resolve them and the whole plugin tree fails to
  load. This zero-dependency version does not.
- Single-file, ~60 lines, easy to review.

Repo declared dsh.bundle manifest (bundle.patch + cordis.patch.yml), real
working code, description matches the code.