### PR TITLE
Add 16512354554/dsh-chat-navigator

### DIFF
--- a/data/plugins/16512354554__dsh-chat-navigator.yml
+++ b/data/plugins/16512354554__dsh-chat-navigator.yml
@@ -1,0 +1,6 @@
+url: https://github.com/16512354554/dsh-chat-navigator
+name: 16512354554/dsh-chat-navigator
+category: ui
+description:
+  en: Right-edge DSH Web navigator for current-session questions, hover previews, and exact click-to-jump navigation.
+  zh: DSH Web 右侧会话提问导航器，支持悬停预览和点击精确跳转。


### PR DESCRIPTION
## Plugin

- Repository: https://github.com/16512354554/dsh-chat-navigator
- Category: ui
- Declares a `dsh.bundle` manifest and root `cordis.patch.yml`.
- Provides a right-edge DSH Web question navigator with hover previews and exact click-to-jump navigation.
- GitHub repository installation and the v0.1.0 release archive have been smoke-tested successfully.

The registry PR check is green. Please merge when the maintainer review is complete.
