### PR TITLE
Add codex-harness-control workflow plugin

### DIFF
--- a/data/plugins/edisontaisite__codex-harness-control.yml
+++ b/data/plugins/edisontaisite__codex-harness-control.yml
@@ -1,0 +1,7 @@
+url: https://github.com/edisontaisite/codex-harness-control
+name: edisontaisite/codex-harness-control
+category: workflow
+tarball: https://github.com/edisontaisite/codex-harness-control/releases/download/v0.7.2/codex-harness-control-0.7.2.tgz
+description:
+  en: Coordinate existing Harness sessions from Codex with task dispatch, review receipts, and scheduled progress checks.
+  zh: 由 Codex 协调已有 Harness 会话，支持任务派发、验收回执和定时进度检查。


### PR DESCRIPTION
Add edisontaisite/codex-harness-control

Adds one workflow entry for a Harness settings plugin and bundled Codex companion skill. Users select existing sessions per project; Codex dispatches scoped tasks, reads receipts and records review evidence. A plugin scheduler supports periodic checks of the associated Codex task.

Compared with the listed kui123456789/dsh-codex-workflow, this entry focuses on selecting multiple existing worker sessions per project, installing the companion skill from the Harness settings page, and configuring periodic coordination and progress reports. It is not a Codex model-provider adapter.

Verification: 96 Python tests and 39 Node tests passed locally, including the packed first-run fixture. Package allowlist validation passed (34 files). Latest five GitHub workflow runs were successful at review time. This does not establish unattended reliability or real Windows Desktop compatibility.

The repository has the dsh-plugin topic and a screenshots.json manifest referencing four demo UI screenshots. The entry uses a pinned v0.7.2 GitHub Release tarball built from that tag, with no install lifecycle scripts.
