### PR TITLE
Add Zn-Dk/dsh-zhipu-toolkit to Models & Providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1079,6 +1079,7 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 - [zhangjunjesse/dsh-claude-driver](https://github.com/zhangjunjesse/dsh-claude-driver) - Run the main session model on a local Claude Code subscription through the official Claude Agent SDK, taking over the llm/stream route for the claude-code provider, with token-level streaming, session resume, and DSH tools bridged in over MCP so they keep DSH sandbox and approval.
 - [zhangyqjiaoshou-oss/dsh-model-sync](https://github.com/zhangyqjiaoshou-oss/dsh-model-sync) - One-click/auto sync provider model lists against /v1/models endpoint.
 - [zhubaohi/dsh-qwen38-compaction-fix](https://github.com/zhubaohi/dsh-qwen38-compaction-fix) - Compaction fix for NInfer-hosted qwen3.8-27b gateways: disables thinking on dsh context-compaction and session-title calls so xhigh reasoning stops burning the whole output budget; the same idea applies to other launch methods, this package targets NInfer only.
+- [Zn-Dk/dsh-zhipu-toolkit](https://github.com/Zn-Dk/dsh-zhipu-toolkit) - Dual-endpoint Zhipu BigModel GLM provider catalog (Coding Plan and ordinary API) with live model discovery, live-tested thinking-tier mapping, and a settings card for keys, endpoints and the default reasoning tier.
 
 ### Identity & Communication
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -1079,6 +1079,7 @@ dsh plugin --profile web add dshmarket
 - [zhangjunjesse/dsh-claude-driver](https://github.com/zhangjunjesse/dsh-claude-driver) — 让会话主模型跑在本机 Claude Code 订阅上：经官方 Claude Agent SDK 接管 claude-code provider 的 llm/stream 路由，支持 token 级流式、会话 resume 续接，并把 DSH 工具经 MCP 桥接进去以保留 DSH 的沙箱与审批。
 - [zhangyqjiaoshou-oss/dsh-model-sync](https://github.com/zhangyqjiaoshou-oss/dsh-model-sync) — 一键同步 / 自动同步供应商模型列表，与 /v1/models 保持一致。
 - [zhubaohi/dsh-qwen38-compaction-fix](https://github.com/zhubaohi/dsh-qwen38-compaction-fix) — 针对 NInfer 托管的 qwen3.8-27b 网关的压缩修复：在 dsh 上下文压缩与会话标题调用中关闭思考，避免 xhigh 推理耗尽全部输出预算；同一思路适用于其他启动方式，本包仅面向 NInfer。
+- [Zn-Dk/dsh-zhipu-toolkit](https://github.com/Zn-Dk/dsh-zhipu-toolkit) — 智谱 BigModel GLM 双端点模型目录（Coding Plan 与普通 API），支持实时模型发现与实测校准的思考档位映射，提供凭据、端点与默认推理档的可视化设置卡片。
 
 ### 🆔 身份与通信
 

--- a/data/plugins/Zn-Dk__dsh-zhipu-toolkit.yml
+++ b/data/plugins/Zn-Dk__dsh-zhipu-toolkit.yml
@@ -1,0 +1,6 @@
+url: https://github.com/Zn-Dk/dsh-zhipu-toolkit
+name: Zn-Dk/dsh-zhipu-toolkit
+category: model
+description:
+  en: Dual-endpoint Zhipu BigModel GLM provider catalog (Coding Plan and ordinary API) with live model discovery, live-tested thinking-tier mapping, and a settings card for keys, endpoints and the default reasoning tier.
+  zh: 智谱 BigModel GLM 双端点模型目录（Coding Plan 与普通 API），支持实时模型发现与实测校准的思考档位映射，提供凭据、端点与默认推理档的可视化设置卡片。


### PR DESCRIPTION
Adds `data/plugins/Zn-Dk__dsh-zhipu-toolkit.yml` (single entry, category: model). README.md / README.zh.md regenerated via `node scripts/generate-readme.mjs` after `npm ci`.

**Plugin**: [Zn-Dk/dsh-zhipu-toolkit](https://github.com/Zn-Dk/dsh-zhipu-toolkit) — dual-endpoint Zhipu BigModel GLM provider catalog (Coding Plan + ordinary API) with live model discovery, live-tested thinking-tier mapping, and a settings card. Published on npm as `dsh-zhipu-toolkit@0.1.0`.

**Submission-gate note**: the repo was created 2026-09-07T11:04:58Z, so it reaches the 24-hour age requirement at 2026-09-08T11:04:58Z. If the gate rejects on age before then, I will push to this branch after that time to re-trigger the check (commit count 11 ≥ 10, `dsh.bundle.patch` declared, `dsh-plugin` topic set).