### PR TITLE
plugin: add dsh-session-tree (append-only multi-branch session trees)

### DIFF
--- a/data/plugins/robiteame__dsh-session-tree-extension.yml
+++ b/data/plugins/robiteame__dsh-session-tree-extension.yml
@@ -1,10 +1,3 @@
-# awesome-dsh-plugin 收录申请(按官方 contributing.md 核实过)
-
-提交方式:向 `github.com/awesome-dsh-plugin/awesome-dsh-plugin` 提 PR,
-**只新增一个文件**:`data/plugins/robiteame__dsh-session-tree-extension.yml`,
-内容如下(与现有条目 schema 一致):
-
-```yaml
 url: "https://github.com/robiteame/dsh-session-tree-extension"
 name: "robiteame/dsh-session-tree-extension"
 category: "tools"
@@ -12,36 +5,3 @@ description:
   en: "Pi-style append-only multi-branch session trees: fork or jump to any historical node without deleting history, clone a branch into a new session, and browse the tree in a WebUI panel. Works on stock Harness via graceful degradation."
   zh: "Pi 风格的追加式多分支会话树:在任意历史节点开分支或跳转而不删除旧历史,可将分支克隆为新会话,并在 WebUI 树面板中浏览(明暗主题)。在原版 Harness 上优雅降级运行。"
 npm: "@robiteame/dsh-session-tree"
-```
-
-> `npm:` 字段属于可选附加项;若 CI lint 报不认识该字段,删掉这一行再推即可。
-> 注意描述里含 `: ` 的值必须带引号(YAML 语法要求)。
-
-## 提交前置检查单(官方 CI 会逐项检查)
-
-| 要求                                  | 状态                                        |
-| ------------------------------------- | ------------------------------------------- |
-| 仓库 `package.json` 声明 `dsh.bundle` | ✅ 已在根 package.json 声明,指向载体包组合层 |
-| 真实可用代码(无占位)                  | ✅ 已发布 4 个 npm 包并有完整测试            |
-| 仓库年龄 ≥ 1 天                       | ✅                                           |
-| 仓库打了 `dsh-plugin` 主题标签        | ⬜ 提 PR 前记得在 GitHub 网页添加(见下)      |
-| 一个 PR 只加一个条目                  | ✅ 我们只加一个文件                          |
-
-## 给仓库打 `dsh-plugin` 主题标签(网页操作)
-
-1. 打开 `github.com/robiteame/dsh-session-tree-extension`
-2. 右侧 About 栏点齿轮 ⚙️
-3. 在 Topics 输入 `dsh-plugin` 回车 → Save changes
-
-## 提 PR 的网页操作步骤
-
-1. 打开 https://github.com/awesome-dsh-plugin/awesome-dsh-plugin → 右上角 **Fork**
-2. 在你的 fork 里进入 `data/plugins/` 目录 → **Add file → Create new file**
-3. 文件名粘贴:`robiteame__dsh-session-tree-extension.yml`
-4. 内容粘贴上面的 YAML → **Commit changes**
-5. 页面会出现 "This branch is X commits ahead" → 点 **Contribute → Open pull request**
-6. PR 标题:`plugin: add dsh-session-tree (append-only multi-branch session trees)`
-7. 提交后等 CI 变绿;若 CI 报错按提示修改(推到同一分支即可,不要重开 PR)
-
-维护者合并后,README 和市场网站会自动重新生成;次日即可在 DSH 插件市场内
-搜索 `session tree` 并一键安装。

--- a/data/plugins/robiteame__dsh-session-tree-extension.yml
+++ b/data/plugins/robiteame__dsh-session-tree-extension.yml
@@ -1,0 +1,47 @@
+# awesome-dsh-plugin 收录申请(按官方 contributing.md 核实过)
+
+提交方式:向 `github.com/awesome-dsh-plugin/awesome-dsh-plugin` 提 PR,
+**只新增一个文件**:`data/plugins/robiteame__dsh-session-tree-extension.yml`,
+内容如下(与现有条目 schema 一致):
+
+```yaml
+url: "https://github.com/robiteame/dsh-session-tree-extension"
+name: "robiteame/dsh-session-tree-extension"
+category: "tools"
+description:
+  en: "Pi-style append-only multi-branch session trees: fork or jump to any historical node without deleting history, clone a branch into a new session, and browse the tree in a WebUI panel. Works on stock Harness via graceful degradation."
+  zh: "Pi 风格的追加式多分支会话树:在任意历史节点开分支或跳转而不删除旧历史,可将分支克隆为新会话,并在 WebUI 树面板中浏览(明暗主题)。在原版 Harness 上优雅降级运行。"
+npm: "@robiteame/dsh-session-tree"
+```
+
+> `npm:` 字段属于可选附加项;若 CI lint 报不认识该字段,删掉这一行再推即可。
+> 注意描述里含 `: ` 的值必须带引号(YAML 语法要求)。
+
+## 提交前置检查单(官方 CI 会逐项检查)
+
+| 要求                                  | 状态                                        |
+| ------------------------------------- | ------------------------------------------- |
+| 仓库 `package.json` 声明 `dsh.bundle` | ✅ 已在根 package.json 声明,指向载体包组合层 |
+| 真实可用代码(无占位)                  | ✅ 已发布 4 个 npm 包并有完整测试            |
+| 仓库年龄 ≥ 1 天                       | ✅                                           |
+| 仓库打了 `dsh-plugin` 主题标签        | ⬜ 提 PR 前记得在 GitHub 网页添加(见下)      |
+| 一个 PR 只加一个条目                  | ✅ 我们只加一个文件                          |
+
+## 给仓库打 `dsh-plugin` 主题标签(网页操作)
+
+1. 打开 `github.com/robiteame/dsh-session-tree-extension`
+2. 右侧 About 栏点齿轮 ⚙️
+3. 在 Topics 输入 `dsh-plugin` 回车 → Save changes
+
+## 提 PR 的网页操作步骤
+
+1. 打开 https://github.com/awesome-dsh-plugin/awesome-dsh-plugin → 右上角 **Fork**
+2. 在你的 fork 里进入 `data/plugins/` 目录 → **Add file → Create new file**
+3. 文件名粘贴:`robiteame__dsh-session-tree-extension.yml`
+4. 内容粘贴上面的 YAML → **Commit changes**
+5. 页面会出现 "This branch is X commits ahead" → 点 **Contribute → Open pull request**
+6. PR 标题:`plugin: add dsh-session-tree (append-only multi-branch session trees)`
+7. 提交后等 CI 变绿;若 CI 报错按提示修改(推到同一分支即可,不要重开 PR)
+
+维护者合并后,README 和市场网站会自动重新生成;次日即可在 DSH 插件市场内
+搜索 `session tree` 并一键安装。

--- a/data/plugins/robiteame__dsh-session-tree-extension.yml
+++ b/data/plugins/robiteame__dsh-session-tree-extension.yml
@@ -4,4 +4,3 @@ category: "tools"
 description:
   en: "Pi-style append-only multi-branch session trees: fork or jump to any historical node without deleting history, clone a branch into a new session, and browse the tree in a WebUI panel. Works on stock Harness via graceful degradation."
   zh: "Pi 风格的追加式多分支会话树:在任意历史节点开分支或跳转而不删除旧历史,可将分支克隆为新会话,并在 WebUI 树面板中浏览(明暗主题)。在原版 Harness 上优雅降级运行。"
-npm: "@robiteame/dsh-session-tree"


### PR DESCRIPTION
<!-- Thanks for contributing! Quick checklist / 提交前快速自查 -->

- [ ] I added **one file** at `data/plugins/<owner>__<repo>.yml` — that single file is the whole submission. The READMEs are regenerated on `main` after merge: don't edit them by hand, and you don't need to commit them either / 我新增了一个 `data/plugins/<owner>__<repo>.yml` 文件——**这一个文件就是全部投稿**。README 会在合并后由 `main` 自动重新生成：不要手工编辑，也不需要提交
- [ ] My repo's `package.json` declares **`dsh.bundle`** (not just `dsh.client`) — [example](../blob/main/contributing.md) / 仓库 `package.json` 已声明 `dsh.bundle`（只有 `dsh.client` 无法安装）
- [ ] My repo is at least **1 day old** / 仓库创建满 1 天
- [ ] `category` is one of `agi ui usage theme model identity session memory tools wsl browser vision voice docs skill workflow git notify dev security remote market fun` ([full list with descriptions](../blob/main/contributing.md)), and themes/skins go under `theme` / `category` 取值正确（完整清单见 contributing.md），主题/皮肤类请用 `theme`
- [ ] Description states what the plugin does, no superlatives / 描述只说功能，不带营销词
- [ ] My repo has the `dsh-plugin` topic / 仓库已打 `dsh-plugin` topic

**Recommended (not required) / 推荐但不强制：**

- 📦 Publish to npm — npm installs are prebuilt and skip the `allowBuilds` approval, so users get a one-command install / 发布 npm 包：预构建产物免 `allowBuilds` 授权，用户一条命令装好
- 🔗 Declare official `@deepseek-ai/*` packages as `peerDependencies` (not `dependencies`) — avoids duplicate runtimes inside the profile / 官方 `@deepseek-ai/*` 包用 `peerDependencies` 声明（而非 `dependencies`），避免 profile 里出现重复运行时
- 🖼️ Screenshots go in **your own repository** now: a `screenshots.json` beside your `package.json`, listing image paths. Nothing to add here, and you can change them later without another pull request ([how](../blob/main/contributing.md#screenshots--截图optional-recommended--可选推荐)) / 截图现在放在**你自己的仓库**里：在 `package.json` 旁边放一个 `screenshots.json`，列出图片路径。这个 PR 里不用加任何东西，以后想换也不必再提 PR（[说明](../blob/main/contributing.md#screenshots--截图optional-recommended--可选推荐)）
