### PR TITLE
Update licyer/dsh-token-monitor entry description

### DIFF
--- a/data/plugins/licyer__dsh-token-monitor.yml
+++ b/data/plugins/licyer__dsh-token-monitor.yml
@@ -2,5 +2,5 @@ url: https://github.com/licyer/dsh-token-monitor
 name: licyer/dsh-token-monitor
 category: usage
 description:
-  en: Header quota badge plus a usage tab tracking tokens and estimated cost per request across sessions, providers and models, with local SQLite history and cross-device import/export.
-  zh: 会话头部余量徽标 + 用量页签：按会话/供应商/模型统计 token 与预估费用，本地 SQLite 留存历史，支持跨设备导入导出。
+  en: 'Header quota badge plus a usage-monitoring tab: live balance/quota remaining and reset countdown per provider, with requests, tokens (input/output/cache-read/cache-write), cache hit rate, estimated cost and average latency tracked per session, provider, model and client, stored locally in SQLite with cross-device import/export.'
+  zh: 会话头部余量徽标 + 用量监控页签：实时展示各供应商余额/额度余量与重置倒计时，按会话/供应商/模型/客户端统计请求量、Token（输入/输出/缓存读/缓存写）、缓存命中率、预估费用与平均时延，本地 SQLite 留存历史，支持跨设备导入导出。


### PR DESCRIPTION
Reword the dsh-token-monitor entry to cover its actual monitoring surface (provider quota remaining/reset countdown; requests, tokens, cache hit rate, estimated cost, latency per session/provider/model/client).

Only the plugin's own YAML entry is changed; no other entries touched.