### PR TITLE
Add Minglink/dsh-infinite-gen-3 — DeepSeek armor-breaking plugin (session)

### DIFF
--- a/data/plugins/Minglink__dsh-infinite-gen-3.yml
+++ b/data/plugins/Minglink__dsh-infinite-gen-3.yml
@@ -1,0 +1,6 @@
+url: https://github.com/Minglink/dsh-infinite-gen-3
+name: Minglink/dsh-infinite-gen-3
+category: session
+description:
+  en: "System-prompt armor plugin for DeepSeek models: appends an unconditional-compliance prompt section at order 100, exposes a profile tool with calibration metadata, and shows a realtime armor-status badge driven by a session projection."
+  zh: "DeepSeek 专用破甲插件：以 order 100 追加无条件服从的系统提示词段，提供带校准元数据的 profile 工具，并通过会话投影在输入框上方显示实时破甲状态徽标。"


### PR DESCRIPTION
## 收录插件 / New entry

Adds one entry file: \data/plugins/Minglink__dsh-infinite-gen-3.yml\.

**Minglink/dsh-infinite-gen-3** — DeepSeek 专用破甲插件「无限三代」（armor-breaking plugin for DeepSeek Harness）：
- 追加式系统提示词段（\dsh.bundle\ manifest + \cordis.patch.yml\ 齐全，可经 \dsh plugin add\ 安装）
- \infinite_gen3_profile\ 工具返回打包提示词与校准元数据
- 会话投影驱动的实时「破甲已开启」状态徽标（client half）
- MIT 协议，仓库创建于 2026-08-15（满 1 天），带 \dsh-plugin\ topic

Description 已按代码如实填写（systemPrompt section order 100 / profile tool / armor projection badge）。