### PR TITLE
Add goodandready plugins 2026 09 08

### DIFF
--- a/data/plugins/GooDAnDReaDY__dsh-agent-loop-guard.yml
+++ b/data/plugins/GooDAnDReaDY__dsh-agent-loop-guard.yml
@@ -1,0 +1,6 @@
+url: https://github.com/GooDAnDReaDY/dsh-agent-loop-guard
+name: GooDAnDReaDY/dsh-agent-loop-guard
+category: security
+description:
+  en: "Fail-closed runtime tool-call loop guard for DeepSeek Harness."
+  zh: "为 DeepSeek Harness 提供故障关闭式运行时工具调用循环防护。"

--- a/data/plugins/GooDAnDReaDY__dsh-cron.yml
+++ b/data/plugins/GooDAnDReaDY__dsh-cron.yml
@@ -1,0 +1,6 @@
+url: https://github.com/GooDAnDReaDY/dsh-cron
+name: GooDAnDReaDY/dsh-cron
+category: workflow
+description:
+  en: "Scheduled cron tasks, background automation and agent execution for DeepSeek Harness."
+  zh: "为 DeepSeek Harness 提供定时任务、后台自动化与 Agent 执行。"

--- a/data/plugins/GooDAnDReaDY__dsh-dsml-artifact-guard.yml
+++ b/data/plugins/GooDAnDReaDY__dsh-dsml-artifact-guard.yml
@@ -1,0 +1,6 @@
+url: https://github.com/GooDAnDReaDY/dsh-dsml-artifact-guard
+name: GooDAnDReaDY/dsh-dsml-artifact-guard
+category: security
+description:
+  en: "Sanitizes leaked DeepSeek DSML closing tags from model text streams."
+  zh: "清理模型文本流中泄漏的 DeepSeek DSML 闭合标签。"

--- a/data/plugins/GooDAnDReaDY__dsh-gitea.yml
+++ b/data/plugins/GooDAnDReaDY__dsh-gitea.yml
@@ -1,0 +1,6 @@
+url: https://github.com/GooDAnDReaDY/dsh-gitea
+name: GooDAnDReaDY/dsh-gitea
+category: git
+description:
+  en: "Gitea and Forgejo integration for DeepSeek Harness with issue, pull-request and worktree tools plus a Git status chip."
+  zh: "为 DeepSeek Harness 集成 Gitea 与 Forgejo，提供 issue、拉取请求和 worktree 工具及 Git 状态芯片。"

--- a/data/plugins/GooDAnDReaDY__dsh-kanban.yml
+++ b/data/plugins/GooDAnDReaDY__dsh-kanban.yml
@@ -1,0 +1,6 @@
+url: https://github.com/GooDAnDReaDY/dsh-kanban
+name: GooDAnDReaDY/dsh-kanban
+category: workflow
+description:
+  en: "Visual Kanban board for DeepSeek Harness with Gitea-backed tasks, workflow columns and a dedicated agent session per task."
+  zh: "为 DeepSeek Harness 提供可视化看板，支持 Gitea 任务、工作流列和每任务独立 Agent 会话。"

--- a/data/plugins/GooDAnDReaDY__dsh-session-control.yml
+++ b/data/plugins/GooDAnDReaDY__dsh-session-control.yml
@@ -1,0 +1,6 @@
+url: https://github.com/GooDAnDReaDY/dsh-session-control
+name: GooDAnDReaDY/dsh-session-control
+category: session
+description:
+  en: "Session management for the DeepSeek Harness sidebar with pinning, content search, archived transcripts and noise hiding."
+  zh: "管理 DeepSeek Harness 侧栏会话，支持置顶、内容搜索、归档记录和隐藏噪声。"

--- a/data/plugins/GooDAnDReaDY__dsh-time-machine.yml
+++ b/data/plugins/GooDAnDReaDY__dsh-time-machine.yml
@@ -1,0 +1,6 @@
+url: https://github.com/GooDAnDReaDY/dsh-time-machine
+name: GooDAnDReaDY/dsh-time-machine
+category: security
+description:
+  en: "Smart checkpoints, workspace safety guards and instant rollback for DeepSeek Harness."
+  zh: "为 DeepSeek Harness 提供智能检查点、工作区安全防护和即时回滚。"

--- a/data/plugins/GooDAnDReaDY__dsh-usage-guard.yml
+++ b/data/plugins/GooDAnDReaDY__dsh-usage-guard.yml
@@ -1,0 +1,6 @@
+url: https://github.com/GooDAnDReaDY/dsh-usage-guard
+name: GooDAnDReaDY/dsh-usage-guard
+category: usage
+description:
+  en: "Normalizes malformed token-usage samples so broken session histories remain loadable."
+  zh: "规范化异常的 Token 用量样本，使损坏的会话历史仍可加载。"


### PR DESCRIPTION
<!-- Thanks for contributing! Quick checklist / 提交前快速自查 -->

- [ ] I added **one file** at `data/plugins/<owner>__<repo>.yml` — that single file is the whole submission. The READMEs are regenerated on `main` after merge: don't edit them by hand, and you don't need to commit them either / 我新增了一个 `data/plugins/<owner>__<repo>.yml` 文件——**这一个文件就是全部投稿**。README 会在合并后由 `main` 自动重新生成：不要手工编辑，也不需要提交
- [ ] My repo's `package.json` declares **`dsh.bundle`** (not just `dsh.client`) — [example](../blob/main/contributing.md) / 仓库 `package.json` 已声明 `dsh.bundle`（只有 `dsh.client` 无法安装）
- [ ] My repo is at least **1 day old** / 仓库创建满 1 天
- [ ] `category` is one of `agi ui usage theme model identity session memory tools wsl browser vision voice docs skill workflow git notify dev security remote market fun` ([full list with descriptions](../blob/main/contributing.md)), and themes/skins go under `theme` / `category` 取值正确（完整清单见 contributing.md），主题/皮肤类请用 `theme`
- [ ] Description states what the plugin does, no superlatives / 描述只说功能，不带营销词
- [ ] My repo has the `dsh-plugin` topic / 仓库已打 `dsh-plugin` topic

**Recommended (not required) / 推荐但不强制：**

- 📦 Publish to npm — npm installs are prebuilt and skip the `allowBuilds` approval, so users get a one-command install / 发布 npm 包：预构建产物免 `allowBuilds` 授权，用户一条命令装好
- 🔗 Declare official `@deepseek-ai/*` packages as `peerDependencies` (not `dependencies`) — avoids duplicate runtimes inside the profile / 官方 `@deepseek-ai/*` 包用 `peerDependencies` 声明（而非 `dependencies`），避免 profile 里出现重复运行时
- 🖼️ Screenshots go in **your own repository** now: a `screenshots.json` beside your `package.json`, listing image paths. Nothing to add here, and you can change them later without another pull request ([how](../blob/main/contributing.md#screenshots--截图optional-recommended--可选推荐)) / 截图现在放在**你自己的仓库**里：在 `package.json` 旁边放一个 `screenshots.json`，列出图片路径。这个 PR 里不用加任何东西，以后想换也不必再提 PR（[说明](../blob/main/contributing.md#screenshots--截图optional-recommended--可选推荐)）
