### PR TITLE
Add dsh-newapi-video plugin

### DIFF
--- a/data/plugins/chen704290901chen__dsh-newapi-video.yml
+++ b/data/plugins/chen704290901chen__dsh-newapi-video.yml
@@ -1,0 +1,6 @@
+url: https://github.com/chen704290901chen/dsh-newapi-video
+name: chen704290901chen/dsh-newapi-video
+category: model
+description:
+  en: Call a new-api (one-api style) relay station's video model from the conversation with @-referenced image/video materials, supporting Seedance 2.0 and Happyhorse text-to-video and image-to-video across four relay protocols.
+  zh: 在对话中用 @ 引用素材调用 new-api 中转站的视频大模型生成视频，支持 Seedance 2.0 与快乐马的文生视频和图生视频，覆盖四种中转协议。


### PR DESCRIPTION
Adds [dsh-newapi-video](https://github.com/chen704290901chen/dsh-newapi-video), a plugin that calls a new-api (one-api style) relay station's video model from the conversation with `@`-referenced image/video materials.

- Two tools: `newapi_generate_video` and `newapi_task_status`.
- Four relay protocols: `v1-videos` (Seedance 2.0 / Happyhorse), `openai-videos`, `modelverse-tasks`, `generic-rest`.
- Persistent per-project task ledger and a visual generation panel.