### PR TITLE
add weisofns/dsh-print3d

### DIFF
--- a/data/plugins/weisofns__dsh-print3d.yml
+++ b/data/plugins/weisofns__dsh-print3d.yml
@@ -1,0 +1,6 @@
+url: https://github.com/weisofns/dsh-print3d
+name: weisofns/dsh-print3d
+category: tools
+description:
+  en: '3D printing & additive manufacturing plugin for DeepSeek Harness: parametric STL generation, calibration G-code, STL/G-code analysis, toolpath rendering and PrusaSlicer bridge, plus 5 skills and a concise persona optimized for local models.'
+  zh: 'DeepSeek Harness 的 3D 打印与增材制造插件：参数化 STL 生成、校准 G-code、STL/G-code 分析、刀路可视化、PrusaSlicer 桥接，含 5 个技能与面向本地小模型的精简 persona。'


### PR DESCRIPTION
## Summary

Adds [weisofns/dsh-print3d](https://github.com/weisofns/dsh-print3d) - a 3D printing & additive manufacturing plugin for DeepSeek Harness.

## What it provides

- **7 model tools**: parametric STL generation (box / cylinder / tube / sphere / cone / rounded_box / gear), calibration G-code, STL analysis, G-code time & filament estimation, toolpath rendering, and a PrusaSlicer bridge.
- **5 skills**: slicing parameters, G-code dialect reference, parametric modeling, mesh/G-code analysis, and print-failure diagnosis.
- A **concise persona** optimized for local models (Ollama + Qwen3).

## Verification

- Install path: package.json#dsh.bundle.patch (via cordis.patch.yml).
- Loads against dsh 0.1.2-alpha.1 (dsh plugin add + --dump-config verified).