### PR TITLE
Add Kalospacer/dsh-model-capabilities

### DIFF
--- a/data/plugins/Kalospacer__dsh-model-capabilities.yml
+++ b/data/plugins/Kalospacer__dsh-model-capabilities.yml
@@ -1,0 +1,7 @@
+url: https://github.com/Kalospacer/dsh-model-capabilities
+name: Kalospacer/dsh-model-capabilities
+category: model
+description:
+  en: 'Adds a settings page for declaring per-model reasoning efforts and vision support on pi-ai provider routes.'
+  zh: 在设置里新增「模型能力」一页，为每个模型声明思考档位与视觉能力。
+tarball: https://github.com/Kalospacer/dsh-model-capabilities/releases/download/v0.1.0/dsh-model-capabilities-0.1.0.tgz


### PR DESCRIPTION
Adds one entry: Kalospacer/dsh-model-capabilities.

A settings page for declaring per-model reasoning effort levels and vision support on llm-pi-ai provider routes, for gateway/custom models that don't advertise their own capabilities.

- dsh.bundle manifest in package.json, cordis.patch.yml at repo root
- dsh-plugin topic added, repo actively maintained
- Prebuilt tarball on release v0.1.0, pinned tag URL in the tarball field