### PR TITLE
Add jixishi/dsh-adapter-qq

### DIFF
--- a/data/plugins/jixishi__dsh-adapter-qq.yml
+++ b/data/plugins/jixishi__dsh-adapter-qq.yml
@@ -1,0 +1,6 @@
+url: https://github.com/jixishi/dsh-adapter-qq
+name: jixishi/dsh-adapter-qq
+category: remote
+description:
+  en: 'QQ Official Bot adapter for C2C single chat, interactive action boards, workspace session management, and real-time Web UI sync.'
+  zh: 'QQ 官方单聊机器人适配器：支持交互操作板、工作区会话管理与 Web UI 实时双向同屏。'


### PR DESCRIPTION
### Plugin Submission

- **Repository**: https://github.com/jixishi/dsh-adapter-qq
- **Package name**: `dsh-adapter-qq`
- **Category**: `remote`
- **Manifests**: Declares `dsh.bundle.patch` pointing to `./cordis.patch.yml` and `dsh.client`.
- **Description**:
  - en: QQ Official Bot adapter for C2C single chat, interactive action boards, workspace session management, and real-time Web UI sync.
  - zh: QQ 官方单聊机器人适配器：支持交互操作板、工作区会话管理与 Web UI 实时双向同屏。