### PR TITLE
Update dsh-ticker-jp description to global-market positioning

### DIFF
--- a/data/plugins/MurasakiIzumi__dsh-ticker-jp.yml
+++ b/data/plugins/MurasakiIzumi__dsh-ticker-jp.yml
@@ -2,5 +2,5 @@ url: https://github.com/MurasakiIzumi/dsh-ticker-jp
 name: MurasakiIzumi/dsh-ticker-jp
 category: ui
 description:
-  en: 'A floating Japanese-stock ticker for DeepSeek Harness: real-time Nikkei 225 and TOPIX ETF quotes from Yahoo Finance, with a customizable watchlist and display-name aliases.'
-  zh: 'DeepSeek Harness 的日股行情悬浮窗：通过 Yahoo Finance 实时显示日经225 与 TOPIX ETF 报价，支持自定义自选代码与显示别名。'
+  en: 'A floating stock ticker for DeepSeek Harness: real-time quotes for Nikkei 225 and TOPIX ETF out of the box, plus worldwide markets via Yahoo Finance — Japan (.T), US, Hong Kong (.HK), China (.SS/.SZ) and any other symbol — with a customizable watchlist, display aliases and 16 UI languages.'
+  zh: 'DeepSeek Harness 的全球股市行情悬浮窗：默认显示日经225 与 TOPIX ETF，另支持通过 Yahoo Finance 实时报价全球市场——日本 .T、美国、香港 .HK、中国 .SS/.SZ 及任意代码，带自选列表、显示别名与 16 种界面语言。'


### PR DESCRIPTION
Updating the description of my own entry `MurasakiIzumi/dsh-ticker-jp`.

The plugin now positions itself as a global stock ticker (Japan `.T`, US, Hong Kong `.HK`, China `.SS/.SZ`, any Yahoo symbol) with 16 UI languages; the repo READMEs and package description were updated in v1.0.3.

- Only my own entry file is touched.
- Description states facts only (worldwide-market support, watchlist/aliases, 16 UI languages) and ends with a period.