### PR TITLE
Add lumoping/dsh-todo-inbox

### DIFF
--- a/data/plugins/lumoping__dsh-todo-inbox.yml
+++ b/data/plugins/lumoping__dsh-todo-inbox.yml
@@ -1,0 +1,6 @@
+url: https://github.com/lumoping/dsh-todo-inbox
+name: lumoping/dsh-todo-inbox
+category: ui
+description:
+  en: 'Global cross-session todo inbox for DSH web: any session''s agent records human-action todos (merge MRs, approve work orders, reviews) via inbox_add/inbox_done/inbox_list; a sidebar entry shows a count badge and an expandable list to open and complete them, persisted to ~/.dsh/todo-inbox.json.'
+  zh: DSH Web 全局跨会话待办收件箱：任意会话的 agent 通过 inbox_add/inbox_done/inbox_list 登记等待人类处理的事项（合并 MR、审批工单、评审等）；侧边栏入口显示未完成数角标与可展开的待办列表，支持打开与完成，数据持久化到 ~/.dsh/todo-inbox.json。


### PR DESCRIPTION
## Submission / 收录申请

Adds one entry: **lumoping/dsh-todo-inbox** — a global cross-session todo inbox plugin for DSH web.

新增一条收录：**lumoping/dsh-todo-inbox** —— DSH Web 全局跨会话待办收件箱插件。

### Requirements / 收录条件核对

- ✅ `dsh.bundle` declared in `package.json` (`patch: ./cordis.patch.yml`, with the patch file at repo root) — installable via `dsh plugin add`
- ✅ Real, working code (host half: `inbox_add` / `inbox_done` / `inbox_list` tools, `/todo-inbox/api` routes, disk persistence; browser half: sidebar entry with count badge, expandable list, markdown detail)
- ✅ Repo age: created 2026-09-07, >1 day at submission
- ✅ `dsh-plugin` topic added
- ✅ Description states what the plugin does, no marketing language; `en` + `zh` provided

### Category / 分类

`ui` — the sidebar entry is the primary user-facing surface.

Note: existing entry `seeingrain/dsh-session-todos` is a *session-scoped* floating panel; this plugin is a *global cross-session* inbox driven by agent tools. Not a duplicate.

注：现有条目 `seeingrain/dsh-session-todos` 是**会话内**悬浮面板；本插件是 **agent 工具驱动的全局跨会话**收件箱，不构成重复。