### PR TITLE
add: motor-case-kb, motor-fault-diagnosis, motor-parts-selector (3/6 motor-repair suite)

### DIFF
--- a/data/plugins/helllo-shijie__motor-hospital-plugins--plugins-motor-case-kb.yml
+++ b/data/plugins/helllo-shijie__motor-hospital-plugins--plugins-motor-case-kb.yml
@@ -1,0 +1,6 @@
+url: https://github.com/helllo-shijie/motor-hospital-plugins/tree/main/plugins/motor-case-kb
+name: helllo-shijie/motor-hospital-plugins#motor-case-kb
+category: tools
+description:
+  en: 'Searches a database of past motor-repair cases by fault description, motor rating and brand, and lets new diagnoses be saved back for future retrieval.'
+  zh: '按故障描述、功率与品牌检索历史电机维修案例，支持将新诊断沉淀回写供后续检索。'

--- a/data/plugins/helllo-shijie__motor-hospital-plugins--plugins-motor-fault-diagnosis.yml
+++ b/data/plugins/helllo-shijie__motor-hospital-plugins--plugins-motor-fault-diagnosis.yml
@@ -1,0 +1,6 @@
+url: https://github.com/helllo-shijie/motor-hospital-plugins/tree/main/plugins/motor-fault-diagnosis
+name: helllo-shijie/motor-hospital-plugins#motor-fault-diagnosis
+category: tools
+description:
+  en: 'Combines fault knowledge-base symptom-to-cause rules with similar past cases to rank candidate motor diagnoses with evidence terms and suggested extra tests.'
+  zh: '结合故障知识库症状-原因规则与相似历史案例，输出电机候选诊断排序、证据词与建议补测项。'

--- a/data/plugins/helllo-shijie__motor-hospital-plugins--plugins-motor-parts-selector.yml
+++ b/data/plugins/helllo-shijie__motor-hospital-plugins--plugins-motor-parts-selector.yml
@@ -1,0 +1,6 @@
+url: https://github.com/helllo-shijie/motor-hospital-plugins/tree/main/plugins/motor-parts-selector
+name: helllo-shijie/motor-hospital-plugins#motor-parts-selector
+category: tools
+description:
+  en: 'Builds a motor-repair replacement-parts BOM from the fault and motor rating, listing stock, lead time and domestic or imported alternatives.'
+  zh: '按故障类型与电机功率生成替换配件 BOM，输出库存、交期与国产/进口替代选项。'


### PR DESCRIPTION
Adds three electric-motor repair plugins from the helllo-shijie/motor-hospital-plugins monorepo. Repository created 2026-09-07 with the `dsh-plugin` topic set; each subpackage under plugins/ declares a `dsh.bundle` manifest and ships cordis.patch.yml, index.js, README.md, test.js and assets/icon.svg.

- motor-case-kb (tools) — searches past motor-repair cases by fault description, motor rating and brand, and saves new diagnoses back for future retrieval.
- motor-fault-diagnosis (tools) — ranks candidate diagnoses from fault knowledge-base symptom-to-cause rules plus similar past cases, with evidence terms and suggested extra tests.
- motor-parts-selector (tools) — builds a replacement-parts BOM from the fault and motor rating, with stock, lead time and domestic/imported alternatives.

Each plugin passes its own `node plugins/<id>/test.js` and shares the node:sqlite engine in engine/ (zero third-party dependencies).