### PR TITLE
Add 3 plugins: MrMu666/dsh-LAN, JustGenius-s/DSH-Plugs (#dsh-flow, #dsh-codex)

### DIFF
--- a/data/plugins/JustGenius-s__DSH-Plugs--plugins-dsh-codex.yml
+++ b/data/plugins/JustGenius-s__DSH-Plugs--plugins-dsh-codex.yml
@@ -1,0 +1,6 @@
+url: https://github.com/JustGenius-s/DSH-Plugs/tree/main/plugins/dsh-codex
+name: JustGenius-s/DSH-Plugs#dsh-codex
+category: ui
+description:
+  en: 'Codex-style shell for the Web UI: per-turn Worked-for collapsing, message navigation, a side panel with file tree / preview / diff, a login-shell PTY terminal, and a read-only git commit-graph panel.'
+  zh: 'Web UI 的 Codex 风格外壳：按轮次折叠的 Worked-for、消息导航、带文件树/预览/差异的侧面板、登录 shell PTY 终端，以及只读 git 提交图面板。'

--- a/data/plugins/JustGenius-s__DSH-Plugs--plugins-dsh-flow.yml
+++ b/data/plugins/JustGenius-s__DSH-Plugs--plugins-dsh-flow.yml
@@ -1,0 +1,6 @@
+url: https://github.com/JustGenius-s/DSH-Plugs/tree/main/plugins/dsh-flow
+name: JustGenius-s/DSH-Plugs#dsh-flow
+category: workflow
+description:
+  en: 'Leader-plans / subagent-executes orchestration: /flow lays work out as a DAG dispatched to child agents, reshapes it with flow.patch, removes execution tools from the Leader, and draws the live graph in a Flow tab.'
+  zh: '主代理规划、子代理执行的编排：/flow 把工作排成 DAG 分派给子代理，可用 flow.patch 中途调整，主代理期间移除执行工具，Flow 标签页实时展示流程图。'

--- a/data/plugins/MrMu666__dsh-LAN.yml
+++ b/data/plugins/MrMu666__dsh-LAN.yml
@@ -1,0 +1,6 @@
+url: https://github.com/MrMu666/dsh-LAN
+name: MrMu666/dsh-LAN
+category: remote
+description:
+  en: 'Password-gated LAN access for the Web GUI: binds 0.0.0.0, auto-allows host firewall ports, injects mobile touch adaptation for phones, and re-exposes local-only privileged methods through a passcode proxy.'
+  zh: 'Web GUI 的口令门禁局域网访问：绑定 0.0.0.0、自动放行主机防火墙端口、为手机注入移动端触控适配，并通过口令代理重新暴露仅本机的特权方法。'


### PR DESCRIPTION
## Entries added (3 files, nothing else touched)

1. **MrMu666/dsh-LAN** — `remote`
   Password-gated LAN access for the Web GUI: binds 0.0.0.0, auto-allows host firewall ports, injects mobile touch adaptation for phones, and re-exposes local-only privileged methods through a passcode proxy.
2. **JustGenius-s/DSH-Plugs#dsh-flow** — `workflow`
   Leader-plans / subagent-executes orchestration: `/flow` lays work out as a DAG dispatched to child agents, reshapes it with `flow.patch`, removes execution tools from the Leader, and draws the live graph in a Flow tab.
3. **JustGenius-s/DSH-Plugs#dsh-codex** — `ui`
   Codex-style shell for the Web UI: per-turn Worked-for collapsing, message navigation, a side panel with file tree / preview / diff, a login-shell PTY terminal, and a read-only git commit-graph panel.

## Qualification notes

- `dsh.bundle` manifests verified in each repo: `MrMu666/dsh-LAN` root `package.json`; `JustGenius-s/DSH-Plugs` at `plugins/dsh-flow/package.json` and `plugins/dsh-codex/package.json` (monorepo entries per the contributing guide).
- Real working code: dsh-flow ships a React Flow client under `src/client/`; dsh-codex has 125 source files under `src/`; dsh-LAN ships install scripts and plugin sources.
- Both repos were created 2026-08-13/14 (well past the 1-day bar) and pushed within the last day; both carry the `dsh-plugin` topic.
- Descriptions were written from each project's README/package description and checked against the code.

## Differentiation from existing entries

- **dsh-LAN vs [AcidGr/dsh-web-lan-access](https://github.com/AcidGr/dsh-web-lan-access)** (existing `remote` entry, crypto.randomUUID polyfill for LAN origins): dsh-LAN adds a password gate with server-side enforcement on privileged methods, firewall auto-allowlisting, and mobile touch adaptation of the official UI — additive, not a duplicate.
- **dsh-codex name-mates**: [WODE25500/dsh-codex](https://github.com/WODE25500/dsh-codex) is a Codex CLI wrapper (`dev`) and [yoshino-xiao7/dsh-codex](https://github.com/yoshino-xiao7/dsh-codex) is a Codex model provider (`model`). This entry is a Web UI shell (`ui`) — same name, different function.
- **dsh-flow**: no existing entry covers leader/subagent DAG orchestration with a live graph tab.

Regenerated both READMEs locally to preview (`npm ci && node scripts/generate-readme.mjs`) — all three lines render as expected; generated files are left to CI.
