### PR TITLE
Add fireworksss/LeisureTimeQueue

### DIFF
--- a/data/plugins/fireworksss__LeisureTimeQueue.yml
+++ b/data/plugins/fireworksss__LeisureTimeQueue.yml
@@ -1,0 +1,6 @@
+url: https://github.com/fireworksss/LeisureTimeQueue
+name: fireworksss/LeisureTimeQueue
+category: tools
+description:
+  en: leisure-time-queue is a local leisure-time task queue plugin for DeepSeek Harness.
+  zh: leisure-time-queue 是一个基于 DeepSeek Harness 的本地闲时任务队列插件。

--- a/data/plugins/fireworksss__LeisureTimeQueue.yml
+++ b/data/plugins/fireworksss__LeisureTimeQueue.yml
@@ -2,5 +2,5 @@ url: https://github.com/fireworksss/LeisureTimeQueue
 name: fireworksss/LeisureTimeQueue
 category: tools
 description:
-  en: leisure-time-queue is a local leisure-time task queue plugin for DeepSeek Harness.
-  zh: leisure-time-queue 是一个基于 DeepSeek Harness 的本地闲时任务队列插件。
+  en: LeisureTimeQueue is a local leisure-time task queue plugin for DeepSeek Harness.
+  zh: LeisureTimeQueue 是一个基于 DeepSeek Harness 的本地闲时任务队列插件。


### PR DESCRIPTION
LeisureTimeQueue 是一个基于 DeepSeek Harness 的本地闲时任务队列插件。

你可以预先写好任务，并指定每周允许开始执行的时间段，例如“工作日 22:00 到次日 07:00”。只要 DeepSeek Harness 保持运行、目标会话可用且 Agent 处于空闲状态，插件就会按队列顺序自动开始任务。

任务仍在你自己的 DeepSeek Harness 中运行，并使用你已经配置的模型、凭据、权限和本地工作区。尽情享受梁文谷吧。