### PR TITLE
docs: update 173787247/dsh-wsl-hostsvc description.

### DIFF
--- a/data/plugins/173787247__dsh-wsl-hostsvc.yml
+++ b/data/plugins/173787247__dsh-wsl-hostsvc.yml
@@ -2,5 +2,5 @@ url: https://github.com/173787247/dsh-wsl-hostsvc
 name: 173787247/dsh-wsl-hostsvc
 category: wsl
 description:
-  en: Probes Windows-host Ollama, LM Studio, vLLM, and llama-server from WSL and suggests a baseURL.
-  zh: 从 WSL 探测 Windows 上的 Ollama、LM Studio、vLLM 与 llama-server，并给出 baseURL。
+  en: Probes Windows-host Ollama, LM Studio, vLLM, and llama-server from WSL, compares ctx, and reports /v1/models apiReady versus TCP.
+  zh: 从 WSL 探测 Windows 上的 Ollama、LM Studio、vLLM 与 llama-server，比对 ctx，并报告 /v1/models 的 apiReady 与 TCP 是否打通。


### PR DESCRIPTION
## Summary
- Update the listing for already-listed `173787247/dsh-wsl-hostsvc` (category stays `wsl`) to mention ctx compare and `/v1/models` apiReady versus TCP.

## Test plan
- [ ] CI green
- [ ] Diff only touches `173787247__dsh-wsl-hostsvc.yml`
