### PR TITLE
docs: clarify 数据清洗补全 search phrases

### DIFF
--- a/data/plugins/duhu2000__dsh-data-cleaning-agent.yml
+++ b/data/plugins/duhu2000__dsh-data-cleaning-agent.yml
@@ -2,5 +2,5 @@ url: https://github.com/duhu2000/dsh-data-cleaning-agent
 name: duhu2000/dsh-data-cleaning-agent
 category: tools
 description:
-  en: 'Clean, complete, profile, and deduplicate CSV/XLSX/JSON enterprise lists in DeepSeek Harness, with optional Qichacha MCP enrichment.'
-  zh: '在 DeepSeek Harness 中清洗、补全、画像和去重 CSV/XLSX/JSON 企业名单，并可选使用企查查 MCP 补全企业数据。'
+  en: 'Data cleaning and data enrichment for CSV/XLSX/JSON enterprise lists in DeepSeek Harness, including spreadsheet cleaning, deduplication, profiling, optional Qichacha MCP and exports.'
+  zh: '数据清洗补全智能体：面向 Excel/CSV/JSON 企业名单，提供数据清洗、表格清洗、清洗补全、去重、企业数据补全与字段补全，支持企查查 MCP 和结果导出。'


### PR DESCRIPTION
# Clarify 数据清洗补全 search phrases

Keep complete Chinese user phrases in one description field and align the English description with supported workflows.

- zh: 数据清洗补全智能体：面向 Excel/CSV/JSON 企业名单，提供数据清洗、表格清洗、清洗补全、去重、企业数据补全与字段补全，支持企查查 MCP 和结果导出。
- en: Data cleaning and data enrichment for CSV/XLSX/JSON enterprise lists in DeepSeek Harness, including spreadsheet cleaning, deduplication, profiling, optional Qichacha MCP and exports.

One YAML only; identity/category unchanged. No aliases, ranking changes, npm version bump or extra capability claims. READMEs regenerated and site built locally with SKIP_PUBLISH_CHECKS=1, matching upstream PR CI.

Full-catalog regression uses 3,363 live entries and dshmarket 1.45.0: product-specific queries return the target first with proposed metadata. AI form filling is simulated pending #4487 merge. Browser verification in a temporary real DSH covers 46 proposed-metadata query cases.
