### PR TITLE
Add 1741505640/capmap-skills#dsh-capmap-viz

### DIFF
--- a/data/plugins/1741505640__capmap-skills--dsh-capmap-viz.yml
+++ b/data/plugins/1741505640__capmap-skills--dsh-capmap-viz.yml
@@ -1,0 +1,6 @@
+url: https://github.com/1741505640/capmap-skills/tree/main/dsh-capmap-viz
+name: 1741505640/capmap-skills#dsh-capmap-viz
+category: docs
+description:
+  en: CapMap docs visualization with Obsidian-style semantic graph and capability panel.
+  zh: CapMap 文档体系可视化：Obsidian 风格语义图谱与能力面板。


### PR DESCRIPTION
## Summary
- Add CapMap docs visualization plugin (`@chenjh12/dsh-capmap-viz`) under `docs`
- Monorepo subpath: `dsh-capmap-viz` in `1741505640/capmap-skills`
- npm: `@chenjh12/dsh-capmap-viz`; screenshots declared in package `screenshots.json`

## Checklist
- [x] `dsh.bundle` present
- [x] Repo topic `dsh-plugin`
- [x] Screenshots in plugin repo