### PR TITLE
Add tr1v3r/dsh-quote-followup

### DIFF
--- a/data/plugins/tr1v3r__dsh-quote-followup.yml
+++ b/data/plugins/tr1v3r__dsh-quote-followup.yml
@@ -1,0 +1,6 @@
+url: https://github.com/tr1v3r/dsh-quote-followup
+name: tr1v3r/dsh-quote-followup
+category: ui
+description:
+  en: Quote selected conversation text into the Web composer as native reference chips for focused follow-up turns.
+  zh: 在网页会话中划选文本，以原生引用 chip 插入输入框，进行针对性追问。

--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -1,1363 +1,442 @@
 {
-  "https://github.com/anweat/dsh-context-console": [
-    "https://raw.githubusercontent.com/anweat/dsh-context-console/main/docs/images/context-console-trajectory.png",
-    "https://raw.githubusercontent.com/anweat/dsh-context-console/main/docs/images/context-console-inventory.png",
-    "https://raw.githubusercontent.com/anweat/dsh-context-console/main/docs/images/context-console-forge.png"
-  ],
-  "https://github.com/jerryqx/dsh-xiaoyuzhou": [
-    "https://raw.githubusercontent.com/jerryqx/dsh-xiaoyuzhou/main/assets/screenshot-bar.png",
-    "https://raw.githubusercontent.com/jerryqx/dsh-xiaoyuzhou/main/assets/screenshot-mysubs.png",
-    "https://raw.githubusercontent.com/jerryqx/dsh-xiaoyuzhou/main/assets/screenshot-podcast.png"
-  ],
-  "https://github.com/fengb3/dsh-session-icons": [
-    "https://raw.githubusercontent.com/fengb3/dsh-session-icons/master/docs/screenshot.png"
-  ],
-  "https://github.com/GreenLv/dsh-session-insights": [
-    "https://raw.githubusercontent.com/GreenLv/dsh-session-insights/main/assets/screenshots/dashboard-overview-en.png",
-    "https://raw.githubusercontent.com/GreenLv/dsh-session-insights/main/assets/screenshots/dashboard-overview-zh.png"
-  ],
-  "https://github.com/xiaoksio/dsh-solution-explorer": [
-    "https://raw.githubusercontent.com/xiaoksio/dsh-solution-explorer/main/assets/screenshot-1-file-explorer.png",
-    "https://raw.githubusercontent.com/xiaoksio/dsh-solution-explorer/main/assets/screenshot-2-source-control.png",
-    "https://raw.githubusercontent.com/xiaoksio/dsh-solution-explorer/main/assets/screenshot-3-diff.png"
-  ],
-  "https://github.com/LayneChai/superpowers-dsh": [
-    "https://raw.githubusercontent.com/LayneChai/superpowers-dsh/main/static/home.png",
-    "https://raw.githubusercontent.com/LayneChai/superpowers-dsh/main/static/install-success.png"
-  ],
-  "https://github.com/kirkchinese/CiteCiter/tree/main/packages/citeciter": [
-    "https://raw.githubusercontent.com/kirkchinese/CiteCiter/main/assets/demo/citeciter-0.4.0.gif",
-    "https://raw.githubusercontent.com/kirkchinese/CiteCiter/main/assets/screenshots/citeciter-settings.png"
-  ],
-  "https://github.com/L3n3L/dsh-resume": [
-    "https://raw.githubusercontent.com/L3n3L/dsh-resume/main/docs/screenshots/workbench.png",
-    "https://raw.githubusercontent.com/L3n3L/dsh-resume/main/docs/screenshots/ai-assistant.png",
-    "https://raw.githubusercontent.com/L3n3L/dsh-resume/main/docs/screenshots/template-library.png"
-  ],
-  "https://github.com/hunter118/dsh-s7r": [
-    "https://raw.githubusercontent.com/hunter118/dsh-s7r/main/docs/screenshots/s7r-desktop.png",
-    "https://raw.githubusercontent.com/hunter118/dsh-s7r/main/docs/screenshots/s7r-agent.png",
-    "https://raw.githubusercontent.com/hunter118/dsh-s7r/main/docs/screenshots/s7r-workflows.png",
-    "https://raw.githubusercontent.com/hunter118/dsh-s7r/main/docs/screenshots/s7r-display.png"
-  ],
-  "https://github.com/HaoyueQin/dsh-usage-statistics-panel": [
-    "https://raw.githubusercontent.com/HaoyueQin/dsh-usage-statistics-panel/main/assets/screenshots/usage-overview.png",
-    "https://raw.githubusercontent.com/HaoyueQin/dsh-usage-statistics-panel/main/assets/screenshots/model-breakdown.png"
-  ],
-  "https://github.com/lavapapa/dsh-composer-layout": [
-    "https://raw.githubusercontent.com/lavapapa/dsh-composer-layout/main/assets/screenshots/hero-en.png",
-    "https://raw.githubusercontent.com/lavapapa/dsh-composer-layout/main/assets/screenshots/hero-zh.png"
-  ],
-  "https://github.com/lengzhanbao/dsh-taffy-theme": [
-    "https://raw.githubusercontent.com/lengzhanbao/dsh-taffy-theme/master/preview/light.webp",
-    "https://raw.githubusercontent.com/lengzhanbao/dsh-taffy-theme/master/preview/dark.webp"
-  ],
-  "https://github.com/liang-today/dsh-liangxiang": [
-    "https://raw.githubusercontent.com/liang-today/dsh-liangxiang/main/assets/main-frame.jpg",
-    "https://raw.githubusercontent.com/liang-today/dsh-liangxiang/main/assets/plugin-panel.jpg",
-    "https://raw.githubusercontent.com/liang-today/dsh-liangxiang/main/assets/liangci.jpg"
-  ],
-  "https://github.com/Little-Star888/dsh-pelican": [
-    "https://raw.githubusercontent.com/Little-Star888/dsh-pelican/main/assets/screenshot-1.png"
-  ],
-  "https://github.com/kendu76/dsh-music-player": [
-    "https://raw.githubusercontent.com/kendu76/dsh-music-player/main/assets/screenshot-bar.png",
-    "https://raw.githubusercontent.com/kendu76/dsh-music-player/main/assets/screenshot-spectrum.png",
-    "https://raw.githubusercontent.com/kendu76/dsh-music-player/main/assets/screenshot-panel.png"
-  ],
-  "https://github.com/030611/qiushi-dsh-evidence-audit": [
-    "https://raw.githubusercontent.com/030611/qiushi-dsh-evidence-audit/main/docs/evidence-flow.svg"
-  ],
-  "https://github.com/263311487-ux/dsh-verify": [
-    "https://raw.githubusercontent.com/263311487-ux/dsh-verify/main/assets/report-screenshot.png",
-    "https://raw.githubusercontent.com/263311487-ux/dsh-verify/main/assets/visual-diff.png"
-  ],
-  "https://github.com/2768651338/dsh-effort-slider": [
-    "https://raw.githubusercontent.com/2768651338/dsh-effort-slider/main/assets/screenshots/灞忓箷鎴浘%202026-08-16%20190943.png",
-    "https://raw.githubusercontent.com/2768651338/dsh-effort-slider/main/assets/screenshots/灞忓箷鎴浘%202026-08-16%20190950.png",
-    "https://raw.githubusercontent.com/2768651338/dsh-effort-slider/main/assets/screenshots/灞忓箷鎴浘%202026-08-16%20190903.png"
-  ],
-  "https://github.com/2768651338/dsh-plugin-manager": [
-    "https://raw.githubusercontent.com/2768651338/dsh-plugin-manager/main/assets/preview.png"
-  ],
-  "https://github.com/2nd1st/dsh-plugin-open-app": [
-    "https://raw.githubusercontent.com/2nd1st/dsh-plugin-open-app/main/docs/screenshot-app-container.jpg",
-    "https://raw.githubusercontent.com/2nd1st/dsh-plugin-open-app/main/docs/screenshot-inline.jpg"
-  ],
-  "https://github.com/534119219/chicheng-cron": [
-    "https://raw.githubusercontent.com/534119219/chicheng-cron/main/assets/sidebar-entry.png",
-    "https://raw.githubusercontent.com/534119219/chicheng-cron/main/assets/settings-1.png",
-    "https://raw.githubusercontent.com/534119219/chicheng-cron/main/assets/settings-2.png",
-    "https://raw.githubusercontent.com/534119219/chicheng-cron/main/assets/output-popup.png"
-  ],
-  "https://github.com/534119219/chicheng-gate": [
-    "https://raw.githubusercontent.com/534119219/chicheng-gate/main/assets/settings.png",
-    "https://raw.githubusercontent.com/534119219/chicheng-gate/main/assets/login-gate.png",
-    "https://raw.githubusercontent.com/534119219/chicheng-gate/main/assets/mobile-ui-1.png",
-    "https://raw.githubusercontent.com/534119219/chicheng-gate/main/assets/mobile-ui-2.png",
-    "https://raw.githubusercontent.com/534119219/chicheng-gate/main/assets/mobile-ui-3.png"
-  ],
-  "https://github.com/534119219/chicheng-push": [
-    "https://raw.githubusercontent.com/534119219/chicheng-push/master/assets/screenshot-settings-entry.png",
-    "https://raw.githubusercontent.com/534119219/chicheng-push/master/assets/screenshot-channel-list.png",
-    "https://raw.githubusercontent.com/534119219/chicheng-push/master/assets/screenshot-add-channel.png"
-  ],
-  "https://github.com/534119219/chicheng-stats": [
-    "https://raw.githubusercontent.com/534119219/chicheng-stats/main/assets/card-mode.png",
-    "https://raw.githubusercontent.com/534119219/chicheng-stats/main/assets/text-mode.png",
-    "https://raw.githubusercontent.com/534119219/chicheng-stats/main/assets/usage-dialog.png",
-    "https://raw.githubusercontent.com/534119219/chicheng-stats/main/assets/card-settings.png",
-    "https://raw.githubusercontent.com/534119219/chicheng-stats/main/assets/text-settings.png"
-  ],
-  "https://github.com/54xkeee/dsh-youreyes": [
-    "https://raw.githubusercontent.com/54xkeee/dsh-youreyes/master/assets/screenshot-panel.png"
-  ],
-  "https://github.com/7dgroup-ai/dsh-skill-7d-code-reviewer": [
-    "https://raw.githubusercontent.com/7dgroup-ai/dsh-skill-7d-code-reviewer/main/screenshots/skills.png",
-    "https://raw.githubusercontent.com/7dgroup-ai/dsh-skill-7d-code-reviewer/main/screenshots/report-preview.png"
-  ],
-  "https://github.com/940842546/dsh-permissions": [
-    "https://raw.githubusercontent.com/940842546/dsh-permissions/main/assets/01-permissions-overview.png",
-    "https://raw.githubusercontent.com/940842546/dsh-permissions/main/assets/02-permissions-rules.png",
-    "https://raw.githubusercontent.com/940842546/dsh-permissions/main/assets/03-permissions-draft.png",
-    "https://raw.githubusercontent.com/940842546/dsh-permissions/main/assets/en-01-permissions-overview.png",
-    "https://raw.githubusercontent.com/940842546/dsh-permissions/main/assets/en-02-permissions-rules.png",
-    "https://raw.githubusercontent.com/940842546/dsh-permissions/main/assets/en-03-permissions-draft.png"
-  ],
-  "https://github.com/940842546/dsh-usage-billing": [
-    "https://raw.githubusercontent.com/940842546/dsh-usage-billing/main/assets/screenshots/02-stats-dialog-overview.png",
-    "https://raw.githubusercontent.com/940842546/dsh-usage-billing/main/assets/screenshots/03-stats-dialog-charts.png",
-    "https://raw.githubusercontent.com/940842546/dsh-usage-billing/main/assets/screenshots/04-settings-usage-overview.png",
-    "https://raw.githubusercontent.com/940842546/dsh-usage-billing/main/assets/screenshots/07-stats-dialog-usd.png",
-    "https://raw.githubusercontent.com/940842546/dsh-usage-billing/main/assets/screenshots/en-02-stats-dialog-overview.png",
-    "https://raw.githubusercontent.com/940842546/dsh-usage-billing/main/assets/screenshots/en-03-stats-dialog-charts.png",
-    "https://raw.githubusercontent.com/940842546/dsh-usage-billing/main/assets/screenshots/en-04-settings-usage-overview.png",
-    "https://raw.githubusercontent.com/940842546/dsh-usage-billing/main/assets/screenshots/en-07-stats-dialog-usd.png"
-  ],
-  "https://github.com/AI-Galaxy-GPU/dsh-sound": [
-    "https://raw.githubusercontent.com/AI-Galaxy-GPU/dsh-sound/main/assets/screenshots/sound-image.png"
-  ],
-  "https://github.com/AcidGr/dsh-web-lan-access": [
-    "https://raw.githubusercontent.com/AcidGr/dsh-web-lan-access/main/assets/screenshot-lan-access.jpg"
-  ],
-  "https://github.com/AcidGr/dsh-web-mobile-fix": [
-    "https://raw.githubusercontent.com/AcidGr/dsh-web-mobile-fix/main/assets/screenshot-1.jpg",
-    "https://raw.githubusercontent.com/AcidGr/dsh-web-mobile-fix/main/assets/screenshot-2.jpg"
-  ],
-  "https://github.com/Airmetro/dsh-update-checker": [
-    "https://raw.githubusercontent.com/Airmetro/dsh-update-checker/main/assets/screenshots/01-banner-update-zh.png",
-    "https://raw.githubusercontent.com/Airmetro/dsh-update-checker/main/assets/screenshots/02-banner-update-en.png",
-    "https://raw.githubusercontent.com/Airmetro/dsh-update-checker/main/assets/screenshots/03-banner-plugins.png",
-    "https://raw.githubusercontent.com/Airmetro/dsh-update-checker/main/assets/screenshots/04-settings-zh.png",
-    "https://raw.githubusercontent.com/Airmetro/dsh-update-checker/main/assets/screenshots/05-settings-en.png"
-  ],
-  "https://github.com/AmeKrance/anan-thermal-monitor": [
-    "https://raw.githubusercontent.com/AmeKrance/anan-thermal-monitor/main/assets/screenshots/screenshot-1.png",
-    "https://raw.githubusercontent.com/AmeKrance/anan-thermal-monitor/main/assets/screenshots/screenshot-2.png",
-    "https://raw.githubusercontent.com/AmeKrance/anan-thermal-monitor/main/assets/screenshots/demo.gif"
-  ],
-  "https://github.com/Awu12277/dsh-stock-watch": [
-    "https://raw.githubusercontent.com/Awu12277/dsh-stock-watch/main/screenshots/detail-kline-dark.png",
-    "https://raw.githubusercontent.com/Awu12277/dsh-stock-watch/main/screenshots/detail-minute-dark.png",
-    "https://raw.githubusercontent.com/Awu12277/dsh-stock-watch/main/screenshots/list-dark.png"
-  ],
-  "https://github.com/ChongCyrus/Vibe-Mathematics": [
-    "https://raw.githubusercontent.com/ChongCyrus/Vibe-Mathematics/main/%E7%A4%BA%E4%BE%8B%E5%9B%BE/%E6%A1%86%E6%9E%B6%E5%9B%BE-v1.png",
-    "https://raw.githubusercontent.com/ChongCyrus/Vibe-Mathematics/main/%E7%A4%BA%E4%BE%8B%E5%9B%BE/%E6%A1%86%E6%9E%B6%E5%9B%BE-v2.png"
-  ],
-  "https://github.com/ChrisZhangWG/dsh-codex-meter": [
-    "https://raw.githubusercontent.com/ChrisZhangWG/dsh-codex-meter/main/docs/settings-usage-overview.png",
-    "https://raw.githubusercontent.com/ChrisZhangWG/dsh-codex-meter/main/docs/settings-usage-cost-history.png"
-  ],
-  "https://github.com/Dely0/dsh-personal-workbench": [
-    "https://raw.githubusercontent.com/Dely0/dsh-personal-workbench/main/screenshot/%E4%B8%BB%E7%95%8C%E9%9D%A2.PNG",
-    "https://raw.githubusercontent.com/Dely0/dsh-personal-workbench/main/screenshot/%E6%97%A5%E5%8E%86%E9%A1%B5%E9%9D%A2.png",
-    "https://raw.githubusercontent.com/Dely0/dsh-personal-workbench/main/screenshot/%E4%BB%BB%E5%8A%A1%E5%88%97%E8%A1%A8%E7%95%8C%E9%9D%A2.png",
-    "https://raw.githubusercontent.com/Dely0/dsh-personal-workbench/main/screenshot/%E7%9F%A5%E8%AF%86%E5%BA%93%E7%95%8C%E9%9D%A2.png",
-    "https://raw.githubusercontent.com/Dely0/dsh-personal-workbench/main/screenshot/%E7%82%B9%E5%AD%90%E7%95%8C%E9%9D%A2.png",
-    "https://raw.githubusercontent.com/Dely0/dsh-personal-workbench/main/screenshot/%E7%82%B9%E5%AD%90%E7%8E%8B.png"
-  ],
-  "https://github.com/DocJlm/dsh-arknights/tree/main/skins/pramanix-eyjafjalla": [
-    "https://raw.githubusercontent.com/DocJlm/dsh-arknights/main/skins/pramanix-eyjafjalla/preview/cover.webp"
-  ],
-  "https://github.com/Eve-146T/DSH-CODEX-SUBSCRIPTION-POOL": [
-    "https://raw.githubusercontent.com/Eve-146T/DSH-CODEX-SUBSCRIPTION-POOL/main/assets/readme/accounts-demo.png"
-  ],
-  "https://github.com/Fantasality/dsh-origin-plugin": [
-    "https://raw.githubusercontent.com/Fantasality/dsh-origin-plugin/main/docs/example.png",
-    "https://raw.githubusercontent.com/Fantasality/dsh-origin-plugin/main/docs/example_3d.png"
-  ],
-  "https://github.com/FengHuoLinShan/dsh-plugin-llm-balance": [
-    "https://raw.githubusercontent.com/FengHuoLinShan/dsh-plugin-llm-balance/main/assets/llm-balance-preview.png"
-  ],
-  "https://github.com/Flyvhidbwo/dsh-vision-proxy": [
-    "https://raw.githubusercontent.com/Flyvhidbwo/dsh-vision-proxy/main/assets/demo-reply.png",
-    "https://raw.githubusercontent.com/Flyvhidbwo/dsh-vision-proxy/main/assets/demo-selector.png"
-  ],
-  "https://github.com/foooold/dsh-message-nav": [
-    "https://raw.githubusercontent.com/foooold/dsh-message-nav/main/assets/rail-hover-preview.png",
-    "https://raw.githubusercontent.com/foooold/dsh-message-nav/main/assets/rail-left-edge.png"
-  ],
-  "https://github.com/GOU-GEE/deepseek-vision/tree/main/plugins/dsh-plugin-deepseek-vision": [
-    "https://raw.githubusercontent.com/GOU-GEE/deepseek-vision/main/docs/screenshots/01-settings.png",
-    "https://raw.githubusercontent.com/GOU-GEE/deepseek-vision/main/docs/screenshots/02-paste-analyze.png",
-    "https://raw.githubusercontent.com/GOU-GEE/deepseek-vision/main/docs/screenshots/03-clipboard.png",
-    "https://raw.githubusercontent.com/GOU-GEE/deepseek-vision/main/docs/screenshots/04-result.png",
-    "https://raw.githubusercontent.com/GOU-GEE/deepseek-vision/main/docs/screenshots/05-market.png"
-  ],
-  "https://github.com/Gin-7/dsh-pet-remielle": [
-    "https://raw.githubusercontent.com/Gin-7/dsh-pet-remielle/main/assets/screenshot-waiting.png",
-    "https://raw.githubusercontent.com/Gin-7/dsh-pet-remielle/main/assets/screenshot-priding.png"
-  ],
-  "https://github.com/HaoyueQin/dsh-better-reasoning-effort": [
-    "https://raw.githubusercontent.com/HaoyueQin/dsh-better-reasoning-effort/master/docs/market-card.png"
-  ],
-  "https://github.com/Harvey-Will/dsh-vision-analysis": [
-    "https://raw.githubusercontent.com/Harvey-Will/dsh-vision-analysis/main/assets/demo-ocr.png",
-    "https://raw.githubusercontent.com/Harvey-Will/dsh-vision-analysis/main/assets/demo-chart.png",
-    "https://raw.githubusercontent.com/Harvey-Will/dsh-vision-analysis/main/assets/demo-ui.png"
-  ],
-  "https://github.com/Isilsolme/dsh-splash-launcher": [
-    "https://raw.githubusercontent.com/Isilsolme/dsh-splash-launcher/main/docs/screenshots/splash-light.png",
-    "https://raw.githubusercontent.com/Isilsolme/dsh-splash-launcher/main/docs/screenshots/splash-drawing.png",
-    "https://raw.githubusercontent.com/Isilsolme/dsh-splash-launcher/main/docs/screenshots/splash-dark.png",
-    "https://raw.githubusercontent.com/Isilsolme/dsh-splash-launcher/main/docs/screenshots/main.png"
-  ],
-  "https://github.com/Jannchie/dsh-bill": [
-    "https://raw.githubusercontent.com/Jannchie/dsh-bill/main/docs/attribution.png",
-    "https://raw.githubusercontent.com/Jannchie/dsh-bill/main/docs/in-chat.png"
-  ],
-  "https://github.com/JimchengChina/dsh-frontier-repro": [
-    "https://raw.githubusercontent.com/JimchengChina/dsh-frontier-repro/main/docs/assets/frontier-repro-hero.png"
-  ],
-  "https://github.com/Jiyr0119/dsh-workspace-explorer": [
-    "https://raw.githubusercontent.com/Jiyr0119/dsh-workspace-explorer/main/assets/screenshots/panel.png",
-    "https://raw.githubusercontent.com/Jiyr0119/dsh-workspace-explorer/main/assets/screenshots/tree.png",
-    "https://raw.githubusercontent.com/Jiyr0119/dsh-workspace-explorer/main/assets/screenshots/insert.png"
-  ],
-  "https://github.com/Js2Hou/dsh-mcp-manager": [
-    "https://raw.githubusercontent.com/Js2Hou/dsh-mcp-manager/main/assets/market-screenshot.png"
-  ],
-  "https://github.com/Jungod1121/dsh-anchored-standard": [
-    "https://raw.githubusercontent.com/Jungod1121/dsh-anchored-standard/main/screenshots/market-1.png",
-    "https://raw.githubusercontent.com/Jungod1121/dsh-anchored-standard/main/screenshots/market-2.png",
-    "https://raw.githubusercontent.com/Jungod1121/dsh-anchored-standard/main/screenshots/market-3.png"
-  ],
-  "https://github.com/KLRSL/dsh-biomemory": [
-    "https://raw.githubusercontent.com/KLRSL/dsh-biomemory/main/assets/screenshot-main.png",
-    "https://raw.githubusercontent.com/KLRSL/dsh-biomemory/main/assets/screenshot-settings.png",
-    "https://raw.githubusercontent.com/KLRSL/dsh-biomemory/main/assets/screenshot-memory-settings.png"
-  ],
-  "https://github.com/LKMeng2001/dsh-mcp-market": [
-    "https://raw.githubusercontent.com/LKMeng2001/dsh-mcp-market/main/assets/market-discover.png"
-  ],
-  "https://github.com/LeemanCheung/dsh-agent-preset-recommender": [
-    "https://raw.githubusercontent.com/LeemanCheung/dsh-agent-preset-recommender/main/docs/screenshot.png",
-    "https://raw.githubusercontent.com/LeemanCheung/dsh-agent-preset-recommender/main/docs/project-detail.png"
-  ],
-  "https://github.com/LeemanCheung/dsh-image-gen": [
-    "https://raw.githubusercontent.com/LeemanCheung/dsh-image-gen/main/assets/demo.svg",
-    "https://raw.githubusercontent.com/LeemanCheung/dsh-image-gen/main/assets/final-card.png"
-  ],
-  "https://github.com/LeemanCheung/dsh-qq2007-skin": [
-    "https://raw.githubusercontent.com/LeemanCheung/dsh-qq2007-skin/main/docs/screenshot.png",
-    "https://raw.githubusercontent.com/LeemanCheung/dsh-qq2007-skin/main/docs/preview.svg"
-  ],
-  "https://github.com/LeemanCheung/dsh-task-dag": [
-    "https://raw.githubusercontent.com/LeemanCheung/dsh-task-dag/main/docs/screenshot.png",
-    "https://raw.githubusercontent.com/LeemanCheung/dsh-task-dag/main/docs/task-dag-preview.svg"
-  ],
-  "https://github.com/LeemanCheung/dsh-token-usage": [
-    "https://raw.githubusercontent.com/LeemanCheung/dsh-token-usage/main/assets/token-usage-overview.png",
-    "https://raw.githubusercontent.com/LeemanCheung/dsh-token-usage/main/assets/token-usage-insights.png",
-    "https://raw.githubusercontent.com/LeemanCheung/dsh-token-usage/main/assets/token-usage-budget.png",
-    "https://raw.githubusercontent.com/LeemanCheung/dsh-token-usage/main/assets/token-usage-ai-analysis.png",
-    "https://raw.githubusercontent.com/LeemanCheung/dsh-token-usage/main/assets/token-usage-trajectory-analysis.png"
-  ],
-  "https://github.com/LeemanCheung/dsh-whale-animation": [
-    "https://raw.githubusercontent.com/LeemanCheung/dsh-whale-animation/main/docs/screenshots/launch.png",
-    "https://raw.githubusercontent.com/LeemanCheung/dsh-whale-animation/main/docs/screenshots/apex.png",
-    "https://raw.githubusercontent.com/LeemanCheung/dsh-whale-animation/main/docs/screenshots/deep-dive.png"
-  ],
-  "https://github.com/Leeminjing/dsh-eyes": [
-    "https://raw.githubusercontent.com/Leeminjing/dsh-eyes/main/assets/demo.png"
-  ],
-  "https://github.com/Lhy723/dsh-agent-canvas": [
-    "https://raw.githubusercontent.com/Lhy723/dsh-agent-canvas/main/docs/assets/agent-canvas-overview.png",
-    "https://raw.githubusercontent.com/Lhy723/dsh-agent-canvas/main/docs/assets/agent-canvas-dark-settings.png"
-  ],
-  "https://github.com/MangMax/dsh-themes": [
-    "https://raw.githubusercontent.com/MangMax/dsh-themes/main/assets/screenshot.png"
-  ],
-  "https://github.com/Mars-Sea/dsh-commandcode-provider": [
-    "https://raw.githubusercontent.com/Mars-Sea/dsh-commandcode-provider/main/assets/screenshots/model-picker.png",
-    "https://raw.githubusercontent.com/Mars-Sea/dsh-commandcode-provider/main/assets/screenshots/usage-dashboard.png"
-  ],
-  "https://github.com/Max-Samson/dsh-usage-chart": [
-    "https://github.com/Max-Samson/dsh-usage-chart/blob/main/docs/images/usage-panel-demo-en-lightv1.0.0.png",
-    "https://github.com/Max-Samson/dsh-usage-chart/blob/main/docs/images/usage-panel-demo-zh-darkv1.0.0.png"
-  ],
-  "https://github.com/MingoZhou/dsh-replay": [
-    "https://raw.githubusercontent.com/MingoZhou/dsh-replay/main/assets/overview-light.png",
-    "https://raw.githubusercontent.com/MingoZhou/dsh-replay/main/assets/timeline-light.png",
-    "https://raw.githubusercontent.com/MingoZhou/dsh-replay/main/assets/audit-light.png"
-  ],
-  "https://github.com/Mu-scorpio/token-usage-counter": [
-    "https://raw.githubusercontent.com/Mu-scorpio/token-usage-counter/main/assets/usage-stats-overview.png",
-    "https://raw.githubusercontent.com/Mu-scorpio/token-usage-counter/main/assets/usage-stats-hover.png"
-  ],
-  "https://github.com/Nanki-nn/dsh-answer-pet": [
-    "https://raw.githubusercontent.com/Nanki-nn/dsh-answer-pet/main/assets/screenshots/blue-whale.png",
-    "https://raw.githubusercontent.com/Nanki-nn/dsh-answer-pet/main/assets/screenshots/orange-cat.png",
-    "https://raw.githubusercontent.com/Nanki-nn/dsh-answer-pet/main/assets/screenshots/silver-shaded-cat.png"
-  ],
-  "https://github.com/NoNameLeGo/dsh-catppuccin-theme": [
-    "https://raw.githubusercontent.com/NoNameLeGo/dsh-catppuccin-theme/main/assets/previews/glass-latte.png",
-    "https://raw.githubusercontent.com/NoNameLeGo/dsh-catppuccin-theme/main/assets/previews/glass-mocha.png",
-    "https://raw.githubusercontent.com/NoNameLeGo/dsh-catppuccin-theme/main/assets/previews/latte.png",
-    "https://raw.githubusercontent.com/NoNameLeGo/dsh-catppuccin-theme/main/assets/previews/frappe.png",
-    "https://raw.githubusercontent.com/NoNameLeGo/dsh-catppuccin-theme/main/assets/previews/macchiato.png",
-    "https://raw.githubusercontent.com/NoNameLeGo/dsh-catppuccin-theme/main/assets/previews/mocha.png"
-  ],
-  "https://github.com/Noob-stupid/dsh-github-login": [
-    "https://github.com/user-attachments/assets/bb7c1991-9346-4c20-8dc2-5d884515c522",
-    "https://github.com/user-attachments/assets/45a31794-ab56-4e34-8826-fb362deef3dc",
-    "https://github.com/user-attachments/assets/e23560ca-41d3-4a83-bc14-1d20f884cd8a"
-  ],
-  "https://github.com/Noob-stupid/dsh-plugin-hub": [
-    "https://github.com/user-attachments/assets/b802d606-14ba-4151-9956-ff642ed12b0a"
-  ],
-  "https://github.com/PC2005-cloud/dsh-pet/tree/main/dsh-pet": [
-    "https://raw.githubusercontent.com/PC2005-cloud/dsh-pet/main/assets/screenshots/dsh-pet-running-1.png",
-    "https://raw.githubusercontent.com/PC2005-cloud/dsh-pet/main/assets/screenshots/dsh-pet-running-2.png"
-  ],
-  "https://github.com/PandaPolo/dsh-voice-call": [
-    "https://raw.githubusercontent.com/PandaPolo/dsh-voice-call/main/promo/screenshots/slide-1.png",
-    "https://raw.githubusercontent.com/PandaPolo/dsh-voice-call/main/promo/screenshots/slide-2.png",
-    "https://raw.githubusercontent.com/PandaPolo/dsh-voice-call/main/promo/screenshots/slide-3.png",
-    "https://raw.githubusercontent.com/PandaPolo/dsh-voice-call/main/promo/screenshots/slide-4.png",
-    "https://raw.githubusercontent.com/PandaPolo/dsh-voice-call/main/promo/screenshots/slide-5.png",
-    "https://raw.githubusercontent.com/PandaPolo/dsh-voice-call/main/promo/screenshots/slide-6.png",
-    "https://raw.githubusercontent.com/PandaPolo/dsh-voice-call/main/promo/screenshots/slide-7.png"
-  ],
-  "https://github.com/ParticleLight/dsh-all-usage": [
-    "https://raw.githubusercontent.com/ParticleLight/dsh-all-usage/main/assets/screenshot-1.png",
-    "https://raw.githubusercontent.com/ParticleLight/dsh-all-usage/main/assets/screenshot-2.png"
-  ],
-  "https://github.com/PeterBon/dsh-hooks": [
-    "https://raw.githubusercontent.com/PeterBon/dsh-hooks/main/assets/screenshot-1.jpg"
-  ],
-  "https://github.com/PicGo/dsh-plugin": [
-    "https://raw.githubusercontent.com/PicGo/dsh-plugin/main/assets/DeepSeek-PicGo.png",
-    "https://raw.githubusercontent.com/PicGo/dsh-plugin/main/assets/dsh-plugin-picgo.png"
-  ],
-  "https://github.com/PwnKY/dsh-session-link": [
-    "https://raw.githubusercontent.com/PwnKY/dsh-session-link/master/assets/screenshots/01-cross-session-context.png",
-    "https://raw.githubusercontent.com/PwnKY/dsh-session-link/master/assets/screenshots/02-source-session.png"
-  ],
-  "https://github.com/QT-Chen/dsh-mic-input": [
-    "https://raw.githubusercontent.com/QT-Chen/dsh-mic-input/main/assets/shot-1-composer.png",
-    "https://raw.githubusercontent.com/QT-Chen/dsh-mic-input/main/assets/shot-2-listening.png",
-    "https://raw.githubusercontent.com/QT-Chen/dsh-mic-input/main/assets/shot-4-punctuation.png",
-    "https://raw.githubusercontent.com/QT-Chen/dsh-mic-input/main/assets/shot-3-settings.png",
-    "https://raw.githubusercontent.com/QT-Chen/dsh-mic-input/main/assets/shot-5-error.png"
-  ],
-  "https://github.com/RevolutionLA/dsh-dream-skin": [
-    "https://raw.githubusercontent.com/RevolutionLA/dsh-dream-skin/main/docs/screenshots/preview.png",
-    "https://raw.githubusercontent.com/RevolutionLA/dsh-dream-skin/main/docs/screenshots/settings.png"
-  ],
-  "https://github.com/SamizuHM/dsh-client-ui-theme-xp": [
-    "https://raw.githubusercontent.com/SamizuHM/dsh-client-ui-theme-xp/main/docs/screenshot.png"
-  ],
-  "https://github.com/Signalight/codex-to-dsh-pet/tree/main/packages/dsh-codex-pet": [
-    "https://raw.githubusercontent.com/Signalight/codex-to-dsh-pet/main/assets/screenshots/screenshot-1.png",
-    "https://raw.githubusercontent.com/Signalight/codex-to-dsh-pet/main/assets/screenshots/screenshot-2.png",
-    "https://raw.githubusercontent.com/Signalight/codex-to-dsh-pet/main/assets/screenshots/screenshot-3.png"
-  ],
-  "https://github.com/SiriLee/dsh-rewind": [
-    "https://raw.githubusercontent.com/SiriLee/dsh-rewind/main/assets/screenshots/rewind-button.png",
-    "https://raw.githubusercontent.com/SiriLee/dsh-rewind/main/assets/screenshots/mode-popover.png",
-    "https://raw.githubusercontent.com/SiriLee/dsh-rewind/main/assets/screenshots/impact-list.png",
-    "https://raw.githubusercontent.com/SiriLee/dsh-rewind/main/assets/screenshots/rewind-candidates.png"
-  ],
-  "https://github.com/Smalldy/godot-bridge": [
-    "https://raw.githubusercontent.com/Smalldy/godot-bridge/main/assets/godot-bridge-env-check.png"
-  ],
-  "https://github.com/StruggleYang/dsh-project-kanban": [
-    "https://raw.githubusercontent.com/StruggleYang/dsh-project-kanban/main/assets/screenshot-board.png"
-  ],
-  "https://github.com/TQSY114514/dsh-ui-appearance": [
-    "https://raw.githubusercontent.com/TQSY114514/dsh-ui-appearance/main/docs/screenshot-settings.png",
-    "https://raw.githubusercontent.com/TQSY114514/dsh-ui-appearance/main/docs/screenshot-wallpaper.png"
-  ],
-  "https://github.com/TZHR-invest/dsh-plugins/tree/main/packages/dsh-lan-access": [
-    "https://raw.githubusercontent.com/TZHR-invest/dsh-plugins/main/packages/dsh-lan-access/assets/screenshot-1-token-gate.png"
-  ],
-  "https://github.com/TZHR-invest/dsh-plugins/tree/main/packages/dsh-mobile-ui": [
-    "https://raw.githubusercontent.com/TZHR-invest/dsh-plugins/main/packages/dsh-mobile-ui/assets/screenshot-1-home.png",
-    "https://raw.githubusercontent.com/TZHR-invest/dsh-plugins/main/packages/dsh-mobile-ui/assets/screenshot-2-composer.png",
-    "https://raw.githubusercontent.com/TZHR-invest/dsh-plugins/main/packages/dsh-mobile-ui/assets/screenshot-3-chat.png",
-    "https://raw.githubusercontent.com/TZHR-invest/dsh-plugins/main/packages/dsh-mobile-ui/assets/screenshot-4-sessions.png"
-  ],
-  "https://github.com/Tkingxiao/dsh-any-background": [
-    "https://raw.githubusercontent.com/Tkingxiao/dsh-any-background/main/example_img/image.png",
-    "https://raw.githubusercontent.com/Tkingxiao/dsh-any-background/main/example_img/image-2.png",
-    "https://raw.githubusercontent.com/Tkingxiao/dsh-any-background/main/example_img/image-3.png",
-    "https://raw.githubusercontent.com/Tkingxiao/dsh-any-background/main/example_img/image-4.png",
-    "https://raw.githubusercontent.com/Tkingxiao/dsh-any-background/main/example_img/image-6.png",
-    "https://raw.githubusercontent.com/Tkingxiao/dsh-any-background/main/example_img/image-9.png",
-    "https://raw.githubusercontent.com/Tkingxiao/dsh-any-background/main/example_img/image-10.png"
-  ],
-  "https://github.com/Totoro-qaq/dsh-plugin-bridge": [
-    "https://raw.githubusercontent.com/Totoro-qaq/dsh-plugin-bridge/main/assets/cover/cover-en.png",
-    "https://raw.githubusercontent.com/Totoro-qaq/dsh-plugin-bridge/main/assets/bridge-demo.en.gif"
-  ],
-  "https://github.com/Ultronen/dsh-archived-chats": [
-    "https://raw.githubusercontent.com/Ultronen/dsh-archived-chats/main/assets/screenshots/1-archived-chats.png",
-    "https://raw.githubusercontent.com/Ultronen/dsh-archived-chats/main/assets/screenshots/2-search.png",
-    "https://raw.githubusercontent.com/Ultronen/dsh-archived-chats/main/assets/screenshots/3-delete-confirm.png",
-    "https://raw.githubusercontent.com/Ultronen/dsh-archived-chats/main/assets/screenshots/4-group-menu.png"
-  ],
-  "https://github.com/Ultronen/dsh-liquid-glass": [
-    "https://raw.githubusercontent.com/Ultronen/dsh-liquid-glass/main/assets/screenshots/1-settings.png",
-    "https://raw.githubusercontent.com/Ultronen/dsh-liquid-glass/main/assets/screenshots/2-glass-shell.png",
-    "https://raw.githubusercontent.com/Ultronen/dsh-liquid-glass/main/assets/screenshots/3-settings-wallpaper.png"
-  ],
-  "https://github.com/V1ki/dsh-plugin-subscriptions": [
-    "https://raw.githubusercontent.com/V1ki/dsh-plugin-subscriptions/main/docs/images/subscriptions.png",
-    "https://raw.githubusercontent.com/V1ki/dsh-plugin-subscriptions/main/docs/images/model-picker.png",
-    "https://raw.githubusercontent.com/V1ki/dsh-plugin-subscriptions/main/docs/images/model-effort.png",
-    "https://raw.githubusercontent.com/V1ki/dsh-plugin-subscriptions/main/docs/images/speed-toggle.png",
-    "https://raw.githubusercontent.com/V1ki/dsh-plugin-subscriptions/main/docs/images/image-generate-inline.png",
-    "https://raw.githubusercontent.com/V1ki/dsh-plugin-subscriptions/main/docs/images/image-generate-providers.png",
-    "https://raw.githubusercontent.com/V1ki/dsh-plugin-subscriptions/main/docs/images/video-generate-inline.png"
-  ],
-  "https://github.com/Vncntvx/dsh-zotero": [
-    "https://raw.githubusercontent.com/Vncntvx/dsh-zotero/main/docs/images/header-collage.png",
-    "https://raw.githubusercontent.com/Vncntvx/dsh-zotero/main/docs/images/zotero-chat-workflow.png",
-    "https://raw.githubusercontent.com/Vncntvx/dsh-zotero/main/docs/images/zotero-sources-overview.png",
-    "https://raw.githubusercontent.com/Vncntvx/dsh-zotero/main/docs/images/zotero-evidence-passages.png",
-    "https://raw.githubusercontent.com/Vncntvx/dsh-zotero/main/docs/images/zotero-export-bibtex.png"
-  ],
-  "https://github.com/WenhongPan/dsh-projects": [
-    "https://raw.githubusercontent.com/WenhongPan/dsh-projects/main/docs/assets/picker.webp",
-    "https://raw.githubusercontent.com/WenhongPan/dsh-projects/main/docs/assets/create.webp",
-    "https://raw.githubusercontent.com/WenhongPan/dsh-projects/main/docs/assets/native.webp"
-  ],
-  "https://github.com/YeqingTang/dsh-session-flow": [
-    "https://raw.githubusercontent.com/YeqingTang/dsh-session-flow/main/assets/screenshots/overview.png",
-    "https://raw.githubusercontent.com/YeqingTang/dsh-session-flow/main/assets/screenshots/session-flow-tab.png",
-    "https://raw.githubusercontent.com/YeqingTang/dsh-session-flow/main/assets/screenshots/turn-rail.png",
-    "https://raw.githubusercontent.com/YeqingTang/dsh-session-flow/main/assets/screenshots/fulltext-search.png",
-    "https://raw.githubusercontent.com/YeqingTang/dsh-session-flow/main/assets/screenshots/dock-right.png",
-    "https://raw.githubusercontent.com/YeqingTang/dsh-session-flow/main/assets/screenshots/folded-detail.png"
-  ],
-  "https://github.com/Yu-tao-Li/dsh-computer-use-win": [
-    "https://raw.githubusercontent.com/Yu-tao-Li/dsh-computer-use-win/main/assets/screenshot-1.png",
-    "https://raw.githubusercontent.com/Yu-tao-Li/dsh-computer-use-win/main/assets/screenshot-2.png",
-    "https://raw.githubusercontent.com/Yu-tao-Li/dsh-computer-use-win/main/assets/screenshot-3.png"
-  ],
-  "https://github.com/Yu-tao-Li/dsh-read-image-view": [
-    "https://raw.githubusercontent.com/Yu-tao-Li/dsh-read-image-view/main/assets/screenshot-1.png",
-    "https://raw.githubusercontent.com/Yu-tao-Li/dsh-read-image-view/main/assets/screenshot-2.png",
-    "https://raw.githubusercontent.com/Yu-tao-Li/dsh-read-image-view/main/assets/screenshot-3.png",
-    "https://raw.githubusercontent.com/Yu-tao-Li/dsh-read-image-view/main/assets/screenshot-4.png"
-  ],
-  "https://github.com/Yu-tao-Li/dsh-reference-checker": [
-    "https://raw.githubusercontent.com/Yu-tao-Li/dsh-reference-checker/main/assets/screenshot-1.png"
-  ],
-  "https://github.com/ZJUZhiyuCai/dsh-ivory": [
-    "https://raw.githubusercontent.com/ZJUZhiyuCai/dsh-ivory/main/assets/hero-light.png",
-    "https://raw.githubusercontent.com/ZJUZhiyuCai/dsh-ivory/main/assets/hero-dark.png",
-    "https://raw.githubusercontent.com/ZJUZhiyuCai/dsh-ivory/main/assets/conversation-light.png",
-    "https://raw.githubusercontent.com/ZJUZhiyuCai/dsh-ivory/main/assets/mobile-light.png"
-  ],
-  "https://github.com/a179-sanae/dsh-auto-collapse": [
-    "https://raw.githubusercontent.com/a179-sanae/dsh-auto-collapse/main/assets/screenshot.png"
-  ],
-  "https://github.com/a903067276-rgb/dsh-file-mentions": [
-    "https://raw.githubusercontent.com/a903067276-rgb/dsh-file-mentions/main/assets/screenshot.png"
-  ],
-  "https://github.com/a903067276-rgb/dsh-file-upload": [
-    "https://raw.githubusercontent.com/a903067276-rgb/dsh-file-upload/main/assets/screenshot.png"
-  ],
-  "https://github.com/a903067276-rgb/dsh-hud": [
-    "https://raw.githubusercontent.com/a903067276-rgb/dsh-hud/main/assets/hud-panel.png"
-  ],
-  "https://github.com/a903067276-rgb/dsh-plan-switch": [
-    "https://raw.githubusercontent.com/a903067276-rgb/dsh-plan-switch/main/assets/plan-button.png"
-  ],
-  "https://github.com/biociao/dsh-science": [
-    "https://raw.githubusercontent.com/biociao/dsh-science/main/assets/screenshots/research-loop.png",
-    "https://raw.githubusercontent.com/biociao/dsh-science/main/assets/screenshots/artifact-provenance.png",
-    "https://raw.githubusercontent.com/biociao/dsh-science/main/assets/screenshots/research-report.png",
-    "https://raw.githubusercontent.com/biociao/dsh-science/main/assets/screenshots/remote-compute.png",
-    "https://raw.githubusercontent.com/biociao/dsh-science/main/assets/screenshots/plugin-inventory.png",
-    "https://raw.githubusercontent.com/biociao/dsh-science/main/assets/screenshots/topology.png"
-  ],
-  "https://github.com/chouyong/dsh-branch-review": [
-    "https://raw.githubusercontent.com/chouyong/dsh-branch-review/main/assets/branch-review-desktop.png",
-    "https://raw.githubusercontent.com/chouyong/dsh-branch-review/main/assets/branch-review-decisions.png"
-  ],
-  "https://github.com/chouyong/dsh-fork-diff": [
-    "https://raw.githubusercontent.com/chouyong/dsh-fork-diff/main/assets/fork-diff-desktop.png",
-    "https://raw.githubusercontent.com/chouyong/dsh-fork-diff/main/assets/fork-diff-selector.png",
-    "https://raw.githubusercontent.com/chouyong/dsh-fork-diff/main/assets/fork-diff-mobile.png"
-  ],
-  "https://github.com/chouyong/dsh-fork-graph": [
-    "https://raw.githubusercontent.com/chouyong/dsh-fork-graph/main/assets/screenshot-trigger.png",
-    "https://raw.githubusercontent.com/chouyong/dsh-fork-graph/main/assets/screenshot-panel.png"
-  ],
-  "https://github.com/cirelir/dsh-change-review": [
-    "https://raw.githubusercontent.com/cirelir/dsh-change-review/main/assets/screenshots/review-tab.png",
-    "https://raw.githubusercontent.com/cirelir/dsh-change-review/main/assets/screenshots/per-turn-card.png",
-    "https://raw.githubusercontent.com/cirelir/dsh-change-review/main/assets/screenshots/diff-detail.png",
-    "https://raw.githubusercontent.com/cirelir/dsh-change-review/main/assets/screenshots/color-settings.png",
-    "https://raw.githubusercontent.com/cirelir/dsh-change-review/main/assets/screenshots/plugin-market.png"
-  ],
-  "https://github.com/coolbreezecoin/dsh-wechat-mp": [
-    "https://raw.githubusercontent.com/coolbreezecoin/dsh-wechat-mp/main/assets/demo.gif"
-  ],
-  "https://github.com/corrinehu/dsh-chat-imagine": [
-    "https://raw.githubusercontent.com/corrinehu/dsh-chat-imagine/main/assets/1.png",
-    "https://raw.githubusercontent.com/corrinehu/dsh-chat-imagine/main/assets/2.png",
-    "https://raw.githubusercontent.com/corrinehu/dsh-chat-imagine/main/assets/3.png",
-    "https://raw.githubusercontent.com/corrinehu/dsh-chat-imagine/main/assets/4.png"
-  ],
-  "https://github.com/creght-dev/skills": [
-    "https://raw.githubusercontent.com/creght-dev/skills/main/assets/screenshot-dsh.jpg",
-    "https://raw.githubusercontent.com/creght-dev/skills/main/assets/screenshot-editor.jpg"
-  ],
-  "https://github.com/d-dev0101/open-sea-skin": [
-    "https://raw.githubusercontent.com/d-dev0101/open-sea-skin/5ae54402ec6d4c961d41aee8ed786280799712c7/docs/marketplace/open-sea-harness-cover.png",
-    "https://raw.githubusercontent.com/d-dev0101/open-sea-skin/5ae54402ec6d4c961d41aee8ed786280799712c7/docs/screenshots/harness-dark-overview-40.gif",
-    "https://raw.githubusercontent.com/d-dev0101/open-sea-skin/5ae54402ec6d4c961d41aee8ed786280799712c7/docs/screenshots/harness-light-overview-40.gif",
-    "https://raw.githubusercontent.com/d-dev0101/open-sea-skin/5ae54402ec6d4c961d41aee8ed786280799712c7/docs/screenshots/harness-wave-control-40.gif",
-    "https://raw.githubusercontent.com/d-dev0101/open-sea-skin/5ae54402ec6d4c961d41aee8ed786280799712c7/docs/screenshots/harness-daylight-sunset-40.gif"
-  ],
-  "https://github.com/daetz-coder/dsh-multi-chat": [
-    "https://raw.githubusercontent.com/daetz-coder/dsh-multi-chat/main/assets/01-windows-dual-chat.png",
-    "https://raw.githubusercontent.com/daetz-coder/dsh-multi-chat/main/assets/02-ipad-dual-chat.png",
-    "https://raw.githubusercontent.com/daetz-coder/dsh-multi-chat/main/assets/03-windows-triple-chat.png"
-  ],
-  "https://github.com/demacia1314/dsh-airdrop": [
-    "https://raw.githubusercontent.com/demacia1314/dsh-airdrop/main/assets/drop-in.png",
-    "https://raw.githubusercontent.com/demacia1314/dsh-airdrop/main/assets/in-chat.png",
-    "https://raw.githubusercontent.com/demacia1314/dsh-airdrop/main/assets/preview-modal.png"
-  ],
-  "https://github.com/detongz/dsh-client-ui-obsidian-memory": [
-    "https://raw.githubusercontent.com/detongz/dsh-client-ui-obsidian-memory/main/assets/screenshot-panel.png"
-  ],
-  "https://github.com/dfycaly98931680/dsh-trajectory-governance": [
-    "https://raw.githubusercontent.com/dfycaly98931680/dsh-trajectory-governance/main/docs/screenshots/tree.png",
-    "https://raw.githubusercontent.com/dfycaly98931680/dsh-trajectory-governance/main/docs/screenshots/alerts.png",
-    "https://raw.githubusercontent.com/dfycaly98931680/dsh-trajectory-governance/main/docs/screenshots/report.png"
-  ],
-  "https://github.com/dickpy/dsh-imagegen": [
-    "https://raw.githubusercontent.com/dickpy/dsh-imagegen/main/docs/images/image-generation-studio.png",
-    "https://raw.githubusercontent.com/dickpy/dsh-imagegen/main/docs/images/plugin-settings.png"
-  ],
-  "https://github.com/disyli/dsh-tool-call-stats": [
-    "https://raw.githubusercontent.com/disyli/dsh-tool-call-stats/main/assets/screenshots/01-session.png",
-    "https://raw.githubusercontent.com/disyli/dsh-tool-call-stats/main/assets/screenshots/02-tool-stats.png",
-    "https://raw.githubusercontent.com/disyli/dsh-tool-call-stats/main/assets/screenshots/03-install.png",
-    "https://raw.githubusercontent.com/disyli/dsh-tool-call-stats/main/assets/screenshots/04-config.png"
-  ],
-  "https://github.com/dsh-market/dsh-market": [
-    "https://raw.githubusercontent.com/dsh-market/dsh-market/main/assets/demo-en.png",
-    "https://raw.githubusercontent.com/dsh-market/dsh-market/main/assets/themes-en.png"
-  ],
-  "https://github.com/elves-ai/dsh-web-search-firecrawl": [
-    "https://raw.githubusercontent.com/elves-ai/dsh-web-search-firecrawl/master/docs/firecrawl-settings.png"
-  ],
-  "https://github.com/franksong2702/dsh-codex-connect": [
-    "https://raw.githubusercontent.com/franksong2702/dsh-codex-connect/main/docs/assets/en/plugin-entry.jpg",
-    "https://raw.githubusercontent.com/franksong2702/dsh-codex-connect/main/docs/assets/en/oauth-status.jpg",
-    "https://raw.githubusercontent.com/franksong2702/dsh-codex-connect/main/docs/assets/en/plugin-configuration.jpg",
-    "https://raw.githubusercontent.com/franksong2702/dsh-codex-connect/main/docs/assets/en/model-selector.jpg",
-    "https://raw.githubusercontent.com/franksong2702/dsh-codex-connect/main/docs/assets/zh/hero.jpg",
-    "https://raw.githubusercontent.com/franksong2702/dsh-codex-connect/main/docs/assets/zh/plugin-entry.jpg",
-    "https://raw.githubusercontent.com/franksong2702/dsh-codex-connect/main/docs/assets/zh/oauth-status.jpg",
-    "https://raw.githubusercontent.com/franksong2702/dsh-codex-connect/main/docs/assets/zh/plugin-configuration.jpg"
-  ],
-  "https://github.com/fuyue521/dsh-desktop-shortcut": [
-    "https://raw.githubusercontent.com/fuyue521/dsh-desktop-shortcut/main/assets/screenshots/screenshot-web-ui.png"
-  ],
-  "https://github.com/haiziyao/dsh-vision-mix": [
-    "https://raw.githubusercontent.com/haiziyao/dsh-vision-mix/main/docs/settings-routing.png",
-    "https://raw.githubusercontent.com/haiziyao/dsh-vision-mix/main/docs/generation-routing.png",
-    "https://raw.githubusercontent.com/haiziyao/dsh-vision-mix/main/docs/vision-history.png",
-    "https://raw.githubusercontent.com/haiziyao/dsh-vision-mix/main/docs/generation-history.png",
-    "https://raw.githubusercontent.com/haiziyao/dsh-vision-mix/main/docs/benchmark-mix.png"
-  ],
-  "https://github.com/hanzhangzzz/dsh-diagram": [
-    "https://raw.githubusercontent.com/hanzhangzzz/dsh-diagram/assets/dsh-diagram-demo.gif",
-    "https://raw.githubusercontent.com/hanzhangzzz/dsh-diagram/assets/screenshot-canvas-architecture.png",
-    "https://raw.githubusercontent.com/hanzhangzzz/dsh-diagram/assets/screenshot-canvas-flow.png",
-    "https://raw.githubusercontent.com/hanzhangzzz/dsh-diagram/assets/screenshot-chat.png"
-  ],
-  "https://github.com/haoku123/dsh-voice": [
-    "https://raw.githubusercontent.com/haoku123/dsh-voice/main/docs/demo.gif"
-  ],
-  "https://github.com/hezhongtang/dsh-capability-optimizer": [
-    "https://raw.githubusercontent.com/hezhongtang/dsh-capability-optimizer/main/assets/screenshot-zh.png"
-  ],
-  "https://github.com/hi-wenw/dsh-telegram-channel": [
-    "https://raw.githubusercontent.com/hi-wenw/dsh-telegram-channel/master/docs/screenshots/hero-flow.png",
-    "https://raw.githubusercontent.com/hi-wenw/dsh-telegram-channel/master/docs/screenshots/mobile-chat.jpg",
-    "https://raw.githubusercontent.com/hi-wenw/dsh-telegram-channel/master/docs/screenshots/desktop-sync.jpg"
-  ],
-  "https://github.com/huguangyu666/dsh-plugin-notify": [
-    "https://raw.githubusercontent.com/huguangyu666/dsh-plugin-notify/main/assets/screenshot.png"
-  ],
-  "https://github.com/huguangyu666/dsh-plugin-session-import": [
-    "https://raw.githubusercontent.com/huguangyu666/dsh-plugin-session-import/main/assets/screenshot.png"
-  ],
-  "https://github.com/huguangyu666/dsh-store": [
-    "https://raw.githubusercontent.com/huguangyu666/dsh-plugin-store/main/assets/screenshot.png"
-  ],
-  "https://github.com/huxint/dsh-team": [
-    "https://raw.githubusercontent.com/huxint/dsh-team/main/screenshots/image.png"
-  ],
-  "https://github.com/hxy91819/dsh-auth": [
-    "https://raw.githubusercontent.com/hxy91819/dsh-auth/main/docs/images/login.png",
-    "https://raw.githubusercontent.com/hxy91819/dsh-auth/main/docs/images/authenticated-harness.png"
-  ],
-  "https://github.com/hyzyn/dsh-plugin-kit/tree/main/packages/rss": [
-    "https://raw.githubusercontent.com/hyzyn/dsh-plugin-kit/main/docs/dsh-plugin-kit-rss-setting.png",
-    "https://raw.githubusercontent.com/hyzyn/dsh-plugin-kit/main/docs/dsh-plugin-kit-rss-view.png"
-  ],
-  "https://github.com/hyzyn/dsh-plugin-kit/tree/main/packages/search": [
-    "https://raw.githubusercontent.com/hyzyn/dsh-plugin-kit/main/docs/dsh-plugin-kit-search.png"
-  ],
-  "https://github.com/iamfromchangsha/dsh-go-balance": [
-    "https://raw.githubusercontent.com/iamfromchangsha/dsh-go-balance/main/docs/screenshot-composer.png",
-    "https://raw.githubusercontent.com/iamfromchangsha/dsh-go-balance/main/docs/screenshot-tooltip.png",
-    "https://raw.githubusercontent.com/iamfromchangsha/dsh-go-balance/main/docs/screenshot-warn.png"
-  ],
-  "https://github.com/iiwish/dsh-testkit": [
-    "https://raw.githubusercontent.com/iiwish/dsh-testkit/main/docs/assets/dsh-testkit-showcase.png"
-  ],
-  "https://github.com/imkingjh999/dsh-shorts-wall": [
-    "https://raw.githubusercontent.com/imkingjh999/dsh-shorts-wall/main/docs/screenshot-stick.png",
-    "https://raw.githubusercontent.com/imkingjh999/dsh-shorts-wall/main/docs/screenshot-float.png",
-    "https://raw.githubusercontent.com/imkingjh999/dsh-shorts-wall/main/docs/screenshot-minimized.png"
-  ],
-  "https://github.com/imkingjh999/dsh-deepsea": [
-    "https://raw.githubusercontent.com/imkingjh999/dsh-deepsea/main/assets/screenshots/deepsea-ocean.png",
-    "https://raw.githubusercontent.com/imkingjh999/dsh-deepsea/main/assets/screenshots/deepsea-wall.png",
-    "https://raw.githubusercontent.com/imkingjh999/dsh-deepsea/main/assets/screenshots/deepsea-pond.png"
-  ],
-  "https://github.com/itr-del/dsh-feishu": [
-    "https://raw.githubusercontent.com/itr-del/dsh-feishu/master/assets/hero.png"
-  ],
-  "https://github.com/izwarm195/dsh-net-tools": [
-    "https://raw.githubusercontent.com/izwarm195/dsh-net-tools/main/assets/net_fetch-demo.png"
-  ],
-  "https://github.com/jiezeng2004-design/dsh-chatgpt-bridge": [
-    "https://raw.githubusercontent.com/jiezeng2004-design/dsh-chatgpt-bridge/main/assets/screenshots/01-human-in-the-loop.png",
-    "https://raw.githubusercontent.com/jiezeng2004-design/dsh-chatgpt-bridge/main/assets/screenshots/02-runtime-goal-update.png",
-    "https://raw.githubusercontent.com/jiezeng2004-design/dsh-chatgpt-bridge/main/assets/screenshots/03-native-dsh-execution.png",
-    "https://raw.githubusercontent.com/jiezeng2004-design/dsh-chatgpt-bridge/main/assets/screenshots/04-workspace-security.png",
-    "https://raw.githubusercontent.com/jiezeng2004-design/dsh-chatgpt-bridge/main/assets/screenshots/05-bridge-health.png"
-  ],
-  "https://github.com/jitengfei/dsh-whale-arcade": [
-    "https://raw.githubusercontent.com/jitengfei/dsh-whale-arcade/main/assets/screenshots/01-catalog.png",
-    "https://raw.githubusercontent.com/jitengfei/dsh-whale-arcade/main/assets/screenshots/02-whale-jump.png",
-    "https://raw.githubusercontent.com/jitengfei/dsh-whale-arcade/main/assets/screenshots/03-blue-whale-treasure.png",
-    "https://raw.githubusercontent.com/jitengfei/dsh-whale-arcade/main/assets/screenshots/04-coast-runner.png",
-    "https://raw.githubusercontent.com/jitengfei/dsh-whale-arcade/main/assets/screenshots/05-ocean-gomoku.png"
-  ],
-  "https://github.com/jyh20030112/dsh-visual-plugin": [
-    "https://raw.githubusercontent.com/jyh20030112/dsh-visual-plugin/main/assets/screenshots/screenshot-1.png",
-    "https://raw.githubusercontent.com/jyh20030112/dsh-visual-plugin/main/assets/screenshots/screenshot-2.png",
-    "https://raw.githubusercontent.com/jyh20030112/dsh-visual-plugin/main/assets/screenshots/screenshot-3.png",
-    "https://raw.githubusercontent.com/jyh20030112/dsh-visual-plugin/main/assets/screenshots/screenshot-4.png"
-  ],
-  "https://github.com/kaixinbaba/dsh-vision-recognizer": [
-    "https://raw.githubusercontent.com/kaixinbaba/dsh-vision-recognizer/main/screenshots/vision-config.png",
-    "https://raw.githubusercontent.com/kaixinbaba/dsh-vision-recognizer/main/screenshots/model-picker.png",
-    "https://raw.githubusercontent.com/kaixinbaba/dsh-vision-recognizer/main/screenshots/chat-demo.png",
-    "https://raw.githubusercontent.com/kaixinbaba/dsh-vision-recognizer/main/screenshots/plugin-list.png"
-  ],
-  "https://github.com/kanchengw/dsh-mindseye": [
-    "https://raw.githubusercontent.com/kanchengw/dsh-mindseye/main/assets/ScreenShot_GUI.png",
-    "https://raw.githubusercontent.com/kanchengw/dsh-mindseye/main/assets/ScreenShot_interaction.png",
-    "https://raw.githubusercontent.com/kanchengw/dsh-mindseye/main/assets/ScreenShot_config.png"
-  ],
-  "https://github.com/kexuejin/dsh-zhihu-dashboard": [
-    "https://raw.githubusercontent.com/kexuejin/dsh-zhihu-dashboard/main/assets/hot.png",
-    "https://raw.githubusercontent.com/kexuejin/dsh-zhihu-dashboard/main/assets/track.png",
-    "https://raw.githubusercontent.com/kexuejin/dsh-zhihu-dashboard/main/assets/feed.png",
-    "https://raw.githubusercontent.com/kexuejin/dsh-zhihu-dashboard/main/assets/onboarding.png"
-  ],
-  "https://github.com/keyiadiannao/dsh-restart-button": [
-    "https://raw.githubusercontent.com/keyiadiannao/dsh-power-button/master/docs/screenshots/en/power-button.png",
-    "https://raw.githubusercontent.com/keyiadiannao/dsh-power-button/master/docs/screenshots/en/power-menu.png",
-    "https://raw.githubusercontent.com/keyiadiannao/dsh-power-button/master/docs/screenshots/en/shutdown-confirm.png",
-    "https://raw.githubusercontent.com/keyiadiannao/dsh-power-button/master/docs/screenshots/en/shutdown-progress.png",
-    "https://raw.githubusercontent.com/keyiadiannao/dsh-power-button/master/docs/screenshots/en/restart-done.png"
-  ],
-  "https://github.com/kinoward/dsh-plugin-subhub": [
-    "https://raw.githubusercontent.com/kinoward/dsh-plugin-subhub/main/assets/models-en-light.png",
-    "https://raw.githubusercontent.com/kinoward/dsh-plugin-subhub/main/assets/models-zh-light.png",
-    "https://raw.githubusercontent.com/kinoward/dsh-plugin-subhub/main/assets/settings-loggedin-en-light.png",
-    "https://raw.githubusercontent.com/kinoward/dsh-plugin-subhub/main/assets/settings-loggedin-zh-light.png"
-  ],
-  "https://github.com/labmimors/dsh-mcp-lens": [
-    "https://raw.githubusercontent.com/labmimors/dsh-mcp-lens/main/assets/mcp-lens-hero.webp",
-    "https://raw.githubusercontent.com/labmimors/dsh-mcp-lens/main/assets/mcp-lens-comparison.svg",
-    "https://raw.githubusercontent.com/labmimors/dsh-mcp-lens/main/assets/mcp-lens-comparison.zh-CN.svg"
-  ],
-  "https://github.com/lire1131/dsh-undo-savepoint": [
-    "https://raw.githubusercontent.com/lire1131/dsh-undo-savepoint/master/docs/webui-panel.png",
-    "https://raw.githubusercontent.com/lire1131/dsh-undo-savepoint/master/docs/webui-settings-section.png",
-    "https://raw.githubusercontent.com/lire1131/dsh-undo-savepoint/master/docs/gui-main.png",
-    "https://raw.githubusercontent.com/lire1131/dsh-undo-savepoint/master/docs/gui-settings.png",
-    "https://raw.githubusercontent.com/lire1131/dsh-undo-savepoint/master/docs/safe-mode-confirm.png",
-    "https://raw.githubusercontent.com/lire1131/dsh-undo-savepoint/master/docs/safe-mode-done.png"
-  ],
-  "https://github.com/literaf/dsh-ai4scholar": [
-    "https://raw.githubusercontent.com/literaf/dsh-ai4scholar/main/docs/ai4scholar-home.jpg",
-    "https://raw.githubusercontent.com/literaf/dsh-ai4scholar/main/docs/settings-card.png",
-    "https://raw.githubusercontent.com/literaf/dsh-ai4scholar/main/docs/balance-card.png"
-  ],
-  "https://github.com/liuwenji007/dsh-muyu": [
-    "https://raw.githubusercontent.com/liuwenji007/dsh-muyu/main/docs/tap.gif",
-    "https://raw.githubusercontent.com/liuwenji007/dsh-muyu/main/docs/auto-tap.gif"
-  ],
-  "https://github.com/liuyuelintop/dsh-conversation-exporter": [
-    "https://raw.githubusercontent.com/liuyuelintop/dsh-conversation-exporter/main/assets/select-turns.png",
-    "https://raw.githubusercontent.com/liuyuelintop/dsh-conversation-exporter/main/assets/selective-export-mermaid.png",
-    "https://raw.githubusercontent.com/liuyuelintop/dsh-conversation-exporter/main/assets/selective-export-result.png"
-  ],
-  "https://github.com/maple-pwn/paperlab": [
-    "https://raw.githubusercontent.com/maple-pwn/paperlab/main/docs/assets/screenshot.png"
-  ],
-  "https://github.com/minivv/dsh-agent-skills": [
-    "https://raw.githubusercontent.com/minivv/dsh-agent-skills/main/agent-skills-page.png"
-  ],
-  "https://github.com/ne-ilyxa/dsh-session-drafts": [
-    "https://raw.githubusercontent.com/ne-ilyxa/dsh-session-drafts/master/assets/drafts-popover.png",
-    "https://raw.githubusercontent.com/ne-ilyxa/dsh-session-drafts/master/assets/drafts-switched.png"
-  ],
-  "https://github.com/niuniuaba/dsh-subagent-vision": [
-    "https://raw.githubusercontent.com/niuniuaba/dsh-subagent-vision/main/assets/screenshot-models.png",
-    "https://raw.githubusercontent.com/niuniuaba/dsh-subagent-vision/main/assets/screenshot-vision-route.png"
-  ],
-  "https://github.com/nonewind/dsh-spend": [
-    "https://raw.githubusercontent.com/nonewind/dsh-spend/main/docs/screenshots/dashboard.png",
-    "https://raw.githubusercontent.com/nonewind/dsh-spend/main/docs/screenshots/details-window.png"
-  ],
-  "https://github.com/nzl153/dsh-pet-whale": [
-    "https://raw.githubusercontent.com/nzl153/dsh-pet-whale/main/docs/screenshots/01-idle.png",
-    "https://raw.githubusercontent.com/nzl153/dsh-pet-whale/main/docs/screenshots/02-think.png",
-    "https://raw.githubusercontent.com/nzl153/dsh-pet-whale/main/docs/screenshots/03-working.png",
-    "https://raw.githubusercontent.com/nzl153/dsh-pet-whale/main/docs/screenshots/04-celebrate.png",
-    "https://raw.githubusercontent.com/nzl153/dsh-pet-whale/main/docs/screenshots/05-error.png",
-    "https://raw.githubusercontent.com/nzl153/dsh-pet-whale/main/docs/screenshots/06-feed.png"
-  ],
-  "https://github.com/omdsh-dev/dsh-annotation": [
-    "https://github.com/user-attachments/assets/c3186efc-44d3-4e7f-9523-1902d9d037e9",
-    "https://github.com/user-attachments/assets/0b48ac02-4648-4b94-8d8f-344f8b7c25b4",
-    "https://github.com/user-attachments/assets/8b2610d0-3d00-41be-b314-bac2fe616787",
-    "https://github.com/user-attachments/assets/9b66deea-3786-4296-9b0d-52873a15f5e1"
-  ],
-  "https://github.com/omdsh-dev/dsh-genui": [
-    "https://raw.githubusercontent.com/omdsh-dev/dsh-genui/main/assets/showcase-panel.png",
-    "https://raw.githubusercontent.com/omdsh-dev/dsh-genui/main/assets/showcase-plot.png",
-    "https://raw.githubusercontent.com/omdsh-dev/dsh-genui/main/assets/showcase.png",
-    "https://raw.githubusercontent.com/omdsh-dev/dsh-genui/main/assets/demo-thumb.png"
-  ],
-  "https://github.com/pengpengyi92/dsh-quant": [
-    "https://raw.githubusercontent.com/pengpengyi92/dsh-quant/master/demos/ui-demo-preview.png"
-  ],
-  "https://github.com/pengyue-polaron/deepseek-harness-genui": [
-    "https://raw.githubusercontent.com/pengyue-polaron/deepseek-harness-genui/main/screenshots/en/code-path-canvas.png",
-    "https://raw.githubusercontent.com/pengyue-polaron/deepseek-harness-genui/main/screenshots/en/code-path-inline.png",
-    "https://raw.githubusercontent.com/pengyue-polaron/deepseek-harness-genui/main/screenshots/en/photosynthesis-explorer.png",
-    "https://raw.githubusercontent.com/pengyue-polaron/deepseek-harness-genui/main/screenshots/en/calendar-planner.png",
-    "https://raw.githubusercontent.com/pengyue-polaron/deepseek-harness-genui/main/screenshots/en/code-path-explorer.png"
-  ],
-  "https://github.com/potoior/dsh-bull-bear": [
-    "https://raw.githubusercontent.com/potoior/dsh-bull-bear/main/assets/screenshot-overview.png",
-    "https://raw.githubusercontent.com/potoior/dsh-bull-bear/main/assets/screenshot-panel.png",
-    "https://raw.githubusercontent.com/potoior/dsh-bull-bear/main/assets/screenshot-watchlist.png"
-  ],
-  "https://github.com/pyf2818/dsh-bili-widget": [
-    "https://raw.githubusercontent.com/pyf2818/dsh-bili-widget/main/assets/main.png",
-    "https://raw.githubusercontent.com/pyf2818/dsh-bili-widget/main/assets/search.png",
-    "https://raw.githubusercontent.com/pyf2818/dsh-bili-widget/main/assets/hot.png",
-    "https://raw.githubusercontent.com/pyf2818/dsh-bili-widget/main/assets/help.png",
-    "https://raw.githubusercontent.com/pyf2818/dsh-bili-widget/main/assets/mini.png"
-  ],
-  "https://github.com/qjcnmd/dsh-reasoning-slider": [
-    "https://raw.githubusercontent.com/qjcnmd/dsh-reasoning-slider/main/assets/screenshots/deepseek-v4-pro-max.png",
-    "https://raw.githubusercontent.com/qjcnmd/dsh-reasoning-slider/main/assets/screenshots/deepseek-v4-pro-off.png",
-    "https://raw.githubusercontent.com/qjcnmd/dsh-reasoning-slider/main/assets/screenshots/kimi-k3-max.png",
-    "https://raw.githubusercontent.com/qjcnmd/dsh-reasoning-slider/main/assets/screenshots/minimax-m3-minimal.png"
-  ],
-  "https://github.com/sanqiPanax/dsh-sticker-board": [
-    "https://raw.githubusercontent.com/sanqiPanax/dsh-sticker-board/master/docs/screenshot-dock.png"
-  ],
-  "https://github.com/siberiah2o/dsh-plugin-terminal": [
-    "https://raw.githubusercontent.com/siberiah2o/dsh-plugin-terminal/main/docs/screenshot-collapsed.png",
-    "https://raw.githubusercontent.com/siberiah2o/dsh-plugin-terminal/main/docs/screenshot-panel.png",
-    "https://raw.githubusercontent.com/siberiah2o/dsh-plugin-terminal/main/docs/screenshot-multitab.png"
-  ],
-  "https://github.com/sjh9714/dsh-movein": [
-    "https://raw.githubusercontent.com/sjh9714/dsh-movein/main/docs/report.png",
-    "https://raw.githubusercontent.com/sjh9714/dsh-movein/main/docs/demo.gif",
-    "https://raw.githubusercontent.com/sjh9714/dsh-movein/main/docs/social.png"
-  ],
-  "https://github.com/sjh9714/dsh-win32": [
-    "https://raw.githubusercontent.com/sjh9714/dsh-win32/master/assets/market-card.png",
-    "https://raw.githubusercontent.com/sjh9714/dsh-win32/master/assets/shot-persistent-sandboxed.png",
-    "https://raw.githubusercontent.com/sjh9714/dsh-win32/master/assets/shot-preset-picker.png"
-  ],
-  "https://github.com/skyhancloud/dsh-client-ui-quote": [
-    "https://raw.githubusercontent.com/skyhancloud/dsh-client-ui-quote/main/assets/preview-1.png",
-    "https://raw.githubusercontent.com/skyhancloud/dsh-client-ui-quote/main/assets/preview-2.png"
-  ],
-  "https://github.com/slywalker2006/dsh-passwords": [
-    "https://raw.githubusercontent.com/slywalker2006/dsh-passwords/main/docs/screenshots/white-login.png",
-    "https://raw.githubusercontent.com/slywalker2006/dsh-passwords/main/docs/screenshots/black-login.png",
-    "https://raw.githubusercontent.com/slywalker2006/dsh-passwords/main/docs/screenshots/white-login-en.png",
-    "https://raw.githubusercontent.com/slywalker2006/dsh-passwords/main/docs/screenshots/main-ui.png",
-    "https://raw.githubusercontent.com/slywalker2006/dsh-passwords/main/docs/screenshots/chat.png",
-    "https://raw.githubusercontent.com/slywalker2006/dsh-passwords/main/docs/screenshots/card-front.png",
-    "https://raw.githubusercontent.com/slywalker2006/dsh-passwords/main/docs/screenshots/card-back.png"
-  ],
-  "https://github.com/starslittle/dsh-blue-whale": [
-    "https://raw.githubusercontent.com/starslittle/dsh-blue-whale/main/docs/compare-home.png",
-    "https://raw.githubusercontent.com/starslittle/dsh-blue-whale/main/docs/compare-brand.png"
-  ],
-  "https://github.com/starslittle/dsh-queue-plus": [
-    "https://raw.githubusercontent.com/starslittle/dsh-queue-plus/main/assets/queue-default.png",
-    "https://raw.githubusercontent.com/starslittle/dsh-queue-plus/main/assets/queue-remove-all.png",
-    "https://raw.githubusercontent.com/starslittle/dsh-queue-plus/main/assets/queue-remove-complete.png",
-    "https://raw.githubusercontent.com/starslittle/dsh-queue-plus/main/assets/queue-sort.png"
-  ],
-  "https://github.com/superagents-lab/dsh-s1": [
-    "https://raw.githubusercontent.com/superagents-lab/dsh-s1/main/assets/dsh-s1.png"
-  ],
-  "https://github.com/text2future/flowix/tree/main/dsh-flowix-memory": [
-    "https://raw.githubusercontent.com/text2future/flowix/main/docs/images/home-write.png",
-    "https://raw.githubusercontent.com/text2future/flowix/main/docs/images/readme-agent.png",
-    "https://raw.githubusercontent.com/text2future/flowix/main/docs/images/gh-detail-4.png",
-    "https://raw.githubusercontent.com/text2future/flowix/main/docs/images/gh-detail-6.png"
-  ],
-  "https://github.com/tpmoonchefryan/dsh-joi-channel-theme": [
-    "https://raw.githubusercontent.com/tpmoonchefryan/dsh-joi-channel-theme/main/docs/settings-wardrobe.png",
-    "https://raw.githubusercontent.com/tpmoonchefryan/dsh-joi-channel-theme/main/docs/settings-wardrobe-dark.png",
-    "https://raw.githubusercontent.com/tpmoonchefryan/dsh-joi-channel-theme/main/docs/new-chat-flowers.png",
-    "https://raw.githubusercontent.com/tpmoonchefryan/dsh-joi-channel-theme/main/docs/new-chat-library.png",
-    "https://raw.githubusercontent.com/tpmoonchefryan/dsh-joi-channel-theme/main/docs/new-chat-flowers-dark.png",
-    "https://raw.githubusercontent.com/tpmoonchefryan/dsh-joi-channel-theme/main/docs/working-flowers.png",
-    "https://raw.githubusercontent.com/tpmoonchefryan/dsh-joi-channel-theme/main/docs/success-library.png",
-    "https://raw.githubusercontent.com/tpmoonchefryan/dsh-joi-channel-theme/main/docs/app-logo-flowers.png"
-  ],
-  "https://github.com/truelove-dreamer/dsh-plugin-vetting": [
-    "https://raw.githubusercontent.com/truelove-dreamer/dsh-plugin-vetting/main/assets/shot-report.png",
-    "https://raw.githubusercontent.com/truelove-dreamer/dsh-plugin-vetting/main/assets/shot-detail.png",
-    "https://raw.githubusercontent.com/truelove-dreamer/dsh-plugin-vetting/main/assets/shot-gate.png"
-  ],
-  "https://github.com/tt-a1i/archify/tree/main/integrations/deepseek-harness": [
-    "https://raw.githubusercontent.com/tt-a1i/archify/main/docs/assets/archify-live-proof.gif",
-    "https://raw.githubusercontent.com/tt-a1i/archify/main/docs/assets/archify-dark.png",
-    "https://raw.githubusercontent.com/tt-a1i/archify/main/docs/assets/archify-light.png"
-  ],
-  "https://github.com/txlznbzsdj-collab/dsh-deepseek-pet": [
-    "https://raw.githubusercontent.com/txlznbzsdj-collab/dsh-deepseek-pet/main/screenshots/1.png",
-    "https://raw.githubusercontent.com/txlznbzsdj-collab/dsh-deepseek-pet/main/screenshots/2.png",
-    "https://raw.githubusercontent.com/txlznbzsdj-collab/dsh-deepseek-pet/main/screenshots/3.png"
-  ],
-  "https://github.com/v587d/dsh-opencode-go-usage": [
-    "https://raw.githubusercontent.com/v587d/dsh-opencode-go-usage/main/assets/custom-footer.png",
-    "https://raw.githubusercontent.com/v587d/dsh-opencode-go-usage/main/assets/usage-detail.png",
-    "https://raw.githubusercontent.com/v587d/dsh-opencode-go-usage/main/assets/set-cookie-wid.png"
-  ],
-  "https://github.com/vdnight89/InfiniteDSH": [
-    "https://raw.githubusercontent.com/vdnight89/InfiniteDSH/main/docs/%E6%88%AA%E5%9B%BE1.png",
-    "https://raw.githubusercontent.com/vdnight89/InfiniteDSH/main/docs/%E6%88%AA%E5%9B%BE2.png",
-    "https://raw.githubusercontent.com/vdnight89/InfiniteDSH/main/docs/%E6%88%AA%E5%9B%BE2.1.png",
-    "https://raw.githubusercontent.com/vdnight89/InfiniteDSH/main/docs/%E6%88%AA%E5%9B%BE2.2.png"
-  ],
-  "https://github.com/weisiren000/dsh-remote-ssh-ops": [
-    "https://raw.githubusercontent.com/weisiren000/dsh-remote-ssh-ops/main/docs/assets/remote-workbench-preview.png"
-  ],
-  "https://github.com/welsione/dsh-mmx-bridge": [
-    "https://raw.githubusercontent.com/welsione/dsh-mmx-bridge/main/docs/image-generation.png",
-    "https://raw.githubusercontent.com/welsione/dsh-mmx-bridge/main/docs/speech-tts.png",
-    "https://raw.githubusercontent.com/welsione/dsh-mmx-bridge/main/docs/vision-demo.png",
-    "https://raw.githubusercontent.com/welsione/dsh-mmx-bridge/main/docs/plugin-settings.png"
-  ],
-  "https://github.com/wloops/dsh-git-worktree": [
-    "https://raw.githubusercontent.com/wloops/dsh-git-worktree/master/docs/screenshots/01-create-worktree.png",
-    "https://raw.githubusercontent.com/wloops/dsh-git-worktree/master/docs/screenshots/02-ready-for-review.png",
-    "https://raw.githubusercontent.com/wloops/dsh-git-worktree/master/docs/screenshots/03-local-preview.png",
-    "https://raw.githubusercontent.com/wloops/dsh-git-worktree/master/docs/screenshots/04-commit-confirmation.png",
-    "https://raw.githubusercontent.com/wloops/dsh-git-worktree/master/docs/screenshots/05-next-iteration.png",
-    "https://raw.githubusercontent.com/wloops/dsh-git-worktree/master/docs/screenshots/06-retain-environment.png"
-  ],
-  "https://github.com/wly8691-jpg/knowlp-rag": [
-    "https://raw.githubusercontent.com/wly8691-jpg/knowlp-rag/main/docs/demo.png",
-    "https://raw.githubusercontent.com/wly8691-jpg/knowlp-rag/main/docs/health.png",
-    "https://raw.githubusercontent.com/wly8691-jpg/knowlp-rag/main/docs/decay.png",
-    "https://raw.githubusercontent.com/wly8691-jpg/knowlp-rag/main/docs/architecture.png"
-  ],
-  "https://github.com/wss534857356/dsh-plugin-codex": [
-    "https://raw.githubusercontent.com/wss534857356/dsh-plugin-codex/main/docs/images/conversation-screenshot.png",
-    "https://raw.githubusercontent.com/wss534857356/dsh-plugin-codex/main/docs/images/model-selector-screenshot.png"
-  ],
-  "https://github.com/wuxiangru915/dsh-review-loop": [
-    "https://raw.githubusercontent.com/wuxiangru915/dsh-review-loop/master/assets/review-panel.en.png",
-    "https://raw.githubusercontent.com/wuxiangru915/dsh-review-loop/master/assets/review-panel.zh.png"
-  ],
-  "https://github.com/wuxiangru915/dsh-session-manager": [
-    "https://raw.githubusercontent.com/wuxiangru915/dsh-session-manager/main/assets/session-manager.png"
-  ],
-  "https://github.com/wx-yss/dsh-message-rail": [
-    "https://raw.githubusercontent.com/wx-yss/dsh-message-rail/main/assets/rail-hover-preview.png"
-  ],
-  "https://github.com/wz-heng/dsh-feishu-bridge": [
-    "https://raw.githubusercontent.com/wz-heng/dsh-feishu-bridge/main/docs/screenshots/fail-closed-boot.png",
-    "https://raw.githubusercontent.com/wz-heng/dsh-feishu-bridge/main/docs/screenshots/dsh-plugin-add.png",
-    "https://raw.githubusercontent.com/wz-heng/dsh-feishu-bridge/main/docs/screenshots/architecture.png"
-  ],
-  "https://github.com/xbzbing/dsh-auth-gateway": [
-    "https://raw.githubusercontent.com/xbzbing/dsh-auth-gateway/main/docs/assets/onboarding.png",
-    "https://raw.githubusercontent.com/xbzbing/dsh-auth-gateway/main/docs/assets/login.png",
-    "https://raw.githubusercontent.com/xbzbing/dsh-auth-gateway/main/docs/assets/login-success.png",
-    "https://raw.githubusercontent.com/xbzbing/dsh-auth-gateway/main/docs/assets/otp-setup.png",
-    "https://raw.githubusercontent.com/xbzbing/dsh-auth-gateway/main/docs/assets/settings-menu.png",
-    "https://raw.githubusercontent.com/xbzbing/dsh-auth-gateway/main/docs/assets/settings-auth.png"
-  ],
-  "https://github.com/xiajiajun516/dsh-config-manager": [
-    "https://raw.githubusercontent.com/xiajiajun516/dsh-config-manager/main/assets/screenshot-export.png",
-    "https://raw.githubusercontent.com/xiajiajun516/dsh-config-manager/main/assets/screenshot-import-preview.png",
-    "https://raw.githubusercontent.com/xiajiajun516/dsh-config-manager/main/assets/screenshot-snapshots.png",
-    "https://raw.githubusercontent.com/xiajiajun516/dsh-config-manager/main/assets/screenshot-sync.png"
-  ],
-  "https://github.com/xohmai/dsh-cpa-status": [
-    "https://raw.githubusercontent.com/xohmai/dsh-cpa-status/main/docs/images/panel.png",
-    "https://raw.githubusercontent.com/xohmai/dsh-cpa-status/main/docs/images/collapsed.png"
-  ],
-  "https://github.com/yflmq001/dsh-cost-tracker": [
-    "https://raw.githubusercontent.com/yflmq001/dsh-cost-tracker/main/assets/screenshots/screenshot-main.png",
-    "https://raw.githubusercontent.com/yflmq001/dsh-cost-tracker/main/assets/screenshots/screenshot-cost-panel.png",
-    "https://raw.githubusercontent.com/yflmq001/dsh-cost-tracker/main/assets/screenshots/screenshot-config.png"
-  ],
-  "https://github.com/yunxiiQwQ/dsh-maid-whale-webUI/tree/main/maid-whale-webui": [
-    "https://raw.githubusercontent.com/yunxiiQwQ/dsh-maid-whale-webUI/main/maid-whale-webui/preview/light.webp",
-    "https://raw.githubusercontent.com/yunxiiQwQ/dsh-maid-whale-webUI/main/maid-whale-webui/preview/dark.webp"
-  ],
-  "https://github.com/yyyyukari/dsh-plugin-workshop": [
-    "https://raw.githubusercontent.com/yyyyukari/dsh-plugin-workshop/master/assets/main-ui.jpg",
-    "https://raw.githubusercontent.com/yyyyukari/dsh-plugin-workshop/master/assets/installed-view.jpg",
-    "https://raw.githubusercontent.com/yyyyukari/dsh-plugin-workshop/master/assets/sidebar-entry.jpg"
-  ],
-  "https://github.com/zdx8637-gitdog/dshmobile/tree/main/plugins": [
-    "https://raw.githubusercontent.com/zdx8637-gitdog/dshmobile/main/docs/images/plugin-panel.jpg",
-    "https://raw.githubusercontent.com/zdx8637-gitdog/dshmobile/main/docs/images/phone-1.jpg",
-    "https://raw.githubusercontent.com/zdx8637-gitdog/dshmobile/main/docs/images/phone-2.jpg",
-    "https://raw.githubusercontent.com/zdx8637-gitdog/dshmobile/main/docs/images/phone-3.jpg"
-  ],
-  "https://github.com/zer0zio-stack/dsh-opencode-go-quota": [
-    "https://raw.githubusercontent.com/zer0zio-stack/dsh-opencode-go-quota/main/assets/screenshot-deepseek-balance.png",
-    "https://raw.githubusercontent.com/zer0zio-stack/dsh-opencode-go-quota/main/assets/screenshot-opencode-go-limit.png"
-  ],
-  "https://github.com/zhtx2024/dsh-pdf": [
-    "https://raw.githubusercontent.com/zhtx2024/dsh-pdf/master/assets/screenshot-schematic.png",
-    "https://raw.githubusercontent.com/zhtx2024/dsh-pdf/master/assets/screenshot-power.png"
-  ],
-  "https://github.com/zljr/dsh-share": [
-    "https://raw.githubusercontent.com/zljr/dsh-share/master/assets/share-dialog.png",
-    "https://raw.githubusercontent.com/zljr/dsh-share/master/assets/share-page-light.png",
-    "https://raw.githubusercontent.com/zljr/dsh-share/master/assets/share-page-dark.png"
-  ],
-  "https://github.com/2008924/dsh-progress-viz/tree/main/plugin": [
-    "https://raw.githubusercontent.com/2008924/dsh-progress-viz/main/docs/screenshot.png"
-  ],
-  "https://github.com/534119219/dsh-messaging/tree/main/packages/messaging-core": [
-    "https://raw.githubusercontent.com/534119219/dsh-messaging/main/assets/sidebar.png",
-    "https://raw.githubusercontent.com/534119219/dsh-messaging/main/assets/dialog.png"
-  ],
-  "https://github.com/Blank-not-black/dsh-Remote/tree/main/packages/plugin": [
-    "https://raw.githubusercontent.com/Blank-not-black/dsh-Remote/main/docs/screenshots/mobile-sessions.png",
-    "https://raw.githubusercontent.com/Blank-not-black/dsh-Remote/main/docs/screenshots/mobile-approvals.png",
-    "https://raw.githubusercontent.com/Blank-not-black/dsh-Remote/main/docs/screenshots/mobile-files.png",
-    "https://raw.githubusercontent.com/Blank-not-black/dsh-Remote/main/docs/screenshots/mobile-settings.png",
-    "https://raw.githubusercontent.com/Blank-not-black/dsh-Remote/main/docs/screenshots/gateway.png",
-    "https://raw.githubusercontent.com/Blank-not-black/dsh-Remote/main/docs/screenshots/settings-mobile.png",
-    "https://raw.githubusercontent.com/Blank-not-black/dsh-Remote/main/docs/screenshots/sessions.png",
-    "https://raw.githubusercontent.com/Blank-not-black/dsh-Remote/main/docs/screenshots/files.png"
-  ],
-  "https://github.com/UndeadSheep/dsh-file-preview/tree/main/packages/dsh-file-preview": [
-    "https://raw.githubusercontent.com/UndeadSheep/dsh-file-preview/main/assets/github-social-preview.png",
-    "https://raw.githubusercontent.com/UndeadSheep/dsh-file-preview/main/assets/btnPos.gif",
-    "https://raw.githubusercontent.com/UndeadSheep/dsh-file-preview/main/assets/write.gif",
-    "https://raw.githubusercontent.com/UndeadSheep/dsh-file-preview/main/assets/clickOpen.gif",
-    "https://raw.githubusercontent.com/UndeadSheep/dsh-file-preview/main/assets/SearchBar.gif"
-  ],
-  "https://github.com/Lzh3070/dsh-file-review-tab": [
-    "https://raw.githubusercontent.com/Lzh3070/dsh-file-review-tab/main/docs/screenshot.png"
-  ],
-  "https://github.com/ayahunter/dsh-trail/tree/main/packages/bundle": [
-    "https://raw.githubusercontent.com/ayahunter/dsh-trail/main/docs/screenshot.png",
-    "https://raw.githubusercontent.com/ayahunter/dsh-trail/main/docs/screenshots/rounds-view.png",
-    "https://raw.githubusercontent.com/ayahunter/dsh-trail/main/docs/screenshots/tool-details.png"
-  ],
-  "https://github.com/kaziii/dsh-github-connector/tree/main/packages/github/github": [
-    "https://raw.githubusercontent.com/kaziii/dsh-github-connector/main/docs/assets/pr-bar.png",
-    "https://raw.githubusercontent.com/kaziii/dsh-github-connector/main/docs/assets/connect-github.png"
-  ],
-  "https://github.com/siberiah2o/dsh-plugin-remote": [
-    "https://raw.githubusercontent.com/siberiah2o/dsh-plugin-remote/main/docs/screenshot-login.png",
-    "https://raw.githubusercontent.com/siberiah2o/dsh-plugin-remote/main/docs/screenshot-settings-panel.png"
-  ],
-  "https://github.com/WilliamShi666/dsh-wsl-workspace-picker": [
-    "https://raw.githubusercontent.com/WilliamShi666/dsh-wsl-workspace-picker/main/assets/workspace-picker-demo.png"
-  ],
-  "https://github.com/Liu-ZA-81/dsh-theme-firefly": [
-    "https://raw.githubusercontent.com/Liu-ZA-81/dsh-theme-firefly/main/docs/screenshots/01-wallpaper.jpg",
-    "https://raw.githubusercontent.com/Liu-ZA-81/dsh-theme-firefly/main/docs/screenshots/02-boot.jpg",
-    "https://raw.githubusercontent.com/Liu-ZA-81/dsh-theme-firefly/main/docs/screenshots/03-firefly.jpg",
-    "https://raw.githubusercontent.com/Liu-ZA-81/dsh-theme-firefly/main/docs/screenshots/04-music.jpg",
-    "https://raw.githubusercontent.com/Liu-ZA-81/dsh-theme-firefly/main/docs/screenshots/05-emote.jpg"
-  ],
-  "https://github.com/cheshireez/dsh-skill-hub": [
-    "https://raw.githubusercontent.com/cheshireez/dsh-skill-hub/main/promo/real-skill-hub.png",
-    "https://raw.githubusercontent.com/cheshireez/dsh-skill-hub/main/promo/real-skill-hub-catalog.png",
-    "https://raw.githubusercontent.com/cheshireez/dsh-skill-hub/main/promo/real-skill-hub-scenes.png"
-  ],
-  "https://github.com/maddogfinance/dsh-trading": [
-    "https://raw.githubusercontent.com/maddogfinance/dsh-trading/main/docs/screenshots/chart-card-panes.png",
-    "https://raw.githubusercontent.com/maddogfinance/dsh-trading/main/docs/screenshots/annotate-levels-table.png"
-  ],
-  "https://github.com/mux9056-bot/dsh-theme": [
-    "https://raw.githubusercontent.com/mux9056-bot/dsh-theme/main/shots/preview-gallery.png",
-    "https://raw.githubusercontent.com/mux9056-bot/dsh-theme/main/shots/mono-dark.png",
-    "https://raw.githubusercontent.com/mux9056-bot/dsh-theme/main/shots/sakura-light.png",
-    "https://raw.githubusercontent.com/mux9056-bot/dsh-theme/main/shots/terminal-dark.png"
-  ],
-  "https://github.com/chinosk6/dsh-roleplay": [
-    "https://raw.githubusercontent.com/chinosk6/dsh-roleplay/main/images/screenshot1.png"
-  ],
-  "https://github.com/starsstreaming/beautiCode/tree/main/integrations/deepseek-harness": [
-    "https://github.com/user-attachments/assets/c943a0fb-ff48-4361-9e6f-c4b1521aee2b",
-    "https://github.com/user-attachments/assets/a9a18412-4c62-4083-ab49-d127f05e61c3"
-  ],
-  "https://github.com/wenheguo2/dsh-delegation-suite": [
-    "https://raw.githubusercontent.com/wenheguo2/dsh-delegation-suite/main/assets/routes.png",
-    "https://raw.githubusercontent.com/wenheguo2/dsh-delegation-suite/main/assets/subagents.png"
-  ],
-  "https://github.com/kanneiren/dsh-network-settings": [
-    "https://raw.githubusercontent.com/kanneiren/dsh-network-settings/main/docs/images/wsl-path-graph.png",
-    "https://raw.githubusercontent.com/kanneiren/dsh-network-settings/main/docs/images/win-path-graph.png",
-    "https://raw.githubusercontent.com/kanneiren/dsh-network-settings/main/docs/images/win-network-config.png"
-  ],
-  "https://github.com/anneheartrecord/dsh-desk-pet": [
-    "https://raw.githubusercontent.com/anneheartrecord/dsh-desk-pet/main/docs/media/diy-skin.png",
-    "https://raw.githubusercontent.com/anneheartrecord/dsh-desk-pet/main/docs/media/floats-above.png",
-    "https://raw.githubusercontent.com/anneheartrecord/dsh-desk-pet/main/docs/media/skins.png",
-    "https://raw.githubusercontent.com/anneheartrecord/dsh-desk-pet/main/docs/media/states.png"
-  ],
-  "https://github.com/wsxwj123/dsh-plugins/tree/main/packages/dsh-appearance-gallery": [
-    "https://raw.githubusercontent.com/wsxwj123/dsh-plugins/main/assets/screenshots/appearance-gallery.png"
-  ],
-  "https://github.com/wsxwj123/dsh-plugins/tree/main/packages/dsh-turn-scrubber": [
-    "https://raw.githubusercontent.com/wsxwj123/dsh-plugins/main/assets/screenshots/turn-scrubber.png"
-  ],
-  "https://github.com/wsxwj123/dsh-plugins/tree/main/packages/dsh-session-manager": [
-    "https://raw.githubusercontent.com/wsxwj123/dsh-plugins/main/assets/screenshots/session-manager.png"
-  ],
-  "https://github.com/wsxwj123/dsh-plugins/tree/main/packages/dsh-composer-tools": [
-    "https://raw.githubusercontent.com/wsxwj123/dsh-plugins/main/assets/screenshots/composer-tools.png"
-  ],
-  "https://github.com/acebang0303/dsh-quick-launch": [
-    "https://raw.githubusercontent.com/acebang0303/dsh-quick-launch/main/docs/preview.png"
-  ],
-  "https://github.com/corrinehu/dsh-workbuddy-connect": [
-    "https://raw.githubusercontent.com/corrinehu/dsh-workbuddy-connect/main/assets/1.png",
-    "https://raw.githubusercontent.com/corrinehu/dsh-workbuddy-connect/main/assets/2.png",
-    "https://raw.githubusercontent.com/corrinehu/dsh-workbuddy-connect/main/assets/3.png"
-  ],
-  "https://github.com/tipoLi5890/dsh-file-mention": [
-    "https://raw.githubusercontent.com/tipoLi5890/dsh-file-mention/main/assets/screenshots/file-mention-browse.png",
-    "https://raw.githubusercontent.com/tipoLi5890/dsh-file-mention/main/assets/screenshots/file-mention-drag-drop.png",
-    "https://raw.githubusercontent.com/tipoLi5890/dsh-file-mention/main/assets/screenshots/file-mention-upload-reference.png"
-  ],
-  "https://github.com/liguobao/deepseek-harness-remote": [
-    "https://raw.githubusercontent.com/liguobao/deepseek-harness-remote/main/docs/images/setting.png",
-    "https://raw.githubusercontent.com/liguobao/deepseek-harness-remote/main/docs/images/host-list.png",
-    "https://raw.githubusercontent.com/liguobao/deepseek-harness-remote/main/docs/images/remote.png"
-  ],
-  "https://github.com/WJZ-P/dsh-attachments": [
-    "https://raw.githubusercontent.com/WJZ-P/dsh-attachments/main/assets/markdown/01-drag-drop-overlay.png",
-    "https://raw.githubusercontent.com/WJZ-P/dsh-attachments/main/assets/markdown/02-image-conversation.png",
-    "https://raw.githubusercontent.com/WJZ-P/dsh-attachments/main/assets/markdown/03-multiple-image-preview.png"
-  ],
-  "https://github.com/WJZ-P/dsh-model-capabilities": [
-    "https://raw.githubusercontent.com/WJZ-P/dsh-model-capabilities/main/assets/screenshots/01-model-input-selector.png"
-  ],
-  "https://github.com/winditer/dsh-elf": [
-    "https://raw.githubusercontent.com/winditer/dsh-elf/main/assets/screenshot-elf.png",
-    "https://raw.githubusercontent.com/winditer/dsh-elf/main/assets/screenshot-chat.png"
-  ],
-  "https://github.com/Frog755/dsh-client-auto-retry": [
-    "https://raw.githubusercontent.com/Frog755/dsh-client-auto-retry/main/assets/demo.svg",
-    "https://raw.githubusercontent.com/Frog755/dsh-client-auto-retry/main/assets/screenshot-settings-card.png"
-  ],
-  "https://github.com/Frog755/dsh-prompt-vault": [
-    "https://raw.githubusercontent.com/Frog755/dsh-prompt-vault/master/assets/screenshot-panel.png"
-  ],
-  "https://github.com/lemonorangeapple/dsh-effort-switcher": [
-    "https://raw.githubusercontent.com/lemonorangeapple/dsh-effort-switcher/master/screenshots/1.png",
-    "https://raw.githubusercontent.com/lemonorangeapple/dsh-effort-switcher/master/screenshots/2.png"
-  ],
-  "https://github.com/falser101/dsh-mascot": [
-    "https://raw.githubusercontent.com/falser101/dsh-mascot/main/assets/cover.jpg",
-    "https://raw.githubusercontent.com/falser101/dsh-mascot/main/assets/faces.jpg",
-    "https://raw.githubusercontent.com/falser101/dsh-mascot/main/assets/skins.jpg"
-  ],
-  "https://github.com/LiZhenNet/dsh-antigravity": [
-    "https://raw.githubusercontent.com/LiZhenNet/dsh-antigravity/main/assets/images/settings-signed-in.png",
-    "https://raw.githubusercontent.com/LiZhenNet/dsh-antigravity/main/assets/images/chat-model-picker.png",
-    "https://raw.githubusercontent.com/LiZhenNet/dsh-antigravity/main/assets/images/settings-not-signed-in.png"
-  ],
-  "https://github.com/geguanming/dsh-office-plugin": [
-    "https://raw.githubusercontent.com/geguanming/dsh-office-plugin/master/assets/entry.png",
-    "https://raw.githubusercontent.com/geguanming/dsh-office-plugin/master/assets/work-monitor.png",
-    "https://raw.githubusercontent.com/geguanming/dsh-office-plugin/master/assets/order-boss.png"
-  ],
-  "https://github.com/lninghaha/dsh-hub-oauth-gateway": [
-    "https://raw.githubusercontent.com/lninghaha/dsh-hub-oauth-gateway/main/docs/images/usage-center-hud.png",
-    "https://raw.githubusercontent.com/lninghaha/dsh-hub-oauth-gateway/main/docs/images/usage-center-peek.png",
-    "https://raw.githubusercontent.com/lninghaha/dsh-hub-oauth-gateway/main/docs/images/usage-center-dashboard.png",
-    "https://raw.githubusercontent.com/lninghaha/dsh-hub-oauth-gateway/main/docs/images/usage-center-settings.png"
-  ],
-  "https://github.com/deepseek-dsh/dsh-workspace": [
-    "https://raw.githubusercontent.com/deepseek-dsh/dsh-workspace/main/assets/Screenshot-1.png",
-    "https://raw.githubusercontent.com/deepseek-dsh/dsh-workspace/main/assets/Screenshot-2.png"
-  ],
-  "https://github.com/CheshireJCat/blender": [
-    "https://raw.githubusercontent.com/CheshireJCat/blender/main/assets/dsh-blender-lamp-preview.png"
-  ],
-  "https://github.com/Y1X1n/dsh-prompt-optimizer": [
-    "https://raw.githubusercontent.com/Y1X1n/dsh-prompt-optimizer/main/docs/screenshots/optimize-panel.png"
-  ],
-  "https://github.com/feng78-boop/dsh-thirteen-bg": [
-    "https://raw.githubusercontent.com/feng78-boop/dsh-thirteen-bg/master/assets/demo-poster.jpg",
-    "https://raw.githubusercontent.com/feng78-boop/dsh-thirteen-bg/master/assets/demo-shot-2.jpg"
-  ],
-  "https://github.com/wsz987/dsh-channels/tree/main/packages/channels": [
-    "https://raw.githubusercontent.com/wsz987/dsh-channels/main/docs/ScreenShot/dsh-channels-setting.png",
-    "https://raw.githubusercontent.com/wsz987/dsh-channels/main/docs/ScreenShot/telegram.png"
-  ],
-  "https://github.com/liustack/modsearch": [
-    "https://raw.githubusercontent.com/liustack/modsearch/main/assets/demo-dsh-settings-card.jpg",
-    "https://raw.githubusercontent.com/liustack/modsearch/main/assets/demo-codex-search.png",
-    "https://raw.githubusercontent.com/liustack/modsearch/main/assets/demo-codex-fetch.png"
-  ],
-  "https://github.com/liustack/modlens": [
-    "https://raw.githubusercontent.com/liustack/modlens/main/assets/demo-dsh-settings-card.jpg",
-    "https://raw.githubusercontent.com/liustack/modlens/main/assets/demo-dsh-paste.jpg",
-    "https://raw.githubusercontent.com/liustack/modlens/main/assets/demo-codex-chart.jpg",
-    "https://raw.githubusercontent.com/liustack/modlens/main/assets/demo-codex-app.jpg"
-  ],
-  "https://github.com/elysia395/dsh-wallpaper-engine": [
-    "https://raw.githubusercontent.com/elysia395/dsh-wallpaper-engine/main/docs/images/showcase.png",
-    "https://raw.githubusercontent.com/elysia395/dsh-wallpaper-engine/main/docs/images/wallpaper-library.png",
-    "https://raw.githubusercontent.com/elysia395/dsh-wallpaper-engine/main/docs/images/liquid-glass-window.png",
-    "https://raw.githubusercontent.com/elysia395/dsh-wallpaper-engine/main/docs/images/features.png",
-    "https://raw.githubusercontent.com/elysia395/dsh-wallpaper-engine/main/docs/images/compact-wallpaper-library.png",
-    "https://raw.githubusercontent.com/elysia395/dsh-wallpaper-engine/main/docs/images/better-sidebar.png"
-  ],
-  "https://github.com/dami9527/dsh-image-pathify": [
-    "https://raw.githubusercontent.com/dami9527/dsh-image-pathify/master/assets/example.png",
-    "https://raw.githubusercontent.com/dami9527/dsh-image-pathify/master/assets/settings.png",
-    "https://raw.githubusercontent.com/dami9527/dsh-image-pathify/master/assets/update.png"
-  ],
-  "https://github.com/WSL043/dsh-chat-manager": [
-    "https://raw.githubusercontent.com/WSL043/dsh-chat-manager/main/docs/assets/archive-manager.en.png",
-    "https://raw.githubusercontent.com/WSL043/dsh-chat-manager/main/docs/assets/confirm-delete.en.png"
-  ],
-  "https://github.com/ryubyte/dsh-a2a": [
-    "https://raw.githubusercontent.com/ryubyte/dsh-a2a/main/docs/screenshots/dashboard-outbound.png",
-    "https://raw.githubusercontent.com/ryubyte/dsh-a2a/main/docs/screenshots/dashboard-inbound.png",
-    "https://raw.githubusercontent.com/ryubyte/dsh-a2a/main/docs/screenshots/server-inbound.png",
-    "https://raw.githubusercontent.com/ryubyte/dsh-a2a/main/docs/screenshots/server-serve.png"
-  ],
-  "https://github.com/EdwinDigital/dsh-web-search-microsoft-webiq": [
-    "https://raw.githubusercontent.com/EdwinDigital/dsh-web-search-microsoft-webiq/main/docs/images/screenshot-1-settings.png",
-    "https://raw.githubusercontent.com/EdwinDigital/dsh-web-search-microsoft-webiq/main/docs/images/screenshot-2-web-search.png",
-    "https://raw.githubusercontent.com/EdwinDigital/dsh-web-search-microsoft-webiq/main/docs/images/screenshot-3-trace.png"
-  ],
-  "https://github.com/SmileBuild/dsh-planchart": [
-    "https://raw.githubusercontent.com/SmileBuild/dsh-planchart/main/assets/screenshot-1.png",
-    "https://raw.githubusercontent.com/SmileBuild/dsh-planchart/main/assets/screenshot-2.png"
-  ],
-  "https://github.com/WSL043/dsh-codex-subscription": [
-    "https://raw.githubusercontent.com/WSL043/dsh-codex-subscription/main/docs/assets/settings-en.png",
-    "https://raw.githubusercontent.com/WSL043/dsh-codex-subscription/main/docs/assets/composer-quota-en.png"
-  ],
-  "https://github.com/mkiea/dsh-forge": [
-    "https://raw.githubusercontent.com/mkiea/dsh-forge/master/assets/screenshot-1.png",
-    "https://raw.githubusercontent.com/mkiea/dsh-forge/master/assets/screenshot-2.png",
-    "https://raw.githubusercontent.com/mkiea/dsh-forge/master/assets/screenshot-3.png"
-  ],
-  "https://github.com/alone-tree/dsh-skill-mcp-manager": [
-    "https://raw.githubusercontent.com/alone-tree/dsh-skill-mcp-manager/main/docs/screenshot-mcp.png",
-    "https://raw.githubusercontent.com/alone-tree/dsh-skill-mcp-manager/main/docs/screenshot-skills.png"
-  ],
-  "https://github.com/liqiming-whu/dsh-status-card": [
-    "https://raw.githubusercontent.com/liqiming-whu/dsh-status-card/main/docs/images/templates/bilingual/template-a.svg",
-    "https://raw.githubusercontent.com/liqiming-whu/dsh-status-card/main/docs/images/templates/bilingual/template-b.svg",
-    "https://raw.githubusercontent.com/liqiming-whu/dsh-status-card/main/docs/images/templates/bilingual/template-c.svg",
-    "https://raw.githubusercontent.com/liqiming-whu/dsh-status-card/main/docs/images/templates/bilingual/template-d.svg",
-    "https://raw.githubusercontent.com/liqiming-whu/dsh-status-card/main/docs/images/templates/bilingual/template-e.svg",
-    "https://raw.githubusercontent.com/liqiming-whu/dsh-status-card/main/docs/images/templates/bilingual/template-f.svg"
-  ],
-  "https://github.com/zhujunpeng12/dsh-memory-system": [
-    "https://raw.githubusercontent.com/zhujunpeng12/dsh-memory-system/master/assets/social-preview.png",
-    "https://raw.githubusercontent.com/zhujunpeng12/dsh-memory-system/master/docs/memory-system-flowchart.png"
-  ],
-  "https://github.com/wangzhishou/onebox-dsh-bridge": [
-    "https://raw.githubusercontent.com/wangzhishou/onebox-dsh-bridge/main/docs/images/pairing-page.png",
-    "https://raw.githubusercontent.com/wangzhishou/onebox-dsh-bridge/main/docs/images/app-connect.png",
-    "https://raw.githubusercontent.com/wangzhishou/onebox-dsh-bridge/main/docs/images/app-chat.png",
-    "https://raw.githubusercontent.com/wangzhishou/onebox-dsh-bridge/main/docs/images/app-feedback.png"
-  ],
-  "https://github.com/EugeneVl/dsh_session_folders": [
-    "https://raw.githubusercontent.com/EugeneVl/dsh_session_folders/master/assets/screenshot-1.jpg",
-    "https://raw.githubusercontent.com/EugeneVl/dsh_session_folders/master/assets/screenshot-2.jpg",
-    "https://raw.githubusercontent.com/EugeneVl/dsh_session_folders/master/assets/screenshot-3.jpg"
-  ],
-  "https://github.com/IceApriler/dsh-remote-mobile": [
-    "https://raw.githubusercontent.com/IceApriler/dsh-remote-mobile/master/images/pc-dsh-setting-1.png",
-    "https://raw.githubusercontent.com/IceApriler/dsh-remote-mobile/master/images/pc-dsh-setting-2.png",
-    "https://raw.githubusercontent.com/IceApriler/dsh-remote-mobile/master/images/mobile-auth.jpg",
-    "https://raw.githubusercontent.com/IceApriler/dsh-remote-mobile/master/images/mobile-dsh.jpg"
-  ],
-  "https://github.com/jhuanxx44/dsh-sseye": [
-    "https://raw.githubusercontent.com/jhuanxx44/dsh-sseye/main/assets/panel-detail.png"
-  ],
-  "https://github.com/wyzh0117/dsh-skill-select": [
-    "https://raw.githubusercontent.com/wyzh0117/dsh-skill-select/main/assets/product.png",
-    "https://raw.githubusercontent.com/wyzh0117/dsh-skill-select/main/assets/better-sidebar.png"
-  ],
-  "https://github.com/wqy8593521/dsh-model-pro": [
-    "https://raw.githubusercontent.com/wqy8593521/dsh-model-pro/main/docs/screenshots/dashboard.png",
-    "https://raw.githubusercontent.com/wqy8593521/dsh-model-pro/main/docs/screenshots/editor.png",
-    "https://raw.githubusercontent.com/wqy8593521/dsh-model-pro/main/docs/screenshots/models.png",
-    "https://raw.githubusercontent.com/wqy8593521/dsh-model-pro/main/docs/screenshots/test.png",
-    "https://raw.githubusercontent.com/wqy8593521/dsh-model-pro/main/docs/screenshots/routes.png"
-  ],
-  "https://github.com/Kenerlee/dsh-moments-aieo": [
-    "https://raw.githubusercontent.com/Kenerlee/dsh-moments-aieo/master/assets/screenshot-dashboard.png",
-    "https://raw.githubusercontent.com/Kenerlee/dsh-moments-aieo/master/assets/screenshot-diagnosis-report.png",
-    "https://raw.githubusercontent.com/Kenerlee/dsh-moments-aieo/master/assets/screenshot-dashboard-mobile.png"
-  ],
-  "https://github.com/FeiZhuNiU-INFJA/dsh-stock-ticker": [
-    "https://raw.githubusercontent.com/FeiZhuNiU-INFJA/dsh-stock-ticker/main/assets/screenshot.png"
-  ],
-  "https://github.com/miuzel/dsh-graph/tree/main/dsh-graph-host": [
-    "https://raw.githubusercontent.com/miuzel/dsh-graph/main/screenshot/screenshot-1.png",
-    "https://raw.githubusercontent.com/miuzel/dsh-graph/main/screenshot/screenshot-2.png"
-  ],
-  "https://github.com/ppy-web/dsh-plugin-xiaomi-mimo-tts": [
-    "https://raw.githubusercontent.com/ppy-web/dsh-plugin-xiaomi-mimo-tts/main/assets/menu.png",
-    "https://raw.githubusercontent.com/ppy-web/dsh-plugin-xiaomi-mimo-tts/main/assets/preset.png",
-    "https://raw.githubusercontent.com/ppy-web/dsh-plugin-xiaomi-mimo-tts/main/assets/image.png"
-  ],
-  "https://github.com/lunaship/dsh-links": [
-    "https://raw.githubusercontent.com/lunaship/dsh-links/main/docs/images/phone-connection-sanitized.png",
-    "https://raw.githubusercontent.com/lunaship/dsh-links/main/docs/images/android-device-list-sanitized.png",
-    "https://raw.githubusercontent.com/lunaship/dsh-links/main/docs/images/android-navigation-drawer.jpg",
-    "https://raw.githubusercontent.com/lunaship/dsh-links/main/docs/images/android-workspace-light.jpg",
-    "https://raw.githubusercontent.com/lunaship/dsh-links/main/docs/images/android-workspace-dark.jpg"
-  ],
-  "https://github.com/qinyre/dsh-plugin-install": [
-    "https://raw.githubusercontent.com/qinyre/dsh-plugin-install/main/docs/images/screenshot-install.png"
-  ],
-  "https://github.com/qinyre/dsh-plugin-capabilities": [
-    "https://raw.githubusercontent.com/qinyre/dsh-plugin-capabilities/main/docs/images/screenshot-skills.png",
-    "https://raw.githubusercontent.com/qinyre/dsh-plugin-capabilities/main/docs/images/screenshot-mcp.png",
-    "https://raw.githubusercontent.com/qinyre/dsh-plugin-capabilities/main/docs/images/screenshot-market-skills.png",
-    "https://raw.githubusercontent.com/qinyre/dsh-plugin-capabilities/main/docs/images/screenshot-market-mcp.png"
-  ],
-  "https://github.com/qinyre/dsh-plugin-atlas": [
-    "https://raw.githubusercontent.com/qinyre/dsh-plugin-atlas/main/docs/images/screenshot-rail.png",
-    "https://raw.githubusercontent.com/qinyre/dsh-plugin-atlas/main/docs/images/screenshot-archive.png"
-  ],
-  "https://github.com/Whale-Zhang/dsh-complete-chime": [
-    "https://raw.githubusercontent.com/Whale-Zhang/dsh-complete-chime/main/docs/settings-card.png"
-  ],
-  "https://github.com/Cerbur/clutch-dsh/tree/main/packages/clutch-dsh-worktree": [
-    "https://raw.githubusercontent.com/Cerbur/clutch-dsh/main/packages/clutch-dsh-worktree/assets/screenshots/screenshots-en.png",
-    "https://raw.githubusercontent.com/Cerbur/clutch-dsh/main/packages/clutch-dsh-worktree/assets/screenshots/screenshots-zh.png"
-  ],
-  "https://github.com/qkycir-123/dsh-run2skill": [
-    "https://raw.githubusercontent.com/qkycir-123/dsh-run2skill/main/docs/assets/01-proposal-inbox.png",
-    "https://raw.githubusercontent.com/qkycir-123/dsh-run2skill/main/docs/assets/02-review-details.png",
-    "https://raw.githubusercontent.com/qkycir-123/dsh-run2skill/main/docs/assets/03-saved-activity.png"
-  ],
-  "https://github.com/BananaSoldier01/dsh-tidychat": [
-    "https://raw.githubusercontent.com/BananaSoldier01/dsh-tidychat/main/assets/navigator.png",
-    "https://raw.githubusercontent.com/BananaSoldier01/dsh-tidychat/main/assets/settings.png"
-  ],
-  "https://github.com/PolinniZhong/dsh-personal-center": [
-    "https://raw.githubusercontent.com/PolinniZhong/dsh-personal-center/main/docs/screenshots/light-profile.png",
-    "https://raw.githubusercontent.com/PolinniZhong/dsh-personal-center/main/docs/screenshots/dark-pet.png",
-    "https://raw.githubusercontent.com/PolinniZhong/dsh-personal-center/main/docs/screenshots/pet-emotions.gif",
-    "https://raw.githubusercontent.com/PolinniZhong/dsh-personal-center/main/docs/screenshots/dark-model-cost.png"
-  ],
-  "https://github.com/KarlOfLaw/dsh-side-chat": [
-    "https://raw.githubusercontent.com/KarlOfLaw/dsh-side-chat/main/docs/assets/dsh-side-chat-hero.png",
-    "https://raw.githubusercontent.com/KarlOfLaw/dsh-side-chat/main/docs/assets/side-chat-parallel.png",
-    "https://raw.githubusercontent.com/KarlOfLaw/dsh-side-chat/main/docs/assets/side-chat-selection.png",
-    "https://raw.githubusercontent.com/KarlOfLaw/dsh-side-chat/main/docs/assets/side-chat-settings.png"
-  ],
-  "https://github.com/biggerboy/dsh-conversation-anchors": [
-    "https://raw.githubusercontent.com/biggerboy/dsh-conversation-anchors/master/assets/anchors-hover.png",
-    "https://raw.githubusercontent.com/biggerboy/dsh-conversation-anchors/master/assets/anchors-wave.png"
-  ],
-  "https://github.com/WSL043/dsh-reasoning-slider": [
-    "https://raw.githubusercontent.com/WSL043/dsh-reasoning-slider/main/docs/assets/reasoning-slider-en.png",
-    "https://raw.githubusercontent.com/WSL043/dsh-reasoning-slider/main/docs/assets/reasoning-slider-energy-zh.png",
-    "https://raw.githubusercontent.com/WSL043/dsh-reasoning-slider/main/docs/assets/mode-settings-en.png",
-    "https://raw.githubusercontent.com/WSL043/dsh-reasoning-slider/main/docs/assets/mode-settings-dark-zh.png"
-  ],
-  "https://github.com/jerryqx/dsh-ximalaya": [
-    "https://raw.githubusercontent.com/jerryqx/dsh-ximalaya/main/assets/panel-search.png",
-    "https://raw.githubusercontent.com/jerryqx/dsh-ximalaya/main/assets/panel-album.png",
-    "https://raw.githubusercontent.com/jerryqx/dsh-ximalaya/main/assets/panel-mine-subs.png",
-    "https://raw.githubusercontent.com/jerryqx/dsh-ximalaya/main/assets/panel-mine-anchors.png"
-  ],
-  "https://github.com/yangdongzhen590/dsh-knj-workflow": [
-    "https://raw.githubusercontent.com/yangdongzhen590/dsh-knj-workflow/main/assets/screenshots/task-detail.png",
-    "https://raw.githubusercontent.com/yangdongzhen590/dsh-knj-workflow/main/assets/screenshots/workflow-editor.png",
-    "https://raw.githubusercontent.com/yangdongzhen590/dsh-knj-workflow/main/assets/screenshots/new-task-modal.png"
-  ],
-  "https://github.com/yangdongzhen590/dsh-knj-menu": [
-    "https://raw.githubusercontent.com/yangdongzhen590/dsh-knj-menu/main/assets/screenshots/menu-manager.png"
-  ],
-  "https://github.com/yangdongzhen590/dsh-knj-scheduler": [
-    "https://raw.githubusercontent.com/yangdongzhen590/dsh-knj-scheduler/main/assets/screenshots/scheduler-panel.png"
-  ],
-  "https://github.com/mienfong/dsh-session-mgr": [
-    "https://raw.githubusercontent.com/mienfong/dsh-session-mgr/main/docs/screenshots/session-manager_EN.png",
-    "https://raw.githubusercontent.com/mienfong/dsh-session-mgr/main/docs/screenshots/move-dialog_EN.png",
-    "https://raw.githubusercontent.com/mienfong/dsh-session-mgr/main/docs/screenshots/backup_EN.png",
-    "https://raw.githubusercontent.com/mienfong/dsh-session-mgr/main/docs/screenshots/import_EN.png",
-    "https://raw.githubusercontent.com/mienfong/dsh-session-mgr/main/docs/screenshots/delete-confirm_EN.png"
-  ],
-  "https://github.com/kenny2077/dsh-web-search-doubao": [
-    "https://raw.githubusercontent.com/kenny2077/dsh-web-search-doubao/main/docs/img/settings-card.png",
-    "https://raw.githubusercontent.com/kenny2077/dsh-web-search-doubao/main/docs/img/console.png"
-  ],
-  "https://github.com/tr1v3r/dsh-quote-followup": [
-    "https://raw.githubusercontent.com/tr1v3r/dsh-quote-followup/v0.2.6/docs/assets/quote-followup-demo.gif"
-  ]
-}
+
+ "https://github.com/anweat/dsh-context-console": [
+
+  "https://raw.githubusercontent.com/anweat/dsh-context-console/main/docs/images/context-console-trajectory.png",
+
+  "https://raw.githubusercontent.com/anweat/dsh-context-console/main/docs/images/context-console-inventory.png",
+
+  "https://raw.githubusercontent.com/anweat/dsh-context-console/main/docs/images/context-console-forge.png"
+
+ ],
+
+ "https://github.com/jerryqx/dsh-xiaoyuzhou": [
+
+  "https://raw.githubusercontent.com/jerryqx/dsh-xiaoyuzhou/main/assets/screenshot-bar.png",
+
+  "https://raw.githubusercontent.com/jerryqx/dsh-xiaoyuzhou/main/assets/screenshot-mysubs.png",
+
+  "https://raw.githubusercontent.com/jerryqx/dsh-xiaoyuzhou/main/assets/screenshot-podcast.png"
+
+ ],
+
+ "https://github.com/fengb3/dsh-session-icons": [
+
+  "https://raw.githubusercontent.com/fengb3/dsh-session-icons/master/docs/screenshot.png"
+
+ ],
+
+ "https://github.com/GreenLv/dsh-session-insights": [
+
+  "https://raw.githubusercontent.com/GreenLv/dsh-session-insights/main/assets/screenshots/dashboard-overview-en.png",
+
+  "https://raw.githubusercontent.com/GreenLv/dsh-session-insights/main/assets/screenshots/dashboard-overview-zh.png"
+
+ ],
+
+ "https://github.com/xiaoksio/dsh-solution-explorer": [
+
+  "https://raw.githubusercontent.com/xiaoksio/dsh-solution-explorer/main/assets/screenshot-1-file-explorer.png",
+
+  "https://raw.githubusercontent.com/xiaoksio/dsh-solution-explorer/main/assets/screenshot-2-source-control.png",
+
+  "https://raw.githubusercontent.com/xiaoksio/dsh-solution-explorer/main/assets/screenshot-3-diff.png"
+
+ ],
+
+ "https://github.com/LayneChai/superpowers-dsh": [
+
+  "https://raw.githubusercontent.com/LayneChai/superpowers-dsh/main/static/home.png",
+
+  "https://raw.githubusercontent.com/LayneChai/superpowers-dsh/main/static/install-success.png"
+
+ ],
+
+ "https://github.com/kirkchinese/CiteCiter/tree/main/packages/citeciter": [
+
+  "https://raw.githubusercontent.com/kirkchinese/CiteCiter/main/assets/demo/citeciter-0.4.0.gif",
+
+  "https://raw.githubusercontent.com/kirkchinese/CiteCiter/main/assets/screenshots/citeciter-settings.png"
+
+ ],
+
+ "https://github.com/L3n3L/dsh-resume": [
+
+  "https://raw.githubusercontent.com/L3n3L/dsh-resume/main/docs/screenshots/workbench.png",
+
+  "https://raw.githubusercontent.com/L3n3L/dsh-resume/main/docs/screenshots/ai-assistant.png",
+
+  "https://raw.githubusercontent.com/L3n3L/dsh-resume/main/docs/screenshots/template-library.png"
+
+ ],
+
+ "https://github.com/hunter118/dsh-s7r": [
+
+  "https://raw.githubusercontent.com/hunter118/dsh-s7r/main/docs/screenshots/s7r-desktop.png",
+
+  "https://raw.githubusercontent.com/hunter118/dsh-s7r/main/docs/screenshots/s7r-agent.png",
+
+  "https://raw.githubusercontent.com/hunter118/dsh-s7r/main/docs/screenshots/s7r-workflows.png",
+
+  "https://raw.githubusercontent.com/hunter118/dsh-s7r/main/docs/screenshots/s7r-display.png"
+
+ ],
+
+ "https://github.com/HaoyueQin/dsh-usage-statistics-panel": [
+
+  "https://raw.githubusercontent.com/HaoyueQin/dsh-usage-statistics-panel/main/assets/screenshots/usage-overview.png",
+
+  "https://raw.githubusercontent.com/HaoyueQin/dsh-usage-statistics-panel/main/assets/screenshots/model-breakdown.png"
+
+ ],
+
+ "https://github.com/lavapapa/dsh-composer-layout": [
+
+  "https://raw.githubusercontent.com/lavapapa/dsh-composer-layout/main/assets/screenshots/hero-en.png",
+
+  "https://raw.githubusercontent.com/lavapapa/dsh-composer-layout/main/assets/screenshots/hero-zh.png"
+
+ ],
+
+ "https://github.com/lengzhanbao/dsh-taffy-theme": [
+
+  "https://raw.githubusercontent.com/lengzhanbao/dsh-taffy-theme/master/preview/light.webp",
+
+  "https://raw.githubusercontent.com/lengzhanbao/dsh-taffy-theme/master/preview/dark.webp"
+
+ ],
+
+ "https://github.com/liang-today/dsh-liangxiang": [
+
+  "https://raw.githubusercontent.com/liang-today/dsh-liangxiang/main/assets/main-frame.jpg",
+
+  "https://raw.githubusercontent.com/liang-today/dsh-liangxiang/main/assets/plugin-panel.jpg",
+
+  "https://raw.githubusercontent.com/liang-today/dsh-liangxiang/main/assets/liangci.jpg"
+
+ ],
+
+
+ "https://github.com/Little-Star888/dsh-pelican": [
+
+  "https://raw.githubusercontent.com/Little-Star888/dsh-pelican/main/assets/screenshot-1.png"
+
+ ],
+
+ "https://github.com/kendu76/dsh-music-player": [
+
+  "https://raw.githubusercontent.com/kendu76/dsh-music-player/main/assets/screenshot-bar.png",
+
+  "https://raw.githubusercontent.com/kendu76/dsh-music-player/main/assets/screenshot-spectrum.png",
+
+  "https://raw.githubusercontent.com/kendu76/dsh-music-player/main/assets/screenshot-panel.png"
+
+ ],
+
+ "https://github.com/030611/qiushi-dsh-evidence-audit": [
+
+  "https://raw.githubusercontent.com/030611/qiushi-dsh-evidence-audit/main/docs/evidence-flow.svg"
+
+ ],
+
+ "https://github.com/263311487-ux/dsh-verify": [
+
+  "https://raw.githubusercontent.com/263311487-ux/dsh-verify/main/assets/report-screenshot.png",
+
+  "https://raw.githubusercontent.com/263311487-ux/dsh-verify/main/assets/visual-diff.png"
+
+ ],
+
+ "https://github.com/2768651338/dsh-effort-slider": [
+
+  "https://raw.githubusercontent.com/2768651338/dsh-effort-slider/main/assets/screenshots/灞忓箷鎴浘%202026-08-16%20190943.png",
+
+  "https://raw.githubusercontent.com/2768651338/dsh-effort-slider/main/assets/screenshots/灞忓箷鎴浘%202026-08-16%20190950.png",
+
+  "https://raw.githubusercontent.com/2768651338/dsh-effort-slider/main/assets/screenshots/灞忓箷鎴浘%202026-08-16%20190903.png"
+
+ ],
+
+ "https://github.com/2768651338/dsh-plugin-manager": [
+
+  "https://raw.githubusercontent.com/2768651338/dsh-plugin-manager/main/assets/preview.png"
+
+ ],
+
+ "https://github.com/2nd1st/dsh-plugin-open-app": [
+
+  "https://raw.githubusercontent.com/2nd1st/dsh-plugin-open-app/main/docs/screenshot-app-container.jpg",
+
+  "https://raw.githubusercontent.com/2nd1st/dsh-plugin-open-app/main/docs/screenshot-inline.jpg"
+
+ ],
+
+ "https://github.com/534119219/chicheng-cron": [
+
+  "https://raw.githubusercontent.com/534119219/chicheng-cron/main/assets/sidebar-entry.png",
+
+  "https://raw.githubusercontent.com/534119219/chicheng-cron/main/assets/settings-1.png",
+
+  "https://raw.githubusercontent.com/534119219/chicheng-cron/main/assets/settings-2.png",
+
+  "https://raw.githubusercontent.com/534119219/chicheng-cron/main/assets/output-popup.png"
+
+ ],
+
+ "https://github.com/534119219/chicheng-gate": [
+
+  "https://raw.githubusercontent.com/534119219/chicheng-gate/main/assets/settings.png",
+
+  "https://raw.githubusercontent.com/534119219/chicheng-gate/main/assets/login-gate.png",
+
+  "https://raw.githubusercontent.com/534119219/chicheng-gate/main/assets/mobile-ui-1.png",
+
+  "https://raw.githubusercontent.com/534119219/chicheng-gate/main/assets/mobile-ui-2.png",
+
+  "https://raw.githubusercontent.com/534119219/chicheng-gate/main/assets/mobile-ui-3.png"
+
+ ],
+
+ "https://github.com/534119219/chicheng-push": [
+
+  "https://raw.githubusercontent.com/534119219/chicheng-push/master/assets/screenshot-settings-entry.png",
+
+  "https://raw.githubusercontent.com/534119219/chicheng-push/master/assets/screenshot-channel-list.png",
+
+  "https://raw.githubusercontent.com/534119219/chicheng-push/master/assets/screenshot-add-channel.png"
+
+ ],
+
+ "https://github.com/534119219/chicheng-stats": [
+
+  "https://raw.githubusercontent.com/534119219/chicheng-stats/main/assets/card-mode.png",
+
+  "https://raw.githubusercontent.com/534119219/chicheng-stats/main/assets/text-mode.png",
+
+  "https://raw.githubusercontent.com/534119219/chicheng-stats/main/assets/usage-dialog.png",
+
+  "https://raw.githubusercontent.com/534119219/chicheng-stats/main/assets/card-settings.png",
+
+  "https://raw.githubusercontent.com/534119219/chicheng-stats/main/assets/text-settings.png"
+
+ ],
+
+ "https://github.com/54xkeee/dsh-youreyes": [
+
+  "https://raw.githubusercontent.com/54xkeee/dsh-youreyes/master/assets/screenshot-panel.png"
+
+ ],
+
+ "https://github.com/7dgroup-ai/dsh-skill-7d-code-reviewer": [
+
+  "https://raw.githubusercontent.com/7dgroup-ai/dsh-skill-7d-code-reviewer/main/screenshots/skills.png",
+
+  "https://raw.githubusercontent.com/7dgroup-ai/dsh-skill-7d-code-reviewer/main/screenshots/report-preview.png"
+
+ ],
+
+ "https://github.com/940842546/dsh-permissions": [
+
+  "https://raw.githubusercontent.com/940842546/dsh-permissions/main/assets/01-permissions-overview.png",
+
+  "https://raw.githubusercontent.com/940842546/dsh-permissions/main/assets/02-permissions-rules.png",
+
+  "https://raw.githubusercontent.com/940842546/dsh-permissions/main/assets/03-permissions-draft.png",
+
+  "https://raw.githubusercontent.com/940842546/dsh-permissions/main/assets/en-01-permissions-overview.png",
+
+  "https://raw.githubusercontent.com/940842546/dsh-permissions/main/assets/en-02-permissions-rules.png",
+
+  "https://raw.githubusercontent.com/940842546/dsh-permissions/main/assets/en-03-permissions-draft.png"
+
+ ],
+
+ "https://github.com/940842546/dsh-usage-billing": [
+
+  "https://raw.githubusercontent.com/940842546/dsh-usage-billing/main/assets/screenshots/02-stats-dialog-overview.png",
+
+  "https://raw.githubusercontent.com/940842546/dsh-usage-billing/main/assets/screenshots/03-stats-dialog-charts.png",
+
+  "https://raw.githubusercontent.com/940842546/dsh-usage-billing/main/assets/screenshots/04-settings-usage-overview.png",
+
+  "https://raw.githubusercontent.com/940842546/dsh-usage-billing/main/assets/screenshots/07-stats-dialog-usd.png",
+
+  "https://raw.githubusercontent.com/940842546/dsh-usage-billing/main/assets/screenshots/en-02-stats-dialog-overview.png",
+
+  "https://raw.githubusercontent.com/940842546/dsh-usage-billing/main/assets/screenshots/en-03-stats-dialog-charts.png",
+
+  "https://raw.githubusercontent.com/940842546/dsh-usage-billing/main/assets/screenshots/en-04-settings-usage-overview.png",
+
+  "https://raw.githubusercontent.com/940842546/dsh-usage-billing/main/assets/screenshots/en-07-stats-dialog-usd.png"
+
+ ],
+
+ "https://github.com/AI-Galaxy-GPU/dsh-sound": [
+
+  "https://raw.githubusercontent.com/AI-Galaxy-GPU/dsh-sound/main/assets/screenshots/sound-image.png"
+
+ ],
+
+ "https://github.com/AcidGr/dsh-web-lan-access": [
+
+  "https://raw.githubusercontent.com/AcidGr/dsh-web-lan-access/main/assets/screenshot-lan-access.jpg"
+
+ ],
+
+ "https://github.com/AcidGr/dsh-web-mobile-fix": [
+
+  "https://raw.githubusercontent.com/AcidGr/dsh-web-mobile-fix/main/assets/screenshot-1.jpg",
+
+  "https://raw.githubusercontent.com/AcidGr/dsh-web-mobile-fix/main/assets/screenshot-2.jpg"
+
+ ],
+
+ "https://github.com/Airmetro/dsh-update-checker": [
+
+  "https://raw.githubusercontent.com/Airmetro/dsh-update-checker/main/assets/screenshots/01-banner-update-zh.png",
+
+  "https://raw.githubusercontent.com/Airmetro/dsh-update-checker/main/assets/screenshots/02-banner-update-en.png",
+
+  "https://raw.githubusercontent.com/Airmetro/dsh-update-checker/main/assets/screenshots/03-banner-plugins.png",
+
+  "https://raw.githubusercontent.com/Airmetro/dsh-update-checker/main/assets/screenshots/04-settings-zh.png",
+
+  "https://raw.githubusercontent.com/Airmetro/dsh-update-checker/main/assets/screenshots/05-settings-en.png"
+
+ ],
+
+ "https://github.com/AmeKrance/anan-thermal-monitor": [
+
+  "https://raw.githubusercontent.com/AmeKrance/anan-thermal-monitor/main/assets/screenshots/screenshot-1.png",
+
+  "https://raw.githubusercontent.com/AmeKrance/anan-thermal-monitor/main/assets/screenshots/screenshot-2.png",
+
+  "https://raw.githubusercontent.com/AmeKrance/anan-thermal-monitor/main/assets/screenshots/demo.gif"
+
+ ],
+
+ "https://github.com/Awu12277/dsh-stock-watch": [
+
+  "https://raw.githubusercontent.com/Awu12277/dsh-stock-watch/main/screenshots/detail-kline-dark.png",
+
+  "https://raw.githubusercontent.com/Awu12277/dsh-stock-watch/main/screenshots/detail-minute-dark.png",
+
+  "https://raw.githubusercontent.com/Awu12277/dsh-stock-watch/main/screenshots/list-dark.png"
+
+ ],
+
+ "https://github.com/ChongCyrus/Vibe-Mathematics": [
+
+  "https://raw.githubusercontent.com/ChongCyrus/Vibe-Mathematics/main/%E7%A4%BA%E4%BE%8B%E5%9B%BE/%E6%A1%86%E6%9E%B6%E5%9B%BE-v1.png",
+
+  "https://raw.githubusercontent.com/ChongCyrus/Vibe-Mathematics/main/%E7%A4%BA%E4%BE%8B%E5%9B%BE/%E6%A1%86%E6%9E%B6%E5%9B%BE-v2.png"
+
+ ],
+
+ "https://github.com/ChrisZhangWG/dsh-codex-meter": [
+
+  "https://raw.githubusercontent.com/ChrisZhangWG/dsh-codex-meter/main/docs/settings-usage-overview.png",
+
+  "https://raw.githubusercontent.com/ChrisZhangWG/dsh-codex-meter/main/docs/settings-usage-cost-history.png"
+
+ ],
+
+ "https://github.com/Dely0/dsh-personal-workbench": [
+
+  "https://raw.githubusercontent.com/Dely0/dsh-personal-workbench/main/screenshot/%E4%B8%BB%E7%95%8C%E9%9D%A2.PNG",
+
+  "https://raw.githubusercontent.com/Dely0/dsh-personal-workbench/main/screenshot/%E6%97%A5%E5%8E%86%E9%A1%B5%E9%9D%A2.png",
+
+  "https://raw.githubusercontent.com/Dely0/dsh-personal-workbench/main/screenshot/%E4%BB%BB%E5%8A%A1%E5%88%97%E8%A1%A8%E7%95%8C%E9%9D%A2.png",
+
+  "https://raw.githubusercontent.com/Dely0/dsh-personal-workbench/main/screenshot/%E7%9F%A5%E8%AF%86%E5%BA%93%E7%95%8C%E9%9D%A2.png",
+
+  "https://raw.githubusercontent.com/Dely0/dsh-personal-workbench/main/screenshot/%E7%82%B9%E5%AD%90%E7%95%8C%E9%9D%A2.png",
+
+  "https://raw.githubusercontent.com/Dely0/dsh-personal-workbench/main/screenshot/%E7%82%B9%E5%AD%90%E7%8E%8B.png"
+
+ ],
+
+ "https://github.com/DocJlm/dsh-arknights/tree/main/skins/pramanix-eyjafjalla": [
+
+  "https://raw.githubusercontent.com/DocJlm/dsh-arknights/main/skins/pramanix-eyjafjalla/preview/cover.webp"
+
+ ],
+
+ "https://github.com/Eve-146T/DSH-CODEX-SUBSCRIPTION-POOL": [
+
+  "https://raw.githubusercontent.com/Eve-146T/DSH-CODEX-SUBSCRIPTION-POOL/main/assets/readme/accounts-demo.png"
+
+ ],
+
+ "https://github.com/Fantasality/dsh-origin-plugin": [
+
+  "https://raw.githubusercontent.com/Fantasality/dsh-origin-plugin/main/docs/example.png",
+
+  "https://raw.githubusercontent.com/Fantasality/dsh-origin-plugin/main/docs/example_3d.png"
+
+ ],
+
+ "https://github.com/FengHuoLinShan/dsh-plugin-llm-balance": [
+
+  "https://raw.githubusercontent.com/FengHuoLinShan/dsh-plugin-llm-balance/main/assets/llm-balance-preview.png"
+
+ ],
+
+ "https://github.com/Flyvhidbwo/dsh-vision-proxy": [
+
+  "https://raw.githubusercontent.com/Flyvhidbwo/dsh-vision-proxy/main/assets/demo-reply.png",
+
+  "https://raw.githubusercontent.com/Flyvhidbwo/dsh-vision-proxy/main/assets/demo-selector.png"
+
+ ],
+
+ "https://github.com/foooold/dsh-message-nav": [
+
+  "https://raw.githubusercontent.com/foooold/dsh-message-nav/main/assets/rail-hover-preview.png",
+
+  "https://raw.githubusercontent.com/foooold/dsh-message-nav/main/assets/rail-left-edge.png"
+
+ ],
+
+ "https://github.com/GOU-GEE/deepseek-vision/tree/main/plugins/dsh-plugin-deepseek-vision": [
+
+  "https://raw.githubusercontent.com/GOU-GEE/deepseek-vision/main/docs/screenshots/01-settings.png",
+
+  "https://raw.githubusercontent.com/GOU-GEE/deepseek-vision/main/docs/screenshots/02-paste-analyze.png",
+
+  "https://raw.githubusercontent.com/GOU-GEE/deepseek-vision/main/docs/screenshots/03-clipboard.png",
+
+  "https://raw.githubusercontent.com/GOU-GEE/deepseek-vision/main/docs/screenshots/04-result.png",
+
+  "https://raw.githubusercontent.com/GOU-GEE/deepseek-vision/main/docs/screenshots/05-market.png"
+
+ ],
+
+ "https://github.com/Gin-7/dsh-pet-remielle": [
+
+  "https://raw.githubusercontent.com/Gin-7/dsh-pet-remielle/main/assets/screenshot-waiting.png",
+
+  "https://raw.githubusercontent.com/Gin-7/dsh-pet-remielle/main/assets/screenshot-priding.png"
+
+ ],
+
+ "https://github.com/HaoyueQin/dsh-better-reasoning-effort": [
+
+  "https://raw.githubusercontent.com/HaoyueQin/dsh-better-reasoning-effort/master/docs/market-card.png"
+
+ ],
+
+ "https://github.com/Harvey-Will/dsh-vision-analysis": [
+
+  "https://raw.githubusercontent.com/Harvey-Will/dsh-vision-analysis/main/assets/demo-ocr.png",
+
+  "https://raw.githubusercontent.com/Harvey-Will/dsh-vision-analysis/main/assets/demo-chart.png",
+
+  "https://raw.githubusercontent.com/Harvey-Will/dsh-vision-analysis/main/assets/demo-ui.png"
+
+],
+
+"https://github.com/Isilsolme/dsh-splash-launcher": [
+
+  "https://raw.githubusercontent.com/Isilsolme/dsh-splash-launcher/main/docs/screenshots/splash-lig<response clipped><NOTE>To save on context only part of this file has been shown to you. You should retry this tool after you have searched inside the file with `grep -n` in order to find the line numbers of what you are looking for.</NOTE>

--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -1,1360 +1,1363 @@
 {
- "https://github.com/anweat/dsh-context-console": [
-  "https://raw.githubusercontent.com/anweat/dsh-context-console/main/docs/images/context-console-trajectory.png",
-  "https://raw.githubusercontent.com/anweat/dsh-context-console/main/docs/images/context-console-inventory.png",
-  "https://raw.githubusercontent.com/anweat/dsh-context-console/main/docs/images/context-console-forge.png"
- ],
- "https://github.com/jerryqx/dsh-xiaoyuzhou": [
-  "https://raw.githubusercontent.com/jerryqx/dsh-xiaoyuzhou/main/assets/screenshot-bar.png",
-  "https://raw.githubusercontent.com/jerryqx/dsh-xiaoyuzhou/main/assets/screenshot-mysubs.png",
-  "https://raw.githubusercontent.com/jerryqx/dsh-xiaoyuzhou/main/assets/screenshot-podcast.png"
- ],
- "https://github.com/fengb3/dsh-session-icons": [
-  "https://raw.githubusercontent.com/fengb3/dsh-session-icons/master/docs/screenshot.png"
- ],
- "https://github.com/GreenLv/dsh-session-insights": [
-  "https://raw.githubusercontent.com/GreenLv/dsh-session-insights/main/assets/screenshots/dashboard-overview-en.png",
-  "https://raw.githubusercontent.com/GreenLv/dsh-session-insights/main/assets/screenshots/dashboard-overview-zh.png"
- ],
- "https://github.com/xiaoksio/dsh-solution-explorer": [
-  "https://raw.githubusercontent.com/xiaoksio/dsh-solution-explorer/main/assets/screenshot-1-file-explorer.png",
-  "https://raw.githubusercontent.com/xiaoksio/dsh-solution-explorer/main/assets/screenshot-2-source-control.png",
-  "https://raw.githubusercontent.com/xiaoksio/dsh-solution-explorer/main/assets/screenshot-3-diff.png"
- ],
- "https://github.com/LayneChai/superpowers-dsh": [
-  "https://raw.githubusercontent.com/LayneChai/superpowers-dsh/main/static/home.png",
-  "https://raw.githubusercontent.com/LayneChai/superpowers-dsh/main/static/install-success.png"
- ],
- "https://github.com/kirkchinese/CiteCiter/tree/main/packages/citeciter": [
-  "https://raw.githubusercontent.com/kirkchinese/CiteCiter/main/assets/demo/citeciter-0.4.0.gif",
-  "https://raw.githubusercontent.com/kirkchinese/CiteCiter/main/assets/screenshots/citeciter-settings.png"
- ],
- "https://github.com/L3n3L/dsh-resume": [
-  "https://raw.githubusercontent.com/L3n3L/dsh-resume/main/docs/screenshots/workbench.png",
-  "https://raw.githubusercontent.com/L3n3L/dsh-resume/main/docs/screenshots/ai-assistant.png",
-  "https://raw.githubusercontent.com/L3n3L/dsh-resume/main/docs/screenshots/template-library.png"
- ],
- "https://github.com/hunter118/dsh-s7r": [
-  "https://raw.githubusercontent.com/hunter118/dsh-s7r/main/docs/screenshots/s7r-desktop.png",
-  "https://raw.githubusercontent.com/hunter118/dsh-s7r/main/docs/screenshots/s7r-agent.png",
-  "https://raw.githubusercontent.com/hunter118/dsh-s7r/main/docs/screenshots/s7r-workflows.png",
-  "https://raw.githubusercontent.com/hunter118/dsh-s7r/main/docs/screenshots/s7r-display.png"
- ],
- "https://github.com/HaoyueQin/dsh-usage-statistics-panel": [
-  "https://raw.githubusercontent.com/HaoyueQin/dsh-usage-statistics-panel/main/assets/screenshots/usage-overview.png",
-  "https://raw.githubusercontent.com/HaoyueQin/dsh-usage-statistics-panel/main/assets/screenshots/model-breakdown.png"
- ],
- "https://github.com/lavapapa/dsh-composer-layout": [
-  "https://raw.githubusercontent.com/lavapapa/dsh-composer-layout/main/assets/screenshots/hero-en.png",
-  "https://raw.githubusercontent.com/lavapapa/dsh-composer-layout/main/assets/screenshots/hero-zh.png"
- ],
- "https://github.com/lengzhanbao/dsh-taffy-theme": [
-  "https://raw.githubusercontent.com/lengzhanbao/dsh-taffy-theme/master/preview/light.webp",
-  "https://raw.githubusercontent.com/lengzhanbao/dsh-taffy-theme/master/preview/dark.webp"
- ],
- "https://github.com/liang-today/dsh-liangxiang": [
-  "https://raw.githubusercontent.com/liang-today/dsh-liangxiang/main/assets/main-frame.jpg",
-  "https://raw.githubusercontent.com/liang-today/dsh-liangxiang/main/assets/plugin-panel.jpg",
-  "https://raw.githubusercontent.com/liang-today/dsh-liangxiang/main/assets/liangci.jpg"
- ],
- "https://github.com/Little-Star888/dsh-pelican": [
-  "https://raw.githubusercontent.com/Little-Star888/dsh-pelican/main/assets/screenshot-1.png"
- ],
- "https://github.com/kendu76/dsh-music-player": [
-  "https://raw.githubusercontent.com/kendu76/dsh-music-player/main/assets/screenshot-bar.png",
-  "https://raw.githubusercontent.com/kendu76/dsh-music-player/main/assets/screenshot-spectrum.png",
-  "https://raw.githubusercontent.com/kendu76/dsh-music-player/main/assets/screenshot-panel.png"
- ],
- "https://github.com/030611/qiushi-dsh-evidence-audit": [
-  "https://raw.githubusercontent.com/030611/qiushi-dsh-evidence-audit/main/docs/evidence-flow.svg"
- ],
- "https://github.com/263311487-ux/dsh-verify": [
-  "https://raw.githubusercontent.com/263311487-ux/dsh-verify/main/assets/report-screenshot.png",
-  "https://raw.githubusercontent.com/263311487-ux/dsh-verify/main/assets/visual-diff.png"
- ],
- "https://github.com/2768651338/dsh-effort-slider": [
-  "https://raw.githubusercontent.com/2768651338/dsh-effort-slider/main/assets/screenshots/灞忓箷鎴浘%202026-08-16%20190943.png",
-  "https://raw.githubusercontent.com/2768651338/dsh-effort-slider/main/assets/screenshots/灞忓箷鎴浘%202026-08-16%20190950.png",
-  "https://raw.githubusercontent.com/2768651338/dsh-effort-slider/main/assets/screenshots/灞忓箷鎴浘%202026-08-16%20190903.png"
- ],
- "https://github.com/2768651338/dsh-plugin-manager": [
-  "https://raw.githubusercontent.com/2768651338/dsh-plugin-manager/main/assets/preview.png"
- ],
- "https://github.com/2nd1st/dsh-plugin-open-app": [
-  "https://raw.githubusercontent.com/2nd1st/dsh-plugin-open-app/main/docs/screenshot-app-container.jpg",
-  "https://raw.githubusercontent.com/2nd1st/dsh-plugin-open-app/main/docs/screenshot-inline.jpg"
- ],
- "https://github.com/534119219/chicheng-cron": [
-  "https://raw.githubusercontent.com/534119219/chicheng-cron/main/assets/sidebar-entry.png",
-  "https://raw.githubusercontent.com/534119219/chicheng-cron/main/assets/settings-1.png",
-  "https://raw.githubusercontent.com/534119219/chicheng-cron/main/assets/settings-2.png",
-  "https://raw.githubusercontent.com/534119219/chicheng-cron/main/assets/output-popup.png"
- ],
- "https://github.com/534119219/chicheng-gate": [
-  "https://raw.githubusercontent.com/534119219/chicheng-gate/main/assets/settings.png",
-  "https://raw.githubusercontent.com/534119219/chicheng-gate/main/assets/login-gate.png",
-  "https://raw.githubusercontent.com/534119219/chicheng-gate/main/assets/mobile-ui-1.png",
-  "https://raw.githubusercontent.com/534119219/chicheng-gate/main/assets/mobile-ui-2.png",
-  "https://raw.githubusercontent.com/534119219/chicheng-gate/main/assets/mobile-ui-3.png"
- ],
- "https://github.com/534119219/chicheng-push": [
-  "https://raw.githubusercontent.com/534119219/chicheng-push/master/assets/screenshot-settings-entry.png",
-  "https://raw.githubusercontent.com/534119219/chicheng-push/master/assets/screenshot-channel-list.png",
-  "https://raw.githubusercontent.com/534119219/chicheng-push/master/assets/screenshot-add-channel.png"
- ],
- "https://github.com/534119219/chicheng-stats": [
-  "https://raw.githubusercontent.com/534119219/chicheng-stats/main/assets/card-mode.png",
-  "https://raw.githubusercontent.com/534119219/chicheng-stats/main/assets/text-mode.png",
-  "https://raw.githubusercontent.com/534119219/chicheng-stats/main/assets/usage-dialog.png",
-  "https://raw.githubusercontent.com/534119219/chicheng-stats/main/assets/card-settings.png",
-  "https://raw.githubusercontent.com/534119219/chicheng-stats/main/assets/text-settings.png"
- ],
- "https://github.com/54xkeee/dsh-youreyes": [
-  "https://raw.githubusercontent.com/54xkeee/dsh-youreyes/master/assets/screenshot-panel.png"
- ],
- "https://github.com/7dgroup-ai/dsh-skill-7d-code-reviewer": [
-  "https://raw.githubusercontent.com/7dgroup-ai/dsh-skill-7d-code-reviewer/main/screenshots/skills.png",
-  "https://raw.githubusercontent.com/7dgroup-ai/dsh-skill-7d-code-reviewer/main/screenshots/report-preview.png"
- ],
- "https://github.com/940842546/dsh-permissions": [
-  "https://raw.githubusercontent.com/940842546/dsh-permissions/main/assets/01-permissions-overview.png",
-  "https://raw.githubusercontent.com/940842546/dsh-permissions/main/assets/02-permissions-rules.png",
-  "https://raw.githubusercontent.com/940842546/dsh-permissions/main/assets/03-permissions-draft.png",
-  "https://raw.githubusercontent.com/940842546/dsh-permissions/main/assets/en-01-permissions-overview.png",
-  "https://raw.githubusercontent.com/940842546/dsh-permissions/main/assets/en-02-permissions-rules.png",
-  "https://raw.githubusercontent.com/940842546/dsh-permissions/main/assets/en-03-permissions-draft.png"
- ],
- "https://github.com/940842546/dsh-usage-billing": [
-  "https://raw.githubusercontent.com/940842546/dsh-usage-billing/main/assets/screenshots/02-stats-dialog-overview.png",
-  "https://raw.githubusercontent.com/940842546/dsh-usage-billing/main/assets/screenshots/03-stats-dialog-charts.png",
-  "https://raw.githubusercontent.com/940842546/dsh-usage-billing/main/assets/screenshots/04-settings-usage-overview.png",
-  "https://raw.githubusercontent.com/940842546/dsh-usage-billing/main/assets/screenshots/07-stats-dialog-usd.png",
-  "https://raw.githubusercontent.com/940842546/dsh-usage-billing/main/assets/screenshots/en-02-stats-dialog-overview.png",
-  "https://raw.githubusercontent.com/940842546/dsh-usage-billing/main/assets/screenshots/en-03-stats-dialog-charts.png",
-  "https://raw.githubusercontent.com/940842546/dsh-usage-billing/main/assets/screenshots/en-04-settings-usage-overview.png",
-  "https://raw.githubusercontent.com/940842546/dsh-usage-billing/main/assets/screenshots/en-07-stats-dialog-usd.png"
- ],
- "https://github.com/AI-Galaxy-GPU/dsh-sound": [
-  "https://raw.githubusercontent.com/AI-Galaxy-GPU/dsh-sound/main/assets/screenshots/sound-image.png"
- ],
- "https://github.com/AcidGr/dsh-web-lan-access": [
-  "https://raw.githubusercontent.com/AcidGr/dsh-web-lan-access/main/assets/screenshot-lan-access.jpg"
- ],
- "https://github.com/AcidGr/dsh-web-mobile-fix": [
-  "https://raw.githubusercontent.com/AcidGr/dsh-web-mobile-fix/main/assets/screenshot-1.jpg",
-  "https://raw.githubusercontent.com/AcidGr/dsh-web-mobile-fix/main/assets/screenshot-2.jpg"
- ],
- "https://github.com/Airmetro/dsh-update-checker": [
-  "https://raw.githubusercontent.com/Airmetro/dsh-update-checker/main/assets/screenshots/01-banner-update-zh.png",
-  "https://raw.githubusercontent.com/Airmetro/dsh-update-checker/main/assets/screenshots/02-banner-update-en.png",
-  "https://raw.githubusercontent.com/Airmetro/dsh-update-checker/main/assets/screenshots/03-banner-plugins.png",
-  "https://raw.githubusercontent.com/Airmetro/dsh-update-checker/main/assets/screenshots/04-settings-zh.png",
-  "https://raw.githubusercontent.com/Airmetro/dsh-update-checker/main/assets/screenshots/05-settings-en.png"
- ],
- "https://github.com/AmeKrance/anan-thermal-monitor": [
-  "https://raw.githubusercontent.com/AmeKrance/anan-thermal-monitor/main/assets/screenshots/screenshot-1.png",
-  "https://raw.githubusercontent.com/AmeKrance/anan-thermal-monitor/main/assets/screenshots/screenshot-2.png",
-  "https://raw.githubusercontent.com/AmeKrance/anan-thermal-monitor/main/assets/screenshots/demo.gif"
- ],
- "https://github.com/Awu12277/dsh-stock-watch": [
-  "https://raw.githubusercontent.com/Awu12277/dsh-stock-watch/main/screenshots/detail-kline-dark.png",
-  "https://raw.githubusercontent.com/Awu12277/dsh-stock-watch/main/screenshots/detail-minute-dark.png",
-  "https://raw.githubusercontent.com/Awu12277/dsh-stock-watch/main/screenshots/list-dark.png"
- ],
- "https://github.com/ChongCyrus/Vibe-Mathematics": [
-  "https://raw.githubusercontent.com/ChongCyrus/Vibe-Mathematics/main/%E7%A4%BA%E4%BE%8B%E5%9B%BE/%E6%A1%86%E6%9E%B6%E5%9B%BE-v1.png",
-  "https://raw.githubusercontent.com/ChongCyrus/Vibe-Mathematics/main/%E7%A4%BA%E4%BE%8B%E5%9B%BE/%E6%A1%86%E6%9E%B6%E5%9B%BE-v2.png"
- ],
- "https://github.com/ChrisZhangWG/dsh-codex-meter": [
-  "https://raw.githubusercontent.com/ChrisZhangWG/dsh-codex-meter/main/docs/settings-usage-overview.png",
-  "https://raw.githubusercontent.com/ChrisZhangWG/dsh-codex-meter/main/docs/settings-usage-cost-history.png"
- ],
- "https://github.com/Dely0/dsh-personal-workbench": [
-  "https://raw.githubusercontent.com/Dely0/dsh-personal-workbench/main/screenshot/%E4%B8%BB%E7%95%8C%E9%9D%A2.PNG",
-  "https://raw.githubusercontent.com/Dely0/dsh-personal-workbench/main/screenshot/%E6%97%A5%E5%8E%86%E9%A1%B5%E9%9D%A2.png",
-  "https://raw.githubusercontent.com/Dely0/dsh-personal-workbench/main/screenshot/%E4%BB%BB%E5%8A%A1%E5%88%97%E8%A1%A8%E7%95%8C%E9%9D%A2.png",
-  "https://raw.githubusercontent.com/Dely0/dsh-personal-workbench/main/screenshot/%E7%9F%A5%E8%AF%86%E5%BA%93%E7%95%8C%E9%9D%A2.png",
-  "https://raw.githubusercontent.com/Dely0/dsh-personal-workbench/main/screenshot/%E7%82%B9%E5%AD%90%E7%95%8C%E9%9D%A2.png",
-  "https://raw.githubusercontent.com/Dely0/dsh-personal-workbench/main/screenshot/%E7%82%B9%E5%AD%90%E7%8E%8B.png"
- ],
- "https://github.com/DocJlm/dsh-arknights/tree/main/skins/pramanix-eyjafjalla": [
-  "https://raw.githubusercontent.com/DocJlm/dsh-arknights/main/skins/pramanix-eyjafjalla/preview/cover.webp"
- ],
- "https://github.com/Eve-146T/DSH-CODEX-SUBSCRIPTION-POOL": [
-  "https://raw.githubusercontent.com/Eve-146T/DSH-CODEX-SUBSCRIPTION-POOL/main/assets/readme/accounts-demo.png"
- ],
- "https://github.com/Fantasality/dsh-origin-plugin": [
-  "https://raw.githubusercontent.com/Fantasality/dsh-origin-plugin/main/docs/example.png",
-  "https://raw.githubusercontent.com/Fantasality/dsh-origin-plugin/main/docs/example_3d.png"
- ],
- "https://github.com/FengHuoLinShan/dsh-plugin-llm-balance": [
-  "https://raw.githubusercontent.com/FengHuoLinShan/dsh-plugin-llm-balance/main/assets/llm-balance-preview.png"
- ],
- "https://github.com/Flyvhidbwo/dsh-vision-proxy": [
-  "https://raw.githubusercontent.com/Flyvhidbwo/dsh-vision-proxy/main/assets/demo-reply.png",
-  "https://raw.githubusercontent.com/Flyvhidbwo/dsh-vision-proxy/main/assets/demo-selector.png"
- ],
- "https://github.com/foooold/dsh-message-nav": [
-  "https://raw.githubusercontent.com/foooold/dsh-message-nav/main/assets/rail-hover-preview.png",
-  "https://raw.githubusercontent.com/foooold/dsh-message-nav/main/assets/rail-left-edge.png"
- ],
- "https://github.com/GOU-GEE/deepseek-vision/tree/main/plugins/dsh-plugin-deepseek-vision": [
-  "https://raw.githubusercontent.com/GOU-GEE/deepseek-vision/main/docs/screenshots/01-settings.png",
-  "https://raw.githubusercontent.com/GOU-GEE/deepseek-vision/main/docs/screenshots/02-paste-analyze.png",
-  "https://raw.githubusercontent.com/GOU-GEE/deepseek-vision/main/docs/screenshots/03-clipboard.png",
-  "https://raw.githubusercontent.com/GOU-GEE/deepseek-vision/main/docs/screenshots/04-result.png",
-  "https://raw.githubusercontent.com/GOU-GEE/deepseek-vision/main/docs/screenshots/05-market.png"
- ],
- "https://github.com/Gin-7/dsh-pet-remielle": [
-  "https://raw.githubusercontent.com/Gin-7/dsh-pet-remielle/main/assets/screenshot-waiting.png",
-  "https://raw.githubusercontent.com/Gin-7/dsh-pet-remielle/main/assets/screenshot-priding.png"
- ],
- "https://github.com/HaoyueQin/dsh-better-reasoning-effort": [
-  "https://raw.githubusercontent.com/HaoyueQin/dsh-better-reasoning-effort/master/docs/market-card.png"
- ],
- "https://github.com/Harvey-Will/dsh-vision-analysis": [
-  "https://raw.githubusercontent.com/Harvey-Will/dsh-vision-analysis/main/assets/demo-ocr.png",
-  "https://raw.githubusercontent.com/Harvey-Will/dsh-vision-analysis/main/assets/demo-chart.png",
-  "https://raw.githubusercontent.com/Harvey-Will/dsh-vision-analysis/main/assets/demo-ui.png"
-],
-"https://github.com/Isilsolme/dsh-splash-launcher": [
-  "https://raw.githubusercontent.com/Isilsolme/dsh-splash-launcher/main/docs/screenshots/splash-light.png",
-  "https://raw.githubusercontent.com/Isilsolme/dsh-splash-launcher/main/docs/screenshots/splash-drawing.png",
-  "https://raw.githubusercontent.com/Isilsolme/dsh-splash-launcher/main/docs/screenshots/splash-dark.png",
-  "https://raw.githubusercontent.com/Isilsolme/dsh-splash-launcher/main/docs/screenshots/main.png"
- ],
- "https://github.com/Jannchie/dsh-bill": [
-  "https://raw.githubusercontent.com/Jannchie/dsh-bill/main/docs/attribution.png",
-  "https://raw.githubusercontent.com/Jannchie/dsh-bill/main/docs/in-chat.png"
- ],
- "https://github.com/JimchengChina/dsh-frontier-repro": [
-  "https://raw.githubusercontent.com/JimchengChina/dsh-frontier-repro/main/docs/assets/frontier-repro-hero.png"
- ],
- "https://github.com/Jiyr0119/dsh-workspace-explorer": [
-  "https://raw.githubusercontent.com/Jiyr0119/dsh-workspace-explorer/main/assets/screenshots/panel.png",
-  "https://raw.githubusercontent.com/Jiyr0119/dsh-workspace-explorer/main/assets/screenshots/tree.png",
-  "https://raw.githubusercontent.com/Jiyr0119/dsh-workspace-explorer/main/assets/screenshots/insert.png"
- ],
- "https://github.com/Js2Hou/dsh-mcp-manager": [
-  "https://raw.githubusercontent.com/Js2Hou/dsh-mcp-manager/main/assets/market-screenshot.png"
- ],
- "https://github.com/Jungod1121/dsh-anchored-standard": [
-  "https://raw.githubusercontent.com/Jungod1121/dsh-anchored-standard/main/screenshots/market-1.png",
-  "https://raw.githubusercontent.com/Jungod1121/dsh-anchored-standard/main/screenshots/market-2.png",
-  "https://raw.githubusercontent.com/Jungod1121/dsh-anchored-standard/main/screenshots/market-3.png"
- ],
- "https://github.com/KLRSL/dsh-biomemory": [
-  "https://raw.githubusercontent.com/KLRSL/dsh-biomemory/main/assets/screenshot-main.png",
-  "https://raw.githubusercontent.com/KLRSL/dsh-biomemory/main/assets/screenshot-settings.png",
-  "https://raw.githubusercontent.com/KLRSL/dsh-biomemory/main/assets/screenshot-memory-settings.png"
- ],
- "https://github.com/LKMeng2001/dsh-mcp-market": [
-  "https://raw.githubusercontent.com/LKMeng2001/dsh-mcp-market/main/assets/market-discover.png"
- ],
- "https://github.com/LeemanCheung/dsh-agent-preset-recommender": [
-  "https://raw.githubusercontent.com/LeemanCheung/dsh-agent-preset-recommender/main/docs/screenshot.png",
-  "https://raw.githubusercontent.com/LeemanCheung/dsh-agent-preset-recommender/main/docs/project-detail.png"
- ],
- "https://github.com/LeemanCheung/dsh-image-gen": [
-  "https://raw.githubusercontent.com/LeemanCheung/dsh-image-gen/main/assets/demo.svg",
-  "https://raw.githubusercontent.com/LeemanCheung/dsh-image-gen/main/assets/final-card.png"
- ],
- "https://github.com/LeemanCheung/dsh-qq2007-skin": [
-  "https://raw.githubusercontent.com/LeemanCheung/dsh-qq2007-skin/main/docs/screenshot.png",
-  "https://raw.githubusercontent.com/LeemanCheung/dsh-qq2007-skin/main/docs/preview.svg"
- ],
- "https://github.com/LeemanCheung/dsh-task-dag": [
-  "https://raw.githubusercontent.com/LeemanCheung/dsh-task-dag/main/docs/screenshot.png",
-  "https://raw.githubusercontent.com/LeemanCheung/dsh-task-dag/main/docs/task-dag-preview.svg"
- ],
- "https://github.com/LeemanCheung/dsh-token-usage": [
-  "https://raw.githubusercontent.com/LeemanCheung/dsh-token-usage/main/assets/token-usage-overview.png",
-  "https://raw.githubusercontent.com/LeemanCheung/dsh-token-usage/main/assets/token-usage-insights.png",
-  "https://raw.githubusercontent.com/LeemanCheung/dsh-token-usage/main/assets/token-usage-budget.png",
-  "https://raw.githubusercontent.com/LeemanCheung/dsh-token-usage/main/assets/token-usage-ai-analysis.png",
-  "https://raw.githubusercontent.com/LeemanCheung/dsh-token-usage/main/assets/token-usage-trajectory-analysis.png"
- ],
- "https://github.com/LeemanCheung/dsh-whale-animation": [
-  "https://raw.githubusercontent.com/LeemanCheung/dsh-whale-animation/main/docs/screenshots/launch.png",
-  "https://raw.githubusercontent.com/LeemanCheung/dsh-whale-animation/main/docs/screenshots/apex.png",
-  "https://raw.githubusercontent.com/LeemanCheung/dsh-whale-animation/main/docs/screenshots/deep-dive.png"
- ],
- "https://github.com/Leeminjing/dsh-eyes": [
-  "https://raw.githubusercontent.com/Leeminjing/dsh-eyes/main/assets/demo.png"
- ],
- "https://github.com/Lhy723/dsh-agent-canvas": [
-  "https://raw.githubusercontent.com/Lhy723/dsh-agent-canvas/main/docs/assets/agent-canvas-overview.png",
-  "https://raw.githubusercontent.com/Lhy723/dsh-agent-canvas/main/docs/assets/agent-canvas-dark-settings.png"
- ],
- "https://github.com/MangMax/dsh-themes": [
-  "https://raw.githubusercontent.com/MangMax/dsh-themes/main/assets/screenshot.png"
- ],
- "https://github.com/Mars-Sea/dsh-commandcode-provider": [
-  "https://raw.githubusercontent.com/Mars-Sea/dsh-commandcode-provider/main/assets/screenshots/model-picker.png",
-  "https://raw.githubusercontent.com/Mars-Sea/dsh-commandcode-provider/main/assets/screenshots/usage-dashboard.png"
- ],
- "https://github.com/Max-Samson/dsh-usage-chart": [
-  "https://github.com/Max-Samson/dsh-usage-chart/blob/main/docs/images/usage-panel-demo-en-lightv1.0.0.png",
-  "https://github.com/Max-Samson/dsh-usage-chart/blob/main/docs/images/usage-panel-demo-zh-darkv1.0.0.png"
- ],
- "https://github.com/MingoZhou/dsh-replay": [
-  "https://raw.githubusercontent.com/MingoZhou/dsh-replay/main/assets/overview-light.png",
-  "https://raw.githubusercontent.com/MingoZhou/dsh-replay/main/assets/timeline-light.png",
-  "https://raw.githubusercontent.com/MingoZhou/dsh-replay/main/assets/audit-light.png"
- ],
- "https://github.com/Mu-scorpio/token-usage-counter": [
-  "https://raw.githubusercontent.com/Mu-scorpio/token-usage-counter/main/assets/usage-stats-overview.png",
-  "https://raw.githubusercontent.com/Mu-scorpio/token-usage-counter/main/assets/usage-stats-hover.png"
- ],
- "https://github.com/Nanki-nn/dsh-answer-pet": [
-  "https://raw.githubusercontent.com/Nanki-nn/dsh-answer-pet/main/assets/screenshots/blue-whale.png",
-  "https://raw.githubusercontent.com/Nanki-nn/dsh-answer-pet/main/assets/screenshots/orange-cat.png",
-  "https://raw.githubusercontent.com/Nanki-nn/dsh-answer-pet/main/assets/screenshots/silver-shaded-cat.png"
- ],
- "https://github.com/NoNameLeGo/dsh-catppuccin-theme": [
-  "https://raw.githubusercontent.com/NoNameLeGo/dsh-catppuccin-theme/main/assets/previews/glass-latte.png",
-  "https://raw.githubusercontent.com/NoNameLeGo/dsh-catppuccin-theme/main/assets/previews/glass-mocha.png",
-  "https://raw.githubusercontent.com/NoNameLeGo/dsh-catppuccin-theme/main/assets/previews/latte.png",
-  "https://raw.githubusercontent.com/NoNameLeGo/dsh-catppuccin-theme/main/assets/previews/frappe.png",
-  "https://raw.githubusercontent.com/NoNameLeGo/dsh-catppuccin-theme/main/assets/previews/macchiato.png",
-  "https://raw.githubusercontent.com/NoNameLeGo/dsh-catppuccin-theme/main/assets/previews/mocha.png"
- ],
- "https://github.com/Noob-stupid/dsh-github-login": [
-  "https://github.com/user-attachments/assets/bb7c1991-9346-4c20-8dc2-5d884515c522",
-  "https://github.com/user-attachments/assets/45a31794-ab56-4e34-8826-fb362deef3dc",
-  "https://github.com/user-attachments/assets/e23560ca-41d3-4a83-bc14-1d20f884cd8a"
- ],
- "https://github.com/Noob-stupid/dsh-plugin-hub": [
-  "https://github.com/user-attachments/assets/b802d606-14ba-4151-9956-ff642ed12b0a"
- ],
- "https://github.com/PC2005-cloud/dsh-pet/tree/main/dsh-pet": [
-  "https://raw.githubusercontent.com/PC2005-cloud/dsh-pet/main/assets/screenshots/dsh-pet-running-1.png",
-  "https://raw.githubusercontent.com/PC2005-cloud/dsh-pet/main/assets/screenshots/dsh-pet-running-2.png"
- ],
- "https://github.com/PandaPolo/dsh-voice-call": [
-  "https://raw.githubusercontent.com/PandaPolo/dsh-voice-call/main/promo/screenshots/slide-1.png",
-  "https://raw.githubusercontent.com/PandaPolo/dsh-voice-call/main/promo/screenshots/slide-2.png",
-  "https://raw.githubusercontent.com/PandaPolo/dsh-voice-call/main/promo/screenshots/slide-3.png",
-  "https://raw.githubusercontent.com/PandaPolo/dsh-voice-call/main/promo/screenshots/slide-4.png",
-  "https://raw.githubusercontent.com/PandaPolo/dsh-voice-call/main/promo/screenshots/slide-5.png",
-  "https://raw.githubusercontent.com/PandaPolo/dsh-voice-call/main/promo/screenshots/slide-6.png",
-  "https://raw.githubusercontent.com/PandaPolo/dsh-voice-call/main/promo/screenshots/slide-7.png"
- ],
- "https://github.com/ParticleLight/dsh-all-usage": [
-  "https://raw.githubusercontent.com/ParticleLight/dsh-all-usage/main/assets/screenshot-1.png",
-  "https://raw.githubusercontent.com/ParticleLight/dsh-all-usage/main/assets/screenshot-2.png"
- ],
- "https://github.com/PeterBon/dsh-hooks": [
-  "https://raw.githubusercontent.com/PeterBon/dsh-hooks/main/assets/screenshot-1.jpg"
- ],
- "https://github.com/PicGo/dsh-plugin": [
-  "https://raw.githubusercontent.com/PicGo/dsh-plugin/main/assets/DeepSeek-PicGo.png",
-  "https://raw.githubusercontent.com/PicGo/dsh-plugin/main/assets/dsh-plugin-picgo.png"
- ],
- "https://github.com/PwnKY/dsh-session-link": [
-  "https://raw.githubusercontent.com/PwnKY/dsh-session-link/master/assets/screenshots/01-cross-session-context.png",
-  "https://raw.githubusercontent.com/PwnKY/dsh-session-link/master/assets/screenshots/02-source-session.png"
- ],
- "https://github.com/QT-Chen/dsh-mic-input": [
-  "https://raw.githubusercontent.com/QT-Chen/dsh-mic-input/main/assets/shot-1-composer.png",
-  "https://raw.githubusercontent.com/QT-Chen/dsh-mic-input/main/assets/shot-2-listening.png",
-  "https://raw.githubusercontent.com/QT-Chen/dsh-mic-input/main/assets/shot-4-punctuation.png",
-  "https://raw.githubusercontent.com/QT-Chen/dsh-mic-input/main/assets/shot-3-settings.png",
-  "https://raw.githubusercontent.com/QT-Chen/dsh-mic-input/main/assets/shot-5-error.png"
- ],
- "https://github.com/RevolutionLA/dsh-dream-skin": [
-  "https://raw.githubusercontent.com/RevolutionLA/dsh-dream-skin/main/docs/screenshots/preview.png",
-  "https://raw.githubusercontent.com/RevolutionLA/dsh-dream-skin/main/docs/screenshots/settings.png"
- ],
- "https://github.com/SamizuHM/dsh-client-ui-theme-xp": [
-  "https://raw.githubusercontent.com/SamizuHM/dsh-client-ui-theme-xp/main/docs/screenshot.png"
- ],
- "https://github.com/Signalight/codex-to-dsh-pet/tree/main/packages/dsh-codex-pet": [
-  "https://raw.githubusercontent.com/Signalight/codex-to-dsh-pet/main/assets/screenshots/screenshot-1.png",
-  "https://raw.githubusercontent.com/Signalight/codex-to-dsh-pet/main/assets/screenshots/screenshot-2.png",
-  "https://raw.githubusercontent.com/Signalight/codex-to-dsh-pet/main/assets/screenshots/screenshot-3.png"
- ],
- "https://github.com/SiriLee/dsh-rewind": [
-  "https://raw.githubusercontent.com/SiriLee/dsh-rewind/main/assets/screenshots/rewind-button.png",
-  "https://raw.githubusercontent.com/SiriLee/dsh-rewind/main/assets/screenshots/mode-popover.png",
-  "https://raw.githubusercontent.com/SiriLee/dsh-rewind/main/assets/screenshots/impact-list.png",
-  "https://raw.githubusercontent.com/SiriLee/dsh-rewind/main/assets/screenshots/rewind-candidates.png"
- ],
- "https://github.com/Smalldy/godot-bridge": [
-  "https://raw.githubusercontent.com/Smalldy/godot-bridge/main/assets/godot-bridge-env-check.png"
- ],
- "https://github.com/StruggleYang/dsh-project-kanban": [
-  "https://raw.githubusercontent.com/StruggleYang/dsh-project-kanban/main/assets/screenshot-board.png"
- ],
- "https://github.com/TQSY114514/dsh-ui-appearance": [
-  "https://raw.githubusercontent.com/TQSY114514/dsh-ui-appearance/main/docs/screenshot-settings.png",
-  "https://raw.githubusercontent.com/TQSY114514/dsh-ui-appearance/main/docs/screenshot-wallpaper.png"
- ],
- "https://github.com/TZHR-invest/dsh-plugins/tree/main/packages/dsh-lan-access": [
-  "https://raw.githubusercontent.com/TZHR-invest/dsh-plugins/main/packages/dsh-lan-access/assets/screenshot-1-token-gate.png"
- ],
- "https://github.com/TZHR-invest/dsh-plugins/tree/main/packages/dsh-mobile-ui": [
-  "https://raw.githubusercontent.com/TZHR-invest/dsh-plugins/main/packages/dsh-mobile-ui/assets/screenshot-1-home.png",
-  "https://raw.githubusercontent.com/TZHR-invest/dsh-plugins/main/packages/dsh-mobile-ui/assets/screenshot-2-composer.png",
-  "https://raw.githubusercontent.com/TZHR-invest/dsh-plugins/main/packages/dsh-mobile-ui/assets/screenshot-3-chat.png",
-  "https://raw.githubusercontent.com/TZHR-invest/dsh-plugins/main/packages/dsh-mobile-ui/assets/screenshot-4-sessions.png"
- ],
- "https://github.com/Tkingxiao/dsh-any-background": [
-  "https://raw.githubusercontent.com/Tkingxiao/dsh-any-background/main/example_img/image.png",
-  "https://raw.githubusercontent.com/Tkingxiao/dsh-any-background/main/example_img/image-2.png",
-  "https://raw.githubusercontent.com/Tkingxiao/dsh-any-background/main/example_img/image-3.png",
-  "https://raw.githubusercontent.com/Tkingxiao/dsh-any-background/main/example_img/image-4.png",
-  "https://raw.githubusercontent.com/Tkingxiao/dsh-any-background/main/example_img/image-6.png",
-  "https://raw.githubusercontent.com/Tkingxiao/dsh-any-background/main/example_img/image-9.png",
-  "https://raw.githubusercontent.com/Tkingxiao/dsh-any-background/main/example_img/image-10.png"
- ],
- "https://github.com/Totoro-qaq/dsh-plugin-bridge": [
-  "https://raw.githubusercontent.com/Totoro-qaq/dsh-plugin-bridge/main/assets/cover/cover-en.png",
-  "https://raw.githubusercontent.com/Totoro-qaq/dsh-plugin-bridge/main/assets/bridge-demo.en.gif"
- ],
- "https://github.com/Ultronen/dsh-archived-chats": [
-  "https://raw.githubusercontent.com/Ultronen/dsh-archived-chats/main/assets/screenshots/1-archived-chats.png",
-  "https://raw.githubusercontent.com/Ultronen/dsh-archived-chats/main/assets/screenshots/2-search.png",
-  "https://raw.githubusercontent.com/Ultronen/dsh-archived-chats/main/assets/screenshots/3-delete-confirm.png",
-  "https://raw.githubusercontent.com/Ultronen/dsh-archived-chats/main/assets/screenshots/4-group-menu.png"
- ],
- "https://github.com/Ultronen/dsh-liquid-glass": [
-  "https://raw.githubusercontent.com/Ultronen/dsh-liquid-glass/main/assets/screenshots/1-settings.png",
-  "https://raw.githubusercontent.com/Ultronen/dsh-liquid-glass/main/assets/screenshots/2-glass-shell.png",
-  "https://raw.githubusercontent.com/Ultronen/dsh-liquid-glass/main/assets/screenshots/3-settings-wallpaper.png"
- ],
- "https://github.com/V1ki/dsh-plugin-subscriptions": [
-  "https://raw.githubusercontent.com/V1ki/dsh-plugin-subscriptions/main/docs/images/subscriptions.png",
-  "https://raw.githubusercontent.com/V1ki/dsh-plugin-subscriptions/main/docs/images/model-picker.png",
-  "https://raw.githubusercontent.com/V1ki/dsh-plugin-subscriptions/main/docs/images/model-effort.png",
-  "https://raw.githubusercontent.com/V1ki/dsh-plugin-subscriptions/main/docs/images/speed-toggle.png",
-  "https://raw.githubusercontent.com/V1ki/dsh-plugin-subscriptions/main/docs/images/image-generate-inline.png",
-  "https://raw.githubusercontent.com/V1ki/dsh-plugin-subscriptions/main/docs/images/image-generate-providers.png",
-  "https://raw.githubusercontent.com/V1ki/dsh-plugin-subscriptions/main/docs/images/video-generate-inline.png"
- ],
- "https://github.com/Vncntvx/dsh-zotero": [
-  "https://raw.githubusercontent.com/Vncntvx/dsh-zotero/main/docs/images/header-collage.png",
-  "https://raw.githubusercontent.com/Vncntvx/dsh-zotero/main/docs/images/zotero-chat-workflow.png",
-  "https://raw.githubusercontent.com/Vncntvx/dsh-zotero/main/docs/images/zotero-sources-overview.png",
-  "https://raw.githubusercontent.com/Vncntvx/dsh-zotero/main/docs/images/zotero-evidence-passages.png",
-  "https://raw.githubusercontent.com/Vncntvx/dsh-zotero/main/docs/images/zotero-export-bibtex.png"
- ],
- "https://github.com/WenhongPan/dsh-projects": [
-  "https://raw.githubusercontent.com/WenhongPan/dsh-projects/main/docs/assets/picker.webp",
-  "https://raw.githubusercontent.com/WenhongPan/dsh-projects/main/docs/assets/create.webp",
-  "https://raw.githubusercontent.com/WenhongPan/dsh-projects/main/docs/assets/native.webp"
- ],
- "https://github.com/YeqingTang/dsh-session-flow": [
-  "https://raw.githubusercontent.com/YeqingTang/dsh-session-flow/main/assets/screenshots/overview.png",
-  "https://raw.githubusercontent.com/YeqingTang/dsh-session-flow/main/assets/screenshots/session-flow-tab.png",
-  "https://raw.githubusercontent.com/YeqingTang/dsh-session-flow/main/assets/screenshots/turn-rail.png",
-  "https://raw.githubusercontent.com/YeqingTang/dsh-session-flow/main/assets/screenshots/fulltext-search.png",
-  "https://raw.githubusercontent.com/YeqingTang/dsh-session-flow/main/assets/screenshots/dock-right.png",
-  "https://raw.githubusercontent.com/YeqingTang/dsh-session-flow/main/assets/screenshots/folded-detail.png"
- ],
- "https://github.com/Yu-tao-Li/dsh-computer-use-win": [
-  "https://raw.githubusercontent.com/Yu-tao-Li/dsh-computer-use-win/main/assets/screenshot-1.png",
-  "https://raw.githubusercontent.com/Yu-tao-Li/dsh-computer-use-win/main/assets/screenshot-2.png",
-  "https://raw.githubusercontent.com/Yu-tao-Li/dsh-computer-use-win/main/assets/screenshot-3.png"
- ],
- "https://github.com/Yu-tao-Li/dsh-read-image-view": [
-  "https://raw.githubusercontent.com/Yu-tao-Li/dsh-read-image-view/main/assets/screenshot-1.png",
-  "https://raw.githubusercontent.com/Yu-tao-Li/dsh-read-image-view/main/assets/screenshot-2.png",
-  "https://raw.githubusercontent.com/Yu-tao-Li/dsh-read-image-view/main/assets/screenshot-3.png",
-  "https://raw.githubusercontent.com/Yu-tao-Li/dsh-read-image-view/main/assets/screenshot-4.png"
- ],
- "https://github.com/Yu-tao-Li/dsh-reference-checker": [
-  "https://raw.githubusercontent.com/Yu-tao-Li/dsh-reference-checker/main/assets/screenshot-1.png"
- ],
- "https://github.com/ZJUZhiyuCai/dsh-ivory": [
-  "https://raw.githubusercontent.com/ZJUZhiyuCai/dsh-ivory/main/assets/hero-light.png",
-  "https://raw.githubusercontent.com/ZJUZhiyuCai/dsh-ivory/main/assets/hero-dark.png",
-  "https://raw.githubusercontent.com/ZJUZhiyuCai/dsh-ivory/main/assets/conversation-light.png",
-  "https://raw.githubusercontent.com/ZJUZhiyuCai/dsh-ivory/main/assets/mobile-light.png"
- ],
- "https://github.com/a179-sanae/dsh-auto-collapse": [
-  "https://raw.githubusercontent.com/a179-sanae/dsh-auto-collapse/main/assets/screenshot.png"
- ],
- "https://github.com/a903067276-rgb/dsh-file-mentions": [
-  "https://raw.githubusercontent.com/a903067276-rgb/dsh-file-mentions/main/assets/screenshot.png"
- ],
- "https://github.com/a903067276-rgb/dsh-file-upload": [
-  "https://raw.githubusercontent.com/a903067276-rgb/dsh-file-upload/main/assets/screenshot.png"
- ],
- "https://github.com/a903067276-rgb/dsh-hud": [
-  "https://raw.githubusercontent.com/a903067276-rgb/dsh-hud/main/assets/hud-panel.png"
- ],
- "https://github.com/a903067276-rgb/dsh-plan-switch": [
-  "https://raw.githubusercontent.com/a903067276-rgb/dsh-plan-switch/main/assets/plan-button.png"
- ],
- "https://github.com/biociao/dsh-science": [
-  "https://raw.githubusercontent.com/biociao/dsh-science/main/assets/screenshots/research-loop.png",
-  "https://raw.githubusercontent.com/biociao/dsh-science/main/assets/screenshots/artifact-provenance.png",
-  "https://raw.githubusercontent.com/biociao/dsh-science/main/assets/screenshots/research-report.png",
-  "https://raw.githubusercontent.com/biociao/dsh-science/main/assets/screenshots/remote-compute.png",
-  "https://raw.githubusercontent.com/biociao/dsh-science/main/assets/screenshots/plugin-inventory.png",
-  "https://raw.githubusercontent.com/biociao/dsh-science/main/assets/screenshots/topology.png"
- ],
- "https://github.com/chouyong/dsh-branch-review": [
-  "https://raw.githubusercontent.com/chouyong/dsh-branch-review/main/assets/branch-review-desktop.png",
-  "https://raw.githubusercontent.com/chouyong/dsh-branch-review/main/assets/branch-review-decisions.png"
- ],
- "https://github.com/chouyong/dsh-fork-diff": [
-  "https://raw.githubusercontent.com/chouyong/dsh-fork-diff/main/assets/fork-diff-desktop.png",
-  "https://raw.githubusercontent.com/chouyong/dsh-fork-diff/main/assets/fork-diff-selector.png",
-  "https://raw.githubusercontent.com/chouyong/dsh-fork-diff/main/assets/fork-diff-mobile.png"
- ],
- "https://github.com/chouyong/dsh-fork-graph": [
-  "https://raw.githubusercontent.com/chouyong/dsh-fork-graph/main/assets/screenshot-trigger.png",
-  "https://raw.githubusercontent.com/chouyong/dsh-fork-graph/main/assets/screenshot-panel.png"
- ],
- "https://github.com/cirelir/dsh-change-review": [
-  "https://raw.githubusercontent.com/cirelir/dsh-change-review/main/assets/screenshots/review-tab.png",
-  "https://raw.githubusercontent.com/cirelir/dsh-change-review/main/assets/screenshots/per-turn-card.png",
-  "https://raw.githubusercontent.com/cirelir/dsh-change-review/main/assets/screenshots/diff-detail.png",
-  "https://raw.githubusercontent.com/cirelir/dsh-change-review/main/assets/screenshots/color-settings.png",
-  "https://raw.githubusercontent.com/cirelir/dsh-change-review/main/assets/screenshots/plugin-market.png"
- ],
- "https://github.com/coolbreezecoin/dsh-wechat-mp": [
-  "https://raw.githubusercontent.com/coolbreezecoin/dsh-wechat-mp/main/assets/demo.gif"
- ],
- "https://github.com/corrinehu/dsh-chat-imagine": [
-  "https://raw.githubusercontent.com/corrinehu/dsh-chat-imagine/main/assets/1.png",
-  "https://raw.githubusercontent.com/corrinehu/dsh-chat-imagine/main/assets/2.png",
-  "https://raw.githubusercontent.com/corrinehu/dsh-chat-imagine/main/assets/3.png",
-  "https://raw.githubusercontent.com/corrinehu/dsh-chat-imagine/main/assets/4.png"
- ],
- "https://github.com/creght-dev/skills": [
-  "https://raw.githubusercontent.com/creght-dev/skills/main/assets/screenshot-dsh.jpg",
-  "https://raw.githubusercontent.com/creght-dev/skills/main/assets/screenshot-editor.jpg"
- ],
- "https://github.com/d-dev0101/open-sea-skin": [
-  "https://raw.githubusercontent.com/d-dev0101/open-sea-skin/5ae54402ec6d4c961d41aee8ed786280799712c7/docs/marketplace/open-sea-harness-cover.png",
-  "https://raw.githubusercontent.com/d-dev0101/open-sea-skin/5ae54402ec6d4c961d41aee8ed786280799712c7/docs/screenshots/harness-dark-overview-40.gif",
-  "https://raw.githubusercontent.com/d-dev0101/open-sea-skin/5ae54402ec6d4c961d41aee8ed786280799712c7/docs/screenshots/harness-light-overview-40.gif",
-  "https://raw.githubusercontent.com/d-dev0101/open-sea-skin/5ae54402ec6d4c961d41aee8ed786280799712c7/docs/screenshots/harness-wave-control-40.gif",
-  "https://raw.githubusercontent.com/d-dev0101/open-sea-skin/5ae54402ec6d4c961d41aee8ed786280799712c7/docs/screenshots/harness-daylight-sunset-40.gif"
- ],
- "https://github.com/daetz-coder/dsh-multi-chat": [
-  "https://raw.githubusercontent.com/daetz-coder/dsh-multi-chat/main/assets/01-windows-dual-chat.png",
-  "https://raw.githubusercontent.com/daetz-coder/dsh-multi-chat/main/assets/02-ipad-dual-chat.png",
-  "https://raw.githubusercontent.com/daetz-coder/dsh-multi-chat/main/assets/03-windows-triple-chat.png"
- ],
- "https://github.com/demacia1314/dsh-airdrop": [
-  "https://raw.githubusercontent.com/demacia1314/dsh-airdrop/main/assets/drop-in.png",
-  "https://raw.githubusercontent.com/demacia1314/dsh-airdrop/main/assets/in-chat.png",
-  "https://raw.githubusercontent.com/demacia1314/dsh-airdrop/main/assets/preview-modal.png"
- ],
- "https://github.com/detongz/dsh-client-ui-obsidian-memory": [
-  "https://raw.githubusercontent.com/detongz/dsh-client-ui-obsidian-memory/main/assets/screenshot-panel.png"
- ],
- "https://github.com/dfycaly98931680/dsh-trajectory-governance": [
-  "https://raw.githubusercontent.com/dfycaly98931680/dsh-trajectory-governance/main/docs/screenshots/tree.png",
-  "https://raw.githubusercontent.com/dfycaly98931680/dsh-trajectory-governance/main/docs/screenshots/alerts.png",
-  "https://raw.githubusercontent.com/dfycaly98931680/dsh-trajectory-governance/main/docs/screenshots/report.png"
- ],
- "https://github.com/dickpy/dsh-imagegen": [
-  "https://raw.githubusercontent.com/dickpy/dsh-imagegen/main/docs/images/image-generation-studio.png",
-  "https://raw.githubusercontent.com/dickpy/dsh-imagegen/main/docs/images/plugin-settings.png"
- ],
- "https://github.com/disyli/dsh-tool-call-stats": [
-  "https://raw.githubusercontent.com/disyli/dsh-tool-call-stats/main/assets/screenshots/01-session.png",
-  "https://raw.githubusercontent.com/disyli/dsh-tool-call-stats/main/assets/screenshots/02-tool-stats.png",
-  "https://raw.githubusercontent.com/disyli/dsh-tool-call-stats/main/assets/screenshots/03-install.png",
-  "https://raw.githubusercontent.com/disyli/dsh-tool-call-stats/main/assets/screenshots/04-config.png"
- ],
- "https://github.com/dsh-market/dsh-market": [
-  "https://raw.githubusercontent.com/dsh-market/dsh-market/main/assets/demo-en.png",
-  "https://raw.githubusercontent.com/dsh-market/dsh-market/main/assets/themes-en.png"
- ],
- "https://github.com/elves-ai/dsh-web-search-firecrawl": [
-  "https://raw.githubusercontent.com/elves-ai/dsh-web-search-firecrawl/master/docs/firecrawl-settings.png"
- ],
- "https://github.com/franksong2702/dsh-codex-connect": [
-  "https://raw.githubusercontent.com/franksong2702/dsh-codex-connect/main/docs/assets/en/plugin-entry.jpg",
-  "https://raw.githubusercontent.com/franksong2702/dsh-codex-connect/main/docs/assets/en/oauth-status.jpg",
-  "https://raw.githubusercontent.com/franksong2702/dsh-codex-connect/main/docs/assets/en/plugin-configuration.jpg",
-  "https://raw.githubusercontent.com/franksong2702/dsh-codex-connect/main/docs/assets/en/model-selector.jpg",
-  "https://raw.githubusercontent.com/franksong2702/dsh-codex-connect/main/docs/assets/zh/hero.jpg",
-  "https://raw.githubusercontent.com/franksong2702/dsh-codex-connect/main/docs/assets/zh/plugin-entry.jpg",
-  "https://raw.githubusercontent.com/franksong2702/dsh-codex-connect/main/docs/assets/zh/oauth-status.jpg",
-  "https://raw.githubusercontent.com/franksong2702/dsh-codex-connect/main/docs/assets/zh/plugin-configuration.jpg"
- ],
- "https://github.com/fuyue521/dsh-desktop-shortcut": [
-  "https://raw.githubusercontent.com/fuyue521/dsh-desktop-shortcut/main/assets/screenshots/screenshot-web-ui.png"
- ],
- "https://github.com/haiziyao/dsh-vision-mix": [
-  "https://raw.githubusercontent.com/haiziyao/dsh-vision-mix/main/docs/settings-routing.png",
-  "https://raw.githubusercontent.com/haiziyao/dsh-vision-mix/main/docs/generation-routing.png",
-  "https://raw.githubusercontent.com/haiziyao/dsh-vision-mix/main/docs/vision-history.png",
-  "https://raw.githubusercontent.com/haiziyao/dsh-vision-mix/main/docs/generation-history.png",
-  "https://raw.githubusercontent.com/haiziyao/dsh-vision-mix/main/docs/benchmark-mix.png"
- ],
- "https://github.com/hanzhangzzz/dsh-diagram": [
-  "https://raw.githubusercontent.com/hanzhangzzz/dsh-diagram/assets/dsh-diagram-demo.gif",
-  "https://raw.githubusercontent.com/hanzhangzzz/dsh-diagram/assets/screenshot-canvas-architecture.png",
-  "https://raw.githubusercontent.com/hanzhangzzz/dsh-diagram/assets/screenshot-canvas-flow.png",
-  "https://raw.githubusercontent.com/hanzhangzzz/dsh-diagram/assets/screenshot-chat.png"
- ],
- "https://github.com/haoku123/dsh-voice": [
-  "https://raw.githubusercontent.com/haoku123/dsh-voice/main/docs/demo.gif"
- ],
- "https://github.com/hezhongtang/dsh-capability-optimizer": [
-  "https://raw.githubusercontent.com/hezhongtang/dsh-capability-optimizer/main/assets/screenshot-zh.png"
- ],
- "https://github.com/hi-wenw/dsh-telegram-channel": [
-  "https://raw.githubusercontent.com/hi-wenw/dsh-telegram-channel/master/docs/screenshots/hero-flow.png",
-  "https://raw.githubusercontent.com/hi-wenw/dsh-telegram-channel/master/docs/screenshots/mobile-chat.jpg",
-  "https://raw.githubusercontent.com/hi-wenw/dsh-telegram-channel/master/docs/screenshots/desktop-sync.jpg"
- ],
- "https://github.com/huguangyu666/dsh-plugin-notify": [
-  "https://raw.githubusercontent.com/huguangyu666/dsh-plugin-notify/main/assets/screenshot.png"
- ],
- "https://github.com/huguangyu666/dsh-plugin-session-import": [
-  "https://raw.githubusercontent.com/huguangyu666/dsh-plugin-session-import/main/assets/screenshot.png"
- ],
- "https://github.com/huguangyu666/dsh-store": [
-  "https://raw.githubusercontent.com/huguangyu666/dsh-plugin-store/main/assets/screenshot.png"
- ],
- "https://github.com/huxint/dsh-team": [
-  "https://raw.githubusercontent.com/huxint/dsh-team/main/screenshots/image.png"
- ],
- "https://github.com/hxy91819/dsh-auth": [
-  "https://raw.githubusercontent.com/hxy91819/dsh-auth/main/docs/images/login.png",
-  "https://raw.githubusercontent.com/hxy91819/dsh-auth/main/docs/images/authenticated-harness.png"
- ],
- "https://github.com/hyzyn/dsh-plugin-kit/tree/main/packages/rss": [
-  "https://raw.githubusercontent.com/hyzyn/dsh-plugin-kit/main/docs/dsh-plugin-kit-rss-setting.png",
-  "https://raw.githubusercontent.com/hyzyn/dsh-plugin-kit/main/docs/dsh-plugin-kit-rss-view.png"
- ],
- "https://github.com/hyzyn/dsh-plugin-kit/tree/main/packages/search": [
-  "https://raw.githubusercontent.com/hyzyn/dsh-plugin-kit/main/docs/dsh-plugin-kit-search.png"
- ],
- "https://github.com/iamfromchangsha/dsh-go-balance": [
-  "https://raw.githubusercontent.com/iamfromchangsha/dsh-go-balance/main/docs/screenshot-composer.png",
-  "https://raw.githubusercontent.com/iamfromchangsha/dsh-go-balance/main/docs/screenshot-tooltip.png",
-  "https://raw.githubusercontent.com/iamfromchangsha/dsh-go-balance/main/docs/screenshot-warn.png"
- ],
- "https://github.com/iiwish/dsh-testkit": [
-  "https://raw.githubusercontent.com/iiwish/dsh-testkit/main/docs/assets/dsh-testkit-showcase.png"
- ],
- "https://github.com/imkingjh999/dsh-shorts-wall": [
-  "https://raw.githubusercontent.com/imkingjh999/dsh-shorts-wall/main/docs/screenshot-stick.png",
-  "https://raw.githubusercontent.com/imkingjh999/dsh-shorts-wall/main/docs/screenshot-float.png",
-  "https://raw.githubusercontent.com/imkingjh999/dsh-shorts-wall/main/docs/screenshot-minimized.png"
- ],
- "https://github.com/imkingjh999/dsh-deepsea": [
-  "https://raw.githubusercontent.com/imkingjh999/dsh-deepsea/main/assets/screenshots/deepsea-ocean.png",
-  "https://raw.githubusercontent.com/imkingjh999/dsh-deepsea/main/assets/screenshots/deepsea-wall.png",
-  "https://raw.githubusercontent.com/imkingjh999/dsh-deepsea/main/assets/screenshots/deepsea-pond.png"
- ],
- "https://github.com/itr-del/dsh-feishu": [
-  "https://raw.githubusercontent.com/itr-del/dsh-feishu/master/assets/hero.png"
- ],
- "https://github.com/izwarm195/dsh-net-tools": [
-  "https://raw.githubusercontent.com/izwarm195/dsh-net-tools/main/assets/net_fetch-demo.png"
- ],
- "https://github.com/jiezeng2004-design/dsh-chatgpt-bridge": [
-  "https://raw.githubusercontent.com/jiezeng2004-design/dsh-chatgpt-bridge/main/assets/screenshots/01-human-in-the-loop.png",
-  "https://raw.githubusercontent.com/jiezeng2004-design/dsh-chatgpt-bridge/main/assets/screenshots/02-runtime-goal-update.png",
-  "https://raw.githubusercontent.com/jiezeng2004-design/dsh-chatgpt-bridge/main/assets/screenshots/03-native-dsh-execution.png",
-  "https://raw.githubusercontent.com/jiezeng2004-design/dsh-chatgpt-bridge/main/assets/screenshots/04-workspace-security.png",
-  "https://raw.githubusercontent.com/jiezeng2004-design/dsh-chatgpt-bridge/main/assets/screenshots/05-bridge-health.png"
- ],
- "https://github.com/jitengfei/dsh-whale-arcade": [
-  "https://raw.githubusercontent.com/jitengfei/dsh-whale-arcade/main/assets/screenshots/01-catalog.png",
-  "https://raw.githubusercontent.com/jitengfei/dsh-whale-arcade/main/assets/screenshots/02-whale-jump.png",
-  "https://raw.githubusercontent.com/jitengfei/dsh-whale-arcade/main/assets/screenshots/03-blue-whale-treasure.png",
-  "https://raw.githubusercontent.com/jitengfei/dsh-whale-arcade/main/assets/screenshots/04-coast-runner.png",
-  "https://raw.githubusercontent.com/jitengfei/dsh-whale-arcade/main/assets/screenshots/05-ocean-gomoku.png"
- ],
- "https://github.com/jyh20030112/dsh-visual-plugin": [
-  "https://raw.githubusercontent.com/jyh20030112/dsh-visual-plugin/main/assets/screenshots/screenshot-1.png",
-  "https://raw.githubusercontent.com/jyh20030112/dsh-visual-plugin/main/assets/screenshots/screenshot-2.png",
-  "https://raw.githubusercontent.com/jyh20030112/dsh-visual-plugin/main/assets/screenshots/screenshot-3.png",
-  "https://raw.githubusercontent.com/jyh20030112/dsh-visual-plugin/main/assets/screenshots/screenshot-4.png"
- ],
- "https://github.com/kaixinbaba/dsh-vision-recognizer": [
-  "https://raw.githubusercontent.com/kaixinbaba/dsh-vision-recognizer/main/screenshots/vision-config.png",
-  "https://raw.githubusercontent.com/kaixinbaba/dsh-vision-recognizer/main/screenshots/model-picker.png",
-  "https://raw.githubusercontent.com/kaixinbaba/dsh-vision-recognizer/main/screenshots/chat-demo.png",
-  "https://raw.githubusercontent.com/kaixinbaba/dsh-vision-recognizer/main/screenshots/plugin-list.png"
- ],
- "https://github.com/kanchengw/dsh-mindseye": [
-  "https://raw.githubusercontent.com/kanchengw/dsh-mindseye/main/assets/ScreenShot_GUI.png",
-  "https://raw.githubusercontent.com/kanchengw/dsh-mindseye/main/assets/ScreenShot_interaction.png",
-  "https://raw.githubusercontent.com/kanchengw/dsh-mindseye/main/assets/ScreenShot_config.png"
- ],
- "https://github.com/kexuejin/dsh-zhihu-dashboard": [
-  "https://raw.githubusercontent.com/kexuejin/dsh-zhihu-dashboard/main/assets/hot.png",
-  "https://raw.githubusercontent.com/kexuejin/dsh-zhihu-dashboard/main/assets/track.png",
-  "https://raw.githubusercontent.com/kexuejin/dsh-zhihu-dashboard/main/assets/feed.png",
-  "https://raw.githubusercontent.com/kexuejin/dsh-zhihu-dashboard/main/assets/onboarding.png"
- ],
- "https://github.com/keyiadiannao/dsh-restart-button": [
-  "https://raw.githubusercontent.com/keyiadiannao/dsh-power-button/master/docs/screenshots/en/power-button.png",
-  "https://raw.githubusercontent.com/keyiadiannao/dsh-power-button/master/docs/screenshots/en/power-menu.png",
-  "https://raw.githubusercontent.com/keyiadiannao/dsh-power-button/master/docs/screenshots/en/shutdown-confirm.png",
-  "https://raw.githubusercontent.com/keyiadiannao/dsh-power-button/master/docs/screenshots/en/shutdown-progress.png",
-  "https://raw.githubusercontent.com/keyiadiannao/dsh-power-button/master/docs/screenshots/en/restart-done.png"
- ],
- "https://github.com/kinoward/dsh-plugin-subhub": [
-  "https://raw.githubusercontent.com/kinoward/dsh-plugin-subhub/main/assets/models-en-light.png",
-  "https://raw.githubusercontent.com/kinoward/dsh-plugin-subhub/main/assets/models-zh-light.png",
-  "https://raw.githubusercontent.com/kinoward/dsh-plugin-subhub/main/assets/settings-loggedin-en-light.png",
-  "https://raw.githubusercontent.com/kinoward/dsh-plugin-subhub/main/assets/settings-loggedin-zh-light.png"
- ],
- "https://github.com/labmimors/dsh-mcp-lens": [
-  "https://raw.githubusercontent.com/labmimors/dsh-mcp-lens/main/assets/mcp-lens-hero.webp",
-  "https://raw.githubusercontent.com/labmimors/dsh-mcp-lens/main/assets/mcp-lens-comparison.svg",
-  "https://raw.githubusercontent.com/labmimors/dsh-mcp-lens/main/assets/mcp-lens-comparison.zh-CN.svg"
- ],
- "https://github.com/lire1131/dsh-undo-savepoint": [
-  "https://raw.githubusercontent.com/lire1131/dsh-undo-savepoint/master/docs/webui-panel.png",
-  "https://raw.githubusercontent.com/lire1131/dsh-undo-savepoint/master/docs/webui-settings-section.png",
-  "https://raw.githubusercontent.com/lire1131/dsh-undo-savepoint/master/docs/gui-main.png",
-  "https://raw.githubusercontent.com/lire1131/dsh-undo-savepoint/master/docs/gui-settings.png",
-  "https://raw.githubusercontent.com/lire1131/dsh-undo-savepoint/master/docs/safe-mode-confirm.png",
-  "https://raw.githubusercontent.com/lire1131/dsh-undo-savepoint/master/docs/safe-mode-done.png"
- ],
- "https://github.com/literaf/dsh-ai4scholar": [
-  "https://raw.githubusercontent.com/literaf/dsh-ai4scholar/main/docs/ai4scholar-home.jpg",
-  "https://raw.githubusercontent.com/literaf/dsh-ai4scholar/main/docs/settings-card.png",
-  "https://raw.githubusercontent.com/literaf/dsh-ai4scholar/main/docs/balance-card.png"
- ],
- "https://github.com/liuwenji007/dsh-muyu": [
-  "https://raw.githubusercontent.com/liuwenji007/dsh-muyu/main/docs/tap.gif",
-  "https://raw.githubusercontent.com/liuwenji007/dsh-muyu/main/docs/auto-tap.gif"
- ],
- "https://github.com/liuyuelintop/dsh-conversation-exporter": [
-  "https://raw.githubusercontent.com/liuyuelintop/dsh-conversation-exporter/main/assets/select-turns.png",
-  "https://raw.githubusercontent.com/liuyuelintop/dsh-conversation-exporter/main/assets/selective-export-mermaid.png",
-  "https://raw.githubusercontent.com/liuyuelintop/dsh-conversation-exporter/main/assets/selective-export-result.png"
- ],
- "https://github.com/maple-pwn/paperlab": [
-  "https://raw.githubusercontent.com/maple-pwn/paperlab/main/docs/assets/screenshot.png"
- ],
- "https://github.com/minivv/dsh-agent-skills": [
-  "https://raw.githubusercontent.com/minivv/dsh-agent-skills/main/agent-skills-page.png"
- ],
- "https://github.com/ne-ilyxa/dsh-session-drafts": [
-  "https://raw.githubusercontent.com/ne-ilyxa/dsh-session-drafts/master/assets/drafts-popover.png",
-  "https://raw.githubusercontent.com/ne-ilyxa/dsh-session-drafts/master/assets/drafts-switched.png"
- ],
- "https://github.com/niuniuaba/dsh-subagent-vision": [
-  "https://raw.githubusercontent.com/niuniuaba/dsh-subagent-vision/main/assets/screenshot-models.png",
-  "https://raw.githubusercontent.com/niuniuaba/dsh-subagent-vision/main/assets/screenshot-vision-route.png"
- ],
- "https://github.com/nonewind/dsh-spend": [
-  "https://raw.githubusercontent.com/nonewind/dsh-spend/main/docs/screenshots/dashboard.png",
-  "https://raw.githubusercontent.com/nonewind/dsh-spend/main/docs/screenshots/details-window.png"
- ],
- "https://github.com/nzl153/dsh-pet-whale": [
-  "https://raw.githubusercontent.com/nzl153/dsh-pet-whale/main/docs/screenshots/01-idle.png",
-  "https://raw.githubusercontent.com/nzl153/dsh-pet-whale/main/docs/screenshots/02-think.png",
-  "https://raw.githubusercontent.com/nzl153/dsh-pet-whale/main/docs/screenshots/03-working.png",
-  "https://raw.githubusercontent.com/nzl153/dsh-pet-whale/main/docs/screenshots/04-celebrate.png",
-  "https://raw.githubusercontent.com/nzl153/dsh-pet-whale/main/docs/screenshots/05-error.png",
-  "https://raw.githubusercontent.com/nzl153/dsh-pet-whale/main/docs/screenshots/06-feed.png"
- ],
- "https://github.com/omdsh-dev/dsh-annotation": [
-  "https://github.com/user-attachments/assets/c3186efc-44d3-4e7f-9523-1902d9d037e9",
-  "https://github.com/user-attachments/assets/0b48ac02-4648-4b94-8d8f-344f8b7c25b4",
-  "https://github.com/user-attachments/assets/8b2610d0-3d00-41be-b314-bac2fe616787",
-  "https://github.com/user-attachments/assets/9b66deea-3786-4296-9b0d-52873a15f5e1"
- ],
- "https://github.com/omdsh-dev/dsh-genui": [
-  "https://raw.githubusercontent.com/omdsh-dev/dsh-genui/main/assets/showcase-panel.png",
-  "https://raw.githubusercontent.com/omdsh-dev/dsh-genui/main/assets/showcase-plot.png",
-  "https://raw.githubusercontent.com/omdsh-dev/dsh-genui/main/assets/showcase.png",
-  "https://raw.githubusercontent.com/omdsh-dev/dsh-genui/main/assets/demo-thumb.png"
- ],
- "https://github.com/pengpengyi92/dsh-quant": [
-  "https://raw.githubusercontent.com/pengpengyi92/dsh-quant/master/demos/ui-demo-preview.png"
- ],
- "https://github.com/pengyue-polaron/deepseek-harness-genui": [
-  "https://raw.githubusercontent.com/pengyue-polaron/deepseek-harness-genui/main/screenshots/en/code-path-canvas.png",
-  "https://raw.githubusercontent.com/pengyue-polaron/deepseek-harness-genui/main/screenshots/en/code-path-inline.png",
-  "https://raw.githubusercontent.com/pengyue-polaron/deepseek-harness-genui/main/screenshots/en/photosynthesis-explorer.png",
-  "https://raw.githubusercontent.com/pengyue-polaron/deepseek-harness-genui/main/screenshots/en/calendar-planner.png",
-  "https://raw.githubusercontent.com/pengyue-polaron/deepseek-harness-genui/main/screenshots/en/code-path-explorer.png"
- ],
- "https://github.com/potoior/dsh-bull-bear": [
-  "https://raw.githubusercontent.com/potoior/dsh-bull-bear/main/assets/screenshot-overview.png",
-  "https://raw.githubusercontent.com/potoior/dsh-bull-bear/main/assets/screenshot-panel.png",
-  "https://raw.githubusercontent.com/potoior/dsh-bull-bear/main/assets/screenshot-watchlist.png"
- ],
- "https://github.com/pyf2818/dsh-bili-widget": [
-  "https://raw.githubusercontent.com/pyf2818/dsh-bili-widget/main/assets/main.png",
-  "https://raw.githubusercontent.com/pyf2818/dsh-bili-widget/main/assets/search.png",
-  "https://raw.githubusercontent.com/pyf2818/dsh-bili-widget/main/assets/hot.png",
-  "https://raw.githubusercontent.com/pyf2818/dsh-bili-widget/main/assets/help.png",
-  "https://raw.githubusercontent.com/pyf2818/dsh-bili-widget/main/assets/mini.png"
- ],
- "https://github.com/qjcnmd/dsh-reasoning-slider": [
-  "https://raw.githubusercontent.com/qjcnmd/dsh-reasoning-slider/main/assets/screenshots/deepseek-v4-pro-max.png",
-  "https://raw.githubusercontent.com/qjcnmd/dsh-reasoning-slider/main/assets/screenshots/deepseek-v4-pro-off.png",
-  "https://raw.githubusercontent.com/qjcnmd/dsh-reasoning-slider/main/assets/screenshots/kimi-k3-max.png",
-  "https://raw.githubusercontent.com/qjcnmd/dsh-reasoning-slider/main/assets/screenshots/minimax-m3-minimal.png"
- ],
- "https://github.com/sanqiPanax/dsh-sticker-board": [
-  "https://raw.githubusercontent.com/sanqiPanax/dsh-sticker-board/master/docs/screenshot-dock.png"
- ],
- "https://github.com/siberiah2o/dsh-plugin-terminal": [
-  "https://raw.githubusercontent.com/siberiah2o/dsh-plugin-terminal/main/docs/screenshot-collapsed.png",
-  "https://raw.githubusercontent.com/siberiah2o/dsh-plugin-terminal/main/docs/screenshot-panel.png",
-  "https://raw.githubusercontent.com/siberiah2o/dsh-plugin-terminal/main/docs/screenshot-multitab.png"
- ],
- "https://github.com/sjh9714/dsh-movein": [
-  "https://raw.githubusercontent.com/sjh9714/dsh-movein/main/docs/report.png",
-  "https://raw.githubusercontent.com/sjh9714/dsh-movein/main/docs/demo.gif",
-  "https://raw.githubusercontent.com/sjh9714/dsh-movein/main/docs/social.png"
- ],
- "https://github.com/sjh9714/dsh-win32": [
-  "https://raw.githubusercontent.com/sjh9714/dsh-win32/master/assets/market-card.png",
-  "https://raw.githubusercontent.com/sjh9714/dsh-win32/master/assets/shot-persistent-sandboxed.png",
-  "https://raw.githubusercontent.com/sjh9714/dsh-win32/master/assets/shot-preset-picker.png"
- ],
- "https://github.com/skyhancloud/dsh-client-ui-quote": [
-  "https://raw.githubusercontent.com/skyhancloud/dsh-client-ui-quote/main/assets/preview-1.png",
-  "https://raw.githubusercontent.com/skyhancloud/dsh-client-ui-quote/main/assets/preview-2.png"
- ],
- "https://github.com/slywalker2006/dsh-passwords": [
-  "https://raw.githubusercontent.com/slywalker2006/dsh-passwords/main/docs/screenshots/white-login.png",
-  "https://raw.githubusercontent.com/slywalker2006/dsh-passwords/main/docs/screenshots/black-login.png",
-  "https://raw.githubusercontent.com/slywalker2006/dsh-passwords/main/docs/screenshots/white-login-en.png",
-  "https://raw.githubusercontent.com/slywalker2006/dsh-passwords/main/docs/screenshots/main-ui.png",
-  "https://raw.githubusercontent.com/slywalker2006/dsh-passwords/main/docs/screenshots/chat.png",
-  "https://raw.githubusercontent.com/slywalker2006/dsh-passwords/main/docs/screenshots/card-front.png",
-  "https://raw.githubusercontent.com/slywalker2006/dsh-passwords/main/docs/screenshots/card-back.png"
- ],
- "https://github.com/starslittle/dsh-blue-whale": [
-  "https://raw.githubusercontent.com/starslittle/dsh-blue-whale/main/docs/compare-home.png",
-  "https://raw.githubusercontent.com/starslittle/dsh-blue-whale/main/docs/compare-brand.png"
- ],
- "https://github.com/starslittle/dsh-queue-plus": [
-  "https://raw.githubusercontent.com/starslittle/dsh-queue-plus/main/assets/queue-default.png",
-  "https://raw.githubusercontent.com/starslittle/dsh-queue-plus/main/assets/queue-remove-all.png",
-  "https://raw.githubusercontent.com/starslittle/dsh-queue-plus/main/assets/queue-remove-complete.png",
-  "https://raw.githubusercontent.com/starslittle/dsh-queue-plus/main/assets/queue-sort.png"
- ],
- "https://github.com/superagents-lab/dsh-s1": [
-  "https://raw.githubusercontent.com/superagents-lab/dsh-s1/main/assets/dsh-s1.png"
- ],
- "https://github.com/text2future/flowix/tree/main/dsh-flowix-memory": [
-  "https://raw.githubusercontent.com/text2future/flowix/main/docs/images/home-write.png",
-  "https://raw.githubusercontent.com/text2future/flowix/main/docs/images/readme-agent.png",
-  "https://raw.githubusercontent.com/text2future/flowix/main/docs/images/gh-detail-4.png",
-  "https://raw.githubusercontent.com/text2future/flowix/main/docs/images/gh-detail-6.png"
- ],
- "https://github.com/tpmoonchefryan/dsh-joi-channel-theme": [
-  "https://raw.githubusercontent.com/tpmoonchefryan/dsh-joi-channel-theme/main/docs/settings-wardrobe.png",
-  "https://raw.githubusercontent.com/tpmoonchefryan/dsh-joi-channel-theme/main/docs/settings-wardrobe-dark.png",
-  "https://raw.githubusercontent.com/tpmoonchefryan/dsh-joi-channel-theme/main/docs/new-chat-flowers.png",
-  "https://raw.githubusercontent.com/tpmoonchefryan/dsh-joi-channel-theme/main/docs/new-chat-library.png",
-  "https://raw.githubusercontent.com/tpmoonchefryan/dsh-joi-channel-theme/main/docs/new-chat-flowers-dark.png",
-  "https://raw.githubusercontent.com/tpmoonchefryan/dsh-joi-channel-theme/main/docs/working-flowers.png",
-  "https://raw.githubusercontent.com/tpmoonchefryan/dsh-joi-channel-theme/main/docs/success-library.png",
-  "https://raw.githubusercontent.com/tpmoonchefryan/dsh-joi-channel-theme/main/docs/app-logo-flowers.png"
- ],
- "https://github.com/truelove-dreamer/dsh-plugin-vetting": [
-  "https://raw.githubusercontent.com/truelove-dreamer/dsh-plugin-vetting/main/assets/shot-report.png",
-  "https://raw.githubusercontent.com/truelove-dreamer/dsh-plugin-vetting/main/assets/shot-detail.png",
-  "https://raw.githubusercontent.com/truelove-dreamer/dsh-plugin-vetting/main/assets/shot-gate.png"
- ],
- "https://github.com/tt-a1i/archify/tree/main/integrations/deepseek-harness": [
-  "https://raw.githubusercontent.com/tt-a1i/archify/main/docs/assets/archify-live-proof.gif",
-  "https://raw.githubusercontent.com/tt-a1i/archify/main/docs/assets/archify-dark.png",
-  "https://raw.githubusercontent.com/tt-a1i/archify/main/docs/assets/archify-light.png"
- ],
- "https://github.com/txlznbzsdj-collab/dsh-deepseek-pet": [
-  "https://raw.githubusercontent.com/txlznbzsdj-collab/dsh-deepseek-pet/main/screenshots/1.png",
-  "https://raw.githubusercontent.com/txlznbzsdj-collab/dsh-deepseek-pet/main/screenshots/2.png",
-  "https://raw.githubusercontent.com/txlznbzsdj-collab/dsh-deepseek-pet/main/screenshots/3.png"
- ],
- "https://github.com/v587d/dsh-opencode-go-usage": [
-  "https://raw.githubusercontent.com/v587d/dsh-opencode-go-usage/main/assets/custom-footer.png",
-  "https://raw.githubusercontent.com/v587d/dsh-opencode-go-usage/main/assets/usage-detail.png",
-  "https://raw.githubusercontent.com/v587d/dsh-opencode-go-usage/main/assets/set-cookie-wid.png"
- ],
- "https://github.com/vdnight89/InfiniteDSH": [
-  "https://raw.githubusercontent.com/vdnight89/InfiniteDSH/main/docs/%E6%88%AA%E5%9B%BE1.png",
-  "https://raw.githubusercontent.com/vdnight89/InfiniteDSH/main/docs/%E6%88%AA%E5%9B%BE2.png",
-  "https://raw.githubusercontent.com/vdnight89/InfiniteDSH/main/docs/%E6%88%AA%E5%9B%BE2.1.png",
-  "https://raw.githubusercontent.com/vdnight89/InfiniteDSH/main/docs/%E6%88%AA%E5%9B%BE2.2.png"
- ],
- "https://github.com/weisiren000/dsh-remote-ssh-ops": [
-  "https://raw.githubusercontent.com/weisiren000/dsh-remote-ssh-ops/main/docs/assets/remote-workbench-preview.png"
- ],
- "https://github.com/welsione/dsh-mmx-bridge": [
-  "https://raw.githubusercontent.com/welsione/dsh-mmx-bridge/main/docs/image-generation.png",
-  "https://raw.githubusercontent.com/welsione/dsh-mmx-bridge/main/docs/speech-tts.png",
-  "https://raw.githubusercontent.com/welsione/dsh-mmx-bridge/main/docs/vision-demo.png",
-  "https://raw.githubusercontent.com/welsione/dsh-mmx-bridge/main/docs/plugin-settings.png"
- ],
- "https://github.com/wloops/dsh-git-worktree": [
-  "https://raw.githubusercontent.com/wloops/dsh-git-worktree/master/docs/screenshots/01-create-worktree.png",
-  "https://raw.githubusercontent.com/wloops/dsh-git-worktree/master/docs/screenshots/02-ready-for-review.png",
-  "https://raw.githubusercontent.com/wloops/dsh-git-worktree/master/docs/screenshots/03-local-preview.png",
-  "https://raw.githubusercontent.com/wloops/dsh-git-worktree/master/docs/screenshots/04-commit-confirmation.png",
-  "https://raw.githubusercontent.com/wloops/dsh-git-worktree/master/docs/screenshots/05-next-iteration.png",
-  "https://raw.githubusercontent.com/wloops/dsh-git-worktree/master/docs/screenshots/06-retain-environment.png"
- ],
- "https://github.com/wly8691-jpg/knowlp-rag": [
-  "https://raw.githubusercontent.com/wly8691-jpg/knowlp-rag/main/docs/demo.png",
-  "https://raw.githubusercontent.com/wly8691-jpg/knowlp-rag/main/docs/health.png",
-  "https://raw.githubusercontent.com/wly8691-jpg/knowlp-rag/main/docs/decay.png",
-  "https://raw.githubusercontent.com/wly8691-jpg/knowlp-rag/main/docs/architecture.png"
- ],
- "https://github.com/wss534857356/dsh-plugin-codex": [
-  "https://raw.githubusercontent.com/wss534857356/dsh-plugin-codex/main/docs/images/conversation-screenshot.png",
-  "https://raw.githubusercontent.com/wss534857356/dsh-plugin-codex/main/docs/images/model-selector-screenshot.png"
- ],
- "https://github.com/wuxiangru915/dsh-review-loop": [
-  "https://raw.githubusercontent.com/wuxiangru915/dsh-review-loop/master/assets/review-panel.en.png",
-  "https://raw.githubusercontent.com/wuxiangru915/dsh-review-loop/master/assets/review-panel.zh.png"
- ],
- "https://github.com/wuxiangru915/dsh-session-manager": [
-  "https://raw.githubusercontent.com/wuxiangru915/dsh-session-manager/main/assets/session-manager.png"
- ],
- "https://github.com/wx-yss/dsh-message-rail": [
-  "https://raw.githubusercontent.com/wx-yss/dsh-message-rail/main/assets/rail-hover-preview.png"
- ],
- "https://github.com/wz-heng/dsh-feishu-bridge": [
-  "https://raw.githubusercontent.com/wz-heng/dsh-feishu-bridge/main/docs/screenshots/fail-closed-boot.png",
-  "https://raw.githubusercontent.com/wz-heng/dsh-feishu-bridge/main/docs/screenshots/dsh-plugin-add.png",
-  "https://raw.githubusercontent.com/wz-heng/dsh-feishu-bridge/main/docs/screenshots/architecture.png"
- ],
- "https://github.com/xbzbing/dsh-auth-gateway": [
-  "https://raw.githubusercontent.com/xbzbing/dsh-auth-gateway/main/docs/assets/onboarding.png",
-  "https://raw.githubusercontent.com/xbzbing/dsh-auth-gateway/main/docs/assets/login.png",
-  "https://raw.githubusercontent.com/xbzbing/dsh-auth-gateway/main/docs/assets/login-success.png",
-  "https://raw.githubusercontent.com/xbzbing/dsh-auth-gateway/main/docs/assets/otp-setup.png",
-  "https://raw.githubusercontent.com/xbzbing/dsh-auth-gateway/main/docs/assets/settings-menu.png",
-  "https://raw.githubusercontent.com/xbzbing/dsh-auth-gateway/main/docs/assets/settings-auth.png"
- ],
- "https://github.com/xiajiajun516/dsh-config-manager": [
-  "https://raw.githubusercontent.com/xiajiajun516/dsh-config-manager/main/assets/screenshot-export.png",
-  "https://raw.githubusercontent.com/xiajiajun516/dsh-config-manager/main/assets/screenshot-import-preview.png",
-  "https://raw.githubusercontent.com/xiajiajun516/dsh-config-manager/main/assets/screenshot-snapshots.png",
-  "https://raw.githubusercontent.com/xiajiajun516/dsh-config-manager/main/assets/screenshot-sync.png"
- ],
- "https://github.com/xohmai/dsh-cpa-status": [
-  "https://raw.githubusercontent.com/xohmai/dsh-cpa-status/main/docs/images/panel.png",
-  "https://raw.githubusercontent.com/xohmai/dsh-cpa-status/main/docs/images/collapsed.png"
- ],
- "https://github.com/yflmq001/dsh-cost-tracker": [
-  "https://raw.githubusercontent.com/yflmq001/dsh-cost-tracker/main/assets/screenshots/screenshot-main.png",
-  "https://raw.githubusercontent.com/yflmq001/dsh-cost-tracker/main/assets/screenshots/screenshot-cost-panel.png",
-  "https://raw.githubusercontent.com/yflmq001/dsh-cost-tracker/main/assets/screenshots/screenshot-config.png"
- ],
- "https://github.com/yunxiiQwQ/dsh-maid-whale-webUI/tree/main/maid-whale-webui": [
-  "https://raw.githubusercontent.com/yunxiiQwQ/dsh-maid-whale-webUI/main/maid-whale-webui/preview/light.webp",
-  "https://raw.githubusercontent.com/yunxiiQwQ/dsh-maid-whale-webUI/main/maid-whale-webui/preview/dark.webp"
- ],
- "https://github.com/yyyyukari/dsh-plugin-workshop": [
-  "https://raw.githubusercontent.com/yyyyukari/dsh-plugin-workshop/master/assets/main-ui.jpg",
-  "https://raw.githubusercontent.com/yyyyukari/dsh-plugin-workshop/master/assets/installed-view.jpg",
-  "https://raw.githubusercontent.com/yyyyukari/dsh-plugin-workshop/master/assets/sidebar-entry.jpg"
- ],
- "https://github.com/zdx8637-gitdog/dshmobile/tree/main/plugins": [
-  "https://raw.githubusercontent.com/zdx8637-gitdog/dshmobile/main/docs/images/plugin-panel.jpg",
-  "https://raw.githubusercontent.com/zdx8637-gitdog/dshmobile/main/docs/images/phone-1.jpg",
-  "https://raw.githubusercontent.com/zdx8637-gitdog/dshmobile/main/docs/images/phone-2.jpg",
-  "https://raw.githubusercontent.com/zdx8637-gitdog/dshmobile/main/docs/images/phone-3.jpg"
- ],
- "https://github.com/zer0zio-stack/dsh-opencode-go-quota": [
-  "https://raw.githubusercontent.com/zer0zio-stack/dsh-opencode-go-quota/main/assets/screenshot-deepseek-balance.png",
-  "https://raw.githubusercontent.com/zer0zio-stack/dsh-opencode-go-quota/main/assets/screenshot-opencode-go-limit.png"
- ],
- "https://github.com/zhtx2024/dsh-pdf": [
-  "https://raw.githubusercontent.com/zhtx2024/dsh-pdf/master/assets/screenshot-schematic.png",
-  "https://raw.githubusercontent.com/zhtx2024/dsh-pdf/master/assets/screenshot-power.png"
- ],
- "https://github.com/zljr/dsh-share": [
-  "https://raw.githubusercontent.com/zljr/dsh-share/master/assets/share-dialog.png",
-  "https://raw.githubusercontent.com/zljr/dsh-share/master/assets/share-page-light.png",
-  "https://raw.githubusercontent.com/zljr/dsh-share/master/assets/share-page-dark.png"
- ],
- "https://github.com/2008924/dsh-progress-viz/tree/main/plugin": [
-  "https://raw.githubusercontent.com/2008924/dsh-progress-viz/main/docs/screenshot.png"
- ],
- "https://github.com/534119219/dsh-messaging/tree/main/packages/messaging-core": [
-  "https://raw.githubusercontent.com/534119219/dsh-messaging/main/assets/sidebar.png",
-  "https://raw.githubusercontent.com/534119219/dsh-messaging/main/assets/dialog.png"
- ],
- "https://github.com/Blank-not-black/dsh-Remote/tree/main/packages/plugin": [
-  "https://raw.githubusercontent.com/Blank-not-black/dsh-Remote/main/docs/screenshots/mobile-sessions.png",
-  "https://raw.githubusercontent.com/Blank-not-black/dsh-Remote/main/docs/screenshots/mobile-approvals.png",
-  "https://raw.githubusercontent.com/Blank-not-black/dsh-Remote/main/docs/screenshots/mobile-files.png",
-  "https://raw.githubusercontent.com/Blank-not-black/dsh-Remote/main/docs/screenshots/mobile-settings.png",
-  "https://raw.githubusercontent.com/Blank-not-black/dsh-Remote/main/docs/screenshots/gateway.png",
-  "https://raw.githubusercontent.com/Blank-not-black/dsh-Remote/main/docs/screenshots/settings-mobile.png",
-  "https://raw.githubusercontent.com/Blank-not-black/dsh-Remote/main/docs/screenshots/sessions.png",
-  "https://raw.githubusercontent.com/Blank-not-black/dsh-Remote/main/docs/screenshots/files.png"
- ],
- "https://github.com/UndeadSheep/dsh-file-preview/tree/main/packages/dsh-file-preview": [
-  "https://raw.githubusercontent.com/UndeadSheep/dsh-file-preview/main/assets/github-social-preview.png",
-  "https://raw.githubusercontent.com/UndeadSheep/dsh-file-preview/main/assets/btnPos.gif",
-  "https://raw.githubusercontent.com/UndeadSheep/dsh-file-preview/main/assets/write.gif",
-  "https://raw.githubusercontent.com/UndeadSheep/dsh-file-preview/main/assets/clickOpen.gif",
-  "https://raw.githubusercontent.com/UndeadSheep/dsh-file-preview/main/assets/SearchBar.gif"
- ],
- "https://github.com/Lzh3070/dsh-file-review-tab": [
-  "https://raw.githubusercontent.com/Lzh3070/dsh-file-review-tab/main/docs/screenshot.png"
- ],
- "https://github.com/ayahunter/dsh-trail/tree/main/packages/bundle": [
-  "https://raw.githubusercontent.com/ayahunter/dsh-trail/main/docs/screenshot.png",
-  "https://raw.githubusercontent.com/ayahunter/dsh-trail/main/docs/screenshots/rounds-view.png",
-  "https://raw.githubusercontent.com/ayahunter/dsh-trail/main/docs/screenshots/tool-details.png"
- ],
- "https://github.com/kaziii/dsh-github-connector/tree/main/packages/github/github": [
-  "https://raw.githubusercontent.com/kaziii/dsh-github-connector/main/docs/assets/pr-bar.png",
-  "https://raw.githubusercontent.com/kaziii/dsh-github-connector/main/docs/assets/connect-github.png"
- ],
- "https://github.com/siberiah2o/dsh-plugin-remote": [
-  "https://raw.githubusercontent.com/siberiah2o/dsh-plugin-remote/main/docs/screenshot-login.png",
-  "https://raw.githubusercontent.com/siberiah2o/dsh-plugin-remote/main/docs/screenshot-settings-panel.png"
- ],
- "https://github.com/WilliamShi666/dsh-wsl-workspace-picker": [
-  "https://raw.githubusercontent.com/WilliamShi666/dsh-wsl-workspace-picker/main/assets/workspace-picker-demo.png"
- ],
- "https://github.com/Liu-ZA-81/dsh-theme-firefly": [
-  "https://raw.githubusercontent.com/Liu-ZA-81/dsh-theme-firefly/main/docs/screenshots/01-wallpaper.jpg",
-  "https://raw.githubusercontent.com/Liu-ZA-81/dsh-theme-firefly/main/docs/screenshots/02-boot.jpg",
-  "https://raw.githubusercontent.com/Liu-ZA-81/dsh-theme-firefly/main/docs/screenshots/03-firefly.jpg",
-  "https://raw.githubusercontent.com/Liu-ZA-81/dsh-theme-firefly/main/docs/screenshots/04-music.jpg",
-  "https://raw.githubusercontent.com/Liu-ZA-81/dsh-theme-firefly/main/docs/screenshots/05-emote.jpg"
- ],
- "https://github.com/cheshireez/dsh-skill-hub": [
-  "https://raw.githubusercontent.com/cheshireez/dsh-skill-hub/main/promo/real-skill-hub.png",
-  "https://raw.githubusercontent.com/cheshireez/dsh-skill-hub/main/promo/real-skill-hub-catalog.png",
-  "https://raw.githubusercontent.com/cheshireez/dsh-skill-hub/main/promo/real-skill-hub-scenes.png"
- ],
- "https://github.com/maddogfinance/dsh-trading": [
-  "https://raw.githubusercontent.com/maddogfinance/dsh-trading/main/docs/screenshots/chart-card-panes.png",
-  "https://raw.githubusercontent.com/maddogfinance/dsh-trading/main/docs/screenshots/annotate-levels-table.png"
- ],
- "https://github.com/mux9056-bot/dsh-theme": [
-  "https://raw.githubusercontent.com/mux9056-bot/dsh-theme/main/shots/preview-gallery.png",
-  "https://raw.githubusercontent.com/mux9056-bot/dsh-theme/main/shots/mono-dark.png",
-  "https://raw.githubusercontent.com/mux9056-bot/dsh-theme/main/shots/sakura-light.png",
-  "https://raw.githubusercontent.com/mux9056-bot/dsh-theme/main/shots/terminal-dark.png"
- ],
- "https://github.com/chinosk6/dsh-roleplay": [
-  "https://raw.githubusercontent.com/chinosk6/dsh-roleplay/main/images/screenshot1.png"
- ],
- "https://github.com/starsstreaming/beautiCode/tree/main/integrations/deepseek-harness": [
-  "https://github.com/user-attachments/assets/c943a0fb-ff48-4361-9e6f-c4b1521aee2b",
-  "https://github.com/user-attachments/assets/a9a18412-4c62-4083-ab49-d127f05e61c3"
- ],
- "https://github.com/wenheguo2/dsh-delegation-suite": [
-  "https://raw.githubusercontent.com/wenheguo2/dsh-delegation-suite/main/assets/routes.png",
-  "https://raw.githubusercontent.com/wenheguo2/dsh-delegation-suite/main/assets/subagents.png"
- ],
- "https://github.com/kanneiren/dsh-network-settings": [
-  "https://raw.githubusercontent.com/kanneiren/dsh-network-settings/main/docs/images/wsl-path-graph.png",
-  "https://raw.githubusercontent.com/kanneiren/dsh-network-settings/main/docs/images/win-path-graph.png",
-  "https://raw.githubusercontent.com/kanneiren/dsh-network-settings/main/docs/images/win-network-config.png"
- ],
- "https://github.com/anneheartrecord/dsh-desk-pet": [
-  "https://raw.githubusercontent.com/anneheartrecord/dsh-desk-pet/main/docs/media/diy-skin.png",
-  "https://raw.githubusercontent.com/anneheartrecord/dsh-desk-pet/main/docs/media/floats-above.png",
-  "https://raw.githubusercontent.com/anneheartrecord/dsh-desk-pet/main/docs/media/skins.png",
-  "https://raw.githubusercontent.com/anneheartrecord/dsh-desk-pet/main/docs/media/states.png"
- ],
- "https://github.com/wsxwj123/dsh-plugins/tree/main/packages/dsh-appearance-gallery": [
-  "https://raw.githubusercontent.com/wsxwj123/dsh-plugins/main/assets/screenshots/appearance-gallery.png"
- ],
- "https://github.com/wsxwj123/dsh-plugins/tree/main/packages/dsh-turn-scrubber": [
-  "https://raw.githubusercontent.com/wsxwj123/dsh-plugins/main/assets/screenshots/turn-scrubber.png"
- ],
- "https://github.com/wsxwj123/dsh-plugins/tree/main/packages/dsh-session-manager": [
-  "https://raw.githubusercontent.com/wsxwj123/dsh-plugins/main/assets/screenshots/session-manager.png"
- ],
- "https://github.com/wsxwj123/dsh-plugins/tree/main/packages/dsh-composer-tools": [
-  "https://raw.githubusercontent.com/wsxwj123/dsh-plugins/main/assets/screenshots/composer-tools.png"
- ],
- "https://github.com/acebang0303/dsh-quick-launch": [
-  "https://raw.githubusercontent.com/acebang0303/dsh-quick-launch/main/docs/preview.png"
- ],
- "https://github.com/corrinehu/dsh-workbuddy-connect": [
-  "https://raw.githubusercontent.com/corrinehu/dsh-workbuddy-connect/main/assets/1.png",
-  "https://raw.githubusercontent.com/corrinehu/dsh-workbuddy-connect/main/assets/2.png",
-  "https://raw.githubusercontent.com/corrinehu/dsh-workbuddy-connect/main/assets/3.png"
- ],
- "https://github.com/tipoLi5890/dsh-file-mention": [
-  "https://raw.githubusercontent.com/tipoLi5890/dsh-file-mention/main/assets/screenshots/file-mention-browse.png",
-  "https://raw.githubusercontent.com/tipoLi5890/dsh-file-mention/main/assets/screenshots/file-mention-drag-drop.png",
-  "https://raw.githubusercontent.com/tipoLi5890/dsh-file-mention/main/assets/screenshots/file-mention-upload-reference.png"
- ],
- "https://github.com/liguobao/deepseek-harness-remote": [
-  "https://raw.githubusercontent.com/liguobao/deepseek-harness-remote/main/docs/images/setting.png",
-  "https://raw.githubusercontent.com/liguobao/deepseek-harness-remote/main/docs/images/host-list.png",
-  "https://raw.githubusercontent.com/liguobao/deepseek-harness-remote/main/docs/images/remote.png"
- ],
- "https://github.com/WJZ-P/dsh-attachments": [
-  "https://raw.githubusercontent.com/WJZ-P/dsh-attachments/main/assets/markdown/01-drag-drop-overlay.png",
-  "https://raw.githubusercontent.com/WJZ-P/dsh-attachments/main/assets/markdown/02-image-conversation.png",
-  "https://raw.githubusercontent.com/WJZ-P/dsh-attachments/main/assets/markdown/03-multiple-image-preview.png"
- ],
- "https://github.com/WJZ-P/dsh-model-capabilities": [
-  "https://raw.githubusercontent.com/WJZ-P/dsh-model-capabilities/main/assets/screenshots/01-model-input-selector.png"
- ],
- "https://github.com/winditer/dsh-elf": [
-  "https://raw.githubusercontent.com/winditer/dsh-elf/main/assets/screenshot-elf.png",
-  "https://raw.githubusercontent.com/winditer/dsh-elf/main/assets/screenshot-chat.png"
- ],
- "https://github.com/Frog755/dsh-client-auto-retry": [
-  "https://raw.githubusercontent.com/Frog755/dsh-client-auto-retry/main/assets/demo.svg",
-  "https://raw.githubusercontent.com/Frog755/dsh-client-auto-retry/main/assets/screenshot-settings-card.png"
- ],
- "https://github.com/Frog755/dsh-prompt-vault": [
-  "https://raw.githubusercontent.com/Frog755/dsh-prompt-vault/master/assets/screenshot-panel.png"
- ],
- "https://github.com/lemonorangeapple/dsh-effort-switcher": [
-  "https://raw.githubusercontent.com/lemonorangeapple/dsh-effort-switcher/master/screenshots/1.png",
-  "https://raw.githubusercontent.com/lemonorangeapple/dsh-effort-switcher/master/screenshots/2.png"
- ],
- "https://github.com/falser101/dsh-mascot": [
-  "https://raw.githubusercontent.com/falser101/dsh-mascot/main/assets/cover.jpg",
-  "https://raw.githubusercontent.com/falser101/dsh-mascot/main/assets/faces.jpg",
-  "https://raw.githubusercontent.com/falser101/dsh-mascot/main/assets/skins.jpg"
- ],
- "https://github.com/LiZhenNet/dsh-antigravity": [
-  "https://raw.githubusercontent.com/LiZhenNet/dsh-antigravity/main/assets/images/settings-signed-in.png",
-  "https://raw.githubusercontent.com/LiZhenNet/dsh-antigravity/main/assets/images/chat-model-picker.png",
-  "https://raw.githubusercontent.com/LiZhenNet/dsh-antigravity/main/assets/images/settings-not-signed-in.png"
- ],
- "https://github.com/geguanming/dsh-office-plugin": [
-  "https://raw.githubusercontent.com/geguanming/dsh-office-plugin/master/assets/entry.png",
-  "https://raw.githubusercontent.com/geguanming/dsh-office-plugin/master/assets/work-monitor.png",
-  "https://raw.githubusercontent.com/geguanming/dsh-office-plugin/master/assets/order-boss.png"
- ],
- "https://github.com/lninghaha/dsh-hub-oauth-gateway": [
-  "https://raw.githubusercontent.com/lninghaha/dsh-hub-oauth-gateway/main/docs/images/usage-center-hud.png",
-  "https://raw.githubusercontent.com/lninghaha/dsh-hub-oauth-gateway/main/docs/images/usage-center-peek.png",
-  "https://raw.githubusercontent.com/lninghaha/dsh-hub-oauth-gateway/main/docs/images/usage-center-dashboard.png",
-  "https://raw.githubusercontent.com/lninghaha/dsh-hub-oauth-gateway/main/docs/images/usage-center-settings.png"
- ],
- "https://github.com/deepseek-dsh/dsh-workspace": [
-  "https://raw.githubusercontent.com/deepseek-dsh/dsh-workspace/main/assets/Screenshot-1.png",
-  "https://raw.githubusercontent.com/deepseek-dsh/dsh-workspace/main/assets/Screenshot-2.png"
- ],
- "https://github.com/CheshireJCat/blender": [
-  "https://raw.githubusercontent.com/CheshireJCat/blender/main/assets/dsh-blender-lamp-preview.png"
- ],
- "https://github.com/Y1X1n/dsh-prompt-optimizer": [
-  "https://raw.githubusercontent.com/Y1X1n/dsh-prompt-optimizer/main/docs/screenshots/optimize-panel.png"
- ],
- "https://github.com/feng78-boop/dsh-thirteen-bg": [
-  "https://raw.githubusercontent.com/feng78-boop/dsh-thirteen-bg/master/assets/demo-poster.jpg",
-  "https://raw.githubusercontent.com/feng78-boop/dsh-thirteen-bg/master/assets/demo-shot-2.jpg"
- ],
- "https://github.com/wsz987/dsh-channels/tree/main/packages/channels": [
-  "https://raw.githubusercontent.com/wsz987/dsh-channels/main/docs/ScreenShot/dsh-channels-setting.png",
-  "https://raw.githubusercontent.com/wsz987/dsh-channels/main/docs/ScreenShot/telegram.png"
- ],
- "https://github.com/liustack/modsearch": [
-  "https://raw.githubusercontent.com/liustack/modsearch/main/assets/demo-dsh-settings-card.jpg",
-  "https://raw.githubusercontent.com/liustack/modsearch/main/assets/demo-codex-search.png",
-  "https://raw.githubusercontent.com/liustack/modsearch/main/assets/demo-codex-fetch.png"
- ],
- "https://github.com/liustack/modlens": [
-  "https://raw.githubusercontent.com/liustack/modlens/main/assets/demo-dsh-settings-card.jpg",
-  "https://raw.githubusercontent.com/liustack/modlens/main/assets/demo-dsh-paste.jpg",
-  "https://raw.githubusercontent.com/liustack/modlens/main/assets/demo-codex-chart.jpg",
-  "https://raw.githubusercontent.com/liustack/modlens/main/assets/demo-codex-app.jpg"
- ],
- "https://github.com/elysia395/dsh-wallpaper-engine": [
-  "https://raw.githubusercontent.com/elysia395/dsh-wallpaper-engine/main/docs/images/showcase.png",
-  "https://raw.githubusercontent.com/elysia395/dsh-wallpaper-engine/main/docs/images/wallpaper-library.png",
-  "https://raw.githubusercontent.com/elysia395/dsh-wallpaper-engine/main/docs/images/liquid-glass-window.png",
-  "https://raw.githubusercontent.com/elysia395/dsh-wallpaper-engine/main/docs/images/features.png",
-  "https://raw.githubusercontent.com/elysia395/dsh-wallpaper-engine/main/docs/images/compact-wallpaper-library.png",
-  "https://raw.githubusercontent.com/elysia395/dsh-wallpaper-engine/main/docs/images/better-sidebar.png"
- ],
- "https://github.com/dami9527/dsh-image-pathify": [
-  "https://raw.githubusercontent.com/dami9527/dsh-image-pathify/master/assets/example.png",
-  "https://raw.githubusercontent.com/dami9527/dsh-image-pathify/master/assets/settings.png",
-  "https://raw.githubusercontent.com/dami9527/dsh-image-pathify/master/assets/update.png"
- ],
- "https://github.com/WSL043/dsh-chat-manager": [
-  "https://raw.githubusercontent.com/WSL043/dsh-chat-manager/main/docs/assets/archive-manager.en.png",
-  "https://raw.githubusercontent.com/WSL043/dsh-chat-manager/main/docs/assets/confirm-delete.en.png"
- ],
- "https://github.com/ryubyte/dsh-a2a": [
-  "https://raw.githubusercontent.com/ryubyte/dsh-a2a/main/docs/screenshots/dashboard-outbound.png",
-  "https://raw.githubusercontent.com/ryubyte/dsh-a2a/main/docs/screenshots/dashboard-inbound.png",
-  "https://raw.githubusercontent.com/ryubyte/dsh-a2a/main/docs/screenshots/server-inbound.png",
-  "https://raw.githubusercontent.com/ryubyte/dsh-a2a/main/docs/screenshots/server-serve.png"
- ],
- "https://github.com/EdwinDigital/dsh-web-search-microsoft-webiq": [
-  "https://raw.githubusercontent.com/EdwinDigital/dsh-web-search-microsoft-webiq/main/docs/images/screenshot-1-settings.png",
-  "https://raw.githubusercontent.com/EdwinDigital/dsh-web-search-microsoft-webiq/main/docs/images/screenshot-2-web-search.png",
-  "https://raw.githubusercontent.com/EdwinDigital/dsh-web-search-microsoft-webiq/main/docs/images/screenshot-3-trace.png"
- ],
- "https://github.com/SmileBuild/dsh-planchart": [
-  "https://raw.githubusercontent.com/SmileBuild/dsh-planchart/main/assets/screenshot-1.png",
-  "https://raw.githubusercontent.com/SmileBuild/dsh-planchart/main/assets/screenshot-2.png"
- ],
- "https://github.com/WSL043/dsh-codex-subscription": [
-  "https://raw.githubusercontent.com/WSL043/dsh-codex-subscription/main/docs/assets/settings-en.png",
-  "https://raw.githubusercontent.com/WSL043/dsh-codex-subscription/main/docs/assets/composer-quota-en.png"
- ],
- "https://github.com/mkiea/dsh-forge": [
-  "https://raw.githubusercontent.com/mkiea/dsh-forge/master/assets/screenshot-1.png",
-  "https://raw.githubusercontent.com/mkiea/dsh-forge/master/assets/screenshot-2.png",
-  "https://raw.githubusercontent.com/mkiea/dsh-forge/master/assets/screenshot-3.png"
- ],
- "https://github.com/alone-tree/dsh-skill-mcp-manager": [
-  "https://raw.githubusercontent.com/alone-tree/dsh-skill-mcp-manager/main/docs/screenshot-mcp.png",
-  "https://raw.githubusercontent.com/alone-tree/dsh-skill-mcp-manager/main/docs/screenshot-skills.png"
- ],
- "https://github.com/liqiming-whu/dsh-status-card": [
-  "https://raw.githubusercontent.com/liqiming-whu/dsh-status-card/main/docs/images/templates/bilingual/template-a.svg",
-  "https://raw.githubusercontent.com/liqiming-whu/dsh-status-card/main/docs/images/templates/bilingual/template-b.svg",
-  "https://raw.githubusercontent.com/liqiming-whu/dsh-status-card/main/docs/images/templates/bilingual/template-c.svg",
-  "https://raw.githubusercontent.com/liqiming-whu/dsh-status-card/main/docs/images/templates/bilingual/template-d.svg",
-  "https://raw.githubusercontent.com/liqiming-whu/dsh-status-card/main/docs/images/templates/bilingual/template-e.svg",
-  "https://raw.githubusercontent.com/liqiming-whu/dsh-status-card/main/docs/images/templates/bilingual/template-f.svg"
- ],
- "https://github.com/zhujunpeng12/dsh-memory-system": [
-  "https://raw.githubusercontent.com/zhujunpeng12/dsh-memory-system/master/assets/social-preview.png",
-  "https://raw.githubusercontent.com/zhujunpeng12/dsh-memory-system/master/docs/memory-system-flowchart.png"
- ],
- "https://github.com/wangzhishou/onebox-dsh-bridge": [
-  "https://raw.githubusercontent.com/wangzhishou/onebox-dsh-bridge/main/docs/images/pairing-page.png",
-  "https://raw.githubusercontent.com/wangzhishou/onebox-dsh-bridge/main/docs/images/app-connect.png",
-  "https://raw.githubusercontent.com/wangzhishou/onebox-dsh-bridge/main/docs/images/app-chat.png",
-  "https://raw.githubusercontent.com/wangzhishou/onebox-dsh-bridge/main/docs/images/app-feedback.png"
- ],
- "https://github.com/EugeneVl/dsh_session_folders": [
-  "https://raw.githubusercontent.com/EugeneVl/dsh_session_folders/master/assets/screenshot-1.jpg",
-  "https://raw.githubusercontent.com/EugeneVl/dsh_session_folders/master/assets/screenshot-2.jpg",
-  "https://raw.githubusercontent.com/EugeneVl/dsh_session_folders/master/assets/screenshot-3.jpg"
- ],
- "https://github.com/IceApriler/dsh-remote-mobile": [
-  "https://raw.githubusercontent.com/IceApriler/dsh-remote-mobile/master/images/pc-dsh-setting-1.png",
-  "https://raw.githubusercontent.com/IceApriler/dsh-remote-mobile/master/images/pc-dsh-setting-2.png",
-  "https://raw.githubusercontent.com/IceApriler/dsh-remote-mobile/master/images/mobile-auth.jpg",
-  "https://raw.githubusercontent.com/IceApriler/dsh-remote-mobile/master/images/mobile-dsh.jpg"
- ],
- "https://github.com/jhuanxx44/dsh-sseye": [
-  "https://raw.githubusercontent.com/jhuanxx44/dsh-sseye/main/assets/panel-detail.png"
- ],
- "https://github.com/wyzh0117/dsh-skill-select": [
-  "https://raw.githubusercontent.com/wyzh0117/dsh-skill-select/main/assets/product.png",
-  "https://raw.githubusercontent.com/wyzh0117/dsh-skill-select/main/assets/better-sidebar.png"
- ],
- "https://github.com/wqy8593521/dsh-model-pro": [
-  "https://raw.githubusercontent.com/wqy8593521/dsh-model-pro/main/docs/screenshots/dashboard.png",
-  "https://raw.githubusercontent.com/wqy8593521/dsh-model-pro/main/docs/screenshots/editor.png",
-  "https://raw.githubusercontent.com/wqy8593521/dsh-model-pro/main/docs/screenshots/models.png",
-  "https://raw.githubusercontent.com/wqy8593521/dsh-model-pro/main/docs/screenshots/test.png",
-  "https://raw.githubusercontent.com/wqy8593521/dsh-model-pro/main/docs/screenshots/routes.png"
- ],
- "https://github.com/Kenerlee/dsh-moments-aieo": [
-  "https://raw.githubusercontent.com/Kenerlee/dsh-moments-aieo/master/assets/screenshot-dashboard.png",
-  "https://raw.githubusercontent.com/Kenerlee/dsh-moments-aieo/master/assets/screenshot-diagnosis-report.png",
-  "https://raw.githubusercontent.com/Kenerlee/dsh-moments-aieo/master/assets/screenshot-dashboard-mobile.png"
- ],
- "https://github.com/FeiZhuNiU-INFJA/dsh-stock-ticker": [
-  "https://raw.githubusercontent.com/FeiZhuNiU-INFJA/dsh-stock-ticker/main/assets/screenshot.png"
- ],
- "https://github.com/miuzel/dsh-graph/tree/main/dsh-graph-host": [
-  "https://raw.githubusercontent.com/miuzel/dsh-graph/main/screenshot/screenshot-1.png",
-  "https://raw.githubusercontent.com/miuzel/dsh-graph/main/screenshot/screenshot-2.png"
- ],
- "https://github.com/ppy-web/dsh-plugin-xiaomi-mimo-tts": [
-  "https://raw.githubusercontent.com/ppy-web/dsh-plugin-xiaomi-mimo-tts/main/assets/menu.png",
-  "https://raw.githubusercontent.com/ppy-web/dsh-plugin-xiaomi-mimo-tts/main/assets/preset.png",
-  "https://raw.githubusercontent.com/ppy-web/dsh-plugin-xiaomi-mimo-tts/main/assets/image.png"
- ],
- "https://github.com/lunaship/dsh-links": [
-  "https://raw.githubusercontent.com/lunaship/dsh-links/main/docs/images/phone-connection-sanitized.png",
-  "https://raw.githubusercontent.com/lunaship/dsh-links/main/docs/images/android-device-list-sanitized.png",
-  "https://raw.githubusercontent.com/lunaship/dsh-links/main/docs/images/android-navigation-drawer.jpg",
-  "https://raw.githubusercontent.com/lunaship/dsh-links/main/docs/images/android-workspace-light.jpg",
-  "https://raw.githubusercontent.com/lunaship/dsh-links/main/docs/images/android-workspace-dark.jpg"
- ],
- "https://github.com/qinyre/dsh-plugin-install": [
-  "https://raw.githubusercontent.com/qinyre/dsh-plugin-install/main/docs/images/screenshot-install.png"
- ],
- "https://github.com/qinyre/dsh-plugin-capabilities": [
-  "https://raw.githubusercontent.com/qinyre/dsh-plugin-capabilities/main/docs/images/screenshot-skills.png",
-  "https://raw.githubusercontent.com/qinyre/dsh-plugin-capabilities/main/docs/images/screenshot-mcp.png",
-  "https://raw.githubusercontent.com/qinyre/dsh-plugin-capabilities/main/docs/images/screenshot-market-skills.png",
-  "https://raw.githubusercontent.com/qinyre/dsh-plugin-capabilities/main/docs/images/screenshot-market-mcp.png"
- ],
- "https://github.com/qinyre/dsh-plugin-atlas": [
-  "https://raw.githubusercontent.com/qinyre/dsh-plugin-atlas/main/docs/images/screenshot-rail.png",
-  "https://raw.githubusercontent.com/qinyre/dsh-plugin-atlas/main/docs/images/screenshot-archive.png"
- ],
- "https://github.com/Whale-Zhang/dsh-complete-chime": [
-  "https://raw.githubusercontent.com/Whale-Zhang/dsh-complete-chime/main/docs/settings-card.png"
- ],
- "https://github.com/Cerbur/clutch-dsh/tree/main/packages/clutch-dsh-worktree": [
-  "https://raw.githubusercontent.com/Cerbur/clutch-dsh/main/packages/clutch-dsh-worktree/assets/screenshots/screenshots-en.png",
-  "https://raw.githubusercontent.com/Cerbur/clutch-dsh/main/packages/clutch-dsh-worktree/assets/screenshots/screenshots-zh.png"
- ],
- "https://github.com/qkycir-123/dsh-run2skill": [
-  "https://raw.githubusercontent.com/qkycir-123/dsh-run2skill/main/docs/assets/01-proposal-inbox.png",
-  "https://raw.githubusercontent.com/qkycir-123/dsh-run2skill/main/docs/assets/02-review-details.png",
-  "https://raw.githubusercontent.com/qkycir-123/dsh-run2skill/main/docs/assets/03-saved-activity.png"
- ],
- "https://github.com/BananaSoldier01/dsh-tidychat": [
-  "https://raw.githubusercontent.com/BananaSoldier01/dsh-tidychat/main/assets/navigator.png",
-  "https://raw.githubusercontent.com/BananaSoldier01/dsh-tidychat/main/assets/settings.png"
- ],
- "https://github.com/PolinniZhong/dsh-personal-center": [
-  "https://raw.githubusercontent.com/PolinniZhong/dsh-personal-center/main/docs/screenshots/light-profile.png",
-  "https://raw.githubusercontent.com/PolinniZhong/dsh-personal-center/main/docs/screenshots/dark-pet.png",
-  "https://raw.githubusercontent.com/PolinniZhong/dsh-personal-center/main/docs/screenshots/pet-emotions.gif",
-  "https://raw.githubusercontent.com/PolinniZhong/dsh-personal-center/main/docs/screenshots/dark-model-cost.png"
- ],
- "https://github.com/KarlOfLaw/dsh-side-chat": [
-  "https://raw.githubusercontent.com/KarlOfLaw/dsh-side-chat/main/docs/assets/dsh-side-chat-hero.png",
-  "https://raw.githubusercontent.com/KarlOfLaw/dsh-side-chat/main/docs/assets/side-chat-parallel.png",
-  "https://raw.githubusercontent.com/KarlOfLaw/dsh-side-chat/main/docs/assets/side-chat-selection.png",
-  "https://raw.githubusercontent.com/KarlOfLaw/dsh-side-chat/main/docs/assets/side-chat-settings.png"
- ],
- "https://github.com/biggerboy/dsh-conversation-anchors": [
-  "https://raw.githubusercontent.com/biggerboy/dsh-conversation-anchors/master/assets/anchors-hover.png",
-  "https://raw.githubusercontent.com/biggerboy/dsh-conversation-anchors/master/assets/anchors-wave.png"
- ],
- "https://github.com/WSL043/dsh-reasoning-slider": [
-  "https://raw.githubusercontent.com/WSL043/dsh-reasoning-slider/main/docs/assets/reasoning-slider-en.png",
-  "https://raw.githubusercontent.com/WSL043/dsh-reasoning-slider/main/docs/assets/reasoning-slider-energy-zh.png",
-  "https://raw.githubusercontent.com/WSL043/dsh-reasoning-slider/main/docs/assets/mode-settings-en.png",
-  "https://raw.githubusercontent.com/WSL043/dsh-reasoning-slider/main/docs/assets/mode-settings-dark-zh.png"
- ],
- "https://github.com/jerryqx/dsh-ximalaya": [
-  "https://raw.githubusercontent.com/jerryqx/dsh-ximalaya/main/assets/panel-search.png",
-  "https://raw.githubusercontent.com/jerryqx/dsh-ximalaya/main/assets/panel-album.png",
-  "https://raw.githubusercontent.com/jerryqx/dsh-ximalaya/main/assets/panel-mine-subs.png",
-  "https://raw.githubusercontent.com/jerryqx/dsh-ximalaya/main/assets/panel-mine-anchors.png"
- ],
- "https://github.com/yangdongzhen590/dsh-knj-workflow": [
-  "https://raw.githubusercontent.com/yangdongzhen590/dsh-knj-workflow/main/assets/screenshots/task-detail.png",
-  "https://raw.githubusercontent.com/yangdongzhen590/dsh-knj-workflow/main/assets/screenshots/workflow-editor.png",
-  "https://raw.githubusercontent.com/yangdongzhen590/dsh-knj-workflow/main/assets/screenshots/new-task-modal.png"
- ],
- "https://github.com/yangdongzhen590/dsh-knj-menu": [
-  "https://raw.githubusercontent.com/yangdongzhen590/dsh-knj-menu/main/assets/screenshots/menu-manager.png"
- ],
- "https://github.com/yangdongzhen590/dsh-knj-scheduler": [
-  "https://raw.githubusercontent.com/yangdongzhen590/dsh-knj-scheduler/main/assets/screenshots/scheduler-panel.png"
- ],
- "https://github.com/mienfong/dsh-session-mgr": [
-  "https://raw.githubusercontent.com/mienfong/dsh-session-mgr/main/docs/screenshots/session-manager_EN.png",
-  "https://raw.githubusercontent.com/mienfong/dsh-session-mgr/main/docs/screenshots/move-dialog_EN.png",
-  "https://raw.githubusercontent.com/mienfong/dsh-session-mgr/main/docs/screenshots/backup_EN.png",
-  "https://raw.githubusercontent.com/mienfong/dsh-session-mgr/main/docs/screenshots/import_EN.png",
-  "https://raw.githubusercontent.com/mienfong/dsh-session-mgr/main/docs/screenshots/delete-confirm_EN.png"
- ],
- "https://github.com/kenny2077/dsh-web-search-doubao": [
-  "https://raw.githubusercontent.com/kenny2077/dsh-web-search-doubao/main/docs/img/settings-card.png",
-  "https://raw.githubusercontent.com/kenny2077/dsh-web-search-doubao/main/docs/img/console.png"
- ]
+  "https://github.com/anweat/dsh-context-console": [
+    "https://raw.githubusercontent.com/anweat/dsh-context-console/main/docs/images/context-console-trajectory.png",
+    "https://raw.githubusercontent.com/anweat/dsh-context-console/main/docs/images/context-console-inventory.png",
+    "https://raw.githubusercontent.com/anweat/dsh-context-console/main/docs/images/context-console-forge.png"
+  ],
+  "https://github.com/jerryqx/dsh-xiaoyuzhou": [
+    "https://raw.githubusercontent.com/jerryqx/dsh-xiaoyuzhou/main/assets/screenshot-bar.png",
+    "https://raw.githubusercontent.com/jerryqx/dsh-xiaoyuzhou/main/assets/screenshot-mysubs.png",
+    "https://raw.githubusercontent.com/jerryqx/dsh-xiaoyuzhou/main/assets/screenshot-podcast.png"
+  ],
+  "https://github.com/fengb3/dsh-session-icons": [
+    "https://raw.githubusercontent.com/fengb3/dsh-session-icons/master/docs/screenshot.png"
+  ],
+  "https://github.com/GreenLv/dsh-session-insights": [
+    "https://raw.githubusercontent.com/GreenLv/dsh-session-insights/main/assets/screenshots/dashboard-overview-en.png",
+    "https://raw.githubusercontent.com/GreenLv/dsh-session-insights/main/assets/screenshots/dashboard-overview-zh.png"
+  ],
+  "https://github.com/xiaoksio/dsh-solution-explorer": [
+    "https://raw.githubusercontent.com/xiaoksio/dsh-solution-explorer/main/assets/screenshot-1-file-explorer.png",
+    "https://raw.githubusercontent.com/xiaoksio/dsh-solution-explorer/main/assets/screenshot-2-source-control.png",
+    "https://raw.githubusercontent.com/xiaoksio/dsh-solution-explorer/main/assets/screenshot-3-diff.png"
+  ],
+  "https://github.com/LayneChai/superpowers-dsh": [
+    "https://raw.githubusercontent.com/LayneChai/superpowers-dsh/main/static/home.png",
+    "https://raw.githubusercontent.com/LayneChai/superpowers-dsh/main/static/install-success.png"
+  ],
+  "https://github.com/kirkchinese/CiteCiter/tree/main/packages/citeciter": [
+    "https://raw.githubusercontent.com/kirkchinese/CiteCiter/main/assets/demo/citeciter-0.4.0.gif",
+    "https://raw.githubusercontent.com/kirkchinese/CiteCiter/main/assets/screenshots/citeciter-settings.png"
+  ],
+  "https://github.com/L3n3L/dsh-resume": [
+    "https://raw.githubusercontent.com/L3n3L/dsh-resume/main/docs/screenshots/workbench.png",
+    "https://raw.githubusercontent.com/L3n3L/dsh-resume/main/docs/screenshots/ai-assistant.png",
+    "https://raw.githubusercontent.com/L3n3L/dsh-resume/main/docs/screenshots/template-library.png"
+  ],
+  "https://github.com/hunter118/dsh-s7r": [
+    "https://raw.githubusercontent.com/hunter118/dsh-s7r/main/docs/screenshots/s7r-desktop.png",
+    "https://raw.githubusercontent.com/hunter118/dsh-s7r/main/docs/screenshots/s7r-agent.png",
+    "https://raw.githubusercontent.com/hunter118/dsh-s7r/main/docs/screenshots/s7r-workflows.png",
+    "https://raw.githubusercontent.com/hunter118/dsh-s7r/main/docs/screenshots/s7r-display.png"
+  ],
+  "https://github.com/HaoyueQin/dsh-usage-statistics-panel": [
+    "https://raw.githubusercontent.com/HaoyueQin/dsh-usage-statistics-panel/main/assets/screenshots/usage-overview.png",
+    "https://raw.githubusercontent.com/HaoyueQin/dsh-usage-statistics-panel/main/assets/screenshots/model-breakdown.png"
+  ],
+  "https://github.com/lavapapa/dsh-composer-layout": [
+    "https://raw.githubusercontent.com/lavapapa/dsh-composer-layout/main/assets/screenshots/hero-en.png",
+    "https://raw.githubusercontent.com/lavapapa/dsh-composer-layout/main/assets/screenshots/hero-zh.png"
+  ],
+  "https://github.com/lengzhanbao/dsh-taffy-theme": [
+    "https://raw.githubusercontent.com/lengzhanbao/dsh-taffy-theme/master/preview/light.webp",
+    "https://raw.githubusercontent.com/lengzhanbao/dsh-taffy-theme/master/preview/dark.webp"
+  ],
+  "https://github.com/liang-today/dsh-liangxiang": [
+    "https://raw.githubusercontent.com/liang-today/dsh-liangxiang/main/assets/main-frame.jpg",
+    "https://raw.githubusercontent.com/liang-today/dsh-liangxiang/main/assets/plugin-panel.jpg",
+    "https://raw.githubusercontent.com/liang-today/dsh-liangxiang/main/assets/liangci.jpg"
+  ],
+  "https://github.com/Little-Star888/dsh-pelican": [
+    "https://raw.githubusercontent.com/Little-Star888/dsh-pelican/main/assets/screenshot-1.png"
+  ],
+  "https://github.com/kendu76/dsh-music-player": [
+    "https://raw.githubusercontent.com/kendu76/dsh-music-player/main/assets/screenshot-bar.png",
+    "https://raw.githubusercontent.com/kendu76/dsh-music-player/main/assets/screenshot-spectrum.png",
+    "https://raw.githubusercontent.com/kendu76/dsh-music-player/main/assets/screenshot-panel.png"
+  ],
+  "https://github.com/030611/qiushi-dsh-evidence-audit": [
+    "https://raw.githubusercontent.com/030611/qiushi-dsh-evidence-audit/main/docs/evidence-flow.svg"
+  ],
+  "https://github.com/263311487-ux/dsh-verify": [
+    "https://raw.githubusercontent.com/263311487-ux/dsh-verify/main/assets/report-screenshot.png",
+    "https://raw.githubusercontent.com/263311487-ux/dsh-verify/main/assets/visual-diff.png"
+  ],
+  "https://github.com/2768651338/dsh-effort-slider": [
+    "https://raw.githubusercontent.com/2768651338/dsh-effort-slider/main/assets/screenshots/灞忓箷鎴浘%202026-08-16%20190943.png",
+    "https://raw.githubusercontent.com/2768651338/dsh-effort-slider/main/assets/screenshots/灞忓箷鎴浘%202026-08-16%20190950.png",
+    "https://raw.githubusercontent.com/2768651338/dsh-effort-slider/main/assets/screenshots/灞忓箷鎴浘%202026-08-16%20190903.png"
+  ],
+  "https://github.com/2768651338/dsh-plugin-manager": [
+    "https://raw.githubusercontent.com/2768651338/dsh-plugin-manager/main/assets/preview.png"
+  ],
+  "https://github.com/2nd1st/dsh-plugin-open-app": [
+    "https://raw.githubusercontent.com/2nd1st/dsh-plugin-open-app/main/docs/screenshot-app-container.jpg",
+    "https://raw.githubusercontent.com/2nd1st/dsh-plugin-open-app/main/docs/screenshot-inline.jpg"
+  ],
+  "https://github.com/534119219/chicheng-cron": [
+    "https://raw.githubusercontent.com/534119219/chicheng-cron/main/assets/sidebar-entry.png",
+    "https://raw.githubusercontent.com/534119219/chicheng-cron/main/assets/settings-1.png",
+    "https://raw.githubusercontent.com/534119219/chicheng-cron/main/assets/settings-2.png",
+    "https://raw.githubusercontent.com/534119219/chicheng-cron/main/assets/output-popup.png"
+  ],
+  "https://github.com/534119219/chicheng-gate": [
+    "https://raw.githubusercontent.com/534119219/chicheng-gate/main/assets/settings.png",
+    "https://raw.githubusercontent.com/534119219/chicheng-gate/main/assets/login-gate.png",
+    "https://raw.githubusercontent.com/534119219/chicheng-gate/main/assets/mobile-ui-1.png",
+    "https://raw.githubusercontent.com/534119219/chicheng-gate/main/assets/mobile-ui-2.png",
+    "https://raw.githubusercontent.com/534119219/chicheng-gate/main/assets/mobile-ui-3.png"
+  ],
+  "https://github.com/534119219/chicheng-push": [
+    "https://raw.githubusercontent.com/534119219/chicheng-push/master/assets/screenshot-settings-entry.png",
+    "https://raw.githubusercontent.com/534119219/chicheng-push/master/assets/screenshot-channel-list.png",
+    "https://raw.githubusercontent.com/534119219/chicheng-push/master/assets/screenshot-add-channel.png"
+  ],
+  "https://github.com/534119219/chicheng-stats": [
+    "https://raw.githubusercontent.com/534119219/chicheng-stats/main/assets/card-mode.png",
+    "https://raw.githubusercontent.com/534119219/chicheng-stats/main/assets/text-mode.png",
+    "https://raw.githubusercontent.com/534119219/chicheng-stats/main/assets/usage-dialog.png",
+    "https://raw.githubusercontent.com/534119219/chicheng-stats/main/assets/card-settings.png",
+    "https://raw.githubusercontent.com/534119219/chicheng-stats/main/assets/text-settings.png"
+  ],
+  "https://github.com/54xkeee/dsh-youreyes": [
+    "https://raw.githubusercontent.com/54xkeee/dsh-youreyes/master/assets/screenshot-panel.png"
+  ],
+  "https://github.com/7dgroup-ai/dsh-skill-7d-code-reviewer": [
+    "https://raw.githubusercontent.com/7dgroup-ai/dsh-skill-7d-code-reviewer/main/screenshots/skills.png",
+    "https://raw.githubusercontent.com/7dgroup-ai/dsh-skill-7d-code-reviewer/main/screenshots/report-preview.png"
+  ],
+  "https://github.com/940842546/dsh-permissions": [
+    "https://raw.githubusercontent.com/940842546/dsh-permissions/main/assets/01-permissions-overview.png",
+    "https://raw.githubusercontent.com/940842546/dsh-permissions/main/assets/02-permissions-rules.png",
+    "https://raw.githubusercontent.com/940842546/dsh-permissions/main/assets/03-permissions-draft.png",
+    "https://raw.githubusercontent.com/940842546/dsh-permissions/main/assets/en-01-permissions-overview.png",
+    "https://raw.githubusercontent.com/940842546/dsh-permissions/main/assets/en-02-permissions-rules.png",
+    "https://raw.githubusercontent.com/940842546/dsh-permissions/main/assets/en-03-permissions-draft.png"
+  ],
+  "https://github.com/940842546/dsh-usage-billing": [
+    "https://raw.githubusercontent.com/940842546/dsh-usage-billing/main/assets/screenshots/02-stats-dialog-overview.png",
+    "https://raw.githubusercontent.com/940842546/dsh-usage-billing/main/assets/screenshots/03-stats-dialog-charts.png",
+    "https://raw.githubusercontent.com/940842546/dsh-usage-billing/main/assets/screenshots/04-settings-usage-overview.png",
+    "https://raw.githubusercontent.com/940842546/dsh-usage-billing/main/assets/screenshots/07-stats-dialog-usd.png",
+    "https://raw.githubusercontent.com/940842546/dsh-usage-billing/main/assets/screenshots/en-02-stats-dialog-overview.png",
+    "https://raw.githubusercontent.com/940842546/dsh-usage-billing/main/assets/screenshots/en-03-stats-dialog-charts.png",
+    "https://raw.githubusercontent.com/940842546/dsh-usage-billing/main/assets/screenshots/en-04-settings-usage-overview.png",
+    "https://raw.githubusercontent.com/940842546/dsh-usage-billing/main/assets/screenshots/en-07-stats-dialog-usd.png"
+  ],
+  "https://github.com/AI-Galaxy-GPU/dsh-sound": [
+    "https://raw.githubusercontent.com/AI-Galaxy-GPU/dsh-sound/main/assets/screenshots/sound-image.png"
+  ],
+  "https://github.com/AcidGr/dsh-web-lan-access": [
+    "https://raw.githubusercontent.com/AcidGr/dsh-web-lan-access/main/assets/screenshot-lan-access.jpg"
+  ],
+  "https://github.com/AcidGr/dsh-web-mobile-fix": [
+    "https://raw.githubusercontent.com/AcidGr/dsh-web-mobile-fix/main/assets/screenshot-1.jpg",
+    "https://raw.githubusercontent.com/AcidGr/dsh-web-mobile-fix/main/assets/screenshot-2.jpg"
+  ],
+  "https://github.com/Airmetro/dsh-update-checker": [
+    "https://raw.githubusercontent.com/Airmetro/dsh-update-checker/main/assets/screenshots/01-banner-update-zh.png",
+    "https://raw.githubusercontent.com/Airmetro/dsh-update-checker/main/assets/screenshots/02-banner-update-en.png",
+    "https://raw.githubusercontent.com/Airmetro/dsh-update-checker/main/assets/screenshots/03-banner-plugins.png",
+    "https://raw.githubusercontent.com/Airmetro/dsh-update-checker/main/assets/screenshots/04-settings-zh.png",
+    "https://raw.githubusercontent.com/Airmetro/dsh-update-checker/main/assets/screenshots/05-settings-en.png"
+  ],
+  "https://github.com/AmeKrance/anan-thermal-monitor": [
+    "https://raw.githubusercontent.com/AmeKrance/anan-thermal-monitor/main/assets/screenshots/screenshot-1.png",
+    "https://raw.githubusercontent.com/AmeKrance/anan-thermal-monitor/main/assets/screenshots/screenshot-2.png",
+    "https://raw.githubusercontent.com/AmeKrance/anan-thermal-monitor/main/assets/screenshots/demo.gif"
+  ],
+  "https://github.com/Awu12277/dsh-stock-watch": [
+    "https://raw.githubusercontent.com/Awu12277/dsh-stock-watch/main/screenshots/detail-kline-dark.png",
+    "https://raw.githubusercontent.com/Awu12277/dsh-stock-watch/main/screenshots/detail-minute-dark.png",
+    "https://raw.githubusercontent.com/Awu12277/dsh-stock-watch/main/screenshots/list-dark.png"
+  ],
+  "https://github.com/ChongCyrus/Vibe-Mathematics": [
+    "https://raw.githubusercontent.com/ChongCyrus/Vibe-Mathematics/main/%E7%A4%BA%E4%BE%8B%E5%9B%BE/%E6%A1%86%E6%9E%B6%E5%9B%BE-v1.png",
+    "https://raw.githubusercontent.com/ChongCyrus/Vibe-Mathematics/main/%E7%A4%BA%E4%BE%8B%E5%9B%BE/%E6%A1%86%E6%9E%B6%E5%9B%BE-v2.png"
+  ],
+  "https://github.com/ChrisZhangWG/dsh-codex-meter": [
+    "https://raw.githubusercontent.com/ChrisZhangWG/dsh-codex-meter/main/docs/settings-usage-overview.png",
+    "https://raw.githubusercontent.com/ChrisZhangWG/dsh-codex-meter/main/docs/settings-usage-cost-history.png"
+  ],
+  "https://github.com/Dely0/dsh-personal-workbench": [
+    "https://raw.githubusercontent.com/Dely0/dsh-personal-workbench/main/screenshot/%E4%B8%BB%E7%95%8C%E9%9D%A2.PNG",
+    "https://raw.githubusercontent.com/Dely0/dsh-personal-workbench/main/screenshot/%E6%97%A5%E5%8E%86%E9%A1%B5%E9%9D%A2.png",
+    "https://raw.githubusercontent.com/Dely0/dsh-personal-workbench/main/screenshot/%E4%BB%BB%E5%8A%A1%E5%88%97%E8%A1%A8%E7%95%8C%E9%9D%A2.png",
+    "https://raw.githubusercontent.com/Dely0/dsh-personal-workbench/main/screenshot/%E7%9F%A5%E8%AF%86%E5%BA%93%E7%95%8C%E9%9D%A2.png",
+    "https://raw.githubusercontent.com/Dely0/dsh-personal-workbench/main/screenshot/%E7%82%B9%E5%AD%90%E7%95%8C%E9%9D%A2.png",
+    "https://raw.githubusercontent.com/Dely0/dsh-personal-workbench/main/screenshot/%E7%82%B9%E5%AD%90%E7%8E%8B.png"
+  ],
+  "https://github.com/DocJlm/dsh-arknights/tree/main/skins/pramanix-eyjafjalla": [
+    "https://raw.githubusercontent.com/DocJlm/dsh-arknights/main/skins/pramanix-eyjafjalla/preview/cover.webp"
+  ],
+  "https://github.com/Eve-146T/DSH-CODEX-SUBSCRIPTION-POOL": [
+    "https://raw.githubusercontent.com/Eve-146T/DSH-CODEX-SUBSCRIPTION-POOL/main/assets/readme/accounts-demo.png"
+  ],
+  "https://github.com/Fantasality/dsh-origin-plugin": [
+    "https://raw.githubusercontent.com/Fantasality/dsh-origin-plugin/main/docs/example.png",
+    "https://raw.githubusercontent.com/Fantasality/dsh-origin-plugin/main/docs/example_3d.png"
+  ],
+  "https://github.com/FengHuoLinShan/dsh-plugin-llm-balance": [
+    "https://raw.githubusercontent.com/FengHuoLinShan/dsh-plugin-llm-balance/main/assets/llm-balance-preview.png"
+  ],
+  "https://github.com/Flyvhidbwo/dsh-vision-proxy": [
+    "https://raw.githubusercontent.com/Flyvhidbwo/dsh-vision-proxy/main/assets/demo-reply.png",
+    "https://raw.githubusercontent.com/Flyvhidbwo/dsh-vision-proxy/main/assets/demo-selector.png"
+  ],
+  "https://github.com/foooold/dsh-message-nav": [
+    "https://raw.githubusercontent.com/foooold/dsh-message-nav/main/assets/rail-hover-preview.png",
+    "https://raw.githubusercontent.com/foooold/dsh-message-nav/main/assets/rail-left-edge.png"
+  ],
+  "https://github.com/GOU-GEE/deepseek-vision/tree/main/plugins/dsh-plugin-deepseek-vision": [
+    "https://raw.githubusercontent.com/GOU-GEE/deepseek-vision/main/docs/screenshots/01-settings.png",
+    "https://raw.githubusercontent.com/GOU-GEE/deepseek-vision/main/docs/screenshots/02-paste-analyze.png",
+    "https://raw.githubusercontent.com/GOU-GEE/deepseek-vision/main/docs/screenshots/03-clipboard.png",
+    "https://raw.githubusercontent.com/GOU-GEE/deepseek-vision/main/docs/screenshots/04-result.png",
+    "https://raw.githubusercontent.com/GOU-GEE/deepseek-vision/main/docs/screenshots/05-market.png"
+  ],
+  "https://github.com/Gin-7/dsh-pet-remielle": [
+    "https://raw.githubusercontent.com/Gin-7/dsh-pet-remielle/main/assets/screenshot-waiting.png",
+    "https://raw.githubusercontent.com/Gin-7/dsh-pet-remielle/main/assets/screenshot-priding.png"
+  ],
+  "https://github.com/HaoyueQin/dsh-better-reasoning-effort": [
+    "https://raw.githubusercontent.com/HaoyueQin/dsh-better-reasoning-effort/master/docs/market-card.png"
+  ],
+  "https://github.com/Harvey-Will/dsh-vision-analysis": [
+    "https://raw.githubusercontent.com/Harvey-Will/dsh-vision-analysis/main/assets/demo-ocr.png",
+    "https://raw.githubusercontent.com/Harvey-Will/dsh-vision-analysis/main/assets/demo-chart.png",
+    "https://raw.githubusercontent.com/Harvey-Will/dsh-vision-analysis/main/assets/demo-ui.png"
+  ],
+  "https://github.com/Isilsolme/dsh-splash-launcher": [
+    "https://raw.githubusercontent.com/Isilsolme/dsh-splash-launcher/main/docs/screenshots/splash-light.png",
+    "https://raw.githubusercontent.com/Isilsolme/dsh-splash-launcher/main/docs/screenshots/splash-drawing.png",
+    "https://raw.githubusercontent.com/Isilsolme/dsh-splash-launcher/main/docs/screenshots/splash-dark.png",
+    "https://raw.githubusercontent.com/Isilsolme/dsh-splash-launcher/main/docs/screenshots/main.png"
+  ],
+  "https://github.com/Jannchie/dsh-bill": [
+    "https://raw.githubusercontent.com/Jannchie/dsh-bill/main/docs/attribution.png",
+    "https://raw.githubusercontent.com/Jannchie/dsh-bill/main/docs/in-chat.png"
+  ],
+  "https://github.com/JimchengChina/dsh-frontier-repro": [
+    "https://raw.githubusercontent.com/JimchengChina/dsh-frontier-repro/main/docs/assets/frontier-repro-hero.png"
+  ],
+  "https://github.com/Jiyr0119/dsh-workspace-explorer": [
+    "https://raw.githubusercontent.com/Jiyr0119/dsh-workspace-explorer/main/assets/screenshots/panel.png",
+    "https://raw.githubusercontent.com/Jiyr0119/dsh-workspace-explorer/main/assets/screenshots/tree.png",
+    "https://raw.githubusercontent.com/Jiyr0119/dsh-workspace-explorer/main/assets/screenshots/insert.png"
+  ],
+  "https://github.com/Js2Hou/dsh-mcp-manager": [
+    "https://raw.githubusercontent.com/Js2Hou/dsh-mcp-manager/main/assets/market-screenshot.png"
+  ],
+  "https://github.com/Jungod1121/dsh-anchored-standard": [
+    "https://raw.githubusercontent.com/Jungod1121/dsh-anchored-standard/main/screenshots/market-1.png",
+    "https://raw.githubusercontent.com/Jungod1121/dsh-anchored-standard/main/screenshots/market-2.png",
+    "https://raw.githubusercontent.com/Jungod1121/dsh-anchored-standard/main/screenshots/market-3.png"
+  ],
+  "https://github.com/KLRSL/dsh-biomemory": [
+    "https://raw.githubusercontent.com/KLRSL/dsh-biomemory/main/assets/screenshot-main.png",
+    "https://raw.githubusercontent.com/KLRSL/dsh-biomemory/main/assets/screenshot-settings.png",
+    "https://raw.githubusercontent.com/KLRSL/dsh-biomemory/main/assets/screenshot-memory-settings.png"
+  ],
+  "https://github.com/LKMeng2001/dsh-mcp-market": [
+    "https://raw.githubusercontent.com/LKMeng2001/dsh-mcp-market/main/assets/market-discover.png"
+  ],
+  "https://github.com/LeemanCheung/dsh-agent-preset-recommender": [
+    "https://raw.githubusercontent.com/LeemanCheung/dsh-agent-preset-recommender/main/docs/screenshot.png",
+    "https://raw.githubusercontent.com/LeemanCheung/dsh-agent-preset-recommender/main/docs/project-detail.png"
+  ],
+  "https://github.com/LeemanCheung/dsh-image-gen": [
+    "https://raw.githubusercontent.com/LeemanCheung/dsh-image-gen/main/assets/demo.svg",
+    "https://raw.githubusercontent.com/LeemanCheung/dsh-image-gen/main/assets/final-card.png"
+  ],
+  "https://github.com/LeemanCheung/dsh-qq2007-skin": [
+    "https://raw.githubusercontent.com/LeemanCheung/dsh-qq2007-skin/main/docs/screenshot.png",
+    "https://raw.githubusercontent.com/LeemanCheung/dsh-qq2007-skin/main/docs/preview.svg"
+  ],
+  "https://github.com/LeemanCheung/dsh-task-dag": [
+    "https://raw.githubusercontent.com/LeemanCheung/dsh-task-dag/main/docs/screenshot.png",
+    "https://raw.githubusercontent.com/LeemanCheung/dsh-task-dag/main/docs/task-dag-preview.svg"
+  ],
+  "https://github.com/LeemanCheung/dsh-token-usage": [
+    "https://raw.githubusercontent.com/LeemanCheung/dsh-token-usage/main/assets/token-usage-overview.png",
+    "https://raw.githubusercontent.com/LeemanCheung/dsh-token-usage/main/assets/token-usage-insights.png",
+    "https://raw.githubusercontent.com/LeemanCheung/dsh-token-usage/main/assets/token-usage-budget.png",
+    "https://raw.githubusercontent.com/LeemanCheung/dsh-token-usage/main/assets/token-usage-ai-analysis.png",
+    "https://raw.githubusercontent.com/LeemanCheung/dsh-token-usage/main/assets/token-usage-trajectory-analysis.png"
+  ],
+  "https://github.com/LeemanCheung/dsh-whale-animation": [
+    "https://raw.githubusercontent.com/LeemanCheung/dsh-whale-animation/main/docs/screenshots/launch.png",
+    "https://raw.githubusercontent.com/LeemanCheung/dsh-whale-animation/main/docs/screenshots/apex.png",
+    "https://raw.githubusercontent.com/LeemanCheung/dsh-whale-animation/main/docs/screenshots/deep-dive.png"
+  ],
+  "https://github.com/Leeminjing/dsh-eyes": [
+    "https://raw.githubusercontent.com/Leeminjing/dsh-eyes/main/assets/demo.png"
+  ],
+  "https://github.com/Lhy723/dsh-agent-canvas": [
+    "https://raw.githubusercontent.com/Lhy723/dsh-agent-canvas/main/docs/assets/agent-canvas-overview.png",
+    "https://raw.githubusercontent.com/Lhy723/dsh-agent-canvas/main/docs/assets/agent-canvas-dark-settings.png"
+  ],
+  "https://github.com/MangMax/dsh-themes": [
+    "https://raw.githubusercontent.com/MangMax/dsh-themes/main/assets/screenshot.png"
+  ],
+  "https://github.com/Mars-Sea/dsh-commandcode-provider": [
+    "https://raw.githubusercontent.com/Mars-Sea/dsh-commandcode-provider/main/assets/screenshots/model-picker.png",
+    "https://raw.githubusercontent.com/Mars-Sea/dsh-commandcode-provider/main/assets/screenshots/usage-dashboard.png"
+  ],
+  "https://github.com/Max-Samson/dsh-usage-chart": [
+    "https://github.com/Max-Samson/dsh-usage-chart/blob/main/docs/images/usage-panel-demo-en-lightv1.0.0.png",
+    "https://github.com/Max-Samson/dsh-usage-chart/blob/main/docs/images/usage-panel-demo-zh-darkv1.0.0.png"
+  ],
+  "https://github.com/MingoZhou/dsh-replay": [
+    "https://raw.githubusercontent.com/MingoZhou/dsh-replay/main/assets/overview-light.png",
+    "https://raw.githubusercontent.com/MingoZhou/dsh-replay/main/assets/timeline-light.png",
+    "https://raw.githubusercontent.com/MingoZhou/dsh-replay/main/assets/audit-light.png"
+  ],
+  "https://github.com/Mu-scorpio/token-usage-counter": [
+    "https://raw.githubusercontent.com/Mu-scorpio/token-usage-counter/main/assets/usage-stats-overview.png",
+    "https://raw.githubusercontent.com/Mu-scorpio/token-usage-counter/main/assets/usage-stats-hover.png"
+  ],
+  "https://github.com/Nanki-nn/dsh-answer-pet": [
+    "https://raw.githubusercontent.com/Nanki-nn/dsh-answer-pet/main/assets/screenshots/blue-whale.png",
+    "https://raw.githubusercontent.com/Nanki-nn/dsh-answer-pet/main/assets/screenshots/orange-cat.png",
+    "https://raw.githubusercontent.com/Nanki-nn/dsh-answer-pet/main/assets/screenshots/silver-shaded-cat.png"
+  ],
+  "https://github.com/NoNameLeGo/dsh-catppuccin-theme": [
+    "https://raw.githubusercontent.com/NoNameLeGo/dsh-catppuccin-theme/main/assets/previews/glass-latte.png",
+    "https://raw.githubusercontent.com/NoNameLeGo/dsh-catppuccin-theme/main/assets/previews/glass-mocha.png",
+    "https://raw.githubusercontent.com/NoNameLeGo/dsh-catppuccin-theme/main/assets/previews/latte.png",
+    "https://raw.githubusercontent.com/NoNameLeGo/dsh-catppuccin-theme/main/assets/previews/frappe.png",
+    "https://raw.githubusercontent.com/NoNameLeGo/dsh-catppuccin-theme/main/assets/previews/macchiato.png",
+    "https://raw.githubusercontent.com/NoNameLeGo/dsh-catppuccin-theme/main/assets/previews/mocha.png"
+  ],
+  "https://github.com/Noob-stupid/dsh-github-login": [
+    "https://github.com/user-attachments/assets/bb7c1991-9346-4c20-8dc2-5d884515c522",
+    "https://github.com/user-attachments/assets/45a31794-ab56-4e34-8826-fb362deef3dc",
+    "https://github.com/user-attachments/assets/e23560ca-41d3-4a83-bc14-1d20f884cd8a"
+  ],
+  "https://github.com/Noob-stupid/dsh-plugin-hub": [
+    "https://github.com/user-attachments/assets/b802d606-14ba-4151-9956-ff642ed12b0a"
+  ],
+  "https://github.com/PC2005-cloud/dsh-pet/tree/main/dsh-pet": [
+    "https://raw.githubusercontent.com/PC2005-cloud/dsh-pet/main/assets/screenshots/dsh-pet-running-1.png",
+    "https://raw.githubusercontent.com/PC2005-cloud/dsh-pet/main/assets/screenshots/dsh-pet-running-2.png"
+  ],
+  "https://github.com/PandaPolo/dsh-voice-call": [
+    "https://raw.githubusercontent.com/PandaPolo/dsh-voice-call/main/promo/screenshots/slide-1.png",
+    "https://raw.githubusercontent.com/PandaPolo/dsh-voice-call/main/promo/screenshots/slide-2.png",
+    "https://raw.githubusercontent.com/PandaPolo/dsh-voice-call/main/promo/screenshots/slide-3.png",
+    "https://raw.githubusercontent.com/PandaPolo/dsh-voice-call/main/promo/screenshots/slide-4.png",
+    "https://raw.githubusercontent.com/PandaPolo/dsh-voice-call/main/promo/screenshots/slide-5.png",
+    "https://raw.githubusercontent.com/PandaPolo/dsh-voice-call/main/promo/screenshots/slide-6.png",
+    "https://raw.githubusercontent.com/PandaPolo/dsh-voice-call/main/promo/screenshots/slide-7.png"
+  ],
+  "https://github.com/ParticleLight/dsh-all-usage": [
+    "https://raw.githubusercontent.com/ParticleLight/dsh-all-usage/main/assets/screenshot-1.png",
+    "https://raw.githubusercontent.com/ParticleLight/dsh-all-usage/main/assets/screenshot-2.png"
+  ],
+  "https://github.com/PeterBon/dsh-hooks": [
+    "https://raw.githubusercontent.com/PeterBon/dsh-hooks/main/assets/screenshot-1.jpg"
+  ],
+  "https://github.com/PicGo/dsh-plugin": [
+    "https://raw.githubusercontent.com/PicGo/dsh-plugin/main/assets/DeepSeek-PicGo.png",
+    "https://raw.githubusercontent.com/PicGo/dsh-plugin/main/assets/dsh-plugin-picgo.png"
+  ],
+  "https://github.com/PwnKY/dsh-session-link": [
+    "https://raw.githubusercontent.com/PwnKY/dsh-session-link/master/assets/screenshots/01-cross-session-context.png",
+    "https://raw.githubusercontent.com/PwnKY/dsh-session-link/master/assets/screenshots/02-source-session.png"
+  ],
+  "https://github.com/QT-Chen/dsh-mic-input": [
+    "https://raw.githubusercontent.com/QT-Chen/dsh-mic-input/main/assets/shot-1-composer.png",
+    "https://raw.githubusercontent.com/QT-Chen/dsh-mic-input/main/assets/shot-2-listening.png",
+    "https://raw.githubusercontent.com/QT-Chen/dsh-mic-input/main/assets/shot-4-punctuation.png",
+    "https://raw.githubusercontent.com/QT-Chen/dsh-mic-input/main/assets/shot-3-settings.png",
+    "https://raw.githubusercontent.com/QT-Chen/dsh-mic-input/main/assets/shot-5-error.png"
+  ],
+  "https://github.com/RevolutionLA/dsh-dream-skin": [
+    "https://raw.githubusercontent.com/RevolutionLA/dsh-dream-skin/main/docs/screenshots/preview.png",
+    "https://raw.githubusercontent.com/RevolutionLA/dsh-dream-skin/main/docs/screenshots/settings.png"
+  ],
+  "https://github.com/SamizuHM/dsh-client-ui-theme-xp": [
+    "https://raw.githubusercontent.com/SamizuHM/dsh-client-ui-theme-xp/main/docs/screenshot.png"
+  ],
+  "https://github.com/Signalight/codex-to-dsh-pet/tree/main/packages/dsh-codex-pet": [
+    "https://raw.githubusercontent.com/Signalight/codex-to-dsh-pet/main/assets/screenshots/screenshot-1.png",
+    "https://raw.githubusercontent.com/Signalight/codex-to-dsh-pet/main/assets/screenshots/screenshot-2.png",
+    "https://raw.githubusercontent.com/Signalight/codex-to-dsh-pet/main/assets/screenshots/screenshot-3.png"
+  ],
+  "https://github.com/SiriLee/dsh-rewind": [
+    "https://raw.githubusercontent.com/SiriLee/dsh-rewind/main/assets/screenshots/rewind-button.png",
+    "https://raw.githubusercontent.com/SiriLee/dsh-rewind/main/assets/screenshots/mode-popover.png",
+    "https://raw.githubusercontent.com/SiriLee/dsh-rewind/main/assets/screenshots/impact-list.png",
+    "https://raw.githubusercontent.com/SiriLee/dsh-rewind/main/assets/screenshots/rewind-candidates.png"
+  ],
+  "https://github.com/Smalldy/godot-bridge": [
+    "https://raw.githubusercontent.com/Smalldy/godot-bridge/main/assets/godot-bridge-env-check.png"
+  ],
+  "https://github.com/StruggleYang/dsh-project-kanban": [
+    "https://raw.githubusercontent.com/StruggleYang/dsh-project-kanban/main/assets/screenshot-board.png"
+  ],
+  "https://github.com/TQSY114514/dsh-ui-appearance": [
+    "https://raw.githubusercontent.com/TQSY114514/dsh-ui-appearance/main/docs/screenshot-settings.png",
+    "https://raw.githubusercontent.com/TQSY114514/dsh-ui-appearance/main/docs/screenshot-wallpaper.png"
+  ],
+  "https://github.com/TZHR-invest/dsh-plugins/tree/main/packages/dsh-lan-access": [
+    "https://raw.githubusercontent.com/TZHR-invest/dsh-plugins/main/packages/dsh-lan-access/assets/screenshot-1-token-gate.png"
+  ],
+  "https://github.com/TZHR-invest/dsh-plugins/tree/main/packages/dsh-mobile-ui": [
+    "https://raw.githubusercontent.com/TZHR-invest/dsh-plugins/main/packages/dsh-mobile-ui/assets/screenshot-1-home.png",
+    "https://raw.githubusercontent.com/TZHR-invest/dsh-plugins/main/packages/dsh-mobile-ui/assets/screenshot-2-composer.png",
+    "https://raw.githubusercontent.com/TZHR-invest/dsh-plugins/main/packages/dsh-mobile-ui/assets/screenshot-3-chat.png",
+    "https://raw.githubusercontent.com/TZHR-invest/dsh-plugins/main/packages/dsh-mobile-ui/assets/screenshot-4-sessions.png"
+  ],
+  "https://github.com/Tkingxiao/dsh-any-background": [
+    "https://raw.githubusercontent.com/Tkingxiao/dsh-any-background/main/example_img/image.png",
+    "https://raw.githubusercontent.com/Tkingxiao/dsh-any-background/main/example_img/image-2.png",
+    "https://raw.githubusercontent.com/Tkingxiao/dsh-any-background/main/example_img/image-3.png",
+    "https://raw.githubusercontent.com/Tkingxiao/dsh-any-background/main/example_img/image-4.png",
+    "https://raw.githubusercontent.com/Tkingxiao/dsh-any-background/main/example_img/image-6.png",
+    "https://raw.githubusercontent.com/Tkingxiao/dsh-any-background/main/example_img/image-9.png",
+    "https://raw.githubusercontent.com/Tkingxiao/dsh-any-background/main/example_img/image-10.png"
+  ],
+  "https://github.com/Totoro-qaq/dsh-plugin-bridge": [
+    "https://raw.githubusercontent.com/Totoro-qaq/dsh-plugin-bridge/main/assets/cover/cover-en.png",
+    "https://raw.githubusercontent.com/Totoro-qaq/dsh-plugin-bridge/main/assets/bridge-demo.en.gif"
+  ],
+  "https://github.com/Ultronen/dsh-archived-chats": [
+    "https://raw.githubusercontent.com/Ultronen/dsh-archived-chats/main/assets/screenshots/1-archived-chats.png",
+    "https://raw.githubusercontent.com/Ultronen/dsh-archived-chats/main/assets/screenshots/2-search.png",
+    "https://raw.githubusercontent.com/Ultronen/dsh-archived-chats/main/assets/screenshots/3-delete-confirm.png",
+    "https://raw.githubusercontent.com/Ultronen/dsh-archived-chats/main/assets/screenshots/4-group-menu.png"
+  ],
+  "https://github.com/Ultronen/dsh-liquid-glass": [
+    "https://raw.githubusercontent.com/Ultronen/dsh-liquid-glass/main/assets/screenshots/1-settings.png",
+    "https://raw.githubusercontent.com/Ultronen/dsh-liquid-glass/main/assets/screenshots/2-glass-shell.png",
+    "https://raw.githubusercontent.com/Ultronen/dsh-liquid-glass/main/assets/screenshots/3-settings-wallpaper.png"
+  ],
+  "https://github.com/V1ki/dsh-plugin-subscriptions": [
+    "https://raw.githubusercontent.com/V1ki/dsh-plugin-subscriptions/main/docs/images/subscriptions.png",
+    "https://raw.githubusercontent.com/V1ki/dsh-plugin-subscriptions/main/docs/images/model-picker.png",
+    "https://raw.githubusercontent.com/V1ki/dsh-plugin-subscriptions/main/docs/images/model-effort.png",
+    "https://raw.githubusercontent.com/V1ki/dsh-plugin-subscriptions/main/docs/images/speed-toggle.png",
+    "https://raw.githubusercontent.com/V1ki/dsh-plugin-subscriptions/main/docs/images/image-generate-inline.png",
+    "https://raw.githubusercontent.com/V1ki/dsh-plugin-subscriptions/main/docs/images/image-generate-providers.png",
+    "https://raw.githubusercontent.com/V1ki/dsh-plugin-subscriptions/main/docs/images/video-generate-inline.png"
+  ],
+  "https://github.com/Vncntvx/dsh-zotero": [
+    "https://raw.githubusercontent.com/Vncntvx/dsh-zotero/main/docs/images/header-collage.png",
+    "https://raw.githubusercontent.com/Vncntvx/dsh-zotero/main/docs/images/zotero-chat-workflow.png",
+    "https://raw.githubusercontent.com/Vncntvx/dsh-zotero/main/docs/images/zotero-sources-overview.png",
+    "https://raw.githubusercontent.com/Vncntvx/dsh-zotero/main/docs/images/zotero-evidence-passages.png",
+    "https://raw.githubusercontent.com/Vncntvx/dsh-zotero/main/docs/images/zotero-export-bibtex.png"
+  ],
+  "https://github.com/WenhongPan/dsh-projects": [
+    "https://raw.githubusercontent.com/WenhongPan/dsh-projects/main/docs/assets/picker.webp",
+    "https://raw.githubusercontent.com/WenhongPan/dsh-projects/main/docs/assets/create.webp",
+    "https://raw.githubusercontent.com/WenhongPan/dsh-projects/main/docs/assets/native.webp"
+  ],
+  "https://github.com/YeqingTang/dsh-session-flow": [
+    "https://raw.githubusercontent.com/YeqingTang/dsh-session-flow/main/assets/screenshots/overview.png",
+    "https://raw.githubusercontent.com/YeqingTang/dsh-session-flow/main/assets/screenshots/session-flow-tab.png",
+    "https://raw.githubusercontent.com/YeqingTang/dsh-session-flow/main/assets/screenshots/turn-rail.png",
+    "https://raw.githubusercontent.com/YeqingTang/dsh-session-flow/main/assets/screenshots/fulltext-search.png",
+    "https://raw.githubusercontent.com/YeqingTang/dsh-session-flow/main/assets/screenshots/dock-right.png",
+    "https://raw.githubusercontent.com/YeqingTang/dsh-session-flow/main/assets/screenshots/folded-detail.png"
+  ],
+  "https://github.com/Yu-tao-Li/dsh-computer-use-win": [
+    "https://raw.githubusercontent.com/Yu-tao-Li/dsh-computer-use-win/main/assets/screenshot-1.png",
+    "https://raw.githubusercontent.com/Yu-tao-Li/dsh-computer-use-win/main/assets/screenshot-2.png",
+    "https://raw.githubusercontent.com/Yu-tao-Li/dsh-computer-use-win/main/assets/screenshot-3.png"
+  ],
+  "https://github.com/Yu-tao-Li/dsh-read-image-view": [
+    "https://raw.githubusercontent.com/Yu-tao-Li/dsh-read-image-view/main/assets/screenshot-1.png",
+    "https://raw.githubusercontent.com/Yu-tao-Li/dsh-read-image-view/main/assets/screenshot-2.png",
+    "https://raw.githubusercontent.com/Yu-tao-Li/dsh-read-image-view/main/assets/screenshot-3.png",
+    "https://raw.githubusercontent.com/Yu-tao-Li/dsh-read-image-view/main/assets/screenshot-4.png"
+  ],
+  "https://github.com/Yu-tao-Li/dsh-reference-checker": [
+    "https://raw.githubusercontent.com/Yu-tao-Li/dsh-reference-checker/main/assets/screenshot-1.png"
+  ],
+  "https://github.com/ZJUZhiyuCai/dsh-ivory": [
+    "https://raw.githubusercontent.com/ZJUZhiyuCai/dsh-ivory/main/assets/hero-light.png",
+    "https://raw.githubusercontent.com/ZJUZhiyuCai/dsh-ivory/main/assets/hero-dark.png",
+    "https://raw.githubusercontent.com/ZJUZhiyuCai/dsh-ivory/main/assets/conversation-light.png",
+    "https://raw.githubusercontent.com/ZJUZhiyuCai/dsh-ivory/main/assets/mobile-light.png"
+  ],
+  "https://github.com/a179-sanae/dsh-auto-collapse": [
+    "https://raw.githubusercontent.com/a179-sanae/dsh-auto-collapse/main/assets/screenshot.png"
+  ],
+  "https://github.com/a903067276-rgb/dsh-file-mentions": [
+    "https://raw.githubusercontent.com/a903067276-rgb/dsh-file-mentions/main/assets/screenshot.png"
+  ],
+  "https://github.com/a903067276-rgb/dsh-file-upload": [
+    "https://raw.githubusercontent.com/a903067276-rgb/dsh-file-upload/main/assets/screenshot.png"
+  ],
+  "https://github.com/a903067276-rgb/dsh-hud": [
+    "https://raw.githubusercontent.com/a903067276-rgb/dsh-hud/main/assets/hud-panel.png"
+  ],
+  "https://github.com/a903067276-rgb/dsh-plan-switch": [
+    "https://raw.githubusercontent.com/a903067276-rgb/dsh-plan-switch/main/assets/plan-button.png"
+  ],
+  "https://github.com/biociao/dsh-science": [
+    "https://raw.githubusercontent.com/biociao/dsh-science/main/assets/screenshots/research-loop.png",
+    "https://raw.githubusercontent.com/biociao/dsh-science/main/assets/screenshots/artifact-provenance.png",
+    "https://raw.githubusercontent.com/biociao/dsh-science/main/assets/screenshots/research-report.png",
+    "https://raw.githubusercontent.com/biociao/dsh-science/main/assets/screenshots/remote-compute.png",
+    "https://raw.githubusercontent.com/biociao/dsh-science/main/assets/screenshots/plugin-inventory.png",
+    "https://raw.githubusercontent.com/biociao/dsh-science/main/assets/screenshots/topology.png"
+  ],
+  "https://github.com/chouyong/dsh-branch-review": [
+    "https://raw.githubusercontent.com/chouyong/dsh-branch-review/main/assets/branch-review-desktop.png",
+    "https://raw.githubusercontent.com/chouyong/dsh-branch-review/main/assets/branch-review-decisions.png"
+  ],
+  "https://github.com/chouyong/dsh-fork-diff": [
+    "https://raw.githubusercontent.com/chouyong/dsh-fork-diff/main/assets/fork-diff-desktop.png",
+    "https://raw.githubusercontent.com/chouyong/dsh-fork-diff/main/assets/fork-diff-selector.png",
+    "https://raw.githubusercontent.com/chouyong/dsh-fork-diff/main/assets/fork-diff-mobile.png"
+  ],
+  "https://github.com/chouyong/dsh-fork-graph": [
+    "https://raw.githubusercontent.com/chouyong/dsh-fork-graph/main/assets/screenshot-trigger.png",
+    "https://raw.githubusercontent.com/chouyong/dsh-fork-graph/main/assets/screenshot-panel.png"
+  ],
+  "https://github.com/cirelir/dsh-change-review": [
+    "https://raw.githubusercontent.com/cirelir/dsh-change-review/main/assets/screenshots/review-tab.png",
+    "https://raw.githubusercontent.com/cirelir/dsh-change-review/main/assets/screenshots/per-turn-card.png",
+    "https://raw.githubusercontent.com/cirelir/dsh-change-review/main/assets/screenshots/diff-detail.png",
+    "https://raw.githubusercontent.com/cirelir/dsh-change-review/main/assets/screenshots/color-settings.png",
+    "https://raw.githubusercontent.com/cirelir/dsh-change-review/main/assets/screenshots/plugin-market.png"
+  ],
+  "https://github.com/coolbreezecoin/dsh-wechat-mp": [
+    "https://raw.githubusercontent.com/coolbreezecoin/dsh-wechat-mp/main/assets/demo.gif"
+  ],
+  "https://github.com/corrinehu/dsh-chat-imagine": [
+    "https://raw.githubusercontent.com/corrinehu/dsh-chat-imagine/main/assets/1.png",
+    "https://raw.githubusercontent.com/corrinehu/dsh-chat-imagine/main/assets/2.png",
+    "https://raw.githubusercontent.com/corrinehu/dsh-chat-imagine/main/assets/3.png",
+    "https://raw.githubusercontent.com/corrinehu/dsh-chat-imagine/main/assets/4.png"
+  ],
+  "https://github.com/creght-dev/skills": [
+    "https://raw.githubusercontent.com/creght-dev/skills/main/assets/screenshot-dsh.jpg",
+    "https://raw.githubusercontent.com/creght-dev/skills/main/assets/screenshot-editor.jpg"
+  ],
+  "https://github.com/d-dev0101/open-sea-skin": [
+    "https://raw.githubusercontent.com/d-dev0101/open-sea-skin/5ae54402ec6d4c961d41aee8ed786280799712c7/docs/marketplace/open-sea-harness-cover.png",
+    "https://raw.githubusercontent.com/d-dev0101/open-sea-skin/5ae54402ec6d4c961d41aee8ed786280799712c7/docs/screenshots/harness-dark-overview-40.gif",
+    "https://raw.githubusercontent.com/d-dev0101/open-sea-skin/5ae54402ec6d4c961d41aee8ed786280799712c7/docs/screenshots/harness-light-overview-40.gif",
+    "https://raw.githubusercontent.com/d-dev0101/open-sea-skin/5ae54402ec6d4c961d41aee8ed786280799712c7/docs/screenshots/harness-wave-control-40.gif",
+    "https://raw.githubusercontent.com/d-dev0101/open-sea-skin/5ae54402ec6d4c961d41aee8ed786280799712c7/docs/screenshots/harness-daylight-sunset-40.gif"
+  ],
+  "https://github.com/daetz-coder/dsh-multi-chat": [
+    "https://raw.githubusercontent.com/daetz-coder/dsh-multi-chat/main/assets/01-windows-dual-chat.png",
+    "https://raw.githubusercontent.com/daetz-coder/dsh-multi-chat/main/assets/02-ipad-dual-chat.png",
+    "https://raw.githubusercontent.com/daetz-coder/dsh-multi-chat/main/assets/03-windows-triple-chat.png"
+  ],
+  "https://github.com/demacia1314/dsh-airdrop": [
+    "https://raw.githubusercontent.com/demacia1314/dsh-airdrop/main/assets/drop-in.png",
+    "https://raw.githubusercontent.com/demacia1314/dsh-airdrop/main/assets/in-chat.png",
+    "https://raw.githubusercontent.com/demacia1314/dsh-airdrop/main/assets/preview-modal.png"
+  ],
+  "https://github.com/detongz/dsh-client-ui-obsidian-memory": [
+    "https://raw.githubusercontent.com/detongz/dsh-client-ui-obsidian-memory/main/assets/screenshot-panel.png"
+  ],
+  "https://github.com/dfycaly98931680/dsh-trajectory-governance": [
+    "https://raw.githubusercontent.com/dfycaly98931680/dsh-trajectory-governance/main/docs/screenshots/tree.png",
+    "https://raw.githubusercontent.com/dfycaly98931680/dsh-trajectory-governance/main/docs/screenshots/alerts.png",
+    "https://raw.githubusercontent.com/dfycaly98931680/dsh-trajectory-governance/main/docs/screenshots/report.png"
+  ],
+  "https://github.com/dickpy/dsh-imagegen": [
+    "https://raw.githubusercontent.com/dickpy/dsh-imagegen/main/docs/images/image-generation-studio.png",
+    "https://raw.githubusercontent.com/dickpy/dsh-imagegen/main/docs/images/plugin-settings.png"
+  ],
+  "https://github.com/disyli/dsh-tool-call-stats": [
+    "https://raw.githubusercontent.com/disyli/dsh-tool-call-stats/main/assets/screenshots/01-session.png",
+    "https://raw.githubusercontent.com/disyli/dsh-tool-call-stats/main/assets/screenshots/02-tool-stats.png",
+    "https://raw.githubusercontent.com/disyli/dsh-tool-call-stats/main/assets/screenshots/03-install.png",
+    "https://raw.githubusercontent.com/disyli/dsh-tool-call-stats/main/assets/screenshots/04-config.png"
+  ],
+  "https://github.com/dsh-market/dsh-market": [
+    "https://raw.githubusercontent.com/dsh-market/dsh-market/main/assets/demo-en.png",
+    "https://raw.githubusercontent.com/dsh-market/dsh-market/main/assets/themes-en.png"
+  ],
+  "https://github.com/elves-ai/dsh-web-search-firecrawl": [
+    "https://raw.githubusercontent.com/elves-ai/dsh-web-search-firecrawl/master/docs/firecrawl-settings.png"
+  ],
+  "https://github.com/franksong2702/dsh-codex-connect": [
+    "https://raw.githubusercontent.com/franksong2702/dsh-codex-connect/main/docs/assets/en/plugin-entry.jpg",
+    "https://raw.githubusercontent.com/franksong2702/dsh-codex-connect/main/docs/assets/en/oauth-status.jpg",
+    "https://raw.githubusercontent.com/franksong2702/dsh-codex-connect/main/docs/assets/en/plugin-configuration.jpg",
+    "https://raw.githubusercontent.com/franksong2702/dsh-codex-connect/main/docs/assets/en/model-selector.jpg",
+    "https://raw.githubusercontent.com/franksong2702/dsh-codex-connect/main/docs/assets/zh/hero.jpg",
+    "https://raw.githubusercontent.com/franksong2702/dsh-codex-connect/main/docs/assets/zh/plugin-entry.jpg",
+    "https://raw.githubusercontent.com/franksong2702/dsh-codex-connect/main/docs/assets/zh/oauth-status.jpg",
+    "https://raw.githubusercontent.com/franksong2702/dsh-codex-connect/main/docs/assets/zh/plugin-configuration.jpg"
+  ],
+  "https://github.com/fuyue521/dsh-desktop-shortcut": [
+    "https://raw.githubusercontent.com/fuyue521/dsh-desktop-shortcut/main/assets/screenshots/screenshot-web-ui.png"
+  ],
+  "https://github.com/haiziyao/dsh-vision-mix": [
+    "https://raw.githubusercontent.com/haiziyao/dsh-vision-mix/main/docs/settings-routing.png",
+    "https://raw.githubusercontent.com/haiziyao/dsh-vision-mix/main/docs/generation-routing.png",
+    "https://raw.githubusercontent.com/haiziyao/dsh-vision-mix/main/docs/vision-history.png",
+    "https://raw.githubusercontent.com/haiziyao/dsh-vision-mix/main/docs/generation-history.png",
+    "https://raw.githubusercontent.com/haiziyao/dsh-vision-mix/main/docs/benchmark-mix.png"
+  ],
+  "https://github.com/hanzhangzzz/dsh-diagram": [
+    "https://raw.githubusercontent.com/hanzhangzzz/dsh-diagram/assets/dsh-diagram-demo.gif",
+    "https://raw.githubusercontent.com/hanzhangzzz/dsh-diagram/assets/screenshot-canvas-architecture.png",
+    "https://raw.githubusercontent.com/hanzhangzzz/dsh-diagram/assets/screenshot-canvas-flow.png",
+    "https://raw.githubusercontent.com/hanzhangzzz/dsh-diagram/assets/screenshot-chat.png"
+  ],
+  "https://github.com/haoku123/dsh-voice": [
+    "https://raw.githubusercontent.com/haoku123/dsh-voice/main/docs/demo.gif"
+  ],
+  "https://github.com/hezhongtang/dsh-capability-optimizer": [
+    "https://raw.githubusercontent.com/hezhongtang/dsh-capability-optimizer/main/assets/screenshot-zh.png"
+  ],
+  "https://github.com/hi-wenw/dsh-telegram-channel": [
+    "https://raw.githubusercontent.com/hi-wenw/dsh-telegram-channel/master/docs/screenshots/hero-flow.png",
+    "https://raw.githubusercontent.com/hi-wenw/dsh-telegram-channel/master/docs/screenshots/mobile-chat.jpg",
+    "https://raw.githubusercontent.com/hi-wenw/dsh-telegram-channel/master/docs/screenshots/desktop-sync.jpg"
+  ],
+  "https://github.com/huguangyu666/dsh-plugin-notify": [
+    "https://raw.githubusercontent.com/huguangyu666/dsh-plugin-notify/main/assets/screenshot.png"
+  ],
+  "https://github.com/huguangyu666/dsh-plugin-session-import": [
+    "https://raw.githubusercontent.com/huguangyu666/dsh-plugin-session-import/main/assets/screenshot.png"
+  ],
+  "https://github.com/huguangyu666/dsh-store": [
+    "https://raw.githubusercontent.com/huguangyu666/dsh-plugin-store/main/assets/screenshot.png"
+  ],
+  "https://github.com/huxint/dsh-team": [
+    "https://raw.githubusercontent.com/huxint/dsh-team/main/screenshots/image.png"
+  ],
+  "https://github.com/hxy91819/dsh-auth": [
+    "https://raw.githubusercontent.com/hxy91819/dsh-auth/main/docs/images/login.png",
+    "https://raw.githubusercontent.com/hxy91819/dsh-auth/main/docs/images/authenticated-harness.png"
+  ],
+  "https://github.com/hyzyn/dsh-plugin-kit/tree/main/packages/rss": [
+    "https://raw.githubusercontent.com/hyzyn/dsh-plugin-kit/main/docs/dsh-plugin-kit-rss-setting.png",
+    "https://raw.githubusercontent.com/hyzyn/dsh-plugin-kit/main/docs/dsh-plugin-kit-rss-view.png"
+  ],
+  "https://github.com/hyzyn/dsh-plugin-kit/tree/main/packages/search": [
+    "https://raw.githubusercontent.com/hyzyn/dsh-plugin-kit/main/docs/dsh-plugin-kit-search.png"
+  ],
+  "https://github.com/iamfromchangsha/dsh-go-balance": [
+    "https://raw.githubusercontent.com/iamfromchangsha/dsh-go-balance/main/docs/screenshot-composer.png",
+    "https://raw.githubusercontent.com/iamfromchangsha/dsh-go-balance/main/docs/screenshot-tooltip.png",
+    "https://raw.githubusercontent.com/iamfromchangsha/dsh-go-balance/main/docs/screenshot-warn.png"
+  ],
+  "https://github.com/iiwish/dsh-testkit": [
+    "https://raw.githubusercontent.com/iiwish/dsh-testkit/main/docs/assets/dsh-testkit-showcase.png"
+  ],
+  "https://github.com/imkingjh999/dsh-shorts-wall": [
+    "https://raw.githubusercontent.com/imkingjh999/dsh-shorts-wall/main/docs/screenshot-stick.png",
+    "https://raw.githubusercontent.com/imkingjh999/dsh-shorts-wall/main/docs/screenshot-float.png",
+    "https://raw.githubusercontent.com/imkingjh999/dsh-shorts-wall/main/docs/screenshot-minimized.png"
+  ],
+  "https://github.com/imkingjh999/dsh-deepsea": [
+    "https://raw.githubusercontent.com/imkingjh999/dsh-deepsea/main/assets/screenshots/deepsea-ocean.png",
+    "https://raw.githubusercontent.com/imkingjh999/dsh-deepsea/main/assets/screenshots/deepsea-wall.png",
+    "https://raw.githubusercontent.com/imkingjh999/dsh-deepsea/main/assets/screenshots/deepsea-pond.png"
+  ],
+  "https://github.com/itr-del/dsh-feishu": [
+    "https://raw.githubusercontent.com/itr-del/dsh-feishu/master/assets/hero.png"
+  ],
+  "https://github.com/izwarm195/dsh-net-tools": [
+    "https://raw.githubusercontent.com/izwarm195/dsh-net-tools/main/assets/net_fetch-demo.png"
+  ],
+  "https://github.com/jiezeng2004-design/dsh-chatgpt-bridge": [
+    "https://raw.githubusercontent.com/jiezeng2004-design/dsh-chatgpt-bridge/main/assets/screenshots/01-human-in-the-loop.png",
+    "https://raw.githubusercontent.com/jiezeng2004-design/dsh-chatgpt-bridge/main/assets/screenshots/02-runtime-goal-update.png",
+    "https://raw.githubusercontent.com/jiezeng2004-design/dsh-chatgpt-bridge/main/assets/screenshots/03-native-dsh-execution.png",
+    "https://raw.githubusercontent.com/jiezeng2004-design/dsh-chatgpt-bridge/main/assets/screenshots/04-workspace-security.png",
+    "https://raw.githubusercontent.com/jiezeng2004-design/dsh-chatgpt-bridge/main/assets/screenshots/05-bridge-health.png"
+  ],
+  "https://github.com/jitengfei/dsh-whale-arcade": [
+    "https://raw.githubusercontent.com/jitengfei/dsh-whale-arcade/main/assets/screenshots/01-catalog.png",
+    "https://raw.githubusercontent.com/jitengfei/dsh-whale-arcade/main/assets/screenshots/02-whale-jump.png",
+    "https://raw.githubusercontent.com/jitengfei/dsh-whale-arcade/main/assets/screenshots/03-blue-whale-treasure.png",
+    "https://raw.githubusercontent.com/jitengfei/dsh-whale-arcade/main/assets/screenshots/04-coast-runner.png",
+    "https://raw.githubusercontent.com/jitengfei/dsh-whale-arcade/main/assets/screenshots/05-ocean-gomoku.png"
+  ],
+  "https://github.com/jyh20030112/dsh-visual-plugin": [
+    "https://raw.githubusercontent.com/jyh20030112/dsh-visual-plugin/main/assets/screenshots/screenshot-1.png",
+    "https://raw.githubusercontent.com/jyh20030112/dsh-visual-plugin/main/assets/screenshots/screenshot-2.png",
+    "https://raw.githubusercontent.com/jyh20030112/dsh-visual-plugin/main/assets/screenshots/screenshot-3.png",
+    "https://raw.githubusercontent.com/jyh20030112/dsh-visual-plugin/main/assets/screenshots/screenshot-4.png"
+  ],
+  "https://github.com/kaixinbaba/dsh-vision-recognizer": [
+    "https://raw.githubusercontent.com/kaixinbaba/dsh-vision-recognizer/main/screenshots/vision-config.png",
+    "https://raw.githubusercontent.com/kaixinbaba/dsh-vision-recognizer/main/screenshots/model-picker.png",
+    "https://raw.githubusercontent.com/kaixinbaba/dsh-vision-recognizer/main/screenshots/chat-demo.png",
+    "https://raw.githubusercontent.com/kaixinbaba/dsh-vision-recognizer/main/screenshots/plugin-list.png"
+  ],
+  "https://github.com/kanchengw/dsh-mindseye": [
+    "https://raw.githubusercontent.com/kanchengw/dsh-mindseye/main/assets/ScreenShot_GUI.png",
+    "https://raw.githubusercontent.com/kanchengw/dsh-mindseye/main/assets/ScreenShot_interaction.png",
+    "https://raw.githubusercontent.com/kanchengw/dsh-mindseye/main/assets/ScreenShot_config.png"
+  ],
+  "https://github.com/kexuejin/dsh-zhihu-dashboard": [
+    "https://raw.githubusercontent.com/kexuejin/dsh-zhihu-dashboard/main/assets/hot.png",
+    "https://raw.githubusercontent.com/kexuejin/dsh-zhihu-dashboard/main/assets/track.png",
+    "https://raw.githubusercontent.com/kexuejin/dsh-zhihu-dashboard/main/assets/feed.png",
+    "https://raw.githubusercontent.com/kexuejin/dsh-zhihu-dashboard/main/assets/onboarding.png"
+  ],
+  "https://github.com/keyiadiannao/dsh-restart-button": [
+    "https://raw.githubusercontent.com/keyiadiannao/dsh-power-button/master/docs/screenshots/en/power-button.png",
+    "https://raw.githubusercontent.com/keyiadiannao/dsh-power-button/master/docs/screenshots/en/power-menu.png",
+    "https://raw.githubusercontent.com/keyiadiannao/dsh-power-button/master/docs/screenshots/en/shutdown-confirm.png",
+    "https://raw.githubusercontent.com/keyiadiannao/dsh-power-button/master/docs/screenshots/en/shutdown-progress.png",
+    "https://raw.githubusercontent.com/keyiadiannao/dsh-power-button/master/docs/screenshots/en/restart-done.png"
+  ],
+  "https://github.com/kinoward/dsh-plugin-subhub": [
+    "https://raw.githubusercontent.com/kinoward/dsh-plugin-subhub/main/assets/models-en-light.png",
+    "https://raw.githubusercontent.com/kinoward/dsh-plugin-subhub/main/assets/models-zh-light.png",
+    "https://raw.githubusercontent.com/kinoward/dsh-plugin-subhub/main/assets/settings-loggedin-en-light.png",
+    "https://raw.githubusercontent.com/kinoward/dsh-plugin-subhub/main/assets/settings-loggedin-zh-light.png"
+  ],
+  "https://github.com/labmimors/dsh-mcp-lens": [
+    "https://raw.githubusercontent.com/labmimors/dsh-mcp-lens/main/assets/mcp-lens-hero.webp",
+    "https://raw.githubusercontent.com/labmimors/dsh-mcp-lens/main/assets/mcp-lens-comparison.svg",
+    "https://raw.githubusercontent.com/labmimors/dsh-mcp-lens/main/assets/mcp-lens-comparison.zh-CN.svg"
+  ],
+  "https://github.com/lire1131/dsh-undo-savepoint": [
+    "https://raw.githubusercontent.com/lire1131/dsh-undo-savepoint/master/docs/webui-panel.png",
+    "https://raw.githubusercontent.com/lire1131/dsh-undo-savepoint/master/docs/webui-settings-section.png",
+    "https://raw.githubusercontent.com/lire1131/dsh-undo-savepoint/master/docs/gui-main.png",
+    "https://raw.githubusercontent.com/lire1131/dsh-undo-savepoint/master/docs/gui-settings.png",
+    "https://raw.githubusercontent.com/lire1131/dsh-undo-savepoint/master/docs/safe-mode-confirm.png",
+    "https://raw.githubusercontent.com/lire1131/dsh-undo-savepoint/master/docs/safe-mode-done.png"
+  ],
+  "https://github.com/literaf/dsh-ai4scholar": [
+    "https://raw.githubusercontent.com/literaf/dsh-ai4scholar/main/docs/ai4scholar-home.jpg",
+    "https://raw.githubusercontent.com/literaf/dsh-ai4scholar/main/docs/settings-card.png",
+    "https://raw.githubusercontent.com/literaf/dsh-ai4scholar/main/docs/balance-card.png"
+  ],
+  "https://github.com/liuwenji007/dsh-muyu": [
+    "https://raw.githubusercontent.com/liuwenji007/dsh-muyu/main/docs/tap.gif",
+    "https://raw.githubusercontent.com/liuwenji007/dsh-muyu/main/docs/auto-tap.gif"
+  ],
+  "https://github.com/liuyuelintop/dsh-conversation-exporter": [
+    "https://raw.githubusercontent.com/liuyuelintop/dsh-conversation-exporter/main/assets/select-turns.png",
+    "https://raw.githubusercontent.com/liuyuelintop/dsh-conversation-exporter/main/assets/selective-export-mermaid.png",
+    "https://raw.githubusercontent.com/liuyuelintop/dsh-conversation-exporter/main/assets/selective-export-result.png"
+  ],
+  "https://github.com/maple-pwn/paperlab": [
+    "https://raw.githubusercontent.com/maple-pwn/paperlab/main/docs/assets/screenshot.png"
+  ],
+  "https://github.com/minivv/dsh-agent-skills": [
+    "https://raw.githubusercontent.com/minivv/dsh-agent-skills/main/agent-skills-page.png"
+  ],
+  "https://github.com/ne-ilyxa/dsh-session-drafts": [
+    "https://raw.githubusercontent.com/ne-ilyxa/dsh-session-drafts/master/assets/drafts-popover.png",
+    "https://raw.githubusercontent.com/ne-ilyxa/dsh-session-drafts/master/assets/drafts-switched.png"
+  ],
+  "https://github.com/niuniuaba/dsh-subagent-vision": [
+    "https://raw.githubusercontent.com/niuniuaba/dsh-subagent-vision/main/assets/screenshot-models.png",
+    "https://raw.githubusercontent.com/niuniuaba/dsh-subagent-vision/main/assets/screenshot-vision-route.png"
+  ],
+  "https://github.com/nonewind/dsh-spend": [
+    "https://raw.githubusercontent.com/nonewind/dsh-spend/main/docs/screenshots/dashboard.png",
+    "https://raw.githubusercontent.com/nonewind/dsh-spend/main/docs/screenshots/details-window.png"
+  ],
+  "https://github.com/nzl153/dsh-pet-whale": [
+    "https://raw.githubusercontent.com/nzl153/dsh-pet-whale/main/docs/screenshots/01-idle.png",
+    "https://raw.githubusercontent.com/nzl153/dsh-pet-whale/main/docs/screenshots/02-think.png",
+    "https://raw.githubusercontent.com/nzl153/dsh-pet-whale/main/docs/screenshots/03-working.png",
+    "https://raw.githubusercontent.com/nzl153/dsh-pet-whale/main/docs/screenshots/04-celebrate.png",
+    "https://raw.githubusercontent.com/nzl153/dsh-pet-whale/main/docs/screenshots/05-error.png",
+    "https://raw.githubusercontent.com/nzl153/dsh-pet-whale/main/docs/screenshots/06-feed.png"
+  ],
+  "https://github.com/omdsh-dev/dsh-annotation": [
+    "https://github.com/user-attachments/assets/c3186efc-44d3-4e7f-9523-1902d9d037e9",
+    "https://github.com/user-attachments/assets/0b48ac02-4648-4b94-8d8f-344f8b7c25b4",
+    "https://github.com/user-attachments/assets/8b2610d0-3d00-41be-b314-bac2fe616787",
+    "https://github.com/user-attachments/assets/9b66deea-3786-4296-9b0d-52873a15f5e1"
+  ],
+  "https://github.com/omdsh-dev/dsh-genui": [
+    "https://raw.githubusercontent.com/omdsh-dev/dsh-genui/main/assets/showcase-panel.png",
+    "https://raw.githubusercontent.com/omdsh-dev/dsh-genui/main/assets/showcase-plot.png",
+    "https://raw.githubusercontent.com/omdsh-dev/dsh-genui/main/assets/showcase.png",
+    "https://raw.githubusercontent.com/omdsh-dev/dsh-genui/main/assets/demo-thumb.png"
+  ],
+  "https://github.com/pengpengyi92/dsh-quant": [
+    "https://raw.githubusercontent.com/pengpengyi92/dsh-quant/master/demos/ui-demo-preview.png"
+  ],
+  "https://github.com/pengyue-polaron/deepseek-harness-genui": [
+    "https://raw.githubusercontent.com/pengyue-polaron/deepseek-harness-genui/main/screenshots/en/code-path-canvas.png",
+    "https://raw.githubusercontent.com/pengyue-polaron/deepseek-harness-genui/main/screenshots/en/code-path-inline.png",
+    "https://raw.githubusercontent.com/pengyue-polaron/deepseek-harness-genui/main/screenshots/en/photosynthesis-explorer.png",
+    "https://raw.githubusercontent.com/pengyue-polaron/deepseek-harness-genui/main/screenshots/en/calendar-planner.png",
+    "https://raw.githubusercontent.com/pengyue-polaron/deepseek-harness-genui/main/screenshots/en/code-path-explorer.png"
+  ],
+  "https://github.com/potoior/dsh-bull-bear": [
+    "https://raw.githubusercontent.com/potoior/dsh-bull-bear/main/assets/screenshot-overview.png",
+    "https://raw.githubusercontent.com/potoior/dsh-bull-bear/main/assets/screenshot-panel.png",
+    "https://raw.githubusercontent.com/potoior/dsh-bull-bear/main/assets/screenshot-watchlist.png"
+  ],
+  "https://github.com/pyf2818/dsh-bili-widget": [
+    "https://raw.githubusercontent.com/pyf2818/dsh-bili-widget/main/assets/main.png",
+    "https://raw.githubusercontent.com/pyf2818/dsh-bili-widget/main/assets/search.png",
+    "https://raw.githubusercontent.com/pyf2818/dsh-bili-widget/main/assets/hot.png",
+    "https://raw.githubusercontent.com/pyf2818/dsh-bili-widget/main/assets/help.png",
+    "https://raw.githubusercontent.com/pyf2818/dsh-bili-widget/main/assets/mini.png"
+  ],
+  "https://github.com/qjcnmd/dsh-reasoning-slider": [
+    "https://raw.githubusercontent.com/qjcnmd/dsh-reasoning-slider/main/assets/screenshots/deepseek-v4-pro-max.png",
+    "https://raw.githubusercontent.com/qjcnmd/dsh-reasoning-slider/main/assets/screenshots/deepseek-v4-pro-off.png",
+    "https://raw.githubusercontent.com/qjcnmd/dsh-reasoning-slider/main/assets/screenshots/kimi-k3-max.png",
+    "https://raw.githubusercontent.com/qjcnmd/dsh-reasoning-slider/main/assets/screenshots/minimax-m3-minimal.png"
+  ],
+  "https://github.com/sanqiPanax/dsh-sticker-board": [
+    "https://raw.githubusercontent.com/sanqiPanax/dsh-sticker-board/master/docs/screenshot-dock.png"
+  ],
+  "https://github.com/siberiah2o/dsh-plugin-terminal": [
+    "https://raw.githubusercontent.com/siberiah2o/dsh-plugin-terminal/main/docs/screenshot-collapsed.png",
+    "https://raw.githubusercontent.com/siberiah2o/dsh-plugin-terminal/main/docs/screenshot-panel.png",
+    "https://raw.githubusercontent.com/siberiah2o/dsh-plugin-terminal/main/docs/screenshot-multitab.png"
+  ],
+  "https://github.com/sjh9714/dsh-movein": [
+    "https://raw.githubusercontent.com/sjh9714/dsh-movein/main/docs/report.png",
+    "https://raw.githubusercontent.com/sjh9714/dsh-movein/main/docs/demo.gif",
+    "https://raw.githubusercontent.com/sjh9714/dsh-movein/main/docs/social.png"
+  ],
+  "https://github.com/sjh9714/dsh-win32": [
+    "https://raw.githubusercontent.com/sjh9714/dsh-win32/master/assets/market-card.png",
+    "https://raw.githubusercontent.com/sjh9714/dsh-win32/master/assets/shot-persistent-sandboxed.png",
+    "https://raw.githubusercontent.com/sjh9714/dsh-win32/master/assets/shot-preset-picker.png"
+  ],
+  "https://github.com/skyhancloud/dsh-client-ui-quote": [
+    "https://raw.githubusercontent.com/skyhancloud/dsh-client-ui-quote/main/assets/preview-1.png",
+    "https://raw.githubusercontent.com/skyhancloud/dsh-client-ui-quote/main/assets/preview-2.png"
+  ],
+  "https://github.com/slywalker2006/dsh-passwords": [
+    "https://raw.githubusercontent.com/slywalker2006/dsh-passwords/main/docs/screenshots/white-login.png",
+    "https://raw.githubusercontent.com/slywalker2006/dsh-passwords/main/docs/screenshots/black-login.png",
+    "https://raw.githubusercontent.com/slywalker2006/dsh-passwords/main/docs/screenshots/white-login-en.png",
+    "https://raw.githubusercontent.com/slywalker2006/dsh-passwords/main/docs/screenshots/main-ui.png",
+    "https://raw.githubusercontent.com/slywalker2006/dsh-passwords/main/docs/screenshots/chat.png",
+    "https://raw.githubusercontent.com/slywalker2006/dsh-passwords/main/docs/screenshots/card-front.png",
+    "https://raw.githubusercontent.com/slywalker2006/dsh-passwords/main/docs/screenshots/card-back.png"
+  ],
+  "https://github.com/starslittle/dsh-blue-whale": [
+    "https://raw.githubusercontent.com/starslittle/dsh-blue-whale/main/docs/compare-home.png",
+    "https://raw.githubusercontent.com/starslittle/dsh-blue-whale/main/docs/compare-brand.png"
+  ],
+  "https://github.com/starslittle/dsh-queue-plus": [
+    "https://raw.githubusercontent.com/starslittle/dsh-queue-plus/main/assets/queue-default.png",
+    "https://raw.githubusercontent.com/starslittle/dsh-queue-plus/main/assets/queue-remove-all.png",
+    "https://raw.githubusercontent.com/starslittle/dsh-queue-plus/main/assets/queue-remove-complete.png",
+    "https://raw.githubusercontent.com/starslittle/dsh-queue-plus/main/assets/queue-sort.png"
+  ],
+  "https://github.com/superagents-lab/dsh-s1": [
+    "https://raw.githubusercontent.com/superagents-lab/dsh-s1/main/assets/dsh-s1.png"
+  ],
+  "https://github.com/text2future/flowix/tree/main/dsh-flowix-memory": [
+    "https://raw.githubusercontent.com/text2future/flowix/main/docs/images/home-write.png",
+    "https://raw.githubusercontent.com/text2future/flowix/main/docs/images/readme-agent.png",
+    "https://raw.githubusercontent.com/text2future/flowix/main/docs/images/gh-detail-4.png",
+    "https://raw.githubusercontent.com/text2future/flowix/main/docs/images/gh-detail-6.png"
+  ],
+  "https://github.com/tpmoonchefryan/dsh-joi-channel-theme": [
+    "https://raw.githubusercontent.com/tpmoonchefryan/dsh-joi-channel-theme/main/docs/settings-wardrobe.png",
+    "https://raw.githubusercontent.com/tpmoonchefryan/dsh-joi-channel-theme/main/docs/settings-wardrobe-dark.png",
+    "https://raw.githubusercontent.com/tpmoonchefryan/dsh-joi-channel-theme/main/docs/new-chat-flowers.png",
+    "https://raw.githubusercontent.com/tpmoonchefryan/dsh-joi-channel-theme/main/docs/new-chat-library.png",
+    "https://raw.githubusercontent.com/tpmoonchefryan/dsh-joi-channel-theme/main/docs/new-chat-flowers-dark.png",
+    "https://raw.githubusercontent.com/tpmoonchefryan/dsh-joi-channel-theme/main/docs/working-flowers.png",
+    "https://raw.githubusercontent.com/tpmoonchefryan/dsh-joi-channel-theme/main/docs/success-library.png",
+    "https://raw.githubusercontent.com/tpmoonchefryan/dsh-joi-channel-theme/main/docs/app-logo-flowers.png"
+  ],
+  "https://github.com/truelove-dreamer/dsh-plugin-vetting": [
+    "https://raw.githubusercontent.com/truelove-dreamer/dsh-plugin-vetting/main/assets/shot-report.png",
+    "https://raw.githubusercontent.com/truelove-dreamer/dsh-plugin-vetting/main/assets/shot-detail.png",
+    "https://raw.githubusercontent.com/truelove-dreamer/dsh-plugin-vetting/main/assets/shot-gate.png"
+  ],
+  "https://github.com/tt-a1i/archify/tree/main/integrations/deepseek-harness": [
+    "https://raw.githubusercontent.com/tt-a1i/archify/main/docs/assets/archify-live-proof.gif",
+    "https://raw.githubusercontent.com/tt-a1i/archify/main/docs/assets/archify-dark.png",
+    "https://raw.githubusercontent.com/tt-a1i/archify/main/docs/assets/archify-light.png"
+  ],
+  "https://github.com/txlznbzsdj-collab/dsh-deepseek-pet": [
+    "https://raw.githubusercontent.com/txlznbzsdj-collab/dsh-deepseek-pet/main/screenshots/1.png",
+    "https://raw.githubusercontent.com/txlznbzsdj-collab/dsh-deepseek-pet/main/screenshots/2.png",
+    "https://raw.githubusercontent.com/txlznbzsdj-collab/dsh-deepseek-pet/main/screenshots/3.png"
+  ],
+  "https://github.com/v587d/dsh-opencode-go-usage": [
+    "https://raw.githubusercontent.com/v587d/dsh-opencode-go-usage/main/assets/custom-footer.png",
+    "https://raw.githubusercontent.com/v587d/dsh-opencode-go-usage/main/assets/usage-detail.png",
+    "https://raw.githubusercontent.com/v587d/dsh-opencode-go-usage/main/assets/set-cookie-wid.png"
+  ],
+  "https://github.com/vdnight89/InfiniteDSH": [
+    "https://raw.githubusercontent.com/vdnight89/InfiniteDSH/main/docs/%E6%88%AA%E5%9B%BE1.png",
+    "https://raw.githubusercontent.com/vdnight89/InfiniteDSH/main/docs/%E6%88%AA%E5%9B%BE2.png",
+    "https://raw.githubusercontent.com/vdnight89/InfiniteDSH/main/docs/%E6%88%AA%E5%9B%BE2.1.png",
+    "https://raw.githubusercontent.com/vdnight89/InfiniteDSH/main/docs/%E6%88%AA%E5%9B%BE2.2.png"
+  ],
+  "https://github.com/weisiren000/dsh-remote-ssh-ops": [
+    "https://raw.githubusercontent.com/weisiren000/dsh-remote-ssh-ops/main/docs/assets/remote-workbench-preview.png"
+  ],
+  "https://github.com/welsione/dsh-mmx-bridge": [
+    "https://raw.githubusercontent.com/welsione/dsh-mmx-bridge/main/docs/image-generation.png",
+    "https://raw.githubusercontent.com/welsione/dsh-mmx-bridge/main/docs/speech-tts.png",
+    "https://raw.githubusercontent.com/welsione/dsh-mmx-bridge/main/docs/vision-demo.png",
+    "https://raw.githubusercontent.com/welsione/dsh-mmx-bridge/main/docs/plugin-settings.png"
+  ],
+  "https://github.com/wloops/dsh-git-worktree": [
+    "https://raw.githubusercontent.com/wloops/dsh-git-worktree/master/docs/screenshots/01-create-worktree.png",
+    "https://raw.githubusercontent.com/wloops/dsh-git-worktree/master/docs/screenshots/02-ready-for-review.png",
+    "https://raw.githubusercontent.com/wloops/dsh-git-worktree/master/docs/screenshots/03-local-preview.png",
+    "https://raw.githubusercontent.com/wloops/dsh-git-worktree/master/docs/screenshots/04-commit-confirmation.png",
+    "https://raw.githubusercontent.com/wloops/dsh-git-worktree/master/docs/screenshots/05-next-iteration.png",
+    "https://raw.githubusercontent.com/wloops/dsh-git-worktree/master/docs/screenshots/06-retain-environment.png"
+  ],
+  "https://github.com/wly8691-jpg/knowlp-rag": [
+    "https://raw.githubusercontent.com/wly8691-jpg/knowlp-rag/main/docs/demo.png",
+    "https://raw.githubusercontent.com/wly8691-jpg/knowlp-rag/main/docs/health.png",
+    "https://raw.githubusercontent.com/wly8691-jpg/knowlp-rag/main/docs/decay.png",
+    "https://raw.githubusercontent.com/wly8691-jpg/knowlp-rag/main/docs/architecture.png"
+  ],
+  "https://github.com/wss534857356/dsh-plugin-codex": [
+    "https://raw.githubusercontent.com/wss534857356/dsh-plugin-codex/main/docs/images/conversation-screenshot.png",
+    "https://raw.githubusercontent.com/wss534857356/dsh-plugin-codex/main/docs/images/model-selector-screenshot.png"
+  ],
+  "https://github.com/wuxiangru915/dsh-review-loop": [
+    "https://raw.githubusercontent.com/wuxiangru915/dsh-review-loop/master/assets/review-panel.en.png",
+    "https://raw.githubusercontent.com/wuxiangru915/dsh-review-loop/master/assets/review-panel.zh.png"
+  ],
+  "https://github.com/wuxiangru915/dsh-session-manager": [
+    "https://raw.githubusercontent.com/wuxiangru915/dsh-session-manager/main/assets/session-manager.png"
+  ],
+  "https://github.com/wx-yss/dsh-message-rail": [
+    "https://raw.githubusercontent.com/wx-yss/dsh-message-rail/main/assets/rail-hover-preview.png"
+  ],
+  "https://github.com/wz-heng/dsh-feishu-bridge": [
+    "https://raw.githubusercontent.com/wz-heng/dsh-feishu-bridge/main/docs/screenshots/fail-closed-boot.png",
+    "https://raw.githubusercontent.com/wz-heng/dsh-feishu-bridge/main/docs/screenshots/dsh-plugin-add.png",
+    "https://raw.githubusercontent.com/wz-heng/dsh-feishu-bridge/main/docs/screenshots/architecture.png"
+  ],
+  "https://github.com/xbzbing/dsh-auth-gateway": [
+    "https://raw.githubusercontent.com/xbzbing/dsh-auth-gateway/main/docs/assets/onboarding.png",
+    "https://raw.githubusercontent.com/xbzbing/dsh-auth-gateway/main/docs/assets/login.png",
+    "https://raw.githubusercontent.com/xbzbing/dsh-auth-gateway/main/docs/assets/login-success.png",
+    "https://raw.githubusercontent.com/xbzbing/dsh-auth-gateway/main/docs/assets/otp-setup.png",
+    "https://raw.githubusercontent.com/xbzbing/dsh-auth-gateway/main/docs/assets/settings-menu.png",
+    "https://raw.githubusercontent.com/xbzbing/dsh-auth-gateway/main/docs/assets/settings-auth.png"
+  ],
+  "https://github.com/xiajiajun516/dsh-config-manager": [
+    "https://raw.githubusercontent.com/xiajiajun516/dsh-config-manager/main/assets/screenshot-export.png",
+    "https://raw.githubusercontent.com/xiajiajun516/dsh-config-manager/main/assets/screenshot-import-preview.png",
+    "https://raw.githubusercontent.com/xiajiajun516/dsh-config-manager/main/assets/screenshot-snapshots.png",
+    "https://raw.githubusercontent.com/xiajiajun516/dsh-config-manager/main/assets/screenshot-sync.png"
+  ],
+  "https://github.com/xohmai/dsh-cpa-status": [
+    "https://raw.githubusercontent.com/xohmai/dsh-cpa-status/main/docs/images/panel.png",
+    "https://raw.githubusercontent.com/xohmai/dsh-cpa-status/main/docs/images/collapsed.png"
+  ],
+  "https://github.com/yflmq001/dsh-cost-tracker": [
+    "https://raw.githubusercontent.com/yflmq001/dsh-cost-tracker/main/assets/screenshots/screenshot-main.png",
+    "https://raw.githubusercontent.com/yflmq001/dsh-cost-tracker/main/assets/screenshots/screenshot-cost-panel.png",
+    "https://raw.githubusercontent.com/yflmq001/dsh-cost-tracker/main/assets/screenshots/screenshot-config.png"
+  ],
+  "https://github.com/yunxiiQwQ/dsh-maid-whale-webUI/tree/main/maid-whale-webui": [
+    "https://raw.githubusercontent.com/yunxiiQwQ/dsh-maid-whale-webUI/main/maid-whale-webui/preview/light.webp",
+    "https://raw.githubusercontent.com/yunxiiQwQ/dsh-maid-whale-webUI/main/maid-whale-webui/preview/dark.webp"
+  ],
+  "https://github.com/yyyyukari/dsh-plugin-workshop": [
+    "https://raw.githubusercontent.com/yyyyukari/dsh-plugin-workshop/master/assets/main-ui.jpg",
+    "https://raw.githubusercontent.com/yyyyukari/dsh-plugin-workshop/master/assets/installed-view.jpg",
+    "https://raw.githubusercontent.com/yyyyukari/dsh-plugin-workshop/master/assets/sidebar-entry.jpg"
+  ],
+  "https://github.com/zdx8637-gitdog/dshmobile/tree/main/plugins": [
+    "https://raw.githubusercontent.com/zdx8637-gitdog/dshmobile/main/docs/images/plugin-panel.jpg",
+    "https://raw.githubusercontent.com/zdx8637-gitdog/dshmobile/main/docs/images/phone-1.jpg",
+    "https://raw.githubusercontent.com/zdx8637-gitdog/dshmobile/main/docs/images/phone-2.jpg",
+    "https://raw.githubusercontent.com/zdx8637-gitdog/dshmobile/main/docs/images/phone-3.jpg"
+  ],
+  "https://github.com/zer0zio-stack/dsh-opencode-go-quota": [
+    "https://raw.githubusercontent.com/zer0zio-stack/dsh-opencode-go-quota/main/assets/screenshot-deepseek-balance.png",
+    "https://raw.githubusercontent.com/zer0zio-stack/dsh-opencode-go-quota/main/assets/screenshot-opencode-go-limit.png"
+  ],
+  "https://github.com/zhtx2024/dsh-pdf": [
+    "https://raw.githubusercontent.com/zhtx2024/dsh-pdf/master/assets/screenshot-schematic.png",
+    "https://raw.githubusercontent.com/zhtx2024/dsh-pdf/master/assets/screenshot-power.png"
+  ],
+  "https://github.com/zljr/dsh-share": [
+    "https://raw.githubusercontent.com/zljr/dsh-share/master/assets/share-dialog.png",
+    "https://raw.githubusercontent.com/zljr/dsh-share/master/assets/share-page-light.png",
+    "https://raw.githubusercontent.com/zljr/dsh-share/master/assets/share-page-dark.png"
+  ],
+  "https://github.com/2008924/dsh-progress-viz/tree/main/plugin": [
+    "https://raw.githubusercontent.com/2008924/dsh-progress-viz/main/docs/screenshot.png"
+  ],
+  "https://github.com/534119219/dsh-messaging/tree/main/packages/messaging-core": [
+    "https://raw.githubusercontent.com/534119219/dsh-messaging/main/assets/sidebar.png",
+    "https://raw.githubusercontent.com/534119219/dsh-messaging/main/assets/dialog.png"
+  ],
+  "https://github.com/Blank-not-black/dsh-Remote/tree/main/packages/plugin": [
+    "https://raw.githubusercontent.com/Blank-not-black/dsh-Remote/main/docs/screenshots/mobile-sessions.png",
+    "https://raw.githubusercontent.com/Blank-not-black/dsh-Remote/main/docs/screenshots/mobile-approvals.png",
+    "https://raw.githubusercontent.com/Blank-not-black/dsh-Remote/main/docs/screenshots/mobile-files.png",
+    "https://raw.githubusercontent.com/Blank-not-black/dsh-Remote/main/docs/screenshots/mobile-settings.png",
+    "https://raw.githubusercontent.com/Blank-not-black/dsh-Remote/main/docs/screenshots/gateway.png",
+    "https://raw.githubusercontent.com/Blank-not-black/dsh-Remote/main/docs/screenshots/settings-mobile.png",
+    "https://raw.githubusercontent.com/Blank-not-black/dsh-Remote/main/docs/screenshots/sessions.png",
+    "https://raw.githubusercontent.com/Blank-not-black/dsh-Remote/main/docs/screenshots/files.png"
+  ],
+  "https://github.com/UndeadSheep/dsh-file-preview/tree/main/packages/dsh-file-preview": [
+    "https://raw.githubusercontent.com/UndeadSheep/dsh-file-preview/main/assets/github-social-preview.png",
+    "https://raw.githubusercontent.com/UndeadSheep/dsh-file-preview/main/assets/btnPos.gif",
+    "https://raw.githubusercontent.com/UndeadSheep/dsh-file-preview/main/assets/write.gif",
+    "https://raw.githubusercontent.com/UndeadSheep/dsh-file-preview/main/assets/clickOpen.gif",
+    "https://raw.githubusercontent.com/UndeadSheep/dsh-file-preview/main/assets/SearchBar.gif"
+  ],
+  "https://github.com/Lzh3070/dsh-file-review-tab": [
+    "https://raw.githubusercontent.com/Lzh3070/dsh-file-review-tab/main/docs/screenshot.png"
+  ],
+  "https://github.com/ayahunter/dsh-trail/tree/main/packages/bundle": [
+    "https://raw.githubusercontent.com/ayahunter/dsh-trail/main/docs/screenshot.png",
+    "https://raw.githubusercontent.com/ayahunter/dsh-trail/main/docs/screenshots/rounds-view.png",
+    "https://raw.githubusercontent.com/ayahunter/dsh-trail/main/docs/screenshots/tool-details.png"
+  ],
+  "https://github.com/kaziii/dsh-github-connector/tree/main/packages/github/github": [
+    "https://raw.githubusercontent.com/kaziii/dsh-github-connector/main/docs/assets/pr-bar.png",
+    "https://raw.githubusercontent.com/kaziii/dsh-github-connector/main/docs/assets/connect-github.png"
+  ],
+  "https://github.com/siberiah2o/dsh-plugin-remote": [
+    "https://raw.githubusercontent.com/siberiah2o/dsh-plugin-remote/main/docs/screenshot-login.png",
+    "https://raw.githubusercontent.com/siberiah2o/dsh-plugin-remote/main/docs/screenshot-settings-panel.png"
+  ],
+  "https://github.com/WilliamShi666/dsh-wsl-workspace-picker": [
+    "https://raw.githubusercontent.com/WilliamShi666/dsh-wsl-workspace-picker/main/assets/workspace-picker-demo.png"
+  ],
+  "https://github.com/Liu-ZA-81/dsh-theme-firefly": [
+    "https://raw.githubusercontent.com/Liu-ZA-81/dsh-theme-firefly/main/docs/screenshots/01-wallpaper.jpg",
+    "https://raw.githubusercontent.com/Liu-ZA-81/dsh-theme-firefly/main/docs/screenshots/02-boot.jpg",
+    "https://raw.githubusercontent.com/Liu-ZA-81/dsh-theme-firefly/main/docs/screenshots/03-firefly.jpg",
+    "https://raw.githubusercontent.com/Liu-ZA-81/dsh-theme-firefly/main/docs/screenshots/04-music.jpg",
+    "https://raw.githubusercontent.com/Liu-ZA-81/dsh-theme-firefly/main/docs/screenshots/05-emote.jpg"
+  ],
+  "https://github.com/cheshireez/dsh-skill-hub": [
+    "https://raw.githubusercontent.com/cheshireez/dsh-skill-hub/main/promo/real-skill-hub.png",
+    "https://raw.githubusercontent.com/cheshireez/dsh-skill-hub/main/promo/real-skill-hub-catalog.png",
+    "https://raw.githubusercontent.com/cheshireez/dsh-skill-hub/main/promo/real-skill-hub-scenes.png"
+  ],
+  "https://github.com/maddogfinance/dsh-trading": [
+    "https://raw.githubusercontent.com/maddogfinance/dsh-trading/main/docs/screenshots/chart-card-panes.png",
+    "https://raw.githubusercontent.com/maddogfinance/dsh-trading/main/docs/screenshots/annotate-levels-table.png"
+  ],
+  "https://github.com/mux9056-bot/dsh-theme": [
+    "https://raw.githubusercontent.com/mux9056-bot/dsh-theme/main/shots/preview-gallery.png",
+    "https://raw.githubusercontent.com/mux9056-bot/dsh-theme/main/shots/mono-dark.png",
+    "https://raw.githubusercontent.com/mux9056-bot/dsh-theme/main/shots/sakura-light.png",
+    "https://raw.githubusercontent.com/mux9056-bot/dsh-theme/main/shots/terminal-dark.png"
+  ],
+  "https://github.com/chinosk6/dsh-roleplay": [
+    "https://raw.githubusercontent.com/chinosk6/dsh-roleplay/main/images/screenshot1.png"
+  ],
+  "https://github.com/starsstreaming/beautiCode/tree/main/integrations/deepseek-harness": [
+    "https://github.com/user-attachments/assets/c943a0fb-ff48-4361-9e6f-c4b1521aee2b",
+    "https://github.com/user-attachments/assets/a9a18412-4c62-4083-ab49-d127f05e61c3"
+  ],
+  "https://github.com/wenheguo2/dsh-delegation-suite": [
+    "https://raw.githubusercontent.com/wenheguo2/dsh-delegation-suite/main/assets/routes.png",
+    "https://raw.githubusercontent.com/wenheguo2/dsh-delegation-suite/main/assets/subagents.png"
+  ],
+  "https://github.com/kanneiren/dsh-network-settings": [
+    "https://raw.githubusercontent.com/kanneiren/dsh-network-settings/main/docs/images/wsl-path-graph.png",
+    "https://raw.githubusercontent.com/kanneiren/dsh-network-settings/main/docs/images/win-path-graph.png",
+    "https://raw.githubusercontent.com/kanneiren/dsh-network-settings/main/docs/images/win-network-config.png"
+  ],
+  "https://github.com/anneheartrecord/dsh-desk-pet": [
+    "https://raw.githubusercontent.com/anneheartrecord/dsh-desk-pet/main/docs/media/diy-skin.png",
+    "https://raw.githubusercontent.com/anneheartrecord/dsh-desk-pet/main/docs/media/floats-above.png",
+    "https://raw.githubusercontent.com/anneheartrecord/dsh-desk-pet/main/docs/media/skins.png",
+    "https://raw.githubusercontent.com/anneheartrecord/dsh-desk-pet/main/docs/media/states.png"
+  ],
+  "https://github.com/wsxwj123/dsh-plugins/tree/main/packages/dsh-appearance-gallery": [
+    "https://raw.githubusercontent.com/wsxwj123/dsh-plugins/main/assets/screenshots/appearance-gallery.png"
+  ],
+  "https://github.com/wsxwj123/dsh-plugins/tree/main/packages/dsh-turn-scrubber": [
+    "https://raw.githubusercontent.com/wsxwj123/dsh-plugins/main/assets/screenshots/turn-scrubber.png"
+  ],
+  "https://github.com/wsxwj123/dsh-plugins/tree/main/packages/dsh-session-manager": [
+    "https://raw.githubusercontent.com/wsxwj123/dsh-plugins/main/assets/screenshots/session-manager.png"
+  ],
+  "https://github.com/wsxwj123/dsh-plugins/tree/main/packages/dsh-composer-tools": [
+    "https://raw.githubusercontent.com/wsxwj123/dsh-plugins/main/assets/screenshots/composer-tools.png"
+  ],
+  "https://github.com/acebang0303/dsh-quick-launch": [
+    "https://raw.githubusercontent.com/acebang0303/dsh-quick-launch/main/docs/preview.png"
+  ],
+  "https://github.com/corrinehu/dsh-workbuddy-connect": [
+    "https://raw.githubusercontent.com/corrinehu/dsh-workbuddy-connect/main/assets/1.png",
+    "https://raw.githubusercontent.com/corrinehu/dsh-workbuddy-connect/main/assets/2.png",
+    "https://raw.githubusercontent.com/corrinehu/dsh-workbuddy-connect/main/assets/3.png"
+  ],
+  "https://github.com/tipoLi5890/dsh-file-mention": [
+    "https://raw.githubusercontent.com/tipoLi5890/dsh-file-mention/main/assets/screenshots/file-mention-browse.png",
+    "https://raw.githubusercontent.com/tipoLi5890/dsh-file-mention/main/assets/screenshots/file-mention-drag-drop.png",
+    "https://raw.githubusercontent.com/tipoLi5890/dsh-file-mention/main/assets/screenshots/file-mention-upload-reference.png"
+  ],
+  "https://github.com/liguobao/deepseek-harness-remote": [
+    "https://raw.githubusercontent.com/liguobao/deepseek-harness-remote/main/docs/images/setting.png",
+    "https://raw.githubusercontent.com/liguobao/deepseek-harness-remote/main/docs/images/host-list.png",
+    "https://raw.githubusercontent.com/liguobao/deepseek-harness-remote/main/docs/images/remote.png"
+  ],
+  "https://github.com/WJZ-P/dsh-attachments": [
+    "https://raw.githubusercontent.com/WJZ-P/dsh-attachments/main/assets/markdown/01-drag-drop-overlay.png",
+    "https://raw.githubusercontent.com/WJZ-P/dsh-attachments/main/assets/markdown/02-image-conversation.png",
+    "https://raw.githubusercontent.com/WJZ-P/dsh-attachments/main/assets/markdown/03-multiple-image-preview.png"
+  ],
+  "https://github.com/WJZ-P/dsh-model-capabilities": [
+    "https://raw.githubusercontent.com/WJZ-P/dsh-model-capabilities/main/assets/screenshots/01-model-input-selector.png"
+  ],
+  "https://github.com/winditer/dsh-elf": [
+    "https://raw.githubusercontent.com/winditer/dsh-elf/main/assets/screenshot-elf.png",
+    "https://raw.githubusercontent.com/winditer/dsh-elf/main/assets/screenshot-chat.png"
+  ],
+  "https://github.com/Frog755/dsh-client-auto-retry": [
+    "https://raw.githubusercontent.com/Frog755/dsh-client-auto-retry/main/assets/demo.svg",
+    "https://raw.githubusercontent.com/Frog755/dsh-client-auto-retry/main/assets/screenshot-settings-card.png"
+  ],
+  "https://github.com/Frog755/dsh-prompt-vault": [
+    "https://raw.githubusercontent.com/Frog755/dsh-prompt-vault/master/assets/screenshot-panel.png"
+  ],
+  "https://github.com/lemonorangeapple/dsh-effort-switcher": [
+    "https://raw.githubusercontent.com/lemonorangeapple/dsh-effort-switcher/master/screenshots/1.png",
+    "https://raw.githubusercontent.com/lemonorangeapple/dsh-effort-switcher/master/screenshots/2.png"
+  ],
+  "https://github.com/falser101/dsh-mascot": [
+    "https://raw.githubusercontent.com/falser101/dsh-mascot/main/assets/cover.jpg",
+    "https://raw.githubusercontent.com/falser101/dsh-mascot/main/assets/faces.jpg",
+    "https://raw.githubusercontent.com/falser101/dsh-mascot/main/assets/skins.jpg"
+  ],
+  "https://github.com/LiZhenNet/dsh-antigravity": [
+    "https://raw.githubusercontent.com/LiZhenNet/dsh-antigravity/main/assets/images/settings-signed-in.png",
+    "https://raw.githubusercontent.com/LiZhenNet/dsh-antigravity/main/assets/images/chat-model-picker.png",
+    "https://raw.githubusercontent.com/LiZhenNet/dsh-antigravity/main/assets/images/settings-not-signed-in.png"
+  ],
+  "https://github.com/geguanming/dsh-office-plugin": [
+    "https://raw.githubusercontent.com/geguanming/dsh-office-plugin/master/assets/entry.png",
+    "https://raw.githubusercontent.com/geguanming/dsh-office-plugin/master/assets/work-monitor.png",
+    "https://raw.githubusercontent.com/geguanming/dsh-office-plugin/master/assets/order-boss.png"
+  ],
+  "https://github.com/lninghaha/dsh-hub-oauth-gateway": [
+    "https://raw.githubusercontent.com/lninghaha/dsh-hub-oauth-gateway/main/docs/images/usage-center-hud.png",
+    "https://raw.githubusercontent.com/lninghaha/dsh-hub-oauth-gateway/main/docs/images/usage-center-peek.png",
+    "https://raw.githubusercontent.com/lninghaha/dsh-hub-oauth-gateway/main/docs/images/usage-center-dashboard.png",
+    "https://raw.githubusercontent.com/lninghaha/dsh-hub-oauth-gateway/main/docs/images/usage-center-settings.png"
+  ],
+  "https://github.com/deepseek-dsh/dsh-workspace": [
+    "https://raw.githubusercontent.com/deepseek-dsh/dsh-workspace/main/assets/Screenshot-1.png",
+    "https://raw.githubusercontent.com/deepseek-dsh/dsh-workspace/main/assets/Screenshot-2.png"
+  ],
+  "https://github.com/CheshireJCat/blender": [
+    "https://raw.githubusercontent.com/CheshireJCat/blender/main/assets/dsh-blender-lamp-preview.png"
+  ],
+  "https://github.com/Y1X1n/dsh-prompt-optimizer": [
+    "https://raw.githubusercontent.com/Y1X1n/dsh-prompt-optimizer/main/docs/screenshots/optimize-panel.png"
+  ],
+  "https://github.com/feng78-boop/dsh-thirteen-bg": [
+    "https://raw.githubusercontent.com/feng78-boop/dsh-thirteen-bg/master/assets/demo-poster.jpg",
+    "https://raw.githubusercontent.com/feng78-boop/dsh-thirteen-bg/master/assets/demo-shot-2.jpg"
+  ],
+  "https://github.com/wsz987/dsh-channels/tree/main/packages/channels": [
+    "https://raw.githubusercontent.com/wsz987/dsh-channels/main/docs/ScreenShot/dsh-channels-setting.png",
+    "https://raw.githubusercontent.com/wsz987/dsh-channels/main/docs/ScreenShot/telegram.png"
+  ],
+  "https://github.com/liustack/modsearch": [
+    "https://raw.githubusercontent.com/liustack/modsearch/main/assets/demo-dsh-settings-card.jpg",
+    "https://raw.githubusercontent.com/liustack/modsearch/main/assets/demo-codex-search.png",
+    "https://raw.githubusercontent.com/liustack/modsearch/main/assets/demo-codex-fetch.png"
+  ],
+  "https://github.com/liustack/modlens": [
+    "https://raw.githubusercontent.com/liustack/modlens/main/assets/demo-dsh-settings-card.jpg",
+    "https://raw.githubusercontent.com/liustack/modlens/main/assets/demo-dsh-paste.jpg",
+    "https://raw.githubusercontent.com/liustack/modlens/main/assets/demo-codex-chart.jpg",
+    "https://raw.githubusercontent.com/liustack/modlens/main/assets/demo-codex-app.jpg"
+  ],
+  "https://github.com/elysia395/dsh-wallpaper-engine": [
+    "https://raw.githubusercontent.com/elysia395/dsh-wallpaper-engine/main/docs/images/showcase.png",
+    "https://raw.githubusercontent.com/elysia395/dsh-wallpaper-engine/main/docs/images/wallpaper-library.png",
+    "https://raw.githubusercontent.com/elysia395/dsh-wallpaper-engine/main/docs/images/liquid-glass-window.png",
+    "https://raw.githubusercontent.com/elysia395/dsh-wallpaper-engine/main/docs/images/features.png",
+    "https://raw.githubusercontent.com/elysia395/dsh-wallpaper-engine/main/docs/images/compact-wallpaper-library.png",
+    "https://raw.githubusercontent.com/elysia395/dsh-wallpaper-engine/main/docs/images/better-sidebar.png"
+  ],
+  "https://github.com/dami9527/dsh-image-pathify": [
+    "https://raw.githubusercontent.com/dami9527/dsh-image-pathify/master/assets/example.png",
+    "https://raw.githubusercontent.com/dami9527/dsh-image-pathify/master/assets/settings.png",
+    "https://raw.githubusercontent.com/dami9527/dsh-image-pathify/master/assets/update.png"
+  ],
+  "https://github.com/WSL043/dsh-chat-manager": [
+    "https://raw.githubusercontent.com/WSL043/dsh-chat-manager/main/docs/assets/archive-manager.en.png",
+    "https://raw.githubusercontent.com/WSL043/dsh-chat-manager/main/docs/assets/confirm-delete.en.png"
+  ],
+  "https://github.com/ryubyte/dsh-a2a": [
+    "https://raw.githubusercontent.com/ryubyte/dsh-a2a/main/docs/screenshots/dashboard-outbound.png",
+    "https://raw.githubusercontent.com/ryubyte/dsh-a2a/main/docs/screenshots/dashboard-inbound.png",
+    "https://raw.githubusercontent.com/ryubyte/dsh-a2a/main/docs/screenshots/server-inbound.png",
+    "https://raw.githubusercontent.com/ryubyte/dsh-a2a/main/docs/screenshots/server-serve.png"
+  ],
+  "https://github.com/EdwinDigital/dsh-web-search-microsoft-webiq": [
+    "https://raw.githubusercontent.com/EdwinDigital/dsh-web-search-microsoft-webiq/main/docs/images/screenshot-1-settings.png",
+    "https://raw.githubusercontent.com/EdwinDigital/dsh-web-search-microsoft-webiq/main/docs/images/screenshot-2-web-search.png",
+    "https://raw.githubusercontent.com/EdwinDigital/dsh-web-search-microsoft-webiq/main/docs/images/screenshot-3-trace.png"
+  ],
+  "https://github.com/SmileBuild/dsh-planchart": [
+    "https://raw.githubusercontent.com/SmileBuild/dsh-planchart/main/assets/screenshot-1.png",
+    "https://raw.githubusercontent.com/SmileBuild/dsh-planchart/main/assets/screenshot-2.png"
+  ],
+  "https://github.com/WSL043/dsh-codex-subscription": [
+    "https://raw.githubusercontent.com/WSL043/dsh-codex-subscription/main/docs/assets/settings-en.png",
+    "https://raw.githubusercontent.com/WSL043/dsh-codex-subscription/main/docs/assets/composer-quota-en.png"
+  ],
+  "https://github.com/mkiea/dsh-forge": [
+    "https://raw.githubusercontent.com/mkiea/dsh-forge/master/assets/screenshot-1.png",
+    "https://raw.githubusercontent.com/mkiea/dsh-forge/master/assets/screenshot-2.png",
+    "https://raw.githubusercontent.com/mkiea/dsh-forge/master/assets/screenshot-3.png"
+  ],
+  "https://github.com/alone-tree/dsh-skill-mcp-manager": [
+    "https://raw.githubusercontent.com/alone-tree/dsh-skill-mcp-manager/main/docs/screenshot-mcp.png",
+    "https://raw.githubusercontent.com/alone-tree/dsh-skill-mcp-manager/main/docs/screenshot-skills.png"
+  ],
+  "https://github.com/liqiming-whu/dsh-status-card": [
+    "https://raw.githubusercontent.com/liqiming-whu/dsh-status-card/main/docs/images/templates/bilingual/template-a.svg",
+    "https://raw.githubusercontent.com/liqiming-whu/dsh-status-card/main/docs/images/templates/bilingual/template-b.svg",
+    "https://raw.githubusercontent.com/liqiming-whu/dsh-status-card/main/docs/images/templates/bilingual/template-c.svg",
+    "https://raw.githubusercontent.com/liqiming-whu/dsh-status-card/main/docs/images/templates/bilingual/template-d.svg",
+    "https://raw.githubusercontent.com/liqiming-whu/dsh-status-card/main/docs/images/templates/bilingual/template-e.svg",
+    "https://raw.githubusercontent.com/liqiming-whu/dsh-status-card/main/docs/images/templates/bilingual/template-f.svg"
+  ],
+  "https://github.com/zhujunpeng12/dsh-memory-system": [
+    "https://raw.githubusercontent.com/zhujunpeng12/dsh-memory-system/master/assets/social-preview.png",
+    "https://raw.githubusercontent.com/zhujunpeng12/dsh-memory-system/master/docs/memory-system-flowchart.png"
+  ],
+  "https://github.com/wangzhishou/onebox-dsh-bridge": [
+    "https://raw.githubusercontent.com/wangzhishou/onebox-dsh-bridge/main/docs/images/pairing-page.png",
+    "https://raw.githubusercontent.com/wangzhishou/onebox-dsh-bridge/main/docs/images/app-connect.png",
+    "https://raw.githubusercontent.com/wangzhishou/onebox-dsh-bridge/main/docs/images/app-chat.png",
+    "https://raw.githubusercontent.com/wangzhishou/onebox-dsh-bridge/main/docs/images/app-feedback.png"
+  ],
+  "https://github.com/EugeneVl/dsh_session_folders": [
+    "https://raw.githubusercontent.com/EugeneVl/dsh_session_folders/master/assets/screenshot-1.jpg",
+    "https://raw.githubusercontent.com/EugeneVl/dsh_session_folders/master/assets/screenshot-2.jpg",
+    "https://raw.githubusercontent.com/EugeneVl/dsh_session_folders/master/assets/screenshot-3.jpg"
+  ],
+  "https://github.com/IceApriler/dsh-remote-mobile": [
+    "https://raw.githubusercontent.com/IceApriler/dsh-remote-mobile/master/images/pc-dsh-setting-1.png",
+    "https://raw.githubusercontent.com/IceApriler/dsh-remote-mobile/master/images/pc-dsh-setting-2.png",
+    "https://raw.githubusercontent.com/IceApriler/dsh-remote-mobile/master/images/mobile-auth.jpg",
+    "https://raw.githubusercontent.com/IceApriler/dsh-remote-mobile/master/images/mobile-dsh.jpg"
+  ],
+  "https://github.com/jhuanxx44/dsh-sseye": [
+    "https://raw.githubusercontent.com/jhuanxx44/dsh-sseye/main/assets/panel-detail.png"
+  ],
+  "https://github.com/wyzh0117/dsh-skill-select": [
+    "https://raw.githubusercontent.com/wyzh0117/dsh-skill-select/main/assets/product.png",
+    "https://raw.githubusercontent.com/wyzh0117/dsh-skill-select/main/assets/better-sidebar.png"
+  ],
+  "https://github.com/wqy8593521/dsh-model-pro": [
+    "https://raw.githubusercontent.com/wqy8593521/dsh-model-pro/main/docs/screenshots/dashboard.png",
+    "https://raw.githubusercontent.com/wqy8593521/dsh-model-pro/main/docs/screenshots/editor.png",
+    "https://raw.githubusercontent.com/wqy8593521/dsh-model-pro/main/docs/screenshots/models.png",
+    "https://raw.githubusercontent.com/wqy8593521/dsh-model-pro/main/docs/screenshots/test.png",
+    "https://raw.githubusercontent.com/wqy8593521/dsh-model-pro/main/docs/screenshots/routes.png"
+  ],
+  "https://github.com/Kenerlee/dsh-moments-aieo": [
+    "https://raw.githubusercontent.com/Kenerlee/dsh-moments-aieo/master/assets/screenshot-dashboard.png",
+    "https://raw.githubusercontent.com/Kenerlee/dsh-moments-aieo/master/assets/screenshot-diagnosis-report.png",
+    "https://raw.githubusercontent.com/Kenerlee/dsh-moments-aieo/master/assets/screenshot-dashboard-mobile.png"
+  ],
+  "https://github.com/FeiZhuNiU-INFJA/dsh-stock-ticker": [
+    "https://raw.githubusercontent.com/FeiZhuNiU-INFJA/dsh-stock-ticker/main/assets/screenshot.png"
+  ],
+  "https://github.com/miuzel/dsh-graph/tree/main/dsh-graph-host": [
+    "https://raw.githubusercontent.com/miuzel/dsh-graph/main/screenshot/screenshot-1.png",
+    "https://raw.githubusercontent.com/miuzel/dsh-graph/main/screenshot/screenshot-2.png"
+  ],
+  "https://github.com/ppy-web/dsh-plugin-xiaomi-mimo-tts": [
+    "https://raw.githubusercontent.com/ppy-web/dsh-plugin-xiaomi-mimo-tts/main/assets/menu.png",
+    "https://raw.githubusercontent.com/ppy-web/dsh-plugin-xiaomi-mimo-tts/main/assets/preset.png",
+    "https://raw.githubusercontent.com/ppy-web/dsh-plugin-xiaomi-mimo-tts/main/assets/image.png"
+  ],
+  "https://github.com/lunaship/dsh-links": [
+    "https://raw.githubusercontent.com/lunaship/dsh-links/main/docs/images/phone-connection-sanitized.png",
+    "https://raw.githubusercontent.com/lunaship/dsh-links/main/docs/images/android-device-list-sanitized.png",
+    "https://raw.githubusercontent.com/lunaship/dsh-links/main/docs/images/android-navigation-drawer.jpg",
+    "https://raw.githubusercontent.com/lunaship/dsh-links/main/docs/images/android-workspace-light.jpg",
+    "https://raw.githubusercontent.com/lunaship/dsh-links/main/docs/images/android-workspace-dark.jpg"
+  ],
+  "https://github.com/qinyre/dsh-plugin-install": [
+    "https://raw.githubusercontent.com/qinyre/dsh-plugin-install/main/docs/images/screenshot-install.png"
+  ],
+  "https://github.com/qinyre/dsh-plugin-capabilities": [
+    "https://raw.githubusercontent.com/qinyre/dsh-plugin-capabilities/main/docs/images/screenshot-skills.png",
+    "https://raw.githubusercontent.com/qinyre/dsh-plugin-capabilities/main/docs/images/screenshot-mcp.png",
+    "https://raw.githubusercontent.com/qinyre/dsh-plugin-capabilities/main/docs/images/screenshot-market-skills.png",
+    "https://raw.githubusercontent.com/qinyre/dsh-plugin-capabilities/main/docs/images/screenshot-market-mcp.png"
+  ],
+  "https://github.com/qinyre/dsh-plugin-atlas": [
+    "https://raw.githubusercontent.com/qinyre/dsh-plugin-atlas/main/docs/images/screenshot-rail.png",
+    "https://raw.githubusercontent.com/qinyre/dsh-plugin-atlas/main/docs/images/screenshot-archive.png"
+  ],
+  "https://github.com/Whale-Zhang/dsh-complete-chime": [
+    "https://raw.githubusercontent.com/Whale-Zhang/dsh-complete-chime/main/docs/settings-card.png"
+  ],
+  "https://github.com/Cerbur/clutch-dsh/tree/main/packages/clutch-dsh-worktree": [
+    "https://raw.githubusercontent.com/Cerbur/clutch-dsh/main/packages/clutch-dsh-worktree/assets/screenshots/screenshots-en.png",
+    "https://raw.githubusercontent.com/Cerbur/clutch-dsh/main/packages/clutch-dsh-worktree/assets/screenshots/screenshots-zh.png"
+  ],
+  "https://github.com/qkycir-123/dsh-run2skill": [
+    "https://raw.githubusercontent.com/qkycir-123/dsh-run2skill/main/docs/assets/01-proposal-inbox.png",
+    "https://raw.githubusercontent.com/qkycir-123/dsh-run2skill/main/docs/assets/02-review-details.png",
+    "https://raw.githubusercontent.com/qkycir-123/dsh-run2skill/main/docs/assets/03-saved-activity.png"
+  ],
+  "https://github.com/BananaSoldier01/dsh-tidychat": [
+    "https://raw.githubusercontent.com/BananaSoldier01/dsh-tidychat/main/assets/navigator.png",
+    "https://raw.githubusercontent.com/BananaSoldier01/dsh-tidychat/main/assets/settings.png"
+  ],
+  "https://github.com/PolinniZhong/dsh-personal-center": [
+    "https://raw.githubusercontent.com/PolinniZhong/dsh-personal-center/main/docs/screenshots/light-profile.png",
+    "https://raw.githubusercontent.com/PolinniZhong/dsh-personal-center/main/docs/screenshots/dark-pet.png",
+    "https://raw.githubusercontent.com/PolinniZhong/dsh-personal-center/main/docs/screenshots/pet-emotions.gif",
+    "https://raw.githubusercontent.com/PolinniZhong/dsh-personal-center/main/docs/screenshots/dark-model-cost.png"
+  ],
+  "https://github.com/KarlOfLaw/dsh-side-chat": [
+    "https://raw.githubusercontent.com/KarlOfLaw/dsh-side-chat/main/docs/assets/dsh-side-chat-hero.png",
+    "https://raw.githubusercontent.com/KarlOfLaw/dsh-side-chat/main/docs/assets/side-chat-parallel.png",
+    "https://raw.githubusercontent.com/KarlOfLaw/dsh-side-chat/main/docs/assets/side-chat-selection.png",
+    "https://raw.githubusercontent.com/KarlOfLaw/dsh-side-chat/main/docs/assets/side-chat-settings.png"
+  ],
+  "https://github.com/biggerboy/dsh-conversation-anchors": [
+    "https://raw.githubusercontent.com/biggerboy/dsh-conversation-anchors/master/assets/anchors-hover.png",
+    "https://raw.githubusercontent.com/biggerboy/dsh-conversation-anchors/master/assets/anchors-wave.png"
+  ],
+  "https://github.com/WSL043/dsh-reasoning-slider": [
+    "https://raw.githubusercontent.com/WSL043/dsh-reasoning-slider/main/docs/assets/reasoning-slider-en.png",
+    "https://raw.githubusercontent.com/WSL043/dsh-reasoning-slider/main/docs/assets/reasoning-slider-energy-zh.png",
+    "https://raw.githubusercontent.com/WSL043/dsh-reasoning-slider/main/docs/assets/mode-settings-en.png",
+    "https://raw.githubusercontent.com/WSL043/dsh-reasoning-slider/main/docs/assets/mode-settings-dark-zh.png"
+  ],
+  "https://github.com/jerryqx/dsh-ximalaya": [
+    "https://raw.githubusercontent.com/jerryqx/dsh-ximalaya/main/assets/panel-search.png",
+    "https://raw.githubusercontent.com/jerryqx/dsh-ximalaya/main/assets/panel-album.png",
+    "https://raw.githubusercontent.com/jerryqx/dsh-ximalaya/main/assets/panel-mine-subs.png",
+    "https://raw.githubusercontent.com/jerryqx/dsh-ximalaya/main/assets/panel-mine-anchors.png"
+  ],
+  "https://github.com/yangdongzhen590/dsh-knj-workflow": [
+    "https://raw.githubusercontent.com/yangdongzhen590/dsh-knj-workflow/main/assets/screenshots/task-detail.png",
+    "https://raw.githubusercontent.com/yangdongzhen590/dsh-knj-workflow/main/assets/screenshots/workflow-editor.png",
+    "https://raw.githubusercontent.com/yangdongzhen590/dsh-knj-workflow/main/assets/screenshots/new-task-modal.png"
+  ],
+  "https://github.com/yangdongzhen590/dsh-knj-menu": [
+    "https://raw.githubusercontent.com/yangdongzhen590/dsh-knj-menu/main/assets/screenshots/menu-manager.png"
+  ],
+  "https://github.com/yangdongzhen590/dsh-knj-scheduler": [
+    "https://raw.githubusercontent.com/yangdongzhen590/dsh-knj-scheduler/main/assets/screenshots/scheduler-panel.png"
+  ],
+  "https://github.com/mienfong/dsh-session-mgr": [
+    "https://raw.githubusercontent.com/mienfong/dsh-session-mgr/main/docs/screenshots/session-manager_EN.png",
+    "https://raw.githubusercontent.com/mienfong/dsh-session-mgr/main/docs/screenshots/move-dialog_EN.png",
+    "https://raw.githubusercontent.com/mienfong/dsh-session-mgr/main/docs/screenshots/backup_EN.png",
+    "https://raw.githubusercontent.com/mienfong/dsh-session-mgr/main/docs/screenshots/import_EN.png",
+    "https://raw.githubusercontent.com/mienfong/dsh-session-mgr/main/docs/screenshots/delete-confirm_EN.png"
+  ],
+  "https://github.com/kenny2077/dsh-web-search-doubao": [
+    "https://raw.githubusercontent.com/kenny2077/dsh-web-search-doubao/main/docs/img/settings-card.png",
+    "https://raw.githubusercontent.com/kenny2077/dsh-web-search-doubao/main/docs/img/console.png"
+  ],
+  "https://github.com/tr1v3r/dsh-quote-followup": [
+    "https://raw.githubusercontent.com/tr1v3r/dsh-quote-followup/v0.2.6/docs/assets/quote-followup-demo.gif"
+  ]
 }

--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -1,442 +1,1363 @@
 {
-
  "https://github.com/anweat/dsh-context-console": [
-
   "https://raw.githubusercontent.com/anweat/dsh-context-console/main/docs/images/context-console-trajectory.png",
-
   "https://raw.githubusercontent.com/anweat/dsh-context-console/main/docs/images/context-console-inventory.png",
-
   "https://raw.githubusercontent.com/anweat/dsh-context-console/main/docs/images/context-console-forge.png"
-
  ],
-
  "https://github.com/jerryqx/dsh-xiaoyuzhou": [
-
   "https://raw.githubusercontent.com/jerryqx/dsh-xiaoyuzhou/main/assets/screenshot-bar.png",
-
   "https://raw.githubusercontent.com/jerryqx/dsh-xiaoyuzhou/main/assets/screenshot-mysubs.png",
-
   "https://raw.githubusercontent.com/jerryqx/dsh-xiaoyuzhou/main/assets/screenshot-podcast.png"
-
  ],
-
  "https://github.com/fengb3/dsh-session-icons": [
-
   "https://raw.githubusercontent.com/fengb3/dsh-session-icons/master/docs/screenshot.png"
-
  ],
-
  "https://github.com/GreenLv/dsh-session-insights": [
-
   "https://raw.githubusercontent.com/GreenLv/dsh-session-insights/main/assets/screenshots/dashboard-overview-en.png",
-
   "https://raw.githubusercontent.com/GreenLv/dsh-session-insights/main/assets/screenshots/dashboard-overview-zh.png"
-
  ],
-
  "https://github.com/xiaoksio/dsh-solution-explorer": [
-
   "https://raw.githubusercontent.com/xiaoksio/dsh-solution-explorer/main/assets/screenshot-1-file-explorer.png",
-
   "https://raw.githubusercontent.com/xiaoksio/dsh-solution-explorer/main/assets/screenshot-2-source-control.png",
-
   "https://raw.githubusercontent.com/xiaoksio/dsh-solution-explorer/main/assets/screenshot-3-diff.png"
-
  ],
-
  "https://github.com/LayneChai/superpowers-dsh": [
-
   "https://raw.githubusercontent.com/LayneChai/superpowers-dsh/main/static/home.png",
-
   "https://raw.githubusercontent.com/LayneChai/superpowers-dsh/main/static/install-success.png"
-
  ],
-
  "https://github.com/kirkchinese/CiteCiter/tree/main/packages/citeciter": [
-
   "https://raw.githubusercontent.com/kirkchinese/CiteCiter/main/assets/demo/citeciter-0.4.0.gif",
-
   "https://raw.githubusercontent.com/kirkchinese/CiteCiter/main/assets/screenshots/citeciter-settings.png"
-
  ],
-
  "https://github.com/L3n3L/dsh-resume": [
-
   "https://raw.githubusercontent.com/L3n3L/dsh-resume/main/docs/screenshots/workbench.png",
-
   "https://raw.githubusercontent.com/L3n3L/dsh-resume/main/docs/screenshots/ai-assistant.png",
-
   "https://raw.githubusercontent.com/L3n3L/dsh-resume/main/docs/screenshots/template-library.png"
-
  ],
-
  "https://github.com/hunter118/dsh-s7r": [
-
   "https://raw.githubusercontent.com/hunter118/dsh-s7r/main/docs/screenshots/s7r-desktop.png",
-
   "https://raw.githubusercontent.com/hunter118/dsh-s7r/main/docs/screenshots/s7r-agent.png",
-
   "https://raw.githubusercontent.com/hunter118/dsh-s7r/main/docs/screenshots/s7r-workflows.png",
-
   "https://raw.githubusercontent.com/hunter118/dsh-s7r/main/docs/screenshots/s7r-display.png"
-
  ],
-
  "https://github.com/HaoyueQin/dsh-usage-statistics-panel": [
-
   "https://raw.githubusercontent.com/HaoyueQin/dsh-usage-statistics-panel/main/assets/screenshots/usage-overview.png",
-
   "https://raw.githubusercontent.com/HaoyueQin/dsh-usage-statistics-panel/main/assets/screenshots/model-breakdown.png"
-
  ],
-
  "https://github.com/lavapapa/dsh-composer-layout": [
-
   "https://raw.githubusercontent.com/lavapapa/dsh-composer-layout/main/assets/screenshots/hero-en.png",
-
   "https://raw.githubusercontent.com/lavapapa/dsh-composer-layout/main/assets/screenshots/hero-zh.png"
-
  ],
-
  "https://github.com/lengzhanbao/dsh-taffy-theme": [
-
   "https://raw.githubusercontent.com/lengzhanbao/dsh-taffy-theme/master/preview/light.webp",
-
   "https://raw.githubusercontent.com/lengzhanbao/dsh-taffy-theme/master/preview/dark.webp"
-
  ],
-
  "https://github.com/liang-today/dsh-liangxiang": [
-
   "https://raw.githubusercontent.com/liang-today/dsh-liangxiang/main/assets/main-frame.jpg",
-
   "https://raw.githubusercontent.com/liang-today/dsh-liangxiang/main/assets/plugin-panel.jpg",
-
   "https://raw.githubusercontent.com/liang-today/dsh-liangxiang/main/assets/liangci.jpg"
-
  ],
-
-
  "https://github.com/Little-Star888/dsh-pelican": [
-
   "https://raw.githubusercontent.com/Little-Star888/dsh-pelican/main/assets/screenshot-1.png"
-
  ],
-
  "https://github.com/kendu76/dsh-music-player": [
-
   "https://raw.githubusercontent.com/kendu76/dsh-music-player/main/assets/screenshot-bar.png",
-
   "https://raw.githubusercontent.com/kendu76/dsh-music-player/main/assets/screenshot-spectrum.png",
-
   "https://raw.githubusercontent.com/kendu76/dsh-music-player/main/assets/screenshot-panel.png"
-
  ],
-
  "https://github.com/030611/qiushi-dsh-evidence-audit": [
-
   "https://raw.githubusercontent.com/030611/qiushi-dsh-evidence-audit/main/docs/evidence-flow.svg"
-
  ],
-
  "https://github.com/263311487-ux/dsh-verify": [
-
   "https://raw.githubusercontent.com/263311487-ux/dsh-verify/main/assets/report-screenshot.png",
-
   "https://raw.githubusercontent.com/263311487-ux/dsh-verify/main/assets/visual-diff.png"
-
  ],
-
  "https://github.com/2768651338/dsh-effort-slider": [
-
   "https://raw.githubusercontent.com/2768651338/dsh-effort-slider/main/assets/screenshots/灞忓箷鎴浘%202026-08-16%20190943.png",
-
   "https://raw.githubusercontent.com/2768651338/dsh-effort-slider/main/assets/screenshots/灞忓箷鎴浘%202026-08-16%20190950.png",
-
   "https://raw.githubusercontent.com/2768651338/dsh-effort-slider/main/assets/screenshots/灞忓箷鎴浘%202026-08-16%20190903.png"
-
  ],
-
  "https://github.com/2768651338/dsh-plugin-manager": [
-
   "https://raw.githubusercontent.com/2768651338/dsh-plugin-manager/main/assets/preview.png"
-
  ],
-
  "https://github.com/2nd1st/dsh-plugin-open-app": [
-
   "https://raw.githubusercontent.com/2nd1st/dsh-plugin-open-app/main/docs/screenshot-app-container.jpg",
-
   "https://raw.githubusercontent.com/2nd1st/dsh-plugin-open-app/main/docs/screenshot-inline.jpg"
-
  ],
-
  "https://github.com/534119219/chicheng-cron": [
-
   "https://raw.githubusercontent.com/534119219/chicheng-cron/main/assets/sidebar-entry.png",
-
   "https://raw.githubusercontent.com/534119219/chicheng-cron/main/assets/settings-1.png",
-
   "https://raw.githubusercontent.com/534119219/chicheng-cron/main/assets/settings-2.png",
-
   "https://raw.githubusercontent.com/534119219/chicheng-cron/main/assets/output-popup.png"
-
  ],
-
  "https://github.com/534119219/chicheng-gate": [
-
   "https://raw.githubusercontent.com/534119219/chicheng-gate/main/assets/settings.png",
-
   "https://raw.githubusercontent.com/534119219/chicheng-gate/main/assets/login-gate.png",
-
   "https://raw.githubusercontent.com/534119219/chicheng-gate/main/assets/mobile-ui-1.png",
-
   "https://raw.githubusercontent.com/534119219/chicheng-gate/main/assets/mobile-ui-2.png",
-
   "https://raw.githubusercontent.com/534119219/chicheng-gate/main/assets/mobile-ui-3.png"
-
  ],
-
  "https://github.com/534119219/chicheng-push": [
-
   "https://raw.githubusercontent.com/534119219/chicheng-push/master/assets/screenshot-settings-entry.png",
-
   "https://raw.githubusercontent.com/534119219/chicheng-push/master/assets/screenshot-channel-list.png",
-
   "https://raw.githubusercontent.com/534119219/chicheng-push/master/assets/screenshot-add-channel.png"
-
  ],
-
  "https://github.com/534119219/chicheng-stats": [
-
   "https://raw.githubusercontent.com/534119219/chicheng-stats/main/assets/card-mode.png",
-
   "https://raw.githubusercontent.com/534119219/chicheng-stats/main/assets/text-mode.png",
-
   "https://raw.githubusercontent.com/534119219/chicheng-stats/main/assets/usage-dialog.png",
-
   "https://raw.githubusercontent.com/534119219/chicheng-stats/main/assets/card-settings.png",
-
   "https://raw.githubusercontent.com/534119219/chicheng-stats/main/assets/text-settings.png"
-
  ],
-
  "https://github.com/54xkeee/dsh-youreyes": [
-
   "https://raw.githubusercontent.com/54xkeee/dsh-youreyes/master/assets/screenshot-panel.png"
-
  ],
-
  "https://github.com/7dgroup-ai/dsh-skill-7d-code-reviewer": [
-
   "https://raw.githubusercontent.com/7dgroup-ai/dsh-skill-7d-code-reviewer/main/screenshots/skills.png",
-
   "https://raw.githubusercontent.com/7dgroup-ai/dsh-skill-7d-code-reviewer/main/screenshots/report-preview.png"
-
  ],
-
  "https://github.com/940842546/dsh-permissions": [
-
   "https://raw.githubusercontent.com/940842546/dsh-permissions/main/assets/01-permissions-overview.png",
-
   "https://raw.githubusercontent.com/940842546/dsh-permissions/main/assets/02-permissions-rules.png",
-
   "https://raw.githubusercontent.com/940842546/dsh-permissions/main/assets/03-permissions-draft.png",
-
   "https://raw.githubusercontent.com/940842546/dsh-permissions/main/assets/en-01-permissions-overview.png",
-
   "https://raw.githubusercontent.com/940842546/dsh-permissions/main/assets/en-02-permissions-rules.png",
-
   "https://raw.githubusercontent.com/940842546/dsh-permissions/main/assets/en-03-permissions-draft.png"
-
  ],
-
  "https://github.com/940842546/dsh-usage-billing": [
-
   "https://raw.githubusercontent.com/940842546/dsh-usage-billing/main/assets/screenshots/02-stats-dialog-overview.png",
-
   "https://raw.githubusercontent.com/940842546/dsh-usage-billing/main/assets/screenshots/03-stats-dialog-charts.png",
-
   "https://raw.githubusercontent.com/940842546/dsh-usage-billing/main/assets/screenshots/04-settings-usage-overview.png",
-
   "https://raw.githubusercontent.com/940842546/dsh-usage-billing/main/assets/screenshots/07-stats-dialog-usd.png",
-
   "https://raw.githubusercontent.com/940842546/dsh-usage-billing/main/assets/screenshots/en-02-stats-dialog-overview.png",
-
   "https://raw.githubusercontent.com/940842546/dsh-usage-billing/main/assets/screenshots/en-03-stats-dialog-charts.png",
-
   "https://raw.githubusercontent.com/940842546/dsh-usage-billing/main/assets/screenshots/en-04-settings-usage-overview.png",
-
   "https://raw.githubusercontent.com/940842546/dsh-usage-billing/main/assets/screenshots/en-07-stats-dialog-usd.png"
-
  ],
-
  "https://github.com/AI-Galaxy-GPU/dsh-sound": [
-
   "https://raw.githubusercontent.com/AI-Galaxy-GPU/dsh-sound/main/assets/screenshots/sound-image.png"
-
  ],
-
  "https://github.com/AcidGr/dsh-web-lan-access": [
-
   "https://raw.githubusercontent.com/AcidGr/dsh-web-lan-access/main/assets/screenshot-lan-access.jpg"
-
  ],
-
  "https://github.com/AcidGr/dsh-web-mobile-fix": [
-
   "https://raw.githubusercontent.com/AcidGr/dsh-web-mobile-fix/main/assets/screenshot-1.jpg",
-
   "https://raw.githubusercontent.com/AcidGr/dsh-web-mobile-fix/main/assets/screenshot-2.jpg"
-
  ],
-
  "https://github.com/Airmetro/dsh-update-checker": [
-
   "https://raw.githubusercontent.com/Airmetro/dsh-update-checker/main/assets/screenshots/01-banner-update-zh.png",
-
   "https://raw.githubusercontent.com/Airmetro/dsh-update-checker/main/assets/screenshots/02-banner-update-en.png",
-
   "https://raw.githubusercontent.com/Airmetro/dsh-update-checker/main/assets/screenshots/03-banner-plugins.png",
-
   "https://raw.githubusercontent.com/Airmetro/dsh-update-checker/main/assets/screenshots/04-settings-zh.png",
-
   "https://raw.githubusercontent.com/Airmetro/dsh-update-checker/main/assets/screenshots/05-settings-en.png"
-
  ],
-
  "https://github.com/AmeKrance/anan-thermal-monitor": [
-
   "https://raw.githubusercontent.com/AmeKrance/anan-thermal-monitor/main/assets/screenshots/screenshot-1.png",
-
   "https://raw.githubusercontent.com/AmeKrance/anan-thermal-monitor/main/assets/screenshots/screenshot-2.png",
-
   "https://raw.githubusercontent.com/AmeKrance/anan-thermal-monitor/main/assets/screenshots/demo.gif"
-
  ],
-
  "https://github.com/Awu12277/dsh-stock-watch": [
-
   "https://raw.githubusercontent.com/Awu12277/dsh-stock-watch/main/screenshots/detail-kline-dark.png",
-
   "https://raw.githubusercontent.com/Awu12277/dsh-stock-watch/main/screenshots/detail-minute-dark.png",
-
   "https://raw.githubusercontent.com/Awu12277/dsh-stock-watch/main/screenshots/list-dark.png"
-
  ],
-
  "https://github.com/ChongCyrus/Vibe-Mathematics": [
-
   "https://raw.githubusercontent.com/ChongCyrus/Vibe-Mathematics/main/%E7%A4%BA%E4%BE%8B%E5%9B%BE/%E6%A1%86%E6%9E%B6%E5%9B%BE-v1.png",
-
   "https://raw.githubusercontent.com/ChongCyrus/Vibe-Mathematics/main/%E7%A4%BA%E4%BE%8B%E5%9B%BE/%E6%A1%86%E6%9E%B6%E5%9B%BE-v2.png"
-
  ],
-
  "https://github.com/ChrisZhangWG/dsh-codex-meter": [
-
   "https://raw.githubusercontent.com/ChrisZhangWG/dsh-codex-meter/main/docs/settings-usage-overview.png",
-
   "https://raw.githubusercontent.com/ChrisZhangWG/dsh-codex-meter/main/docs/settings-usage-cost-history.png"
-
  ],
-
  "https://github.com/Dely0/dsh-personal-workbench": [
-
   "https://raw.githubusercontent.com/Dely0/dsh-personal-workbench/main/screenshot/%E4%B8%BB%E7%95%8C%E9%9D%A2.PNG",
-
   "https://raw.githubusercontent.com/Dely0/dsh-personal-workbench/main/screenshot/%E6%97%A5%E5%8E%86%E9%A1%B5%E9%9D%A2.png",
-
   "https://raw.githubusercontent.com/Dely0/dsh-personal-workbench/main/screenshot/%E4%BB%BB%E5%8A%A1%E5%88%97%E8%A1%A8%E7%95%8C%E9%9D%A2.png",
-
   "https://raw.githubusercontent.com/Dely0/dsh-personal-workbench/main/screenshot/%E7%9F%A5%E8%AF%86%E5%BA%93%E7%95%8C%E9%9D%A2.png",
-
   "https://raw.githubusercontent.com/Dely0/dsh-personal-workbench/main/screenshot/%E7%82%B9%E5%AD%90%E7%95%8C%E9%9D%A2.png",
-
   "https://raw.githubusercontent.com/Dely0/dsh-personal-workbench/main/screenshot/%E7%82%B9%E5%AD%90%E7%8E%8B.png"
-
  ],
-
  "https://github.com/DocJlm/dsh-arknights/tree/main/skins/pramanix-eyjafjalla": [
-
   "https://raw.githubusercontent.com/DocJlm/dsh-arknights/main/skins/pramanix-eyjafjalla/preview/cover.webp"
-
  ],
-
  "https://github.com/Eve-146T/DSH-CODEX-SUBSCRIPTION-POOL": [
-
   "https://raw.githubusercontent.com/Eve-146T/DSH-CODEX-SUBSCRIPTION-POOL/main/assets/readme/accounts-demo.png"
-
  ],
-
  "https://github.com/Fantasality/dsh-origin-plugin": [
-
   "https://raw.githubusercontent.com/Fantasality/dsh-origin-plugin/main/docs/example.png",
-
   "https://raw.githubusercontent.com/Fantasality/dsh-origin-plugin/main/docs/example_3d.png"
-
  ],
-
  "https://github.com/FengHuoLinShan/dsh-plugin-llm-balance": [
-
   "https://raw.githubusercontent.com/FengHuoLinShan/dsh-plugin-llm-balance/main/assets/llm-balance-preview.png"
-
  ],
-
  "https://github.com/Flyvhidbwo/dsh-vision-proxy": [
-
   "https://raw.githubusercontent.com/Flyvhidbwo/dsh-vision-proxy/main/assets/demo-reply.png",
-
   "https://raw.githubusercontent.com/Flyvhidbwo/dsh-vision-proxy/main/assets/demo-selector.png"
-
  ],
-
  "https://github.com/foooold/dsh-message-nav": [
-
   "https://raw.githubusercontent.com/foooold/dsh-message-nav/main/assets/rail-hover-preview.png",
-
   "https://raw.githubusercontent.com/foooold/dsh-message-nav/main/assets/rail-left-edge.png"
-
  ],
-
  "https://github.com/GOU-GEE/deepseek-vision/tree/main/plugins/dsh-plugin-deepseek-vision": [
-
   "https://raw.githubusercontent.com/GOU-GEE/deepseek-vision/main/docs/screenshots/01-settings.png",
-
   "https://raw.githubusercontent.com/GOU-GEE/deepseek-vision/main/docs/screenshots/02-paste-analyze.png",
-
   "https://raw.githubusercontent.com/GOU-GEE/deepseek-vision/main/docs/screenshots/03-clipboard.png",
-
   "https://raw.githubusercontent.com/GOU-GEE/deepseek-vision/main/docs/screenshots/04-result.png",
-
   "https://raw.githubusercontent.com/GOU-GEE/deepseek-vision/main/docs/screenshots/05-market.png"
-
  ],
-
  "https://github.com/Gin-7/dsh-pet-remielle": [
-
   "https://raw.githubusercontent.com/Gin-7/dsh-pet-remielle/main/assets/screenshot-waiting.png",
-
   "https://raw.githubusercontent.com/Gin-7/dsh-pet-remielle/main/assets/screenshot-priding.png"
-
  ],
-
  "https://github.com/HaoyueQin/dsh-better-reasoning-effort": [
-
   "https://raw.githubusercontent.com/HaoyueQin/dsh-better-reasoning-effort/master/docs/market-card.png"
-
  ],
-
  "https://github.com/Harvey-Will/dsh-vision-analysis": [
-
   "https://raw.githubusercontent.com/Harvey-Will/dsh-vision-analysis/main/assets/demo-ocr.png",
-
   "https://raw.githubusercontent.com/Harvey-Will/dsh-vision-analysis/main/assets/demo-chart.png",
-
   "https://raw.githubusercontent.com/Harvey-Will/dsh-vision-analysis/main/assets/demo-ui.png"
-
 ],
-
 "https://github.com/Isilsolme/dsh-splash-launcher": [
-
-  "https://raw.githubusercontent.com/Isilsolme/dsh-splash-launcher/main/docs/screenshots/splash-lig<response clipped><NOTE>To save on context only part of this file has been shown to you. You should retry this tool after you have searched inside the file with `grep -n` in order to find the line numbers of what you are looking for.</NOTE>
+  "https://raw.githubusercontent.com/Isilsolme/dsh-splash-launcher/main/docs/screenshots/splash-light.png",
+  "https://raw.githubusercontent.com/Isilsolme/dsh-splash-launcher/main/docs/screenshots/splash-drawing.png",
+  "https://raw.githubusercontent.com/Isilsolme/dsh-splash-launcher/main/docs/screenshots/splash-dark.png",
+  "https://raw.githubusercontent.com/Isilsolme/dsh-splash-launcher/main/docs/screenshots/main.png"
+ ],
+ "https://github.com/Jannchie/dsh-bill": [
+  "https://raw.githubusercontent.com/Jannchie/dsh-bill/main/docs/attribution.png",
+  "https://raw.githubusercontent.com/Jannchie/dsh-bill/main/docs/in-chat.png"
+ ],
+ "https://github.com/JimchengChina/dsh-frontier-repro": [
+  "https://raw.githubusercontent.com/JimchengChina/dsh-frontier-repro/main/docs/assets/frontier-repro-hero.png"
+ ],
+ "https://github.com/Jiyr0119/dsh-workspace-explorer": [
+  "https://raw.githubusercontent.com/Jiyr0119/dsh-workspace-explorer/main/assets/screenshots/panel.png",
+  "https://raw.githubusercontent.com/Jiyr0119/dsh-workspace-explorer/main/assets/screenshots/tree.png",
+  "https://raw.githubusercontent.com/Jiyr0119/dsh-workspace-explorer/main/assets/screenshots/insert.png"
+ ],
+ "https://github.com/Js2Hou/dsh-mcp-manager": [
+  "https://raw.githubusercontent.com/Js2Hou/dsh-mcp-manager/main/assets/market-screenshot.png"
+ ],
+ "https://github.com/Jungod1121/dsh-anchored-standard": [
+  "https://raw.githubusercontent.com/Jungod1121/dsh-anchored-standard/main/screenshots/market-1.png",
+  "https://raw.githubusercontent.com/Jungod1121/dsh-anchored-standard/main/screenshots/market-2.png",
+  "https://raw.githubusercontent.com/Jungod1121/dsh-anchored-standard/main/screenshots/market-3.png"
+ ],
+ "https://github.com/KLRSL/dsh-biomemory": [
+  "https://raw.githubusercontent.com/KLRSL/dsh-biomemory/main/assets/screenshot-main.png",
+  "https://raw.githubusercontent.com/KLRSL/dsh-biomemory/main/assets/screenshot-settings.png",
+  "https://raw.githubusercontent.com/KLRSL/dsh-biomemory/main/assets/screenshot-memory-settings.png"
+ ],
+ "https://github.com/LKMeng2001/dsh-mcp-market": [
+  "https://raw.githubusercontent.com/LKMeng2001/dsh-mcp-market/main/assets/market-discover.png"
+ ],
+ "https://github.com/LeemanCheung/dsh-agent-preset-recommender": [
+  "https://raw.githubusercontent.com/LeemanCheung/dsh-agent-preset-recommender/main/docs/screenshot.png",
+  "https://raw.githubusercontent.com/LeemanCheung/dsh-agent-preset-recommender/main/docs/project-detail.png"
+ ],
+ "https://github.com/LeemanCheung/dsh-image-gen": [
+  "https://raw.githubusercontent.com/LeemanCheung/dsh-image-gen/main/assets/demo.svg",
+  "https://raw.githubusercontent.com/LeemanCheung/dsh-image-gen/main/assets/final-card.png"
+ ],
+ "https://github.com/LeemanCheung/dsh-qq2007-skin": [
+  "https://raw.githubusercontent.com/LeemanCheung/dsh-qq2007-skin/main/docs/screenshot.png",
+  "https://raw.githubusercontent.com/LeemanCheung/dsh-qq2007-skin/main/docs/preview.svg"
+ ],
+ "https://github.com/LeemanCheung/dsh-task-dag": [
+  "https://raw.githubusercontent.com/LeemanCheung/dsh-task-dag/main/docs/screenshot.png",
+  "https://raw.githubusercontent.com/LeemanCheung/dsh-task-dag/main/docs/task-dag-preview.svg"
+ ],
+ "https://github.com/LeemanCheung/dsh-token-usage": [
+  "https://raw.githubusercontent.com/LeemanCheung/dsh-token-usage/main/assets/token-usage-overview.png",
+  "https://raw.githubusercontent.com/LeemanCheung/dsh-token-usage/main/assets/token-usage-insights.png",
+  "https://raw.githubusercontent.com/LeemanCheung/dsh-token-usage/main/assets/token-usage-budget.png",
+  "https://raw.githubusercontent.com/LeemanCheung/dsh-token-usage/main/assets/token-usage-ai-analysis.png",
+  "https://raw.githubusercontent.com/LeemanCheung/dsh-token-usage/main/assets/token-usage-trajectory-analysis.png"
+ ],
+ "https://github.com/LeemanCheung/dsh-whale-animation": [
+  "https://raw.githubusercontent.com/LeemanCheung/dsh-whale-animation/main/docs/screenshots/launch.png",
+  "https://raw.githubusercontent.com/LeemanCheung/dsh-whale-animation/main/docs/screenshots/apex.png",
+  "https://raw.githubusercontent.com/LeemanCheung/dsh-whale-animation/main/docs/screenshots/deep-dive.png"
+ ],
+ "https://github.com/Leeminjing/dsh-eyes": [
+  "https://raw.githubusercontent.com/Leeminjing/dsh-eyes/main/assets/demo.png"
+ ],
+ "https://github.com/Lhy723/dsh-agent-canvas": [
+  "https://raw.githubusercontent.com/Lhy723/dsh-agent-canvas/main/docs/assets/agent-canvas-overview.png",
+  "https://raw.githubusercontent.com/Lhy723/dsh-agent-canvas/main/docs/assets/agent-canvas-dark-settings.png"
+ ],
+ "https://github.com/MangMax/dsh-themes": [
+  "https://raw.githubusercontent.com/MangMax/dsh-themes/main/assets/screenshot.png"
+ ],
+ "https://github.com/Mars-Sea/dsh-commandcode-provider": [
+  "https://raw.githubusercontent.com/Mars-Sea/dsh-commandcode-provider/main/assets/screenshots/model-picker.png",
+  "https://raw.githubusercontent.com/Mars-Sea/dsh-commandcode-provider/main/assets/screenshots/usage-dashboard.png"
+ ],
+ "https://github.com/Max-Samson/dsh-usage-chart": [
+  "https://github.com/Max-Samson/dsh-usage-chart/blob/main/docs/images/usage-panel-demo-en-lightv1.0.0.png",
+  "https://github.com/Max-Samson/dsh-usage-chart/blob/main/docs/images/usage-panel-demo-zh-darkv1.0.0.png"
+ ],
+ "https://github.com/MingoZhou/dsh-replay": [
+  "https://raw.githubusercontent.com/MingoZhou/dsh-replay/main/assets/overview-light.png",
+  "https://raw.githubusercontent.com/MingoZhou/dsh-replay/main/assets/timeline-light.png",
+  "https://raw.githubusercontent.com/MingoZhou/dsh-replay/main/assets/audit-light.png"
+ ],
+ "https://github.com/Mu-scorpio/token-usage-counter": [
+  "https://raw.githubusercontent.com/Mu-scorpio/token-usage-counter/main/assets/usage-stats-overview.png",
+  "https://raw.githubusercontent.com/Mu-scorpio/token-usage-counter/main/assets/usage-stats-hover.png"
+ ],
+ "https://github.com/Nanki-nn/dsh-answer-pet": [
+  "https://raw.githubusercontent.com/Nanki-nn/dsh-answer-pet/main/assets/screenshots/blue-whale.png",
+  "https://raw.githubusercontent.com/Nanki-nn/dsh-answer-pet/main/assets/screenshots/orange-cat.png",
+  "https://raw.githubusercontent.com/Nanki-nn/dsh-answer-pet/main/assets/screenshots/silver-shaded-cat.png"
+ ],
+ "https://github.com/NoNameLeGo/dsh-catppuccin-theme": [
+  "https://raw.githubusercontent.com/NoNameLeGo/dsh-catppuccin-theme/main/assets/previews/glass-latte.png",
+  "https://raw.githubusercontent.com/NoNameLeGo/dsh-catppuccin-theme/main/assets/previews/glass-mocha.png",
+  "https://raw.githubusercontent.com/NoNameLeGo/dsh-catppuccin-theme/main/assets/previews/latte.png",
+  "https://raw.githubusercontent.com/NoNameLeGo/dsh-catppuccin-theme/main/assets/previews/frappe.png",
+  "https://raw.githubusercontent.com/NoNameLeGo/dsh-catppuccin-theme/main/assets/previews/macchiato.png",
+  "https://raw.githubusercontent.com/NoNameLeGo/dsh-catppuccin-theme/main/assets/previews/mocha.png"
+ ],
+ "https://github.com/Noob-stupid/dsh-github-login": [
+  "https://github.com/user-attachments/assets/bb7c1991-9346-4c20-8dc2-5d884515c522",
+  "https://github.com/user-attachments/assets/45a31794-ab56-4e34-8826-fb362deef3dc",
+  "https://github.com/user-attachments/assets/e23560ca-41d3-4a83-bc14-1d20f884cd8a"
+ ],
+ "https://github.com/Noob-stupid/dsh-plugin-hub": [
+  "https://github.com/user-attachments/assets/b802d606-14ba-4151-9956-ff642ed12b0a"
+ ],
+ "https://github.com/PC2005-cloud/dsh-pet/tree/main/dsh-pet": [
+  "https://raw.githubusercontent.com/PC2005-cloud/dsh-pet/main/assets/screenshots/dsh-pet-running-1.png",
+  "https://raw.githubusercontent.com/PC2005-cloud/dsh-pet/main/assets/screenshots/dsh-pet-running-2.png"
+ ],
+ "https://github.com/PandaPolo/dsh-voice-call": [
+  "https://raw.githubusercontent.com/PandaPolo/dsh-voice-call/main/promo/screenshots/slide-1.png",
+  "https://raw.githubusercontent.com/PandaPolo/dsh-voice-call/main/promo/screenshots/slide-2.png",
+  "https://raw.githubusercontent.com/PandaPolo/dsh-voice-call/main/promo/screenshots/slide-3.png",
+  "https://raw.githubusercontent.com/PandaPolo/dsh-voice-call/main/promo/screenshots/slide-4.png",
+  "https://raw.githubusercontent.com/PandaPolo/dsh-voice-call/main/promo/screenshots/slide-5.png",
+  "https://raw.githubusercontent.com/PandaPolo/dsh-voice-call/main/promo/screenshots/slide-6.png",
+  "https://raw.githubusercontent.com/PandaPolo/dsh-voice-call/main/promo/screenshots/slide-7.png"
+ ],
+ "https://github.com/ParticleLight/dsh-all-usage": [
+  "https://raw.githubusercontent.com/ParticleLight/dsh-all-usage/main/assets/screenshot-1.png",
+  "https://raw.githubusercontent.com/ParticleLight/dsh-all-usage/main/assets/screenshot-2.png"
+ ],
+ "https://github.com/PeterBon/dsh-hooks": [
+  "https://raw.githubusercontent.com/PeterBon/dsh-hooks/main/assets/screenshot-1.jpg"
+ ],
+ "https://github.com/PicGo/dsh-plugin": [
+  "https://raw.githubusercontent.com/PicGo/dsh-plugin/main/assets/DeepSeek-PicGo.png",
+  "https://raw.githubusercontent.com/PicGo/dsh-plugin/main/assets/dsh-plugin-picgo.png"
+ ],
+ "https://github.com/PwnKY/dsh-session-link": [
+  "https://raw.githubusercontent.com/PwnKY/dsh-session-link/master/assets/screenshots/01-cross-session-context.png",
+  "https://raw.githubusercontent.com/PwnKY/dsh-session-link/master/assets/screenshots/02-source-session.png"
+ ],
+ "https://github.com/QT-Chen/dsh-mic-input": [
+  "https://raw.githubusercontent.com/QT-Chen/dsh-mic-input/main/assets/shot-1-composer.png",
+  "https://raw.githubusercontent.com/QT-Chen/dsh-mic-input/main/assets/shot-2-listening.png",
+  "https://raw.githubusercontent.com/QT-Chen/dsh-mic-input/main/assets/shot-4-punctuation.png",
+  "https://raw.githubusercontent.com/QT-Chen/dsh-mic-input/main/assets/shot-3-settings.png",
+  "https://raw.githubusercontent.com/QT-Chen/dsh-mic-input/main/assets/shot-5-error.png"
+ ],
+ "https://github.com/RevolutionLA/dsh-dream-skin": [
+  "https://raw.githubusercontent.com/RevolutionLA/dsh-dream-skin/main/docs/screenshots/preview.png",
+  "https://raw.githubusercontent.com/RevolutionLA/dsh-dream-skin/main/docs/screenshots/settings.png"
+ ],
+ "https://github.com/SamizuHM/dsh-client-ui-theme-xp": [
+  "https://raw.githubusercontent.com/SamizuHM/dsh-client-ui-theme-xp/main/docs/screenshot.png"
+ ],
+ "https://github.com/Signalight/codex-to-dsh-pet/tree/main/packages/dsh-codex-pet": [
+  "https://raw.githubusercontent.com/Signalight/codex-to-dsh-pet/main/assets/screenshots/screenshot-1.png",
+  "https://raw.githubusercontent.com/Signalight/codex-to-dsh-pet/main/assets/screenshots/screenshot-2.png",
+  "https://raw.githubusercontent.com/Signalight/codex-to-dsh-pet/main/assets/screenshots/screenshot-3.png"
+ ],
+ "https://github.com/SiriLee/dsh-rewind": [
+  "https://raw.githubusercontent.com/SiriLee/dsh-rewind/main/assets/screenshots/rewind-button.png",
+  "https://raw.githubusercontent.com/SiriLee/dsh-rewind/main/assets/screenshots/mode-popover.png",
+  "https://raw.githubusercontent.com/SiriLee/dsh-rewind/main/assets/screenshots/impact-list.png",
+  "https://raw.githubusercontent.com/SiriLee/dsh-rewind/main/assets/screenshots/rewind-candidates.png"
+ ],
+ "https://github.com/Smalldy/godot-bridge": [
+  "https://raw.githubusercontent.com/Smalldy/godot-bridge/main/assets/godot-bridge-env-check.png"
+ ],
+ "https://github.com/StruggleYang/dsh-project-kanban": [
+  "https://raw.githubusercontent.com/StruggleYang/dsh-project-kanban/main/assets/screenshot-board.png"
+ ],
+ "https://github.com/TQSY114514/dsh-ui-appearance": [
+  "https://raw.githubusercontent.com/TQSY114514/dsh-ui-appearance/main/docs/screenshot-settings.png",
+  "https://raw.githubusercontent.com/TQSY114514/dsh-ui-appearance/main/docs/screenshot-wallpaper.png"
+ ],
+ "https://github.com/TZHR-invest/dsh-plugins/tree/main/packages/dsh-lan-access": [
+  "https://raw.githubusercontent.com/TZHR-invest/dsh-plugins/main/packages/dsh-lan-access/assets/screenshot-1-token-gate.png"
+ ],
+ "https://github.com/TZHR-invest/dsh-plugins/tree/main/packages/dsh-mobile-ui": [
+  "https://raw.githubusercontent.com/TZHR-invest/dsh-plugins/main/packages/dsh-mobile-ui/assets/screenshot-1-home.png",
+  "https://raw.githubusercontent.com/TZHR-invest/dsh-plugins/main/packages/dsh-mobile-ui/assets/screenshot-2-composer.png",
+  "https://raw.githubusercontent.com/TZHR-invest/dsh-plugins/main/packages/dsh-mobile-ui/assets/screenshot-3-chat.png",
+  "https://raw.githubusercontent.com/TZHR-invest/dsh-plugins/main/packages/dsh-mobile-ui/assets/screenshot-4-sessions.png"
+ ],
+ "https://github.com/Tkingxiao/dsh-any-background": [
+  "https://raw.githubusercontent.com/Tkingxiao/dsh-any-background/main/example_img/image.png",
+  "https://raw.githubusercontent.com/Tkingxiao/dsh-any-background/main/example_img/image-2.png",
+  "https://raw.githubusercontent.com/Tkingxiao/dsh-any-background/main/example_img/image-3.png",
+  "https://raw.githubusercontent.com/Tkingxiao/dsh-any-background/main/example_img/image-4.png",
+  "https://raw.githubusercontent.com/Tkingxiao/dsh-any-background/main/example_img/image-6.png",
+  "https://raw.githubusercontent.com/Tkingxiao/dsh-any-background/main/example_img/image-9.png",
+  "https://raw.githubusercontent.com/Tkingxiao/dsh-any-background/main/example_img/image-10.png"
+ ],
+ "https://github.com/Totoro-qaq/dsh-plugin-bridge": [
+  "https://raw.githubusercontent.com/Totoro-qaq/dsh-plugin-bridge/main/assets/cover/cover-en.png",
+  "https://raw.githubusercontent.com/Totoro-qaq/dsh-plugin-bridge/main/assets/bridge-demo.en.gif"
+ ],
+ "https://github.com/Ultronen/dsh-archived-chats": [
+  "https://raw.githubusercontent.com/Ultronen/dsh-archived-chats/main/assets/screenshots/1-archived-chats.png",
+  "https://raw.githubusercontent.com/Ultronen/dsh-archived-chats/main/assets/screenshots/2-search.png",
+  "https://raw.githubusercontent.com/Ultronen/dsh-archived-chats/main/assets/screenshots/3-delete-confirm.png",
+  "https://raw.githubusercontent.com/Ultronen/dsh-archived-chats/main/assets/screenshots/4-group-menu.png"
+ ],
+ "https://github.com/Ultronen/dsh-liquid-glass": [
+  "https://raw.githubusercontent.com/Ultronen/dsh-liquid-glass/main/assets/screenshots/1-settings.png",
+  "https://raw.githubusercontent.com/Ultronen/dsh-liquid-glass/main/assets/screenshots/2-glass-shell.png",
+  "https://raw.githubusercontent.com/Ultronen/dsh-liquid-glass/main/assets/screenshots/3-settings-wallpaper.png"
+ ],
+ "https://github.com/V1ki/dsh-plugin-subscriptions": [
+  "https://raw.githubusercontent.com/V1ki/dsh-plugin-subscriptions/main/docs/images/subscriptions.png",
+  "https://raw.githubusercontent.com/V1ki/dsh-plugin-subscriptions/main/docs/images/model-picker.png",
+  "https://raw.githubusercontent.com/V1ki/dsh-plugin-subscriptions/main/docs/images/model-effort.png",
+  "https://raw.githubusercontent.com/V1ki/dsh-plugin-subscriptions/main/docs/images/speed-toggle.png",
+  "https://raw.githubusercontent.com/V1ki/dsh-plugin-subscriptions/main/docs/images/image-generate-inline.png",
+  "https://raw.githubusercontent.com/V1ki/dsh-plugin-subscriptions/main/docs/images/image-generate-providers.png",
+  "https://raw.githubusercontent.com/V1ki/dsh-plugin-subscriptions/main/docs/images/video-generate-inline.png"
+ ],
+ "https://github.com/Vncntvx/dsh-zotero": [
+  "https://raw.githubusercontent.com/Vncntvx/dsh-zotero/main/docs/images/header-collage.png",
+  "https://raw.githubusercontent.com/Vncntvx/dsh-zotero/main/docs/images/zotero-chat-workflow.png",
+  "https://raw.githubusercontent.com/Vncntvx/dsh-zotero/main/docs/images/zotero-sources-overview.png",
+  "https://raw.githubusercontent.com/Vncntvx/dsh-zotero/main/docs/images/zotero-evidence-passages.png",
+  "https://raw.githubusercontent.com/Vncntvx/dsh-zotero/main/docs/images/zotero-export-bibtex.png"
+ ],
+ "https://github.com/WenhongPan/dsh-projects": [
+  "https://raw.githubusercontent.com/WenhongPan/dsh-projects/main/docs/assets/picker.webp",
+  "https://raw.githubusercontent.com/WenhongPan/dsh-projects/main/docs/assets/create.webp",
+  "https://raw.githubusercontent.com/WenhongPan/dsh-projects/main/docs/assets/native.webp"
+ ],
+ "https://github.com/YeqingTang/dsh-session-flow": [
+  "https://raw.githubusercontent.com/YeqingTang/dsh-session-flow/main/assets/screenshots/overview.png",
+  "https://raw.githubusercontent.com/YeqingTang/dsh-session-flow/main/assets/screenshots/session-flow-tab.png",
+  "https://raw.githubusercontent.com/YeqingTang/dsh-session-flow/main/assets/screenshots/turn-rail.png",
+  "https://raw.githubusercontent.com/YeqingTang/dsh-session-flow/main/assets/screenshots/fulltext-search.png",
+  "https://raw.githubusercontent.com/YeqingTang/dsh-session-flow/main/assets/screenshots/dock-right.png",
+  "https://raw.githubusercontent.com/YeqingTang/dsh-session-flow/main/assets/screenshots/folded-detail.png"
+ ],
+ "https://github.com/Yu-tao-Li/dsh-computer-use-win": [
+  "https://raw.githubusercontent.com/Yu-tao-Li/dsh-computer-use-win/main/assets/screenshot-1.png",
+  "https://raw.githubusercontent.com/Yu-tao-Li/dsh-computer-use-win/main/assets/screenshot-2.png",
+  "https://raw.githubusercontent.com/Yu-tao-Li/dsh-computer-use-win/main/assets/screenshot-3.png"
+ ],
+ "https://github.com/Yu-tao-Li/dsh-read-image-view": [
+  "https://raw.githubusercontent.com/Yu-tao-Li/dsh-read-image-view/main/assets/screenshot-1.png",
+  "https://raw.githubusercontent.com/Yu-tao-Li/dsh-read-image-view/main/assets/screenshot-2.png",
+  "https://raw.githubusercontent.com/Yu-tao-Li/dsh-read-image-view/main/assets/screenshot-3.png",
+  "https://raw.githubusercontent.com/Yu-tao-Li/dsh-read-image-view/main/assets/screenshot-4.png"
+ ],
+ "https://github.com/Yu-tao-Li/dsh-reference-checker": [
+  "https://raw.githubusercontent.com/Yu-tao-Li/dsh-reference-checker/main/assets/screenshot-1.png"
+ ],
+ "https://github.com/ZJUZhiyuCai/dsh-ivory": [
+  "https://raw.githubusercontent.com/ZJUZhiyuCai/dsh-ivory/main/assets/hero-light.png",
+  "https://raw.githubusercontent.com/ZJUZhiyuCai/dsh-ivory/main/assets/hero-dark.png",
+  "https://raw.githubusercontent.com/ZJUZhiyuCai/dsh-ivory/main/assets/conversation-light.png",
+  "https://raw.githubusercontent.com/ZJUZhiyuCai/dsh-ivory/main/assets/mobile-light.png"
+ ],
+ "https://github.com/a179-sanae/dsh-auto-collapse": [
+  "https://raw.githubusercontent.com/a179-sanae/dsh-auto-collapse/main/assets/screenshot.png"
+ ],
+ "https://github.com/a903067276-rgb/dsh-file-mentions": [
+  "https://raw.githubusercontent.com/a903067276-rgb/dsh-file-mentions/main/assets/screenshot.png"
+ ],
+ "https://github.com/a903067276-rgb/dsh-file-upload": [
+  "https://raw.githubusercontent.com/a903067276-rgb/dsh-file-upload/main/assets/screenshot.png"
+ ],
+ "https://github.com/a903067276-rgb/dsh-hud": [
+  "https://raw.githubusercontent.com/a903067276-rgb/dsh-hud/main/assets/hud-panel.png"
+ ],
+ "https://github.com/a903067276-rgb/dsh-plan-switch": [
+  "https://raw.githubusercontent.com/a903067276-rgb/dsh-plan-switch/main/assets/plan-button.png"
+ ],
+ "https://github.com/biociao/dsh-science": [
+  "https://raw.githubusercontent.com/biociao/dsh-science/main/assets/screenshots/research-loop.png",
+  "https://raw.githubusercontent.com/biociao/dsh-science/main/assets/screenshots/artifact-provenance.png",
+  "https://raw.githubusercontent.com/biociao/dsh-science/main/assets/screenshots/research-report.png",
+  "https://raw.githubusercontent.com/biociao/dsh-science/main/assets/screenshots/remote-compute.png",
+  "https://raw.githubusercontent.com/biociao/dsh-science/main/assets/screenshots/plugin-inventory.png",
+  "https://raw.githubusercontent.com/biociao/dsh-science/main/assets/screenshots/topology.png"
+ ],
+ "https://github.com/chouyong/dsh-branch-review": [
+  "https://raw.githubusercontent.com/chouyong/dsh-branch-review/main/assets/branch-review-desktop.png",
+  "https://raw.githubusercontent.com/chouyong/dsh-branch-review/main/assets/branch-review-decisions.png"
+ ],
+ "https://github.com/chouyong/dsh-fork-diff": [
+  "https://raw.githubusercontent.com/chouyong/dsh-fork-diff/main/assets/fork-diff-desktop.png",
+  "https://raw.githubusercontent.com/chouyong/dsh-fork-diff/main/assets/fork-diff-selector.png",
+  "https://raw.githubusercontent.com/chouyong/dsh-fork-diff/main/assets/fork-diff-mobile.png"
+ ],
+ "https://github.com/chouyong/dsh-fork-graph": [
+  "https://raw.githubusercontent.com/chouyong/dsh-fork-graph/main/assets/screenshot-trigger.png",
+  "https://raw.githubusercontent.com/chouyong/dsh-fork-graph/main/assets/screenshot-panel.png"
+ ],
+ "https://github.com/cirelir/dsh-change-review": [
+  "https://raw.githubusercontent.com/cirelir/dsh-change-review/main/assets/screenshots/review-tab.png",
+  "https://raw.githubusercontent.com/cirelir/dsh-change-review/main/assets/screenshots/per-turn-card.png",
+  "https://raw.githubusercontent.com/cirelir/dsh-change-review/main/assets/screenshots/diff-detail.png",
+  "https://raw.githubusercontent.com/cirelir/dsh-change-review/main/assets/screenshots/color-settings.png",
+  "https://raw.githubusercontent.com/cirelir/dsh-change-review/main/assets/screenshots/plugin-market.png"
+ ],
+ "https://github.com/coolbreezecoin/dsh-wechat-mp": [
+  "https://raw.githubusercontent.com/coolbreezecoin/dsh-wechat-mp/main/assets/demo.gif"
+ ],
+ "https://github.com/corrinehu/dsh-chat-imagine": [
+  "https://raw.githubusercontent.com/corrinehu/dsh-chat-imagine/main/assets/1.png",
+  "https://raw.githubusercontent.com/corrinehu/dsh-chat-imagine/main/assets/2.png",
+  "https://raw.githubusercontent.com/corrinehu/dsh-chat-imagine/main/assets/3.png",
+  "https://raw.githubusercontent.com/corrinehu/dsh-chat-imagine/main/assets/4.png"
+ ],
+ "https://github.com/creght-dev/skills": [
+  "https://raw.githubusercontent.com/creght-dev/skills/main/assets/screenshot-dsh.jpg",
+  "https://raw.githubusercontent.com/creght-dev/skills/main/assets/screenshot-editor.jpg"
+ ],
+ "https://github.com/d-dev0101/open-sea-skin": [
+  "https://raw.githubusercontent.com/d-dev0101/open-sea-skin/5ae54402ec6d4c961d41aee8ed786280799712c7/docs/marketplace/open-sea-harness-cover.png",
+  "https://raw.githubusercontent.com/d-dev0101/open-sea-skin/5ae54402ec6d4c961d41aee8ed786280799712c7/docs/screenshots/harness-dark-overview-40.gif",
+  "https://raw.githubusercontent.com/d-dev0101/open-sea-skin/5ae54402ec6d4c961d41aee8ed786280799712c7/docs/screenshots/harness-light-overview-40.gif",
+  "https://raw.githubusercontent.com/d-dev0101/open-sea-skin/5ae54402ec6d4c961d41aee8ed786280799712c7/docs/screenshots/harness-wave-control-40.gif",
+  "https://raw.githubusercontent.com/d-dev0101/open-sea-skin/5ae54402ec6d4c961d41aee8ed786280799712c7/docs/screenshots/harness-daylight-sunset-40.gif"
+ ],
+ "https://github.com/daetz-coder/dsh-multi-chat": [
+  "https://raw.githubusercontent.com/daetz-coder/dsh-multi-chat/main/assets/01-windows-dual-chat.png",
+  "https://raw.githubusercontent.com/daetz-coder/dsh-multi-chat/main/assets/02-ipad-dual-chat.png",
+  "https://raw.githubusercontent.com/daetz-coder/dsh-multi-chat/main/assets/03-windows-triple-chat.png"
+ ],
+ "https://github.com/demacia1314/dsh-airdrop": [
+  "https://raw.githubusercontent.com/demacia1314/dsh-airdrop/main/assets/drop-in.png",
+  "https://raw.githubusercontent.com/demacia1314/dsh-airdrop/main/assets/in-chat.png",
+  "https://raw.githubusercontent.com/demacia1314/dsh-airdrop/main/assets/preview-modal.png"
+ ],
+ "https://github.com/detongz/dsh-client-ui-obsidian-memory": [
+  "https://raw.githubusercontent.com/detongz/dsh-client-ui-obsidian-memory/main/assets/screenshot-panel.png"
+ ],
+ "https://github.com/dfycaly98931680/dsh-trajectory-governance": [
+  "https://raw.githubusercontent.com/dfycaly98931680/dsh-trajectory-governance/main/docs/screenshots/tree.png",
+  "https://raw.githubusercontent.com/dfycaly98931680/dsh-trajectory-governance/main/docs/screenshots/alerts.png",
+  "https://raw.githubusercontent.com/dfycaly98931680/dsh-trajectory-governance/main/docs/screenshots/report.png"
+ ],
+ "https://github.com/dickpy/dsh-imagegen": [
+  "https://raw.githubusercontent.com/dickpy/dsh-imagegen/main/docs/images/image-generation-studio.png",
+  "https://raw.githubusercontent.com/dickpy/dsh-imagegen/main/docs/images/plugin-settings.png"
+ ],
+ "https://github.com/disyli/dsh-tool-call-stats": [
+  "https://raw.githubusercontent.com/disyli/dsh-tool-call-stats/main/assets/screenshots/01-session.png",
+  "https://raw.githubusercontent.com/disyli/dsh-tool-call-stats/main/assets/screenshots/02-tool-stats.png",
+  "https://raw.githubusercontent.com/disyli/dsh-tool-call-stats/main/assets/screenshots/03-install.png",
+  "https://raw.githubusercontent.com/disyli/dsh-tool-call-stats/main/assets/screenshots/04-config.png"
+ ],
+ "https://github.com/dsh-market/dsh-market": [
+  "https://raw.githubusercontent.com/dsh-market/dsh-market/main/assets/demo-en.png",
+  "https://raw.githubusercontent.com/dsh-market/dsh-market/main/assets/themes-en.png"
+ ],
+ "https://github.com/elves-ai/dsh-web-search-firecrawl": [
+  "https://raw.githubusercontent.com/elves-ai/dsh-web-search-firecrawl/master/docs/firecrawl-settings.png"
+ ],
+ "https://github.com/franksong2702/dsh-codex-connect": [
+  "https://raw.githubusercontent.com/franksong2702/dsh-codex-connect/main/docs/assets/en/plugin-entry.jpg",
+  "https://raw.githubusercontent.com/franksong2702/dsh-codex-connect/main/docs/assets/en/oauth-status.jpg",
+  "https://raw.githubusercontent.com/franksong2702/dsh-codex-connect/main/docs/assets/en/plugin-configuration.jpg",
+  "https://raw.githubusercontent.com/franksong2702/dsh-codex-connect/main/docs/assets/en/model-selector.jpg",
+  "https://raw.githubusercontent.com/franksong2702/dsh-codex-connect/main/docs/assets/zh/hero.jpg",
+  "https://raw.githubusercontent.com/franksong2702/dsh-codex-connect/main/docs/assets/zh/plugin-entry.jpg",
+  "https://raw.githubusercontent.com/franksong2702/dsh-codex-connect/main/docs/assets/zh/oauth-status.jpg",
+  "https://raw.githubusercontent.com/franksong2702/dsh-codex-connect/main/docs/assets/zh/plugin-configuration.jpg"
+ ],
+ "https://github.com/fuyue521/dsh-desktop-shortcut": [
+  "https://raw.githubusercontent.com/fuyue521/dsh-desktop-shortcut/main/assets/screenshots/screenshot-web-ui.png"
+ ],
+ "https://github.com/haiziyao/dsh-vision-mix": [
+  "https://raw.githubusercontent.com/haiziyao/dsh-vision-mix/main/docs/settings-routing.png",
+  "https://raw.githubusercontent.com/haiziyao/dsh-vision-mix/main/docs/generation-routing.png",
+  "https://raw.githubusercontent.com/haiziyao/dsh-vision-mix/main/docs/vision-history.png",
+  "https://raw.githubusercontent.com/haiziyao/dsh-vision-mix/main/docs/generation-history.png",
+  "https://raw.githubusercontent.com/haiziyao/dsh-vision-mix/main/docs/benchmark-mix.png"
+ ],
+ "https://github.com/hanzhangzzz/dsh-diagram": [
+  "https://raw.githubusercontent.com/hanzhangzzz/dsh-diagram/assets/dsh-diagram-demo.gif",
+  "https://raw.githubusercontent.com/hanzhangzzz/dsh-diagram/assets/screenshot-canvas-architecture.png",
+  "https://raw.githubusercontent.com/hanzhangzzz/dsh-diagram/assets/screenshot-canvas-flow.png",
+  "https://raw.githubusercontent.com/hanzhangzzz/dsh-diagram/assets/screenshot-chat.png"
+ ],
+ "https://github.com/haoku123/dsh-voice": [
+  "https://raw.githubusercontent.com/haoku123/dsh-voice/main/docs/demo.gif"
+ ],
+ "https://github.com/hezhongtang/dsh-capability-optimizer": [
+  "https://raw.githubusercontent.com/hezhongtang/dsh-capability-optimizer/main/assets/screenshot-zh.png"
+ ],
+ "https://github.com/hi-wenw/dsh-telegram-channel": [
+  "https://raw.githubusercontent.com/hi-wenw/dsh-telegram-channel/master/docs/screenshots/hero-flow.png",
+  "https://raw.githubusercontent.com/hi-wenw/dsh-telegram-channel/master/docs/screenshots/mobile-chat.jpg",
+  "https://raw.githubusercontent.com/hi-wenw/dsh-telegram-channel/master/docs/screenshots/desktop-sync.jpg"
+ ],
+ "https://github.com/huguangyu666/dsh-plugin-notify": [
+  "https://raw.githubusercontent.com/huguangyu666/dsh-plugin-notify/main/assets/screenshot.png"
+ ],
+ "https://github.com/huguangyu666/dsh-plugin-session-import": [
+  "https://raw.githubusercontent.com/huguangyu666/dsh-plugin-session-import/main/assets/screenshot.png"
+ ],
+ "https://github.com/huguangyu666/dsh-store": [
+  "https://raw.githubusercontent.com/huguangyu666/dsh-plugin-store/main/assets/screenshot.png"
+ ],
+ "https://github.com/huxint/dsh-team": [
+  "https://raw.githubusercontent.com/huxint/dsh-team/main/screenshots/image.png"
+ ],
+ "https://github.com/hxy91819/dsh-auth": [
+  "https://raw.githubusercontent.com/hxy91819/dsh-auth/main/docs/images/login.png",
+  "https://raw.githubusercontent.com/hxy91819/dsh-auth/main/docs/images/authenticated-harness.png"
+ ],
+ "https://github.com/hyzyn/dsh-plugin-kit/tree/main/packages/rss": [
+  "https://raw.githubusercontent.com/hyzyn/dsh-plugin-kit/main/docs/dsh-plugin-kit-rss-setting.png",
+  "https://raw.githubusercontent.com/hyzyn/dsh-plugin-kit/main/docs/dsh-plugin-kit-rss-view.png"
+ ],
+ "https://github.com/hyzyn/dsh-plugin-kit/tree/main/packages/search": [
+  "https://raw.githubusercontent.com/hyzyn/dsh-plugin-kit/main/docs/dsh-plugin-kit-search.png"
+ ],
+ "https://github.com/iamfromchangsha/dsh-go-balance": [
+  "https://raw.githubusercontent.com/iamfromchangsha/dsh-go-balance/main/docs/screenshot-composer.png",
+  "https://raw.githubusercontent.com/iamfromchangsha/dsh-go-balance/main/docs/screenshot-tooltip.png",
+  "https://raw.githubusercontent.com/iamfromchangsha/dsh-go-balance/main/docs/screenshot-warn.png"
+ ],
+ "https://github.com/iiwish/dsh-testkit": [
+  "https://raw.githubusercontent.com/iiwish/dsh-testkit/main/docs/assets/dsh-testkit-showcase.png"
+ ],
+ "https://github.com/imkingjh999/dsh-shorts-wall": [
+  "https://raw.githubusercontent.com/imkingjh999/dsh-shorts-wall/main/docs/screenshot-stick.png",
+  "https://raw.githubusercontent.com/imkingjh999/dsh-shorts-wall/main/docs/screenshot-float.png",
+  "https://raw.githubusercontent.com/imkingjh999/dsh-shorts-wall/main/docs/screenshot-minimized.png"
+ ],
+ "https://github.com/imkingjh999/dsh-deepsea": [
+  "https://raw.githubusercontent.com/imkingjh999/dsh-deepsea/main/assets/screenshots/deepsea-ocean.png",
+  "https://raw.githubusercontent.com/imkingjh999/dsh-deepsea/main/assets/screenshots/deepsea-wall.png",
+  "https://raw.githubusercontent.com/imkingjh999/dsh-deepsea/main/assets/screenshots/deepsea-pond.png"
+ ],
+ "https://github.com/itr-del/dsh-feishu": [
+  "https://raw.githubusercontent.com/itr-del/dsh-feishu/master/assets/hero.png"
+ ],
+ "https://github.com/izwarm195/dsh-net-tools": [
+  "https://raw.githubusercontent.com/izwarm195/dsh-net-tools/main/assets/net_fetch-demo.png"
+ ],
+ "https://github.com/jiezeng2004-design/dsh-chatgpt-bridge": [
+  "https://raw.githubusercontent.com/jiezeng2004-design/dsh-chatgpt-bridge/main/assets/screenshots/01-human-in-the-loop.png",
+  "https://raw.githubusercontent.com/jiezeng2004-design/dsh-chatgpt-bridge/main/assets/screenshots/02-runtime-goal-update.png",
+  "https://raw.githubusercontent.com/jiezeng2004-design/dsh-chatgpt-bridge/main/assets/screenshots/03-native-dsh-execution.png",
+  "https://raw.githubusercontent.com/jiezeng2004-design/dsh-chatgpt-bridge/main/assets/screenshots/04-workspace-security.png",
+  "https://raw.githubusercontent.com/jiezeng2004-design/dsh-chatgpt-bridge/main/assets/screenshots/05-bridge-health.png"
+ ],
+ "https://github.com/jitengfei/dsh-whale-arcade": [
+  "https://raw.githubusercontent.com/jitengfei/dsh-whale-arcade/main/assets/screenshots/01-catalog.png",
+  "https://raw.githubusercontent.com/jitengfei/dsh-whale-arcade/main/assets/screenshots/02-whale-jump.png",
+  "https://raw.githubusercontent.com/jitengfei/dsh-whale-arcade/main/assets/screenshots/03-blue-whale-treasure.png",
+  "https://raw.githubusercontent.com/jitengfei/dsh-whale-arcade/main/assets/screenshots/04-coast-runner.png",
+  "https://raw.githubusercontent.com/jitengfei/dsh-whale-arcade/main/assets/screenshots/05-ocean-gomoku.png"
+ ],
+ "https://github.com/jyh20030112/dsh-visual-plugin": [
+  "https://raw.githubusercontent.com/jyh20030112/dsh-visual-plugin/main/assets/screenshots/screenshot-1.png",
+  "https://raw.githubusercontent.com/jyh20030112/dsh-visual-plugin/main/assets/screenshots/screenshot-2.png",
+  "https://raw.githubusercontent.com/jyh20030112/dsh-visual-plugin/main/assets/screenshots/screenshot-3.png",
+  "https://raw.githubusercontent.com/jyh20030112/dsh-visual-plugin/main/assets/screenshots/screenshot-4.png"
+ ],
+ "https://github.com/kaixinbaba/dsh-vision-recognizer": [
+  "https://raw.githubusercontent.com/kaixinbaba/dsh-vision-recognizer/main/screenshots/vision-config.png",
+  "https://raw.githubusercontent.com/kaixinbaba/dsh-vision-recognizer/main/screenshots/model-picker.png",
+  "https://raw.githubusercontent.com/kaixinbaba/dsh-vision-recognizer/main/screenshots/chat-demo.png",
+  "https://raw.githubusercontent.com/kaixinbaba/dsh-vision-recognizer/main/screenshots/plugin-list.png"
+ ],
+ "https://github.com/kanchengw/dsh-mindseye": [
+  "https://raw.githubusercontent.com/kanchengw/dsh-mindseye/main/assets/ScreenShot_GUI.png",
+  "https://raw.githubusercontent.com/kanchengw/dsh-mindseye/main/assets/ScreenShot_interaction.png",
+  "https://raw.githubusercontent.com/kanchengw/dsh-mindseye/main/assets/ScreenShot_config.png"
+ ],
+ "https://github.com/kexuejin/dsh-zhihu-dashboard": [
+  "https://raw.githubusercontent.com/kexuejin/dsh-zhihu-dashboard/main/assets/hot.png",
+  "https://raw.githubusercontent.com/kexuejin/dsh-zhihu-dashboard/main/assets/track.png",
+  "https://raw.githubusercontent.com/kexuejin/dsh-zhihu-dashboard/main/assets/feed.png",
+  "https://raw.githubusercontent.com/kexuejin/dsh-zhihu-dashboard/main/assets/onboarding.png"
+ ],
+ "https://github.com/keyiadiannao/dsh-restart-button": [
+  "https://raw.githubusercontent.com/keyiadiannao/dsh-power-button/master/docs/screenshots/en/power-button.png",
+  "https://raw.githubusercontent.com/keyiadiannao/dsh-power-button/master/docs/screenshots/en/power-menu.png",
+  "https://raw.githubusercontent.com/keyiadiannao/dsh-power-button/master/docs/screenshots/en/shutdown-confirm.png",
+  "https://raw.githubusercontent.com/keyiadiannao/dsh-power-button/master/docs/screenshots/en/shutdown-progress.png",
+  "https://raw.githubusercontent.com/keyiadiannao/dsh-power-button/master/docs/screenshots/en/restart-done.png"
+ ],
+ "https://github.com/kinoward/dsh-plugin-subhub": [
+  "https://raw.githubusercontent.com/kinoward/dsh-plugin-subhub/main/assets/models-en-light.png",
+  "https://raw.githubusercontent.com/kinoward/dsh-plugin-subhub/main/assets/models-zh-light.png",
+  "https://raw.githubusercontent.com/kinoward/dsh-plugin-subhub/main/assets/settings-loggedin-en-light.png",
+  "https://raw.githubusercontent.com/kinoward/dsh-plugin-subhub/main/assets/settings-loggedin-zh-light.png"
+ ],
+ "https://github.com/labmimors/dsh-mcp-lens": [
+  "https://raw.githubusercontent.com/labmimors/dsh-mcp-lens/main/assets/mcp-lens-hero.webp",
+  "https://raw.githubusercontent.com/labmimors/dsh-mcp-lens/main/assets/mcp-lens-comparison.svg",
+  "https://raw.githubusercontent.com/labmimors/dsh-mcp-lens/main/assets/mcp-lens-comparison.zh-CN.svg"
+ ],
+ "https://github.com/lire1131/dsh-undo-savepoint": [
+  "https://raw.githubusercontent.com/lire1131/dsh-undo-savepoint/master/docs/webui-panel.png",
+  "https://raw.githubusercontent.com/lire1131/dsh-undo-savepoint/master/docs/webui-settings-section.png",
+  "https://raw.githubusercontent.com/lire1131/dsh-undo-savepoint/master/docs/gui-main.png",
+  "https://raw.githubusercontent.com/lire1131/dsh-undo-savepoint/master/docs/gui-settings.png",
+  "https://raw.githubusercontent.com/lire1131/dsh-undo-savepoint/master/docs/safe-mode-confirm.png",
+  "https://raw.githubusercontent.com/lire1131/dsh-undo-savepoint/master/docs/safe-mode-done.png"
+ ],
+ "https://github.com/literaf/dsh-ai4scholar": [
+  "https://raw.githubusercontent.com/literaf/dsh-ai4scholar/main/docs/ai4scholar-home.jpg",
+  "https://raw.githubusercontent.com/literaf/dsh-ai4scholar/main/docs/settings-card.png",
+  "https://raw.githubusercontent.com/literaf/dsh-ai4scholar/main/docs/balance-card.png"
+ ],
+ "https://github.com/liuwenji007/dsh-muyu": [
+  "https://raw.githubusercontent.com/liuwenji007/dsh-muyu/main/docs/tap.gif",
+  "https://raw.githubusercontent.com/liuwenji007/dsh-muyu/main/docs/auto-tap.gif"
+ ],
+ "https://github.com/liuyuelintop/dsh-conversation-exporter": [
+  "https://raw.githubusercontent.com/liuyuelintop/dsh-conversation-exporter/main/assets/select-turns.png",
+  "https://raw.githubusercontent.com/liuyuelintop/dsh-conversation-exporter/main/assets/selective-export-mermaid.png",
+  "https://raw.githubusercontent.com/liuyuelintop/dsh-conversation-exporter/main/assets/selective-export-result.png"
+ ],
+ "https://github.com/maple-pwn/paperlab": [
+  "https://raw.githubusercontent.com/maple-pwn/paperlab/main/docs/assets/screenshot.png"
+ ],
+ "https://github.com/minivv/dsh-agent-skills": [
+  "https://raw.githubusercontent.com/minivv/dsh-agent-skills/main/agent-skills-page.png"
+ ],
+ "https://github.com/ne-ilyxa/dsh-session-drafts": [
+  "https://raw.githubusercontent.com/ne-ilyxa/dsh-session-drafts/master/assets/drafts-popover.png",
+  "https://raw.githubusercontent.com/ne-ilyxa/dsh-session-drafts/master/assets/drafts-switched.png"
+ ],
+ "https://github.com/niuniuaba/dsh-subagent-vision": [
+  "https://raw.githubusercontent.com/niuniuaba/dsh-subagent-vision/main/assets/screenshot-models.png",
+  "https://raw.githubusercontent.com/niuniuaba/dsh-subagent-vision/main/assets/screenshot-vision-route.png"
+ ],
+ "https://github.com/nonewind/dsh-spend": [
+  "https://raw.githubusercontent.com/nonewind/dsh-spend/main/docs/screenshots/dashboard.png",
+  "https://raw.githubusercontent.com/nonewind/dsh-spend/main/docs/screenshots/details-window.png"
+ ],
+ "https://github.com/nzl153/dsh-pet-whale": [
+  "https://raw.githubusercontent.com/nzl153/dsh-pet-whale/main/docs/screenshots/01-idle.png",
+  "https://raw.githubusercontent.com/nzl153/dsh-pet-whale/main/docs/screenshots/02-think.png",
+  "https://raw.githubusercontent.com/nzl153/dsh-pet-whale/main/docs/screenshots/03-working.png",
+  "https://raw.githubusercontent.com/nzl153/dsh-pet-whale/main/docs/screenshots/04-celebrate.png",
+  "https://raw.githubusercontent.com/nzl153/dsh-pet-whale/main/docs/screenshots/05-error.png",
+  "https://raw.githubusercontent.com/nzl153/dsh-pet-whale/main/docs/screenshots/06-feed.png"
+ ],
+ "https://github.com/omdsh-dev/dsh-annotation": [
+  "https://github.com/user-attachments/assets/c3186efc-44d3-4e7f-9523-1902d9d037e9",
+  "https://github.com/user-attachments/assets/0b48ac02-4648-4b94-8d8f-344f8b7c25b4",
+  "https://github.com/user-attachments/assets/8b2610d0-3d00-41be-b314-bac2fe616787",
+  "https://github.com/user-attachments/assets/9b66deea-3786-4296-9b0d-52873a15f5e1"
+ ],
+ "https://github.com/omdsh-dev/dsh-genui": [
+  "https://raw.githubusercontent.com/omdsh-dev/dsh-genui/main/assets/showcase-panel.png",
+  "https://raw.githubusercontent.com/omdsh-dev/dsh-genui/main/assets/showcase-plot.png",
+  "https://raw.githubusercontent.com/omdsh-dev/dsh-genui/main/assets/showcase.png",
+  "https://raw.githubusercontent.com/omdsh-dev/dsh-genui/main/assets/demo-thumb.png"
+ ],
+ "https://github.com/pengpengyi92/dsh-quant": [
+  "https://raw.githubusercontent.com/pengpengyi92/dsh-quant/master/demos/ui-demo-preview.png"
+ ],
+ "https://github.com/pengyue-polaron/deepseek-harness-genui": [
+  "https://raw.githubusercontent.com/pengyue-polaron/deepseek-harness-genui/main/screenshots/en/code-path-canvas.png",
+  "https://raw.githubusercontent.com/pengyue-polaron/deepseek-harness-genui/main/screenshots/en/code-path-inline.png",
+  "https://raw.githubusercontent.com/pengyue-polaron/deepseek-harness-genui/main/screenshots/en/photosynthesis-explorer.png",
+  "https://raw.githubusercontent.com/pengyue-polaron/deepseek-harness-genui/main/screenshots/en/calendar-planner.png",
+  "https://raw.githubusercontent.com/pengyue-polaron/deepseek-harness-genui/main/screenshots/en/code-path-explorer.png"
+ ],
+ "https://github.com/potoior/dsh-bull-bear": [
+  "https://raw.githubusercontent.com/potoior/dsh-bull-bear/main/assets/screenshot-overview.png",
+  "https://raw.githubusercontent.com/potoior/dsh-bull-bear/main/assets/screenshot-panel.png",
+  "https://raw.githubusercontent.com/potoior/dsh-bull-bear/main/assets/screenshot-watchlist.png"
+ ],
+ "https://github.com/pyf2818/dsh-bili-widget": [
+  "https://raw.githubusercontent.com/pyf2818/dsh-bili-widget/main/assets/main.png",
+  "https://raw.githubusercontent.com/pyf2818/dsh-bili-widget/main/assets/search.png",
+  "https://raw.githubusercontent.com/pyf2818/dsh-bili-widget/main/assets/hot.png",
+  "https://raw.githubusercontent.com/pyf2818/dsh-bili-widget/main/assets/help.png",
+  "https://raw.githubusercontent.com/pyf2818/dsh-bili-widget/main/assets/mini.png"
+ ],
+ "https://github.com/qjcnmd/dsh-reasoning-slider": [
+  "https://raw.githubusercontent.com/qjcnmd/dsh-reasoning-slider/main/assets/screenshots/deepseek-v4-pro-max.png",
+  "https://raw.githubusercontent.com/qjcnmd/dsh-reasoning-slider/main/assets/screenshots/deepseek-v4-pro-off.png",
+  "https://raw.githubusercontent.com/qjcnmd/dsh-reasoning-slider/main/assets/screenshots/kimi-k3-max.png",
+  "https://raw.githubusercontent.com/qjcnmd/dsh-reasoning-slider/main/assets/screenshots/minimax-m3-minimal.png"
+ ],
+ "https://github.com/sanqiPanax/dsh-sticker-board": [
+  "https://raw.githubusercontent.com/sanqiPanax/dsh-sticker-board/master/docs/screenshot-dock.png"
+ ],
+ "https://github.com/siberiah2o/dsh-plugin-terminal": [
+  "https://raw.githubusercontent.com/siberiah2o/dsh-plugin-terminal/main/docs/screenshot-collapsed.png",
+  "https://raw.githubusercontent.com/siberiah2o/dsh-plugin-terminal/main/docs/screenshot-panel.png",
+  "https://raw.githubusercontent.com/siberiah2o/dsh-plugin-terminal/main/docs/screenshot-multitab.png"
+ ],
+ "https://github.com/sjh9714/dsh-movein": [
+  "https://raw.githubusercontent.com/sjh9714/dsh-movein/main/docs/report.png",
+  "https://raw.githubusercontent.com/sjh9714/dsh-movein/main/docs/demo.gif",
+  "https://raw.githubusercontent.com/sjh9714/dsh-movein/main/docs/social.png"
+ ],
+ "https://github.com/sjh9714/dsh-win32": [
+  "https://raw.githubusercontent.com/sjh9714/dsh-win32/master/assets/market-card.png",
+  "https://raw.githubusercontent.com/sjh9714/dsh-win32/master/assets/shot-persistent-sandboxed.png",
+  "https://raw.githubusercontent.com/sjh9714/dsh-win32/master/assets/shot-preset-picker.png"
+ ],
+ "https://github.com/skyhancloud/dsh-client-ui-quote": [
+  "https://raw.githubusercontent.com/skyhancloud/dsh-client-ui-quote/main/assets/preview-1.png",
+  "https://raw.githubusercontent.com/skyhancloud/dsh-client-ui-quote/main/assets/preview-2.png"
+ ],
+ "https://github.com/slywalker2006/dsh-passwords": [
+  "https://raw.githubusercontent.com/slywalker2006/dsh-passwords/main/docs/screenshots/white-login.png",
+  "https://raw.githubusercontent.com/slywalker2006/dsh-passwords/main/docs/screenshots/black-login.png",
+  "https://raw.githubusercontent.com/slywalker2006/dsh-passwords/main/docs/screenshots/white-login-en.png",
+  "https://raw.githubusercontent.com/slywalker2006/dsh-passwords/main/docs/screenshots/main-ui.png",
+  "https://raw.githubusercontent.com/slywalker2006/dsh-passwords/main/docs/screenshots/chat.png",
+  "https://raw.githubusercontent.com/slywalker2006/dsh-passwords/main/docs/screenshots/card-front.png",
+  "https://raw.githubusercontent.com/slywalker2006/dsh-passwords/main/docs/screenshots/card-back.png"
+ ],
+ "https://github.com/starslittle/dsh-blue-whale": [
+  "https://raw.githubusercontent.com/starslittle/dsh-blue-whale/main/docs/compare-home.png",
+  "https://raw.githubusercontent.com/starslittle/dsh-blue-whale/main/docs/compare-brand.png"
+ ],
+ "https://github.com/starslittle/dsh-queue-plus": [
+  "https://raw.githubusercontent.com/starslittle/dsh-queue-plus/main/assets/queue-default.png",
+  "https://raw.githubusercontent.com/starslittle/dsh-queue-plus/main/assets/queue-remove-all.png",
+  "https://raw.githubusercontent.com/starslittle/dsh-queue-plus/main/assets/queue-remove-complete.png",
+  "https://raw.githubusercontent.com/starslittle/dsh-queue-plus/main/assets/queue-sort.png"
+ ],
+ "https://github.com/superagents-lab/dsh-s1": [
+  "https://raw.githubusercontent.com/superagents-lab/dsh-s1/main/assets/dsh-s1.png"
+ ],
+ "https://github.com/text2future/flowix/tree/main/dsh-flowix-memory": [
+  "https://raw.githubusercontent.com/text2future/flowix/main/docs/images/home-write.png",
+  "https://raw.githubusercontent.com/text2future/flowix/main/docs/images/readme-agent.png",
+  "https://raw.githubusercontent.com/text2future/flowix/main/docs/images/gh-detail-4.png",
+  "https://raw.githubusercontent.com/text2future/flowix/main/docs/images/gh-detail-6.png"
+ ],
+ "https://github.com/tpmoonchefryan/dsh-joi-channel-theme": [
+  "https://raw.githubusercontent.com/tpmoonchefryan/dsh-joi-channel-theme/main/docs/settings-wardrobe.png",
+  "https://raw.githubusercontent.com/tpmoonchefryan/dsh-joi-channel-theme/main/docs/settings-wardrobe-dark.png",
+  "https://raw.githubusercontent.com/tpmoonchefryan/dsh-joi-channel-theme/main/docs/new-chat-flowers.png",
+  "https://raw.githubusercontent.com/tpmoonchefryan/dsh-joi-channel-theme/main/docs/new-chat-library.png",
+  "https://raw.githubusercontent.com/tpmoonchefryan/dsh-joi-channel-theme/main/docs/new-chat-flowers-dark.png",
+  "https://raw.githubusercontent.com/tpmoonchefryan/dsh-joi-channel-theme/main/docs/working-flowers.png",
+  "https://raw.githubusercontent.com/tpmoonchefryan/dsh-joi-channel-theme/main/docs/success-library.png",
+  "https://raw.githubusercontent.com/tpmoonchefryan/dsh-joi-channel-theme/main/docs/app-logo-flowers.png"
+ ],
+ "https://github.com/truelove-dreamer/dsh-plugin-vetting": [
+  "https://raw.githubusercontent.com/truelove-dreamer/dsh-plugin-vetting/main/assets/shot-report.png",
+  "https://raw.githubusercontent.com/truelove-dreamer/dsh-plugin-vetting/main/assets/shot-detail.png",
+  "https://raw.githubusercontent.com/truelove-dreamer/dsh-plugin-vetting/main/assets/shot-gate.png"
+ ],
+ "https://github.com/tt-a1i/archify/tree/main/integrations/deepseek-harness": [
+  "https://raw.githubusercontent.com/tt-a1i/archify/main/docs/assets/archify-live-proof.gif",
+  "https://raw.githubusercontent.com/tt-a1i/archify/main/docs/assets/archify-dark.png",
+  "https://raw.githubusercontent.com/tt-a1i/archify/main/docs/assets/archify-light.png"
+ ],
+ "https://github.com/txlznbzsdj-collab/dsh-deepseek-pet": [
+  "https://raw.githubusercontent.com/txlznbzsdj-collab/dsh-deepseek-pet/main/screenshots/1.png",
+  "https://raw.githubusercontent.com/txlznbzsdj-collab/dsh-deepseek-pet/main/screenshots/2.png",
+  "https://raw.githubusercontent.com/txlznbzsdj-collab/dsh-deepseek-pet/main/screenshots/3.png"
+ ],
+ "https://github.com/v587d/dsh-opencode-go-usage": [
+  "https://raw.githubusercontent.com/v587d/dsh-opencode-go-usage/main/assets/custom-footer.png",
+  "https://raw.githubusercontent.com/v587d/dsh-opencode-go-usage/main/assets/usage-detail.png",
+  "https://raw.githubusercontent.com/v587d/dsh-opencode-go-usage/main/assets/set-cookie-wid.png"
+ ],
+ "https://github.com/vdnight89/InfiniteDSH": [
+  "https://raw.githubusercontent.com/vdnight89/InfiniteDSH/main/docs/%E6%88%AA%E5%9B%BE1.png",
+  "https://raw.githubusercontent.com/vdnight89/InfiniteDSH/main/docs/%E6%88%AA%E5%9B%BE2.png",
+  "https://raw.githubusercontent.com/vdnight89/InfiniteDSH/main/docs/%E6%88%AA%E5%9B%BE2.1.png",
+  "https://raw.githubusercontent.com/vdnight89/InfiniteDSH/main/docs/%E6%88%AA%E5%9B%BE2.2.png"
+ ],
+ "https://github.com/weisiren000/dsh-remote-ssh-ops": [
+  "https://raw.githubusercontent.com/weisiren000/dsh-remote-ssh-ops/main/docs/assets/remote-workbench-preview.png"
+ ],
+ "https://github.com/welsione/dsh-mmx-bridge": [
+  "https://raw.githubusercontent.com/welsione/dsh-mmx-bridge/main/docs/image-generation.png",
+  "https://raw.githubusercontent.com/welsione/dsh-mmx-bridge/main/docs/speech-tts.png",
+  "https://raw.githubusercontent.com/welsione/dsh-mmx-bridge/main/docs/vision-demo.png",
+  "https://raw.githubusercontent.com/welsione/dsh-mmx-bridge/main/docs/plugin-settings.png"
+ ],
+ "https://github.com/wloops/dsh-git-worktree": [
+  "https://raw.githubusercontent.com/wloops/dsh-git-worktree/master/docs/screenshots/01-create-worktree.png",
+  "https://raw.githubusercontent.com/wloops/dsh-git-worktree/master/docs/screenshots/02-ready-for-review.png",
+  "https://raw.githubusercontent.com/wloops/dsh-git-worktree/master/docs/screenshots/03-local-preview.png",
+  "https://raw.githubusercontent.com/wloops/dsh-git-worktree/master/docs/screenshots/04-commit-confirmation.png",
+  "https://raw.githubusercontent.com/wloops/dsh-git-worktree/master/docs/screenshots/05-next-iteration.png",
+  "https://raw.githubusercontent.com/wloops/dsh-git-worktree/master/docs/screenshots/06-retain-environment.png"
+ ],
+ "https://github.com/wly8691-jpg/knowlp-rag": [
+  "https://raw.githubusercontent.com/wly8691-jpg/knowlp-rag/main/docs/demo.png",
+  "https://raw.githubusercontent.com/wly8691-jpg/knowlp-rag/main/docs/health.png",
+  "https://raw.githubusercontent.com/wly8691-jpg/knowlp-rag/main/docs/decay.png",
+  "https://raw.githubusercontent.com/wly8691-jpg/knowlp-rag/main/docs/architecture.png"
+ ],
+ "https://github.com/wss534857356/dsh-plugin-codex": [
+  "https://raw.githubusercontent.com/wss534857356/dsh-plugin-codex/main/docs/images/conversation-screenshot.png",
+  "https://raw.githubusercontent.com/wss534857356/dsh-plugin-codex/main/docs/images/model-selector-screenshot.png"
+ ],
+ "https://github.com/wuxiangru915/dsh-review-loop": [
+  "https://raw.githubusercontent.com/wuxiangru915/dsh-review-loop/master/assets/review-panel.en.png",
+  "https://raw.githubusercontent.com/wuxiangru915/dsh-review-loop/master/assets/review-panel.zh.png"
+ ],
+ "https://github.com/wuxiangru915/dsh-session-manager": [
+  "https://raw.githubusercontent.com/wuxiangru915/dsh-session-manager/main/assets/session-manager.png"
+ ],
+ "https://github.com/wx-yss/dsh-message-rail": [
+  "https://raw.githubusercontent.com/wx-yss/dsh-message-rail/main/assets/rail-hover-preview.png"
+ ],
+ "https://github.com/wz-heng/dsh-feishu-bridge": [
+  "https://raw.githubusercontent.com/wz-heng/dsh-feishu-bridge/main/docs/screenshots/fail-closed-boot.png",
+  "https://raw.githubusercontent.com/wz-heng/dsh-feishu-bridge/main/docs/screenshots/dsh-plugin-add.png",
+  "https://raw.githubusercontent.com/wz-heng/dsh-feishu-bridge/main/docs/screenshots/architecture.png"
+ ],
+ "https://github.com/xbzbing/dsh-auth-gateway": [
+  "https://raw.githubusercontent.com/xbzbing/dsh-auth-gateway/main/docs/assets/onboarding.png",
+  "https://raw.githubusercontent.com/xbzbing/dsh-auth-gateway/main/docs/assets/login.png",
+  "https://raw.githubusercontent.com/xbzbing/dsh-auth-gateway/main/docs/assets/login-success.png",
+  "https://raw.githubusercontent.com/xbzbing/dsh-auth-gateway/main/docs/assets/otp-setup.png",
+  "https://raw.githubusercontent.com/xbzbing/dsh-auth-gateway/main/docs/assets/settings-menu.png",
+  "https://raw.githubusercontent.com/xbzbing/dsh-auth-gateway/main/docs/assets/settings-auth.png"
+ ],
+ "https://github.com/xiajiajun516/dsh-config-manager": [
+  "https://raw.githubusercontent.com/xiajiajun516/dsh-config-manager/main/assets/screenshot-export.png",
+  "https://raw.githubusercontent.com/xiajiajun516/dsh-config-manager/main/assets/screenshot-import-preview.png",
+  "https://raw.githubusercontent.com/xiajiajun516/dsh-config-manager/main/assets/screenshot-snapshots.png",
+  "https://raw.githubusercontent.com/xiajiajun516/dsh-config-manager/main/assets/screenshot-sync.png"
+ ],
+ "https://github.com/xohmai/dsh-cpa-status": [
+  "https://raw.githubusercontent.com/xohmai/dsh-cpa-status/main/docs/images/panel.png",
+  "https://raw.githubusercontent.com/xohmai/dsh-cpa-status/main/docs/images/collapsed.png"
+ ],
+ "https://github.com/yflmq001/dsh-cost-tracker": [
+  "https://raw.githubusercontent.com/yflmq001/dsh-cost-tracker/main/assets/screenshots/screenshot-main.png",
+  "https://raw.githubusercontent.com/yflmq001/dsh-cost-tracker/main/assets/screenshots/screenshot-cost-panel.png",
+  "https://raw.githubusercontent.com/yflmq001/dsh-cost-tracker/main/assets/screenshots/screenshot-config.png"
+ ],
+ "https://github.com/yunxiiQwQ/dsh-maid-whale-webUI/tree/main/maid-whale-webui": [
+  "https://raw.githubusercontent.com/yunxiiQwQ/dsh-maid-whale-webUI/main/maid-whale-webui/preview/light.webp",
+  "https://raw.githubusercontent.com/yunxiiQwQ/dsh-maid-whale-webUI/main/maid-whale-webui/preview/dark.webp"
+ ],
+ "https://github.com/yyyyukari/dsh-plugin-workshop": [
+  "https://raw.githubusercontent.com/yyyyukari/dsh-plugin-workshop/master/assets/main-ui.jpg",
+  "https://raw.githubusercontent.com/yyyyukari/dsh-plugin-workshop/master/assets/installed-view.jpg",
+  "https://raw.githubusercontent.com/yyyyukari/dsh-plugin-workshop/master/assets/sidebar-entry.jpg"
+ ],
+ "https://github.com/zdx8637-gitdog/dshmobile/tree/main/plugins": [
+  "https://raw.githubusercontent.com/zdx8637-gitdog/dshmobile/main/docs/images/plugin-panel.jpg",
+  "https://raw.githubusercontent.com/zdx8637-gitdog/dshmobile/main/docs/images/phone-1.jpg",
+  "https://raw.githubusercontent.com/zdx8637-gitdog/dshmobile/main/docs/images/phone-2.jpg",
+  "https://raw.githubusercontent.com/zdx8637-gitdog/dshmobile/main/docs/images/phone-3.jpg"
+ ],
+ "https://github.com/zer0zio-stack/dsh-opencode-go-quota": [
+  "https://raw.githubusercontent.com/zer0zio-stack/dsh-opencode-go-quota/main/assets/screenshot-deepseek-balance.png",
+  "https://raw.githubusercontent.com/zer0zio-stack/dsh-opencode-go-quota/main/assets/screenshot-opencode-go-limit.png"
+ ],
+ "https://github.com/zhtx2024/dsh-pdf": [
+  "https://raw.githubusercontent.com/zhtx2024/dsh-pdf/master/assets/screenshot-schematic.png",
+  "https://raw.githubusercontent.com/zhtx2024/dsh-pdf/master/assets/screenshot-power.png"
+ ],
+ "https://github.com/zljr/dsh-share": [
+  "https://raw.githubusercontent.com/zljr/dsh-share/master/assets/share-dialog.png",
+  "https://raw.githubusercontent.com/zljr/dsh-share/master/assets/share-page-light.png",
+  "https://raw.githubusercontent.com/zljr/dsh-share/master/assets/share-page-dark.png"
+ ],
+ "https://github.com/2008924/dsh-progress-viz/tree/main/plugin": [
+  "https://raw.githubusercontent.com/2008924/dsh-progress-viz/main/docs/screenshot.png"
+ ],
+ "https://github.com/534119219/dsh-messaging/tree/main/packages/messaging-core": [
+  "https://raw.githubusercontent.com/534119219/dsh-messaging/main/assets/sidebar.png",
+  "https://raw.githubusercontent.com/534119219/dsh-messaging/main/assets/dialog.png"
+ ],
+ "https://github.com/Blank-not-black/dsh-Remote/tree/main/packages/plugin": [
+  "https://raw.githubusercontent.com/Blank-not-black/dsh-Remote/main/docs/screenshots/mobile-sessions.png",
+  "https://raw.githubusercontent.com/Blank-not-black/dsh-Remote/main/docs/screenshots/mobile-approvals.png",
+  "https://raw.githubusercontent.com/Blank-not-black/dsh-Remote/main/docs/screenshots/mobile-files.png",
+  "https://raw.githubusercontent.com/Blank-not-black/dsh-Remote/main/docs/screenshots/mobile-settings.png",
+  "https://raw.githubusercontent.com/Blank-not-black/dsh-Remote/main/docs/screenshots/gateway.png",
+  "https://raw.githubusercontent.com/Blank-not-black/dsh-Remote/main/docs/screenshots/settings-mobile.png",
+  "https://raw.githubusercontent.com/Blank-not-black/dsh-Remote/main/docs/screenshots/sessions.png",
+  "https://raw.githubusercontent.com/Blank-not-black/dsh-Remote/main/docs/screenshots/files.png"
+ ],
+ "https://github.com/UndeadSheep/dsh-file-preview/tree/main/packages/dsh-file-preview": [
+  "https://raw.githubusercontent.com/UndeadSheep/dsh-file-preview/main/assets/github-social-preview.png",
+  "https://raw.githubusercontent.com/UndeadSheep/dsh-file-preview/main/assets/btnPos.gif",
+  "https://raw.githubusercontent.com/UndeadSheep/dsh-file-preview/main/assets/write.gif",
+  "https://raw.githubusercontent.com/UndeadSheep/dsh-file-preview/main/assets/clickOpen.gif",
+  "https://raw.githubusercontent.com/UndeadSheep/dsh-file-preview/main/assets/SearchBar.gif"
+ ],
+ "https://github.com/Lzh3070/dsh-file-review-tab": [
+  "https://raw.githubusercontent.com/Lzh3070/dsh-file-review-tab/main/docs/screenshot.png"
+ ],
+ "https://github.com/ayahunter/dsh-trail/tree/main/packages/bundle": [
+  "https://raw.githubusercontent.com/ayahunter/dsh-trail/main/docs/screenshot.png",
+  "https://raw.githubusercontent.com/ayahunter/dsh-trail/main/docs/screenshots/rounds-view.png",
+  "https://raw.githubusercontent.com/ayahunter/dsh-trail/main/docs/screenshots/tool-details.png"
+ ],
+ "https://github.com/kaziii/dsh-github-connector/tree/main/packages/github/github": [
+  "https://raw.githubusercontent.com/kaziii/dsh-github-connector/main/docs/assets/pr-bar.png",
+  "https://raw.githubusercontent.com/kaziii/dsh-github-connector/main/docs/assets/connect-github.png"
+ ],
+ "https://github.com/siberiah2o/dsh-plugin-remote": [
+  "https://raw.githubusercontent.com/siberiah2o/dsh-plugin-remote/main/docs/screenshot-login.png",
+  "https://raw.githubusercontent.com/siberiah2o/dsh-plugin-remote/main/docs/screenshot-settings-panel.png"
+ ],
+ "https://github.com/WilliamShi666/dsh-wsl-workspace-picker": [
+  "https://raw.githubusercontent.com/WilliamShi666/dsh-wsl-workspace-picker/main/assets/workspace-picker-demo.png"
+ ],
+ "https://github.com/Liu-ZA-81/dsh-theme-firefly": [
+  "https://raw.githubusercontent.com/Liu-ZA-81/dsh-theme-firefly/main/docs/screenshots/01-wallpaper.jpg",
+  "https://raw.githubusercontent.com/Liu-ZA-81/dsh-theme-firefly/main/docs/screenshots/02-boot.jpg",
+  "https://raw.githubusercontent.com/Liu-ZA-81/dsh-theme-firefly/main/docs/screenshots/03-firefly.jpg",
+  "https://raw.githubusercontent.com/Liu-ZA-81/dsh-theme-firefly/main/docs/screenshots/04-music.jpg",
+  "https://raw.githubusercontent.com/Liu-ZA-81/dsh-theme-firefly/main/docs/screenshots/05-emote.jpg"
+ ],
+ "https://github.com/cheshireez/dsh-skill-hub": [
+  "https://raw.githubusercontent.com/cheshireez/dsh-skill-hub/main/promo/real-skill-hub.png",
+  "https://raw.githubusercontent.com/cheshireez/dsh-skill-hub/main/promo/real-skill-hub-catalog.png",
+  "https://raw.githubusercontent.com/cheshireez/dsh-skill-hub/main/promo/real-skill-hub-scenes.png"
+ ],
+ "https://github.com/maddogfinance/dsh-trading": [
+  "https://raw.githubusercontent.com/maddogfinance/dsh-trading/main/docs/screenshots/chart-card-panes.png",
+  "https://raw.githubusercontent.com/maddogfinance/dsh-trading/main/docs/screenshots/annotate-levels-table.png"
+ ],
+ "https://github.com/mux9056-bot/dsh-theme": [
+  "https://raw.githubusercontent.com/mux9056-bot/dsh-theme/main/shots/preview-gallery.png",
+  "https://raw.githubusercontent.com/mux9056-bot/dsh-theme/main/shots/mono-dark.png",
+  "https://raw.githubusercontent.com/mux9056-bot/dsh-theme/main/shots/sakura-light.png",
+  "https://raw.githubusercontent.com/mux9056-bot/dsh-theme/main/shots/terminal-dark.png"
+ ],
+ "https://github.com/chinosk6/dsh-roleplay": [
+  "https://raw.githubusercontent.com/chinosk6/dsh-roleplay/main/images/screenshot1.png"
+ ],
+ "https://github.com/starsstreaming/beautiCode/tree/main/integrations/deepseek-harness": [
+  "https://github.com/user-attachments/assets/c943a0fb-ff48-4361-9e6f-c4b1521aee2b",
+  "https://github.com/user-attachments/assets/a9a18412-4c62-4083-ab49-d127f05e61c3"
+ ],
+ "https://github.com/wenheguo2/dsh-delegation-suite": [
+  "https://raw.githubusercontent.com/wenheguo2/dsh-delegation-suite/main/assets/routes.png",
+  "https://raw.githubusercontent.com/wenheguo2/dsh-delegation-suite/main/assets/subagents.png"
+ ],
+ "https://github.com/kanneiren/dsh-network-settings": [
+  "https://raw.githubusercontent.com/kanneiren/dsh-network-settings/main/docs/images/wsl-path-graph.png",
+  "https://raw.githubusercontent.com/kanneiren/dsh-network-settings/main/docs/images/win-path-graph.png",
+  "https://raw.githubusercontent.com/kanneiren/dsh-network-settings/main/docs/images/win-network-config.png"
+ ],
+ "https://github.com/anneheartrecord/dsh-desk-pet": [
+  "https://raw.githubusercontent.com/anneheartrecord/dsh-desk-pet/main/docs/media/diy-skin.png",
+  "https://raw.githubusercontent.com/anneheartrecord/dsh-desk-pet/main/docs/media/floats-above.png",
+  "https://raw.githubusercontent.com/anneheartrecord/dsh-desk-pet/main/docs/media/skins.png",
+  "https://raw.githubusercontent.com/anneheartrecord/dsh-desk-pet/main/docs/media/states.png"
+ ],
+ "https://github.com/wsxwj123/dsh-plugins/tree/main/packages/dsh-appearance-gallery": [
+  "https://raw.githubusercontent.com/wsxwj123/dsh-plugins/main/assets/screenshots/appearance-gallery.png"
+ ],
+ "https://github.com/wsxwj123/dsh-plugins/tree/main/packages/dsh-turn-scrubber": [
+  "https://raw.githubusercontent.com/wsxwj123/dsh-plugins/main/assets/screenshots/turn-scrubber.png"
+ ],
+ "https://github.com/wsxwj123/dsh-plugins/tree/main/packages/dsh-session-manager": [
+  "https://raw.githubusercontent.com/wsxwj123/dsh-plugins/main/assets/screenshots/session-manager.png"
+ ],
+ "https://github.com/wsxwj123/dsh-plugins/tree/main/packages/dsh-composer-tools": [
+  "https://raw.githubusercontent.com/wsxwj123/dsh-plugins/main/assets/screenshots/composer-tools.png"
+ ],
+ "https://github.com/acebang0303/dsh-quick-launch": [
+  "https://raw.githubusercontent.com/acebang0303/dsh-quick-launch/main/docs/preview.png"
+ ],
+ "https://github.com/corrinehu/dsh-workbuddy-connect": [
+  "https://raw.githubusercontent.com/corrinehu/dsh-workbuddy-connect/main/assets/1.png",
+  "https://raw.githubusercontent.com/corrinehu/dsh-workbuddy-connect/main/assets/2.png",
+  "https://raw.githubusercontent.com/corrinehu/dsh-workbuddy-connect/main/assets/3.png"
+ ],
+ "https://github.com/tipoLi5890/dsh-file-mention": [
+  "https://raw.githubusercontent.com/tipoLi5890/dsh-file-mention/main/assets/screenshots/file-mention-browse.png",
+  "https://raw.githubusercontent.com/tipoLi5890/dsh-file-mention/main/assets/screenshots/file-mention-drag-drop.png",
+  "https://raw.githubusercontent.com/tipoLi5890/dsh-file-mention/main/assets/screenshots/file-mention-upload-reference.png"
+ ],
+ "https://github.com/liguobao/deepseek-harness-remote": [
+  "https://raw.githubusercontent.com/liguobao/deepseek-harness-remote/main/docs/images/setting.png",
+  "https://raw.githubusercontent.com/liguobao/deepseek-harness-remote/main/docs/images/host-list.png",
+  "https://raw.githubusercontent.com/liguobao/deepseek-harness-remote/main/docs/images/remote.png"
+ ],
+ "https://github.com/WJZ-P/dsh-attachments": [
+  "https://raw.githubusercontent.com/WJZ-P/dsh-attachments/main/assets/markdown/01-drag-drop-overlay.png",
+  "https://raw.githubusercontent.com/WJZ-P/dsh-attachments/main/assets/markdown/02-image-conversation.png",
+  "https://raw.githubusercontent.com/WJZ-P/dsh-attachments/main/assets/markdown/03-multiple-image-preview.png"
+ ],
+ "https://github.com/WJZ-P/dsh-model-capabilities": [
+  "https://raw.githubusercontent.com/WJZ-P/dsh-model-capabilities/main/assets/screenshots/01-model-input-selector.png"
+ ],
+ "https://github.com/winditer/dsh-elf": [
+  "https://raw.githubusercontent.com/winditer/dsh-elf/main/assets/screenshot-elf.png",
+  "https://raw.githubusercontent.com/winditer/dsh-elf/main/assets/screenshot-chat.png"
+ ],
+ "https://github.com/Frog755/dsh-client-auto-retry": [
+  "https://raw.githubusercontent.com/Frog755/dsh-client-auto-retry/main/assets/demo.svg",
+  "https://raw.githubusercontent.com/Frog755/dsh-client-auto-retry/main/assets/screenshot-settings-card.png"
+ ],
+ "https://github.com/Frog755/dsh-prompt-vault": [
+  "https://raw.githubusercontent.com/Frog755/dsh-prompt-vault/master/assets/screenshot-panel.png"
+ ],
+ "https://github.com/lemonorangeapple/dsh-effort-switcher": [
+  "https://raw.githubusercontent.com/lemonorangeapple/dsh-effort-switcher/master/screenshots/1.png",
+  "https://raw.githubusercontent.com/lemonorangeapple/dsh-effort-switcher/master/screenshots/2.png"
+ ],
+ "https://github.com/falser101/dsh-mascot": [
+  "https://raw.githubusercontent.com/falser101/dsh-mascot/main/assets/cover.jpg",
+  "https://raw.githubusercontent.com/falser101/dsh-mascot/main/assets/faces.jpg",
+  "https://raw.githubusercontent.com/falser101/dsh-mascot/main/assets/skins.jpg"
+ ],
+ "https://github.com/LiZhenNet/dsh-antigravity": [
+  "https://raw.githubusercontent.com/LiZhenNet/dsh-antigravity/main/assets/images/settings-signed-in.png",
+  "https://raw.githubusercontent.com/LiZhenNet/dsh-antigravity/main/assets/images/chat-model-picker.png",
+  "https://raw.githubusercontent.com/LiZhenNet/dsh-antigravity/main/assets/images/settings-not-signed-in.png"
+ ],
+ "https://github.com/geguanming/dsh-office-plugin": [
+  "https://raw.githubusercontent.com/geguanming/dsh-office-plugin/master/assets/entry.png",
+  "https://raw.githubusercontent.com/geguanming/dsh-office-plugin/master/assets/work-monitor.png",
+  "https://raw.githubusercontent.com/geguanming/dsh-office-plugin/master/assets/order-boss.png"
+ ],
+ "https://github.com/lninghaha/dsh-hub-oauth-gateway": [
+  "https://raw.githubusercontent.com/lninghaha/dsh-hub-oauth-gateway/main/docs/images/usage-center-hud.png",
+  "https://raw.githubusercontent.com/lninghaha/dsh-hub-oauth-gateway/main/docs/images/usage-center-peek.png",
+  "https://raw.githubusercontent.com/lninghaha/dsh-hub-oauth-gateway/main/docs/images/usage-center-dashboard.png",
+  "https://raw.githubusercontent.com/lninghaha/dsh-hub-oauth-gateway/main/docs/images/usage-center-settings.png"
+ ],
+ "https://github.com/deepseek-dsh/dsh-workspace": [
+  "https://raw.githubusercontent.com/deepseek-dsh/dsh-workspace/main/assets/Screenshot-1.png",
+  "https://raw.githubusercontent.com/deepseek-dsh/dsh-workspace/main/assets/Screenshot-2.png"
+ ],
+ "https://github.com/CheshireJCat/blender": [
+  "https://raw.githubusercontent.com/CheshireJCat/blender/main/assets/dsh-blender-lamp-preview.png"
+ ],
+ "https://github.com/Y1X1n/dsh-prompt-optimizer": [
+  "https://raw.githubusercontent.com/Y1X1n/dsh-prompt-optimizer/main/docs/screenshots/optimize-panel.png"
+ ],
+ "https://github.com/feng78-boop/dsh-thirteen-bg": [
+  "https://raw.githubusercontent.com/feng78-boop/dsh-thirteen-bg/master/assets/demo-poster.jpg",
+  "https://raw.githubusercontent.com/feng78-boop/dsh-thirteen-bg/master/assets/demo-shot-2.jpg"
+ ],
+ "https://github.com/wsz987/dsh-channels/tree/main/packages/channels": [
+  "https://raw.githubusercontent.com/wsz987/dsh-channels/main/docs/ScreenShot/dsh-channels-setting.png",
+  "https://raw.githubusercontent.com/wsz987/dsh-channels/main/docs/ScreenShot/telegram.png"
+ ],
+ "https://github.com/liustack/modsearch": [
+  "https://raw.githubusercontent.com/liustack/modsearch/main/assets/demo-dsh-settings-card.jpg",
+  "https://raw.githubusercontent.com/liustack/modsearch/main/assets/demo-codex-search.png",
+  "https://raw.githubusercontent.com/liustack/modsearch/main/assets/demo-codex-fetch.png"
+ ],
+ "https://github.com/liustack/modlens": [
+  "https://raw.githubusercontent.com/liustack/modlens/main/assets/demo-dsh-settings-card.jpg",
+  "https://raw.githubusercontent.com/liustack/modlens/main/assets/demo-dsh-paste.jpg",
+  "https://raw.githubusercontent.com/liustack/modlens/main/assets/demo-codex-chart.jpg",
+  "https://raw.githubusercontent.com/liustack/modlens/main/assets/demo-codex-app.jpg"
+ ],
+ "https://github.com/elysia395/dsh-wallpaper-engine": [
+  "https://raw.githubusercontent.com/elysia395/dsh-wallpaper-engine/main/docs/images/showcase.png",
+  "https://raw.githubusercontent.com/elysia395/dsh-wallpaper-engine/main/docs/images/wallpaper-library.png",
+  "https://raw.githubusercontent.com/elysia395/dsh-wallpaper-engine/main/docs/images/liquid-glass-window.png",
+  "https://raw.githubusercontent.com/elysia395/dsh-wallpaper-engine/main/docs/images/features.png",
+  "https://raw.githubusercontent.com/elysia395/dsh-wallpaper-engine/main/docs/images/compact-wallpaper-library.png",
+  "https://raw.githubusercontent.com/elysia395/dsh-wallpaper-engine/main/docs/images/better-sidebar.png"
+ ],
+ "https://github.com/dami9527/dsh-image-pathify": [
+  "https://raw.githubusercontent.com/dami9527/dsh-image-pathify/master/assets/example.png",
+  "https://raw.githubusercontent.com/dami9527/dsh-image-pathify/master/assets/settings.png",
+  "https://raw.githubusercontent.com/dami9527/dsh-image-pathify/master/assets/update.png"
+ ],
+ "https://github.com/WSL043/dsh-chat-manager": [
+  "https://raw.githubusercontent.com/WSL043/dsh-chat-manager/main/docs/assets/archive-manager.en.png",
+  "https://raw.githubusercontent.com/WSL043/dsh-chat-manager/main/docs/assets/confirm-delete.en.png"
+ ],
+ "https://github.com/ryubyte/dsh-a2a": [
+  "https://raw.githubusercontent.com/ryubyte/dsh-a2a/main/docs/screenshots/dashboard-outbound.png",
+  "https://raw.githubusercontent.com/ryubyte/dsh-a2a/main/docs/screenshots/dashboard-inbound.png",
+  "https://raw.githubusercontent.com/ryubyte/dsh-a2a/main/docs/screenshots/server-inbound.png",
+  "https://raw.githubusercontent.com/ryubyte/dsh-a2a/main/docs/screenshots/server-serve.png"
+ ],
+ "https://github.com/EdwinDigital/dsh-web-search-microsoft-webiq": [
+  "https://raw.githubusercontent.com/EdwinDigital/dsh-web-search-microsoft-webiq/main/docs/images/screenshot-1-settings.png",
+  "https://raw.githubusercontent.com/EdwinDigital/dsh-web-search-microsoft-webiq/main/docs/images/screenshot-2-web-search.png",
+  "https://raw.githubusercontent.com/EdwinDigital/dsh-web-search-microsoft-webiq/main/docs/images/screenshot-3-trace.png"
+ ],
+ "https://github.com/SmileBuild/dsh-planchart": [
+  "https://raw.githubusercontent.com/SmileBuild/dsh-planchart/main/assets/screenshot-1.png",
+  "https://raw.githubusercontent.com/SmileBuild/dsh-planchart/main/assets/screenshot-2.png"
+ ],
+ "https://github.com/WSL043/dsh-codex-subscription": [
+  "https://raw.githubusercontent.com/WSL043/dsh-codex-subscription/main/docs/assets/settings-en.png",
+  "https://raw.githubusercontent.com/WSL043/dsh-codex-subscription/main/docs/assets/composer-quota-en.png"
+ ],
+ "https://github.com/mkiea/dsh-forge": [
+  "https://raw.githubusercontent.com/mkiea/dsh-forge/master/assets/screenshot-1.png",
+  "https://raw.githubusercontent.com/mkiea/dsh-forge/master/assets/screenshot-2.png",
+  "https://raw.githubusercontent.com/mkiea/dsh-forge/master/assets/screenshot-3.png"
+ ],
+ "https://github.com/alone-tree/dsh-skill-mcp-manager": [
+  "https://raw.githubusercontent.com/alone-tree/dsh-skill-mcp-manager/main/docs/screenshot-mcp.png",
+  "https://raw.githubusercontent.com/alone-tree/dsh-skill-mcp-manager/main/docs/screenshot-skills.png"
+ ],
+ "https://github.com/liqiming-whu/dsh-status-card": [
+  "https://raw.githubusercontent.com/liqiming-whu/dsh-status-card/main/docs/images/templates/bilingual/template-a.svg",
+  "https://raw.githubusercontent.com/liqiming-whu/dsh-status-card/main/docs/images/templates/bilingual/template-b.svg",
+  "https://raw.githubusercontent.com/liqiming-whu/dsh-status-card/main/docs/images/templates/bilingual/template-c.svg",
+  "https://raw.githubusercontent.com/liqiming-whu/dsh-status-card/main/docs/images/templates/bilingual/template-d.svg",
+  "https://raw.githubusercontent.com/liqiming-whu/dsh-status-card/main/docs/images/templates/bilingual/template-e.svg",
+  "https://raw.githubusercontent.com/liqiming-whu/dsh-status-card/main/docs/images/templates/bilingual/template-f.svg"
+ ],
+ "https://github.com/zhujunpeng12/dsh-memory-system": [
+  "https://raw.githubusercontent.com/zhujunpeng12/dsh-memory-system/master/assets/social-preview.png",
+  "https://raw.githubusercontent.com/zhujunpeng12/dsh-memory-system/master/docs/memory-system-flowchart.png"
+ ],
+ "https://github.com/wangzhishou/onebox-dsh-bridge": [
+  "https://raw.githubusercontent.com/wangzhishou/onebox-dsh-bridge/main/docs/images/pairing-page.png",
+  "https://raw.githubusercontent.com/wangzhishou/onebox-dsh-bridge/main/docs/images/app-connect.png",
+  "https://raw.githubusercontent.com/wangzhishou/onebox-dsh-bridge/main/docs/images/app-chat.png",
+  "https://raw.githubusercontent.com/wangzhishou/onebox-dsh-bridge/main/docs/images/app-feedback.png"
+ ],
+ "https://github.com/EugeneVl/dsh_session_folders": [
+  "https://raw.githubusercontent.com/EugeneVl/dsh_session_folders/master/assets/screenshot-1.jpg",
+  "https://raw.githubusercontent.com/EugeneVl/dsh_session_folders/master/assets/screenshot-2.jpg",
+  "https://raw.githubusercontent.com/EugeneVl/dsh_session_folders/master/assets/screenshot-3.jpg"
+ ],
+ "https://github.com/IceApriler/dsh-remote-mobile": [
+  "https://raw.githubusercontent.com/IceApriler/dsh-remote-mobile/master/images/pc-dsh-setting-1.png",
+  "https://raw.githubusercontent.com/IceApriler/dsh-remote-mobile/master/images/pc-dsh-setting-2.png",
+  "https://raw.githubusercontent.com/IceApriler/dsh-remote-mobile/master/images/mobile-auth.jpg",
+  "https://raw.githubusercontent.com/IceApriler/dsh-remote-mobile/master/images/mobile-dsh.jpg"
+ ],
+ "https://github.com/jhuanxx44/dsh-sseye": [
+  "https://raw.githubusercontent.com/jhuanxx44/dsh-sseye/main/assets/panel-detail.png"
+ ],
+ "https://github.com/wyzh0117/dsh-skill-select": [
+  "https://raw.githubusercontent.com/wyzh0117/dsh-skill-select/main/assets/product.png",
+  "https://raw.githubusercontent.com/wyzh0117/dsh-skill-select/main/assets/better-sidebar.png"
+ ],
+ "https://github.com/wqy8593521/dsh-model-pro": [
+  "https://raw.githubusercontent.com/wqy8593521/dsh-model-pro/main/docs/screenshots/dashboard.png",
+  "https://raw.githubusercontent.com/wqy8593521/dsh-model-pro/main/docs/screenshots/editor.png",
+  "https://raw.githubusercontent.com/wqy8593521/dsh-model-pro/main/docs/screenshots/models.png",
+  "https://raw.githubusercontent.com/wqy8593521/dsh-model-pro/main/docs/screenshots/test.png",
+  "https://raw.githubusercontent.com/wqy8593521/dsh-model-pro/main/docs/screenshots/routes.png"
+ ],
+ "https://github.com/Kenerlee/dsh-moments-aieo": [
+  "https://raw.githubusercontent.com/Kenerlee/dsh-moments-aieo/master/assets/screenshot-dashboard.png",
+  "https://raw.githubusercontent.com/Kenerlee/dsh-moments-aieo/master/assets/screenshot-diagnosis-report.png",
+  "https://raw.githubusercontent.com/Kenerlee/dsh-moments-aieo/master/assets/screenshot-dashboard-mobile.png"
+ ],
+ "https://github.com/FeiZhuNiU-INFJA/dsh-stock-ticker": [
+  "https://raw.githubusercontent.com/FeiZhuNiU-INFJA/dsh-stock-ticker/main/assets/screenshot.png"
+ ],
+ "https://github.com/miuzel/dsh-graph/tree/main/dsh-graph-host": [
+  "https://raw.githubusercontent.com/miuzel/dsh-graph/main/screenshot/screenshot-1.png",
+  "https://raw.githubusercontent.com/miuzel/dsh-graph/main/screenshot/screenshot-2.png"
+ ],
+ "https://github.com/ppy-web/dsh-plugin-xiaomi-mimo-tts": [
+  "https://raw.githubusercontent.com/ppy-web/dsh-plugin-xiaomi-mimo-tts/main/assets/menu.png",
+  "https://raw.githubusercontent.com/ppy-web/dsh-plugin-xiaomi-mimo-tts/main/assets/preset.png",
+  "https://raw.githubusercontent.com/ppy-web/dsh-plugin-xiaomi-mimo-tts/main/assets/image.png"
+ ],
+ "https://github.com/lunaship/dsh-links": [
+  "https://raw.githubusercontent.com/lunaship/dsh-links/main/docs/images/phone-connection-sanitized.png",
+  "https://raw.githubusercontent.com/lunaship/dsh-links/main/docs/images/android-device-list-sanitized.png",
+  "https://raw.githubusercontent.com/lunaship/dsh-links/main/docs/images/android-navigation-drawer.jpg",
+  "https://raw.githubusercontent.com/lunaship/dsh-links/main/docs/images/android-workspace-light.jpg",
+  "https://raw.githubusercontent.com/lunaship/dsh-links/main/docs/images/android-workspace-dark.jpg"
+ ],
+ "https://github.com/qinyre/dsh-plugin-install": [
+  "https://raw.githubusercontent.com/qinyre/dsh-plugin-install/main/docs/images/screenshot-install.png"
+ ],
+ "https://github.com/qinyre/dsh-plugin-capabilities": [
+  "https://raw.githubusercontent.com/qinyre/dsh-plugin-capabilities/main/docs/images/screenshot-skills.png",
+  "https://raw.githubusercontent.com/qinyre/dsh-plugin-capabilities/main/docs/images/screenshot-mcp.png",
+  "https://raw.githubusercontent.com/qinyre/dsh-plugin-capabilities/main/docs/images/screenshot-market-skills.png",
+  "https://raw.githubusercontent.com/qinyre/dsh-plugin-capabilities/main/docs/images/screenshot-market-mcp.png"
+ ],
+ "https://github.com/qinyre/dsh-plugin-atlas": [
+  "https://raw.githubusercontent.com/qinyre/dsh-plugin-atlas/main/docs/images/screenshot-rail.png",
+  "https://raw.githubusercontent.com/qinyre/dsh-plugin-atlas/main/docs/images/screenshot-archive.png"
+ ],
+ "https://github.com/Whale-Zhang/dsh-complete-chime": [
+  "https://raw.githubusercontent.com/Whale-Zhang/dsh-complete-chime/main/docs/settings-card.png"
+ ],
+ "https://github.com/Cerbur/clutch-dsh/tree/main/packages/clutch-dsh-worktree": [
+  "https://raw.githubusercontent.com/Cerbur/clutch-dsh/main/packages/clutch-dsh-worktree/assets/screenshots/screenshots-en.png",
+  "https://raw.githubusercontent.com/Cerbur/clutch-dsh/main/packages/clutch-dsh-worktree/assets/screenshots/screenshots-zh.png"
+ ],
+ "https://github.com/qkycir-123/dsh-run2skill": [
+  "https://raw.githubusercontent.com/qkycir-123/dsh-run2skill/main/docs/assets/01-proposal-inbox.png",
+  "https://raw.githubusercontent.com/qkycir-123/dsh-run2skill/main/docs/assets/02-review-details.png",
+  "https://raw.githubusercontent.com/qkycir-123/dsh-run2skill/main/docs/assets/03-saved-activity.png"
+ ],
+ "https://github.com/BananaSoldier01/dsh-tidychat": [
+  "https://raw.githubusercontent.com/BananaSoldier01/dsh-tidychat/main/assets/navigator.png",
+  "https://raw.githubusercontent.com/BananaSoldier01/dsh-tidychat/main/assets/settings.png"
+ ],
+ "https://github.com/PolinniZhong/dsh-personal-center": [
+  "https://raw.githubusercontent.com/PolinniZhong/dsh-personal-center/main/docs/screenshots/light-profile.png",
+  "https://raw.githubusercontent.com/PolinniZhong/dsh-personal-center/main/docs/screenshots/dark-pet.png",
+  "https://raw.githubusercontent.com/PolinniZhong/dsh-personal-center/main/docs/screenshots/pet-emotions.gif",
+  "https://raw.githubusercontent.com/PolinniZhong/dsh-personal-center/main/docs/screenshots/dark-model-cost.png"
+ ],
+ "https://github.com/KarlOfLaw/dsh-side-chat": [
+  "https://raw.githubusercontent.com/KarlOfLaw/dsh-side-chat/main/docs/assets/dsh-side-chat-hero.png",
+  "https://raw.githubusercontent.com/KarlOfLaw/dsh-side-chat/main/docs/assets/side-chat-parallel.png",
+  "https://raw.githubusercontent.com/KarlOfLaw/dsh-side-chat/main/docs/assets/side-chat-selection.png",
+  "https://raw.githubusercontent.com/KarlOfLaw/dsh-side-chat/main/docs/assets/side-chat-settings.png"
+ ],
+ "https://github.com/biggerboy/dsh-conversation-anchors": [
+  "https://raw.githubusercontent.com/biggerboy/dsh-conversation-anchors/master/assets/anchors-hover.png",
+  "https://raw.githubusercontent.com/biggerboy/dsh-conversation-anchors/master/assets/anchors-wave.png"
+ ],
+ "https://github.com/WSL043/dsh-reasoning-slider": [
+  "https://raw.githubusercontent.com/WSL043/dsh-reasoning-slider/main/docs/assets/reasoning-slider-en.png",
+  "https://raw.githubusercontent.com/WSL043/dsh-reasoning-slider/main/docs/assets/reasoning-slider-energy-zh.png",
+  "https://raw.githubusercontent.com/WSL043/dsh-reasoning-slider/main/docs/assets/mode-settings-en.png",
+  "https://raw.githubusercontent.com/WSL043/dsh-reasoning-slider/main/docs/assets/mode-settings-dark-zh.png"
+ ],
+ "https://github.com/jerryqx/dsh-ximalaya": [
+  "https://raw.githubusercontent.com/jerryqx/dsh-ximalaya/main/assets/panel-search.png",
+  "https://raw.githubusercontent.com/jerryqx/dsh-ximalaya/main/assets/panel-album.png",
+  "https://raw.githubusercontent.com/jerryqx/dsh-ximalaya/main/assets/panel-mine-subs.png",
+  "https://raw.githubusercontent.com/jerryqx/dsh-ximalaya/main/assets/panel-mine-anchors.png"
+ ],
+ "https://github.com/yangdongzhen590/dsh-knj-workflow": [
+  "https://raw.githubusercontent.com/yangdongzhen590/dsh-knj-workflow/main/assets/screenshots/task-detail.png",
+  "https://raw.githubusercontent.com/yangdongzhen590/dsh-knj-workflow/main/assets/screenshots/workflow-editor.png",
+  "https://raw.githubusercontent.com/yangdongzhen590/dsh-knj-workflow/main/assets/screenshots/new-task-modal.png"
+ ],
+ "https://github.com/yangdongzhen590/dsh-knj-menu": [
+  "https://raw.githubusercontent.com/yangdongzhen590/dsh-knj-menu/main/assets/screenshots/menu-manager.png"
+ ],
+ "https://github.com/yangdongzhen590/dsh-knj-scheduler": [
+  "https://raw.githubusercontent.com/yangdongzhen590/dsh-knj-scheduler/main/assets/screenshots/scheduler-panel.png"
+ ],
+ "https://github.com/mienfong/dsh-session-mgr": [
+  "https://raw.githubusercontent.com/mienfong/dsh-session-mgr/main/docs/screenshots/session-manager_EN.png",
+  "https://raw.githubusercontent.com/mienfong/dsh-session-mgr/main/docs/screenshots/move-dialog_EN.png",
+  "https://raw.githubusercontent.com/mienfong/dsh-session-mgr/main/docs/screenshots/backup_EN.png",
+  "https://raw.githubusercontent.com/mienfong/dsh-session-mgr/main/docs/screenshots/import_EN.png",
+  "https://raw.githubusercontent.com/mienfong/dsh-session-mgr/main/docs/screenshots/delete-confirm_EN.png"
+ ],
+ "https://github.com/kenny2077/dsh-web-search-doubao": [
+  "https://raw.githubusercontent.com/kenny2077/dsh-web-search-doubao/main/docs/img/settings-card.png",
+  "https://raw.githubusercontent.com/kenny2077/dsh-web-search-doubao/main/docs/img/console.png"
+ ],
+ "https://github.com/tr1v3r/dsh-quote-followup": [
+  "https://raw.githubusercontent.com/tr1v3r/dsh-quote-followup/v0.2.6/docs/assets/quote-followup-demo.gif"
+ ]
+}


### PR DESCRIPTION
![demo](https://raw.githubusercontent.com/tr1v3r/dsh-quote-followup/v0.2.6/docs/assets/quote-followup-demo.gif)

Adds `data/plugins/tr1v3r__dsh-quote-followup.yml` plus a `data/screenshots.json` entry pointing at the same demo gif on `raw.githubusercontent.com` (per dsh-market #61, so storefront detail views show it). READMEs untouched (generated).

**What it does** (Web-only, TUI unsupported): select text inside the Web conversation transcript → a floating Quote button appends a native DSH conversation-reference chip to the composer (reuses the same `ReferenceChipNode` as `@file`/`@session`) → on send the codec expands each chip into a Markdown blockquote. Supports multiple excerpts per message, attaches the turn ordinal when the selection comes from a chat row, and falls back to a plain-text quote when native chips are unavailable. The gif above shows the flow end to end.

**Checklist (contributing.md)**
- `dsh.bundle` manifest declared in `package.json` (`bundle.patch` → `cordis.patch.yml` at repo root) ✅
- Repo created 2026-09-06, not archived, actively maintained ✅
- `dsh-plugin` topic on the repo ✅
- Published to npm as [dsh-quote-followup](https://www.npmjs.com/package/dsh-quote-followup) (latest v0.2.6) — prebuilt installs ✅
- Category `ui`: composer/transcript interaction
- Description states behavior only; en required field present, zh included
- Screenshot URL pinned to tag `v0.2.6`, host `raw.githubusercontent.com` (allowed host), key matches the entry `url` exactly

**vs. zzx-dear/dsh-selection-followup (already listed):** different implementation, not a reskin — that one offers a floating Follow-up/Copy pill; this one inserts native reference chips through the composer codec, keeps multiple excerpts, carries turn-number provenance, and degrades to a text fallback. Sharing a category with it seems right either way.
