### PR TITLE
fix: refresh Open Sea theme download for DSH Desktop glass fix

### DIFF
--- a/data/plugins/d-dev0101__open-sea-skin.yml
+++ b/data/plugins/d-dev0101__open-sea-skin.yml
@@ -1,7 +1,7 @@
 url: https://github.com/d-dev0101/open-sea-skin
 name: d-dev0101/open-sea-skin
 category: theme
-tarball: https://github.com/d-dev0101/open-sea-skin/releases/download/v1.2.0/open-sea-skin-1.2.0.tgz
+tarball: https://github.com/d-dev0101/open-sea-skin/releases/latest/download/open-sea-skin.tgz
 description:
   en: Realtime WebGPU ocean skin with quick controls for waves, daylight, glass opacity, and an automatic day cycle.
   zh: 实时 WebGPU 海洋皮肤，可快捷调节波浪、日光、玻璃不透明度与自动昼夜循环。


### PR DESCRIPTION
The Open Sea entry currently pins its release tarball to v1.2.0, so consumers using that field cannot receive later fixes. This changes only our entry's tarball to a version-free latest-release asset; `category: theme` and both descriptions remain unchanged.

Open Sea v1.2.3 fixes uneven sidebar/conversation/details glass in DSH Desktop's advanced and extended shells. We attach a byte-identical `open-sea-skin.tgz` to this release and document preserving that asset name for future releases.

- Release: https://github.com/d-dev0101/open-sea-skin/releases/tag/v1.2.3
- npm: https://www.npmjs.com/package/open-sea-skin
- Project demo: https://d-dev0101.github.io/open-sea-skin/
- Validation: 16 repository tests, browser/static-install acceptance, website acceptance and 24 Desktop-shell regression combinations. The Desktop test uses a reduced shell fixture based on 2.0.5-beta.1, not a full native end-to-end run.

The user installed via dsh-market 1.38.1 in DSH Desktop Beta and also asked for placement in the Themes tab. I checked the live catalog: it already reports `category: theme` and `npm: open-sea-skin`. Please retain that classification and confirm the refreshed release is visible in Themes; no duplicate listing is needed. Thank you!
