### PR TITLE
Add ThoughtDAG DeepSeek Harness plugin

### DIFF
--- a/data/plugins/chenxiachan__thoughtdag--dsh.yml
+++ b/data/plugins/chenxiachan__thoughtdag--dsh.yml
@@ -1,0 +1,6 @@
+url: https://github.com/chenxiachan/thoughtdag/tree/main/dsh
+name: chenxiachan/thoughtdag#dsh
+category: ui
+description:
+  en: Adds an editable conversation canvas to DeepSeek Harness, where graph connections select context for canvas requests, with branching, merging, and local agent session imports.
+  zh: 在 DeepSeek Harness 中嵌入可编辑对话画布，通过连线选择画布请求的上下文，支持分支、合并与本地 Agent 会话导入。


### PR DESCRIPTION
## Summary

Add the DeepSeek Harness plugin of ThoughtDAG under **UI Enhancements**.

The plugin lives in the `dsh/` subdirectory of the ThoughtDAG monorepo and is published to npm as `dsh-thoughtdag` (currently 0.4.10). It embeds an editable conversation canvas in the Harness web UI. Graph connections select the context for canvas requests; users can branch and merge conversations and import supported local agent sessions. Editing a canvas does not rewrite the original agent session logs.

Install:

```sh
dsh plugin --profile web add dsh-thoughtdag
```

## Checklist

- [x] Added one entry file: `data/plugins/chenxiachan__thoughtdag--dsh.yml`; no generated READMEs or unrelated entries changed.
- [x] The subpackage's `package.json` declares `dsh.bundle.patch`, with `cordis.patch.yml` present beside it.
- [x] The repository is more than one day old and actively maintained.
- [x] Category is `ui`; the description states implemented behavior without superlatives.
- [x] The repository has the `dsh-plugin` topic.
- [x] The published npm package points back to `chenxiachan/thoughtdag`, directory `dsh`.
- [x] Official `@deepseek-ai/*` runtime packages are peer dependencies.

## Review references

- [Plugin documentation and implementation](https://github.com/chenxiachan/thoughtdag/tree/main/dsh)
- [Manifest](https://github.com/chenxiachan/thoughtdag/blob/main/dsh/package.json)
- [Bundle patch](https://github.com/chenxiachan/thoughtdag/blob/main/dsh/cordis.patch.yml)
- [Published npm package](https://www.npmjs.com/package/dsh-thoughtdag)
- Suggested by a user in [ThoughtDAG #25](https://github.com/chenxiachan/thoughtdag/issues/25).

Disclosure: I am the creator and primary maintainer of ThoughtDAG.
