### PR TITLE
Update dsh-mneme description (heat model removed in v0.7.12; reflects current feature set)

### DIFF
--- a/data/plugins/modusensus__dsh-mneme.yml
+++ b/data/plugins/modusensus__dsh-mneme.yml
@@ -2,5 +2,5 @@ url: https://github.com/modusensus/dsh-mneme
 name: modusensus/dsh-mneme
 category: memory
 description:
-  en: "Self-evolving AI memory engine with heat-powered decay (power-law forgetting), sleep consolidation, entity heat projection, and offline semantic search — memories grow, cool down, and fade just like a real brain."
-  zh: "AI 自进化记忆引擎：heat 热度模型驱动的记忆遗忘与巩固、sleep 深度维护、实体热投影、离线语义搜索 — 让 AI 的记忆像人脑一样会生长、会淡忘。"
+  en: "Cross-session memory plugin for DeepSeek Harness: remembers across sessions, consolidates in the background (autoDream), and manages everything through an interactive memory library panel — SQLite storage with human-editable Markdown mirrors, offline semantic search, and a standalone external API and CLI."
+  zh: "DeepSeek Harness 跨会话记忆插件：跨会话记住用户与项目、后台 autoDream 自动巩固记忆、交互式记忆库面板统一管理（浏览/搜索/编辑/导入导出）——SQLite 存储配可人工编辑的 Markdown 镜像，支持离线语义检索、独立外部 API 与 CLI。"


### PR DESCRIPTION
## What changed / 改了什么

Only the `description` lines of `data/plugins/modusensus__dsh-mneme.yml` — no category/name/url changes.

## Why / 为什么

The current entry still describes the **v0.7.11-era** feature set:

- `heat-powered decay` / `heat 热度模型驱动的记忆遗忘` — the heat model was removed in the v0.7.12 near-rewrite (documented in the repo README's historical archive note)
- `entity heat projection` / `实体热投影` — replaced by entity extraction + knowledge graph in later releases

## Current feature set (v0.7.17) / 现在的实际能力

- Cross-session memory (SQLite store + human-editable Markdown mirrors, byte-identical round-trip)
- Interactive memory library panel (browse / search / edit / archive / import / export)
- Background `autoDream` consolidation + `autoSummarize`, with an llm-audit workbench
- 7 model tools with automatic injection, offline semantic search (vector + BM25)
- Standalone external HTTP API (127.0.0.1, Bearer auth) + zero-dependency CLI
- Feature-flag panel (30 keys), light mode preset

The repo's GitHub About has already been updated to match; 664 tests green on the latest release.