### PR TITLE
Reword dsh-model-context-catalog description: what it does, not how

### DIFF
--- a/data/plugins/HOWILLMAKEIT__dsh-model-context-catalog.yml
+++ b/data/plugins/HOWILLMAKEIT__dsh-model-context-catalog.yml
@@ -2,5 +2,5 @@ url: https://github.com/HOWILLMAKEIT/dsh-model-context-catalog
 name: HOWILLMAKEIT/dsh-model-context-catalog
 category: model
 description:
-  en: 'Route-level contextWindow catalog for llm-pi-ai models: a Settings page lists configured routes, stores the real window per route, and syncs it through the public Settings API so long sessions are no longer misjudged as context overflow.'
-  zh: '为 llm-pi-ai 模型维护路由级 contextWindow：设置页列出已配置路由、按路由保存真实窗口值，并经公开 Settings API 同步，避免长会话被误判为上下文溢出。'
+  en: 'Configure the contextWindow for models registered in dsh, so long sessions are no longer misjudged as context overflow.'
+  zh: '为 dsh 已注册的模型配置上下文窗口，避免长会话被误判为上下文溢出。'


### PR DESCRIPTION
Updates the `description` (`en` + `zh`) of my own entry `data/plugins/HOWILLMAKEIT__dsh-model-context-catalog.yml` — wording only, one file, READMEs left for regeneration.

The merged line described the mechanism (Settings page, per-route storage, Settings API sync) rather than what the plugin is for. The new line states the purpose plainly:

> Configure the contextWindow for models registered in dsh, so long sessions are no longer misjudged as context overflow.

One deliberate change worth flagging for review: I dropped the `llm-pi-ai` qualifier to keep the line readable. The plugin's actual scope is unchanged — it only writes `contextWindow` for routes configured under `llm-pi-ai`. Happy to restore the qualifier (e.g. "…for models registered in dsh via llm-pi-ai…") if you prefer the scope stated explicitly.
