### PR TITLE
Add zampie/sakura-afternoon-skin (theme)

### DIFF
--- a/data/plugins/zampie__sakura-afternoon-skin.yml
+++ b/data/plugins/zampie__sakura-afternoon-skin.yml
@@ -1,0 +1,6 @@
+url: https://github.com/zampie/sakura-afternoon-skin
+name: zampie/sakura-afternoon-skin
+category: theme
+description:
+  en: 'Sakura-afternoon pastel skin for the DSH Web UI: light and dark sakura token palettes, a click-through falling-petal overlay with a soft vignette, a header petal toggle and a General-settings master switch.'
+  zh: '樱色午后主题皮肤：浅色/深色各配一套柔和的樱色令牌配色，全屏飘落樱瓣与柔光晕（点击穿透），会话头部的樱瓣开关与「通用设置」里的皮肤总开关。'


### PR DESCRIPTION
Add **zampie/sakura-afternoon-skin** — a pastel sakura-afternoon (樱色午后) theme skin for the DSH Web UI.

- Repo: https://github.com/zampie/sakura-afternoon-skin
- Category: theme (installs into the dsh-market Themes tab)
- One entry file: `data/plugins/zampie__sakura-afternoon-skin.yml`

What the skin does:
- Light and dark sakura token palettes (both schemes covered by a single `theme.overrideTokens` layer over the active built-in theme).
- Click-through falling-petal overlay + soft vignette (shell.overlay slot).
- Header petal toggle (session header utilities) and a General-settings master switch.
- Both switches persist in localStorage; every side effect disposes on stop/uninstall.

Install: `dsh plugin --profile web add sakura-afternoon-skin`.