### PR TITLE
docs: dsh-code-index 0.4.0 — 8 languages incl. C/C++（双语描述更新）

### DIFF
--- a/data/plugins/lemonxiny55__dsh-code-index.yml
+++ b/data/plugins/lemonxiny55__dsh-code-index.yml
@@ -2,5 +2,5 @@ url: https://github.com/lemonxiny55/dsh-code-index
 name: lemonxiny55/dsh-code-index
 category: tools
 description:
-  en: 'Semantic repo index: tree-sitter symbol search across 6 languages, plus a bounded repo map ranked by import-graph PageRank that auto-updates in the system prompt.'
-  zh: '语义仓库索引：基于 tree-sitter 的符号索引、带排名的符号搜索，以及注入系统提示词的限量自动更新仓库地图。'
+  en: 'Semantic repo index: tree-sitter symbol search across 8 languages (incl. C/C++), plus a bounded repo map ranked by import-graph PageRank that auto-updates in the system prompt.'
+  zh: '语义仓库索引：基于 tree-sitter 的跨 8 种语言（含 C/C++）符号搜索与排名，以及注入系统提示词、按 import-graph PageRank 排序的限量自动更新仓库地图。'


### PR DESCRIPTION
## docs: dsh-code-index 0.4.0 — 8 languages incl. C/C++（双语描述更新）

**EN**: Updates the `dsh-code-index` entry for the 0.4.0 release. Language count 6 → 8 (C/C++ added via `tree-sitter-cpp`/`tree-sitter-c`, zero new dependencies), and the Chinese description now mirrors the English one (PageRank repo map + auto-injection).

**中文**：随 dsh-code-index 0.4.0 发布更新条目。支持语言 6 → 8（通过 `tree-sitter-cpp`/`tree-sitter-c` 新增 C/C++，零新增依赖），中文描述同步补齐英文要点（import-graph PageRank 仓库地图 + 系统提示词自动注入）。

- npm: `dsh-code-index@0.4.0` (latest)
- Release: https://github.com/lemonxiny55/dsh-code-index/releases/tag/v0.4.0

Only `data/plugins/lemonxiny55__dsh-code-index.yml` is touched — no generated README files.
