### PR TITLE
add gcry13067381632-jpg/dsh-qqbot — QQ official bot channel for DeepSeek Harness

### DIFF
--- a/data/plugins/gcry13067381632-jpg__dsh-qqbot.yml
+++ b/data/plugins/gcry13067381632-jpg__dsh-qqbot.yml
@@ -1,0 +1,6 @@
+url: https://github.com/gcry13067381632-jpg/dsh-qqbot
+name: gcry13067381632-jpg/dsh-qqbot
+category: notify
+description:
+  en: 'QQ official bot channel for DeepSeek Harness (feature-rich fork of tencent-connect/dsh-qqbot): group and private chat with the full agent, sticker library with auto-tagging and AI meme replies, group management (join approval and mute), botplay interactive card events with paginated catalogs, user extension registry (custom slash commands and QQ tools), scheduled wakeups, remote approvals over QQ, and a floating dock web UI.'
+  zh: '接入 QQ 官方机器人的 DeepSeek Harness 通道(tencent-connect/dsh-qqbot 功能增强 fork): 群/私聊与完整 agent 对话、表情包图库(自动打标+AI 斗图)、群管理(入群审批/禁言)、botplay 互动事件卡与翻页目录、用户扩展注册表(自定义斜杠命令与 QQ 工具)、定时唤醒、QQ 远程审批、悬浮球 dock Web UI。'


### PR DESCRIPTION
<!-- Thanks for contributing! Quick checklist / 提交前快速自查 -->

- [x] I added **one file** at data/plugins/gcry13067381632-jpg__dsh-qqbot.yml — that single file is the whole submission. / 新增了一个 data/plugins/<owner>__<repo>.yml 文件, 一个文件就是全部投稿
- [x] My repo's package.json declares **dsh.bundle** (not just dsh.client). / package.json 已声明 dsh.bundle(patch: ./cordis.patch.yml), 仓库根有 cordis.patch.yml
- [x] My repo is at least **1 day old** (created 2026-09-04). / 仓库创建满 1 天(2026-09-04)
- [x] category is one of the valid list (notify). / category 取值 notify
- [x] Description states what the plugin does, no superlatives. / 描述只说功能
- [x] My repo has the **dsh-plugin** topic. / 仓库已打 dsh-plugin topic

**Recommended / 推荐项:**
- [x] Published to npm: @zaofan/dsh-qqbot@1.0.0 / 已发布 npm @zaofan/dsh-qqbot@1.0.0
- [x] Official @deepseek-ai/* packages declared as peerDependencies (with prerelease branches). / @deepseek-ai/* 全部在 peerDependencies 且带预发布分支

---

dsh-qqbot is a QQ official bot channel for DeepSeek Harness — a feature-rich fork of tencent-connect/dsh-qqbot (upstream itself is not listed yet). Highlights beyond upstream: sticker library with tagging and AI meme replies, QQ group management (join approval / mute), botplay interactive card events with paginated catalogs, user extension registry (custom slash commands + QQ tools), scheduled wakeups, remote approvals over QQ, and a floating dock web UI.