### PR TITLE
docs: update 173787247/dsh-wsl-expose description.

### DIFF
--- a/data/plugins/173787247__dsh-wsl-expose.yml
+++ b/data/plugins/173787247__dsh-wsl-expose.yml
@@ -2,5 +2,5 @@ url: https://github.com/173787247/dsh-wsl-expose
 name: 173787247/dsh-wsl-expose
 category: wsl
 description:
-  en: Advises or applies allowlisted Windows portproxy for a WSL listen port.
-  zh: 为 WSL 监听端口提供白名单 Windows portproxy 建议或应用。
+  en: 'Advises or applies allowlisted Windows portproxy for a WSL listen port, preferring the kit :3081 relay and launch token for local dsh UI.'
+  zh: '为 WSL 监听端口提供白名单 Windows portproxy 建议或应用；本机 dsh UI 优先用 kit 的 :3081 中继与 launch token。'


### PR DESCRIPTION
## Summary
- Update the listing for already-listed `173787247/dsh-wsl-expose` (category stays `wsl`) to prefer the kit :3081 relay and launch token for local dsh UI.

## Test plan
- [ ] CI green
- [ ] Diff only touches `173787247__dsh-wsl-expose.yml`
