### PR TITLE
Add rayafriandion/dsh-oc-tui plugin

### DIFF
--- a/data/plugins/rayafriandion__dsh-oc-tui.yml
+++ b/data/plugins/rayafriandion__dsh-oc-tui.yml
@@ -1,0 +1,6 @@
+url: https://github.com/rayafriandion/dsh-oc-tui
+name: rayafriandion/dsh-oc-tui
+category: ui
+description:
+  en: An opencode-inspired terminal UI for DeepSeek Harness that boots as a dsh profile app plugin, with a session sidebar, streaming chat, markdown tool cards, todo lists, slash-command suggestions, a telemetry footer with a context meter and inline approval prompts.
+  zh: 受 opencode 启发的 DeepSeek Harness 终端界面，以 dsh profile 应用插件形式启动，提供会话侧栏、流式聊天、markdown 工具卡片、待办列表、斜杠命令建议、带上下文用量表的遥测底栏与内联审批提示。


### PR DESCRIPTION
Add [rayafriandion/dsh-oc-tui](https://github.com/rayafriandion/dsh-oc-tui) to the ui category.

**dsh-oc-tui** is an opencode-inspired terminal UI (TUI) for DeepSeek Harness. It boots as a profile app plugin (`dsh.bundle` declared): it creates/resumes agents through `ctx.agents`, renders the durable session/event stream (streaming assistant tokens, tool cards, todo lists), routes human input back via `agent.followup()`, and answers `approval/request` prompts inline. Includes a session sidebar, multiline composer with slash-command suggestions, telemetry footer (tokens, TTFT, throughput, KV-cache hit rate, context meter), a settings tab and an in-app update manager.

- [x] `dsh.bundle` manifest declared in package.json (`cordis.patch.yml` at repo root)
- [x] `dsh-plugin` topic added
- [x] One-line description in the YAML entry (en + zh)