### PR TITLE
Add @tnnevol/dsh-codebuddy

### DIFF
--- a/data/plugins/tnnevol__fn-os-apps--plugins-dsh-codebuddy-plugin.yml
+++ b/data/plugins/tnnevol__fn-os-apps--plugins-dsh-codebuddy-plugin.yml
@@ -1,0 +1,6 @@
+url: https://github.com/tnnevol/fn-os-apps/tree/main/plugins/dsh-codebuddy-plugin
+name: tnnevol/fn-os-apps#dsh-codebuddy-plugin
+category: model
+description:
+  en: 'Tencent CodeBuddy model provider for DeepSeek Harness with browser OAuth sign-in and Web UI quota display; install from npm with `dsh plugin --profile web add @tnnevol/dsh-codebuddy`.'
+  zh: '为 DeepSeek Harness 接入腾讯 CodeBuddy 模型提供方，支持浏览器 OAuth 登录和 Web UI 用量显示；npm 安装：`dsh plugin --profile web add @tnnevol/dsh-codebuddy`。'


### PR DESCRIPTION
## Summary

- Add the `tnnevol/fn-os-apps#dsh-codebuddy-plugin` monorepo subpackage to the Models & Providers category.
- The plugin provides Tencent CodeBuddy model access with browser OAuth sign-in and Web UI quota display.
- npm installation: `dsh plugin --profile web add @tnnevol/dsh-codebuddy`

## Checklist

- [x] Added one file at `data/plugins/tnnevol__fn-os-apps--plugins-dsh-codebuddy-plugin.yml`.
- [x] The package declares a `dsh.bundle` manifest and points at the listed repository subpackage.
- [x] The repository is more than one day old.
- [x] The category is `model`.
- [x] The description states the plugin's behavior without marketing claims.
- [x] The repository has the `dsh-plugin` topic.

Validation completed locally:

- `node scripts/generate-readme.mjs`
- `SKIP_PUBLISH_CHECKS=1 node scripts/build-site.mjs`
- `npx awesome-lint`
- `node scripts/check-submission.mjs` (entry gate passed)
