### PR TITLE
docs: clarify 访前尽调 search phrases

### DIFF
--- a/data/plugins/duhu2000__dsh-pre-duediligence.yml
+++ b/data/plugins/duhu2000__dsh-pre-duediligence.yml
@@ -2,5 +2,5 @@ url: https://github.com/duhu2000/dsh-pre-duediligence
 name: duhu2000/dsh-pre-duediligence
 category: workflow
 description:
-  en: 'Prepare a session-scoped enterprise pre-visit due-diligence brief in DeepSeek Harness, with explicit entity confirmation and tool-call budget approval for Qichacha MCP queries.'
-  zh: '在 DeepSeek Harness 中按会话准备企业访前尽调简报，并在调用企查查 MCP 前要求明确的主体确认和工具调用预算授权。'
+  en: 'Pre-visit due diligence and company research in DeepSeek Harness for customer background checks and risk briefs, with Qichacha MCP tool-call budget approval and entity confirmation.'
+  zh: '访前尽调智能体：面向拜访前调查，提供企业尽调、客户尽调、客户背景调查、工商核验与风险信息整理；使用企查查 MCP，设有调用预算授权和主体确认。'


### PR DESCRIPTION
# Clarify 访前尽调 search phrases

Keep complete Chinese user phrases in one description field and align the English description with supported workflows.

- zh: 访前尽调智能体：面向拜访前调查，提供企业尽调、客户尽调、客户背景调查、工商核验与风险信息整理；使用企查查 MCP，设有调用预算授权和主体确认。
- en: Pre-visit due diligence and company research in DeepSeek Harness for customer background checks and risk briefs, with Qichacha MCP tool-call budget approval and entity confirmation.

One YAML only; identity/category unchanged. No aliases, ranking changes, npm version bump or extra capability claims. READMEs regenerated and site built locally with SKIP_PUBLISH_CHECKS=1, matching upstream PR CI.

Full-catalog regression uses 3,363 live entries and dshmarket 1.45.0: product-specific queries return the target first with proposed metadata. AI form filling is simulated pending #4487 merge. Browser verification in a temporary real DSH covers 46 proposed-metadata query cases.
