### PR TITLE
Add weibaohui/dsh-smart-title

### DIFF
--- a/data/plugins/weibaohui__dsh-smart-title.yml
+++ b/data/plugins/weibaohui__dsh-smart-title.yml
@@ -1,0 +1,6 @@
+url: https://github.com/weibaohui/dsh-smart-title
+name: weibaohui/dsh-smart-title
+category: session
+description:
+  en: "Smart session titles for DSH: after each conversation turn an independent auxiliary LLM call summarizes the full user+assistant transcript into a title that follows the session's real topic instead of echoing the first message; the first message is titled instantly, failed built-in titles auto-retry on later turns, manual renames are never overwritten, and subagent/fork sessions are skipped."
+  zh: 会话智能标题：每轮对话结束后用一次独立的辅助 LLM 调用对「用户消息+助手回答」的完整转写做总结，标题跟随会话真实主题而不是复述第一句话；首条消息即时出题、内置标题失败在后续轮次自动重试、用户手动改名绝不被覆盖、自动跳过子代理与 fork 会话。


### PR DESCRIPTION
Adds **weibaohui/dsh-smart-title** — smart session titles for DSH.

After each conversation turn an independent auxiliary LLM call (`ctx.llm`, purpose: `session-title`, not consuming the main conversation context) summarizes the full user-message + assistant-answer transcript and rewrites the sidebar session title to follow the session's real topic, instead of the built-in behavior of echoing the first message. The first message is titled instantly; when the official built-in title request fails it auto-retries on later turns; titles the user renamed manually are never overwritten; subagent/fork sessions are skipped. A cheaper model can be routed separately for title calls, and existing fallback titles can optionally be backfilled on startup.

- 📦 npm: [@weibaohui/dsh-smart-title](https://www.npmjs.com/package/@weibaohui/dsh-smart-title) (v0.1.0, MIT) → `dsh plugin add @weibaohui/dsh-smart-title`
- ✅ `package.json` declares `dsh.bundle.patch = ./cordis.patch.yml`
- ✅ Repo has the `dsh-plugin` topic (plus `dsh`, `deepseek-harness`)

Checklist / 自查:

- [x] I added **one file** at `data/plugins/weibaohui__dsh-smart-title.yml` — that single file is the whole submission. The READMEs are regenerated on `main` after merge: don't edit them by hand, and you don't need to commit them either / 我新增了一个 `data/plugins/weibaohui__dsh-smart-title.yml` 文件——**这一个文件就是全部投稿**
- [x] My repo's `package.json` declares **`dsh.bundle`** (not just `dsh.client`) — `dsh.bundle.patch = ./cordis.patch.yml` / 仓库 `package.json` 已声明 `dsh.bundle`
- [ ] My repo is at least **1 day old** — repo created 2026-09-08 (today); the automated submission gate flags "<1 day old" as expected and re-runs automatically (regate), so this is satisfied after 2026-09-09 / 仓库于 2026-09-08 新建，未满 1 天；门禁会自动重跑，满 1 天后即通过
- [x] `category` is one of the valid values ([full list](../blob/main/contributing.md)) — using `session`
- [x] Description states what the plugin does, no superlatives / 描述只说功能，不带营销词
- [x] My repo has the `dsh-plugin` topic / 仓库已打 `dsh-plugin` topic

**Recommended (not required) / 推荐但不强制：**

- [x] 📦 Published to npm — prebuilt installs skip the `allowBuilds` approval / 已发布 npm 包
- [ ] 🔗 Official `@deepseek-ai/*` packages as `peerDependencies` — not applicable, no official runtime deps
- [ ] 🖼️ `screenshots.json` in our own repository — planned follow-up
