### PR TITLE
add: motor-repair-flow, motor-cost-quote, motor-decision-report (3/6 motor-repair suite)Add files via upload

### DIFF
--- a/data/plugins/helllo-shijie__motor-hospital-plugins--plugins-motor-cost-quote.yml
+++ b/data/plugins/helllo-shijie__motor-hospital-plugins--plugins-motor-cost-quote.yml
@@ -1,0 +1,6 @@
+url: https://github.com/helllo-shijie/motor-hospital-plugins/tree/main/plugins/motor-cost-quote
+name: helllo-shijie/motor-hospital-plugins#motor-cost-quote
+category: tools
+description:
+  en: 'Combines historical supplier quotes and service rates into onsite-repair, factory-overhaul, green-remanufacture and replacement options for a motor, then recommends one by total cost of ownership.'
+  zh: '组合历史供应商报价与工时，生成现场抢修/返厂大修/绿色再制造/整机更换等维修方案，并按综合持有成本给出决策建议。'

--- a/data/plugins/helllo-shijie__motor-hospital-plugins--plugins-motor-decision-report.yml
+++ b/data/plugins/helllo-shijie__motor-hospital-plugins--plugins-motor-decision-report.yml
@@ -1,0 +1,6 @@
+url: https://github.com/helllo-shijie/motor-hospital-plugins/tree/main/plugins/motor-decision-report
+name: helllo-shijie/motor-hospital-plugins#motor-decision-report
+category: tools
+description:
+  en: 'Summarises the case evidence, diagnosis, repair procedure, parts list and cost-option comparison for a motor into a Markdown repair recommendation report with data provenance.'
+  zh: '将案例依据、诊断结论、维修工序、配件清单与方案对比汇总为带数据溯源的 Markdown 维修建议书。'

--- a/data/plugins/helllo-shijie__motor-hospital-plugins--plugins-motor-repair-flow.yml
+++ b/data/plugins/helllo-shijie__motor-hospital-plugins--plugins-motor-repair-flow.yml
@@ -1,0 +1,6 @@
+url: https://github.com/helllo-shijie/motor-hospital-plugins/tree/main/plugins/motor-repair-flow
+name: helllo-shijie/motor-hospital-plugins#motor-repair-flow
+category: workflow
+description:
+  en: 'Generates a standard motor-repair procedure from the diagnosis and motor rating, with labour time, staffing and a quality-check point for each step.'
+  zh: '按诊断结论与电机功率编排标准化维修工序，每步含工时、人员与质检点。'


### PR DESCRIPTION
Adds the remaining three electric-motor repair plugins from the
helllo-shijie/motor-hospital-plugins monorepo (the other three were submitted in a
separate PR — one PR may add at most 3 entries). Each subpackage declares a `dsh.bundle`
manifest and ships cordis.patch.yml, index.js, README.md, test.js and assets/icon.svg.

- motor-repair-flow (workflow) — generates a standard repair procedure from the
  diagnosis and motor rating, with labour time, staffing and a quality-check point per
  step.
- motor-cost-quote (tools) — combines historical supplier quotes and service rates into
  onsite-repair, factory-overhaul, green-remanufacture and replacement options, and
  recommends one by total cost of ownership.
- motor-decision-report (tools) — summarises case evidence, diagnosis, procedure, parts
  list and option comparison into a Markdown repair recommendation report with data
  provenance.

Each plugin passes its own `node plugins/<id>/test.js` and shares the node:sqlite engine
in engine/ (zero third-party dependencies).