### PR TITLE
docs: clarify 招投标 search phrases

### DIFF
--- a/data/plugins/duhu2000__dsh-tender-workbench.yml
+++ b/data/plugins/duhu2000__dsh-tender-workbench.yml
@@ -2,5 +2,5 @@ url: https://github.com/duhu2000/dsh-tender-workbench
 name: duhu2000/dsh-tender-workbench
 category: workflow
 description:
-  en: 'Session-scoped tender workbench using user-authorized QCC MCP tools for tender and proposed-project search, rule screening, human review, and Excel/PDF reports.'
-  zh: '招投标智能体：通过用户自备授权的企查查 MCP 工具，在独立会话中查询标讯与拟建项目、执行规则筛选和人工复核，并导出 Excel/PDF 报告。'
+  en: 'Tender search and bid intelligence in DeepSeek Harness with proposed project search, rule screening, human review and Excel/PDF exports using user-authorized Qichacha MCP.'
+  zh: '招投标智能体：支持招投标搜索、招标查询、投标查询、标讯查询、拟建项目与项目筛选，辅助商机发现、人工复核及 Excel/PDF 导出，使用客户自备授权的企查查 MCP。'


### PR DESCRIPTION
# Clarify 招投标 search phrases

Keep complete Chinese user phrases in one description field and align the English description with supported workflows.

- zh: 招投标智能体：支持招投标搜索、招标查询、投标查询、标讯查询、拟建项目与项目筛选，辅助商机发现、人工复核及 Excel/PDF 导出，使用客户自备授权的企查查 MCP。
- en: Tender search and bid intelligence in DeepSeek Harness with proposed project search, rule screening, human review and Excel/PDF exports using user-authorized Qichacha MCP.

One YAML only; identity/category unchanged. No aliases, ranking changes, npm version bump or extra capability claims. READMEs regenerated and site built locally with SKIP_PUBLISH_CHECKS=1, matching upstream PR CI.

Full-catalog regression uses 3,363 live entries and dshmarket 1.45.0: product-specific queries return the target first with proposed metadata. AI form filling is simulated pending #4487 merge. Browser verification in a temporary real DSH covers 46 proposed-metadata query cases.
