### PR TITLE
Add Senguo read-only query plugin for DSH Deskwork

### DIFF
--- a/data/plugins/GuoMonth__dsh-deskwork--plugins-senguo-query.yml
+++ b/data/plugins/GuoMonth__dsh-deskwork--plugins-senguo-query.yml
@@ -1,0 +1,7 @@
+url: https://github.com/GuoMonth/dsh-deskwork/tree/senguo-query-v0.1.0-alpha.1/plugins/senguo-query
+name: GuoMonth/dsh-deskwork#senguo-query
+category: browser
+description:
+  en: 'Native Skill and read-only category query tool for Senguo wholesale PC pages; requires the DSH Deskwork task browser bridge and a user login.'
+  zh: '面向森果档口批发 PC 页面的原生 Skill 与只读类别查询工具，依赖 DSH Deskwork 任务浏览器接口及用户自行登录。'
+tarball: https://github.com/GuoMonth/dsh-deskwork/releases/download/senguo-query-v0.1.0-alpha.1/guomonth-dsh-senguo-query-0.1.0-alpha.1.tgz


### PR DESCRIPTION
Adds one standard DSH plugin entry for the Senguo query subpackage. The source URL pins the published tag; the prebuilt GitHub Release tarball avoids a source-build requirement.

The plugin registers a native Skill and a bounded read-only browser query tool. It requires DSH Deskwork’s task browser bridge and a user-authenticated Senguo wholesale PC page. It does not claim to run browser actions in a generic DSH Web host, enumerate all hidden categories, or perform writes.

Verified with DSH 0.1.2-rc.1, real Electron and a real DeepSeek query. The published tarball was installed again through Deskwork successfully. The bundle manifest, implementation and licenses are included in the release.

Only the new YAML entry is changed; generated READMEs are untouched.
