### PR TITLE
Add big0lives/dsh-web-window-companion

### DIFF
--- a/data/plugins/big0lives__dsh-web-window-companion.yml
+++ b/data/plugins/big0lives__dsh-web-window-companion.yml
@@ -1,0 +1,6 @@
+url: https://github.com/big0lives/dsh-web-window-companion
+name: big0lives/dsh-web-window-companion
+category: browser
+description:
+  en: Opens the dsh web GUI in a dedicated Edge/Chrome app-mode window on its own browser profile and gracefully stops the server when that window is closed.
+  zh: 在独立浏览器 profile 的 Edge/Chrome 应用模式窗口中打开 dsh web 界面，关闭窗口即优雅停止服务。


### PR DESCRIPTION
Adds one entry: `data/plugins/big0lives__dsh-web-window-companion.yml` (category: browser).

**What the plugin does:** a DSH Web profile bundle plugin — when `dsh web` starts, it opens the authenticated GUI URL in a dedicated Edge/Chrome app-mode window (own `--user-data-dir`, so the browser process's lifetime matches the window); when that window closes, it disposes the root context so the server shuts down gracefully. It also patches `web-runtime openBrowser: false` to suppress the default-browser tab, keeps the printed URL as fallback, and stays silent under SSH. Pure JavaScript, zero dependencies.

**Requirements check:**
- `dsh.bundle` manifest declared in `package.json` (`patch: ./cordis.patch.yml`, file present at repo root)
- Repo created 2026-08-31, over 1 day old
- `dsh-plugin` topic added
- Real, working code (validated end-to-end on Windows)