### PR TITLE
Add duhu2000/dsh-pre-duediligence

### DIFF
--- a/data/plugins/duhu2000__dsh-pre-duediligence.yml
+++ b/data/plugins/duhu2000__dsh-pre-duediligence.yml
@@ -1,0 +1,6 @@
+url: https://github.com/duhu2000/dsh-pre-duediligence
+name: duhu2000/dsh-pre-duediligence
+category: workflow
+description:
+  en: 'Prepare a session-scoped enterprise pre-visit due-diligence brief in DeepSeek Harness, with explicit entity confirmation and tool-call budget approval for Qichacha MCP queries.'
+  zh: '在 DeepSeek Harness 中按会话准备企业访前尽调简报，并在调用企查查 MCP 前要求明确的主体确认和工具调用预算授权。'


### PR DESCRIPTION
## Summary

- Add the session-scoped pre-visit due-diligence workflow plugin.
- Keep the submission to one YAML file, based on the current upstream `main`.
- Describe entity confirmation and Qichacha MCP tool-budget approval without claiming pending real-host/provider validation.

## Verification

- Public repository, MIT license, `dsh-plugin` topic, older than one day, 19 commits at submission time.
- `package.json` declares `dsh.bundle.patch`; `cordis.patch.yml` and built entry points are present.
- npm `latest` and GitHub Release are both `0.1.9`; the npm repository field points to the submitted repository.
- Repository-owned `screenshots.json` contains four sanitized synthetic UI screenshots.
- Local marketplace schema validation passed; the PR adds one file and does not edit generated READMEs.

## Compatibility boundary

Real DSH four-plugin integration and live Qichacha Provider validation remain pending and are documented in the plugin repository. Users bring their own QCC account, permissions, and quota.