### PR TITLE
docs: update 173787247/dsh-wsl-docker description.

### DIFF
--- a/data/plugins/173787247__dsh-wsl-docker.yml
+++ b/data/plugins/173787247__dsh-wsl-docker.yml
@@ -2,5 +2,5 @@ url: https://github.com/173787247/dsh-wsl-docker
 name: 173787247/dsh-wsl-docker
 category: wsl
 description:
-  en: Reports Docker CLI, context, and daemon reachability inside WSL.
-  zh: 报告 WSL 内 Docker CLI、context 与 daemon 是否可达。
+  en: 'Reports Docker CLI, context, and daemon reachability in WSL, plus vLLM :8000 /v1/models health and GPU runtime hints.'
+  zh: '报告 WSL 内 Docker CLI、context 与 daemon 是否可达，并探测 vLLM :8000 的 /v1/models 健康与 GPU runtime。'


### PR DESCRIPTION
## Summary
- Update the listing for already-listed `173787247/dsh-wsl-docker` (category stays `wsl`) to mention vLLM `/v1/models` health and GPU runtime hints.

## Test plan
- [ ] CI green
- [ ] Diff only touches `173787247__dsh-wsl-docker.yml`
