### PR TITLE
docs: update 173787247/dsh-wsl-tray description.

### DIFF
--- a/data/plugins/173787247__dsh-wsl-tray.yml
+++ b/data/plugins/173787247__dsh-wsl-tray.yml
@@ -2,5 +2,5 @@ url: https://github.com/173787247/dsh-wsl-tray
 name: 173787247/dsh-wsl-tray
 category: wsl
 description:
-  en: Writes a Windows shortcut and script to start dsh web inside WSL.
-  zh: 生成 Windows 快捷方式与脚本，用于在 WSL 中启动 dsh web。
+  en: 'Writes a Windows shortcut and tray launcher to start dsh web in WSL, with Health/Restart and the :3081 launch-token URL.'
+  zh: '生成 Windows 快捷方式与托盘启动器，在 WSL 中启动 dsh web，并提供 Health/Restart 与 :3081 launch token 地址。'


### PR DESCRIPTION
## Summary
- Update the listing for already-listed `173787247/dsh-wsl-tray` (category stays `wsl`) to mention Health/Restart and the :3081 launch-token URL.

## Test plan
- [ ] CI green
- [ ] Diff only touches `173787247__dsh-wsl-tray.yml`
