### PR TITLE
Add Sycada/dsh-remote-ssh-tools

### DIFF
--- a/data/plugins/Sycada__dsh-remote-ssh-tools.yml
+++ b/data/plugins/Sycada__dsh-remote-ssh-tools.yml
@@ -1,0 +1,6 @@
+url: https://github.com/Sycada/dsh-remote-ssh-tools
+name: Sycada/dsh-remote-ssh-tools
+category: remote
+description:
+  en: 'SSH session manager for DeepSeek Harness: saved profiles, agent ssh_run, interactive terminals, and SFTP with secrets kept in the DSH credential center.'
+  zh: 'DeepSeek Harness 的 SSH 会话管理：连接档案、Agent 远程执行、交互终端与 SFTP；秘密仅存于 DSH 凭据中心。'


### PR DESCRIPTION
SSH session manager for DeepSeek Harness, category: remote.

<!-- Thanks for contributing! Quick checklist / 提交前快速自查 -->

- [√] I added **one file** at `data/plugins/<owner>__<repo>.yml` — that single file is the whole submission. The READMEs are regenerated on `main` after merge: don't edit them by hand, and you don't need to commit them either / 我新增了一个 `data/plugins/<owner>__<repo>.yml` 文件——**这一个文件就是全部投稿**。README 会在合并后由 `main` 自动重新生成：不要手工编辑，也不需要提交
- [√] My repo's `package.json` declares **`dsh.bundle`** (not just `dsh.client`) — [example](../blob/main/contributing.md) / 仓库 `package.json` 已声明 `dsh.bundle`（只有 `dsh.client` 无法安装）
- [√] My repo is at least **1 day old** / 仓库创建满 1 天
- [√] `category` is one of `agi ui usage theme model identity session memory tools wsl browser vision voice docs skill workflow git notify dev security remote market fun` ([full list with descriptions](../blob/main/contributing.md)), and themes/skins go under `theme` / `category` 取值正确（完整清单见 contributing.md），主题/皮肤类请用 `theme`
- [√] Description states what the plugin does, no superlatives / 描述只说功能，不带营销词
- [√] My repo has the `dsh-plugin` topic / 仓库已打 `dsh-plugin` topic

