### PR TITLE
Add tr1v3r/dsh-proxy

### DIFF
--- a/data/plugins/tr1v3r__dsh-proxy.yml
+++ b/data/plugins/tr1v3r__dsh-proxy.yml
@@ -1,0 +1,6 @@
+url: https://github.com/tr1v3r/dsh-proxy
+name: tr1v3r/dsh-proxy
+category: tools
+description:
+  en: Hot-switches in-process DSH fetch traffic among direct, manual HTTP(S)/SOCKS5 proxy, and ambient system-proxy modes, with no-proxy rules and optional proxy-environment export for newly spawned child processes.
+  zh: 在直连、手动 HTTP(S)/SOCKS5 代理和环境/系统代理模式间热切换 DSH 进程内 fetch 流量，支持免代理规则，并可为之后启动的子进程导出代理环境变量。


### PR DESCRIPTION
## What

Add `tr1v3r/dsh-proxy` to the **Tools & Utilities** catalog.

The entry describes its settings-driven routing for in-process DSH fetch traffic and links the repository whose published npm package is `@tr1v3r/dsh-proxy`.

## Qualification

- The root `package.json` declares `dsh.bundle` and points at `cordis.patch.yml`.
- The repository contains the runtime implementation and end-to-end transport tests; `npm test` passes all 26 tests.
- `@tr1v3r/dsh-proxy@0.1.2` is public on npm, and its `repository` field maps back to this GitHub repository.
- The repository is public, unarchived, and carries the `dsh-plugin` topic.

## Differentiation from the existing dsh-proxy-routing entry

The existing `chenjiyan2001/dsh-proxy-routing` provides per-execution/per-provider isolation together with agent control tools, a Web settings surface, endpoint discovery, and approval gates.

`tr1v3r/dsh-proxy` is instead a minimal settings-only, process-wide `globalThis.fetch` switch. It replaces the current DSH process’s undici global dispatcher, supports environment/macOS-system proxy detection, and can export proxy variables for newly spawned child processes. The tradeoff is explicit: it provides no per-execution/provider isolation, Web UI, discovery, or control tools.

Hot reload, HTTP/SOCKS5 proxy support, and shell environment inheritance are shared capabilities rather than claimed differentiators.

## Validation

- Regenerated both catalog READMEs locally; the new English and Chinese lines render correctly.
- `npx awesome-lint` passes (only existing repository warnings).
- `SKIP_PUBLISH_CHECKS=1 node scripts/build-site.mjs` passes.

The source repository reaches the one-day age threshold at 2026-09-08 15:29 UTC. The submission gate documents that this age-only result is rechecked automatically, so no resubmission or empty push should be needed.