### PR TITLE
docs: update 173787247/dsh-wsl-port description.

### DIFF
--- a/data/plugins/173787247__dsh-wsl-port.yml
+++ b/data/plugins/173787247__dsh-wsl-port.yml
@@ -2,5 +2,5 @@ url: https://github.com/173787247/dsh-wsl-port
 name: 173787247/dsh-wsl-port
 category: wsl
 description:
-  en: Diagnoses WSL port listening and Windows localhost forwarding.
-  zh: 诊断 WSL 端口监听与 Windows localhost 转发。
+  en: Diagnoses WSL port listening and Windows localhost forwarding, with a 3080/3081 uiPlaybook for the dsh web relay and launch token.
+  zh: 诊断 WSL 端口监听与 Windows localhost 转发，并对 dsh web 中继的 3080/3081 给出含 launch token 的 uiPlaybook。


### PR DESCRIPTION
## Summary
- Update the listing for already-listed `173787247/dsh-wsl-port` (category stays `wsl`) to mention the 3080/3081 uiPlaybook and dsh 0.1.2 launch token.

## Test plan
- [ ] CI green
- [ ] Diff only touches `173787247__dsh-wsl-port.yml`
