### PR TITLE
Add sanqiPanax/jieyaTool to tools category

### DIFF
--- a/data/plugins/sanqiPanax__jieyaTool.yml
+++ b/data/plugins/sanqiPanax__jieyaTool.yml
@@ -1,0 +1,6 @@
+url: https://github.com/sanqiPanax/jieyaTool
+name: sanqiPanax/jieyaTool
+category: tools
+description:
+  en: 'Batch recursive extraction: magic-byte format detection (disguised extensions), nested archive auto-unroll, multi-password pool with per-layer dynamic discovery, SFX/split-volume pairing.'
+  zh: '批量递归解压：魔数识别真实格式（伪装后缀/无后缀/乱序后缀）、嵌套压缩包自动解到底、多密码池+层内动态发现（"第二层密码:xxx"）、SFX/分卷自动配对、工具运行库目录防误递归。'


### PR DESCRIPTION
添加 dsh-auto-extract(原 jieyaTool v2)自动批量递归解压插件。

- 魔数识别真实格式(伪装后缀/无后缀/乱序后缀都支持)
- 递归解压嵌套压缩包到尽头
- 多密码:全局密码文件 + 解出内容自动发现"第二层密码:xxx"
- SFX/分卷自动配对,跳过附属卷;exe 7z 探测排除成品(Type=PE)
- 工具运行库目录跳过防误递归
- package.json 声明 dsh.bundle,可 dsh plugin add 安装
