### PR TITLE
Add 招投标智能体 / tender workbench workflow plugin

### DIFF
--- a/data/plugins/duhu2000__dsh-tender-workbench.yml
+++ b/data/plugins/duhu2000__dsh-tender-workbench.yml
@@ -1,0 +1,6 @@
+url: https://github.com/duhu2000/dsh-tender-workbench
+name: duhu2000/dsh-tender-workbench
+category: workflow
+description:
+  en: 'Session-scoped tender workbench using user-authorized QCC MCP tools for tender and proposed-project search, rule screening, human review, and Excel/PDF reports.'
+  zh: '招投标智能体：通过用户自备授权的企查查 MCP 工具，在独立会话中查询标讯与拟建项目、执行规则筛选和人工复核，并导出 Excel/PDF 报告。'


### PR DESCRIPTION
## Plugin submission / 招投标智能体

Adds one `workflow` entry for [duhu2000/dsh-tender-workbench](https://github.com/duhu2000/dsh-tender-workbench). No other entries or generated READMEs are changed.

The plugin provides a Session-scoped tender workflow: searches tenders and proposed projects through the user's authorized QCC MCP tools, previews/confirms screening rules, keeps Agent suggestions separate from human review, and exports Excel/PDF reports. It does not supply shared credentials or free data quota.

### Eligibility and installation

- Public MIT repository, created 2026-09-04 (older than one day), real Host/Client source and active maintenance; `dsh-plugin` topic added.
- `package.json` declares `dsh.bundle.patch: ./cordis.patch.yml`; the patch inserts the `dsh-tender-workbench` loader.
- [npm 0.5.2](https://www.npmjs.com/package/dsh-tender-workbench/v/0.5.2) is prebuilt and points back to the submitted repository. [Release v0.5.2](https://github.com/duhu2000/dsh-tender-workbench/releases/tag/v0.5.2) and npm gitHead match `b946e97063ef3de44e6897ce429fc4c4f1d4ca52`. No immutable release/tag/package is changed by this submission.
- Node `^22.19.0 || >=24.0.0`; DSH public packages baseline 0.1.1-rc.2, explicit 0.1.2 prerelease peer branch. Requires JSONL session persistence, public Host services, Better Sidebar >=0.17.1 (`targetedOpen`/`stateSubscription`) and MCP Connector >=0.2.31. The supported UI is Web; declared ranges are not a claim that every future build was tested.
- BYO authorized `qcc-tender` connection exposing `mcp__qcc-tender__search_tenders` and `mcp__qcc-tender__search_proposed_projects`. QCC permissions/quotas/fees and model configuration are the user's; no bundled keys, resale, quota promise, or Web-search fallback.

### Evidence and limitations

- [Market registration, compatibility and evidence](https://github.com/duhu2000/dsh-tender-workbench/blob/main/docs/MARKET-SUBMISSION.md).
- Fresh temporary `DSH_HOME`: DSH CLI 0.1.1-rc.2 / pnpm 11.1.1 installed npm 0.5.2 with `--ignore-scripts`, exit 0; version, bundle layer, patch and built Host/Client files verified. Uninstall exit 0; dependency, bundle layer and package directory removed. Peer warnings were present. This proves isolated package management/bundle reconciliation only, NOT a live Web boot, real QCC query, or marketplace one-click installation.
- 219 tests passed / 1 existing skip; 8 isolated React/Chromium UI cases passed; [release CI](https://github.com/duhu2000/dsh-tender-workbench/actions/runs/34071262963) and [OIDC publication](https://github.com/duhu2000/dsh-tender-workbench/actions/runs/34071395235) passed.
- Repository `screenshots.json` declares two actual-component fixture screenshots, visibly labeled isolated UI validation without DSH/MCP. No customer data, credentials, production configuration or real business responses. These are UI illustrations, not live-host acceptance evidence.
- Local entry schema validation passed. Submission/PR checks and maintainer review remain the authority for this PR. An open PR is not a completed listing.
