### PR TITLE
Add Icstick/dsh-inject-scheduler (memory)

### DIFF
--- a/data/plugins/Icstick__dsh-inject-scheduler.yml
+++ b/data/plugins/Icstick__dsh-inject-scheduler.yml
@@ -1,0 +1,6 @@
+url: https://github.com/Icstick/dsh-inject-scheduler
+name: Icstick/dsh-inject-scheduler
+category: memory
+description:
+  zh: "DSH 注入调度器：跨插件注入段的注册/排序/记账落在官方 storageDomain，含冲突检测与每会话预算汇总（B10 面板数据源）。"
+  en: "Injection scheduler for DeepSeek Harness injection planes: cross-plugin sections register/order/account on the official storageDomain, with conflict detection and per-session budget summaries (B10 panel data source)."


### PR DESCRIPTION
Single DSH plugin **@Icstick/dsh-inject-scheduler** v0.1.0: injection-plane scheduler/observer — cross-plugin injection sections (ACP composer / WC work_state / future) register key/order/budget and report actual injected chars; conflicts detected (warn/reject), per-session budget summaries exported (B10 panel data source). Runs on the official storageDomain (domain \inject_scheduler\), zero self-hosted storage, fully fail-open for consumers. Repo: https://github.com/Icstick/dsh-inject-scheduler · install: \dsh plugin add Icstick/dsh-inject-scheduler\. 30 tests green, oxlint clean. Category memory.