### PR TITLE
Add dsh-token-plan-quota (usage)

### DIFF
--- a/data/plugins/xinghe-1018__dsh-token-plan-quota.yml
+++ b/data/plugins/xinghe-1018__dsh-token-plan-quota.yml
@@ -1,0 +1,6 @@
+url: https://github.com/xinghe-1018/dsh-token-plan-quota
+name: xinghe-1018/dsh-token-plan-quota
+category: usage
+description:
+  en: 'Balance badge that follows the active model provider: official readings for DeepSeek, Qwen Token Plan and Aliyun BSS, plus Moonshot and OpenRouter endpoints not yet key-verified.'
+  zh: '跟随当前模型供应商的额度徽标：DeepSeek、千问 Token Plan、阿里云费用中心取官方真值，Moonshot / OpenRouter 已接官方端点但字段未用真 Key 核对；其余只报本实例实测。'


### PR DESCRIPTION
Balance/quota badge for DeepSeek Harness web UI that follows the active model provider. Official readings: DeepSeek /user/balance, Qwen Token Plan console gateway, Aliyun BSS; Moonshot and OpenRouter endpoints are wired but their field names are not yet verified with a real key; everything else shows a clearly-labelled measured (this-instance only) window. No Credits conversion, no remaining-quota estimation.

<!-- Thanks for contributing! Quick checklist / 提交前快速自查 -->

- [x] I added **one file** at `data/plugins/<owner>__<repo>.yml` — that single file is the whole submission. The READMEs are regenerated on `main` after merge: don't edit them by hand, and you don't need to commit them either / 我新增了一个 `data/plugins/<owner>__<repo>.yml` 文件——**这一个文件就是全部投稿**。README 会在合并后由 `main` 自动重新生成：不要手工编辑，也不需要提交
- [x] My repo's `package.json` declares **`dsh.bundle`** (not just `dsh.client`) — [example](../blob/main/contributing.md) / 仓库 `package.json` 已声明 `dsh.bundle`（只有 `dsh.client` 无法安装）
- [x] My repo is at least **1 day old** / 仓库创建满 1 天
- [x] `category` is one of `agi ui usage theme model identity session memory tools wsl browser vision voice docs skill workflow git notify dev security remote market fun` ([full list with descriptions](../blob/main/contributing.md)), and themes/skins go under `theme` / `category` 取值正确（完整清单见 contributing.md），主题/皮肤类请用 `theme`
- [x] Description states what the plugin does, no superlatives / 描述只说功能，不带营销词
- [x] My repo has the `dsh-plugin` topic / 仓库已打 `dsh-plugin` topic

**与相邻插件的区别 / How this differs from the neighbour**
`dsh-cost-meter`（已在榜）做的是九家 Coding Plan 的**用量与成本**；本插件做的是**额度**：
官方接口给真值，没有官方额度接口的一家只显示明确标注「实测」的本实例窗口。
`dsh-cost-meter` 已在榜，两者不重叠：本插件不折算 Credits、不做抵扣率、不"按历史推算剩余"。

**关于描述里的收窄 / About the narrowed description**
`description` 故意写明"哪三家核过、哪两家待核"。Moonshot 与 OpenRouter 的官方端点已接通，
但字段名未用真 Key 逐一核对——README 的表格逐字段标了核对状态，所以描述不能写成"全部官方余额"。

**已满足的推荐项 / Recommended items already done**
- 已发布 npm：`dsh-token-plan-quota@0.4.2`（预构建产物，`dsh plugin add dsh-token-plan-quota` 一条命令装好）
- `dependencies` 与 `peerDependencies` **均为空**：插件零运行时依赖，不存在 profile 里重复运行时的风险

**Recommended (not required) / 推荐但不强制：**

- 📦 Publish to npm — npm installs are prebuilt and skip the `allowBuilds` approval, so users get a one-command install / 发布 npm 包：预构建产物免 `allowBuilds` 授权，用户一条命令装好
- 🔗 Declare official `@deepseek-ai/*` packages as `peerDependencies` (not `dependencies`) — avoids duplicate runtimes inside the profile / 官方 `@deepseek-ai/*` 包用 `peerDependencies` 声明（而非 `dependencies`），避免 profile 里出现重复运行时
- 🖼️ Screenshots go in **your own repository** now: a `screenshots.json` beside your `package.json`, listing image paths. Nothing to add here, and you can change them later without another pull request ([how](../blob/main/contributing.md#screenshots--截图optional-recommended--可选推荐)) / 截图现在放在**你自己的仓库**里：在 `package.json` 旁边放一个 `screenshots.json`，列出图片路径。这个 PR 里不用加任何东西，以后想换也不必再提 PR（[说明](../blob/main/contributing.md#screenshots--截图optional-recommended--可选推荐)）
