### PR TITLE
Add langyo/dsh-mobile-upgrade to UI Enhancements.

### DIFF
--- a/data/plugins/langyo__dsh-mobile-ui-fix.yml
+++ b/data/plugins/langyo__dsh-mobile-ui-fix.yml
@@ -4,4 +4,4 @@ category: ui
 description:
   en: 'Mobile UI fixes for the dsh web profile: composer upload, restart row, input-modality switches, narrow-screen drawer and settings tabs, and a full-width model menu.'
   zh: dsh web profile 的手机端体验修复：输入框上传、重启行、输入模态开关、窄屏抽屉与设置标签，以及全宽模型菜单。
-tarball: https://github.com/langyo/dsh-mobile-ui-fix/releases/latest/download/dsh-mobile-ui-fix-0.10.0.tgz
+tarball: https://github.com/langyo/dsh-mobile-ui-fix/releases/latest/download/dsh-mobile-ui-fix-0.1.0.tgz

--- a/data/plugins/langyo__dsh-mobile-ui-fix.yml
+++ b/data/plugins/langyo__dsh-mobile-ui-fix.yml
@@ -1,7 +1,0 @@
-url: https://github.com/langyo/dsh-mobile-ui-fix
-name: langyo/dsh-mobile-ui-fix
-category: ui
-description:
-  en: 'Mobile UI fixes for the dsh web profile: composer upload, restart row, input-modality switches, narrow-screen drawer and settings tabs, and a full-width model menu.'
-  zh: dsh web profile 的手机端体验修复：输入框上传、重启行、输入模态开关、窄屏抽屉与设置标签，以及全宽模型菜单。
-tarball: https://github.com/langyo/dsh-mobile-ui-fix/releases/latest/download/dsh-mobile-ui-fix-0.1.0.tgz

--- a/data/plugins/langyo__dsh-mobile-ui-fix.yml
+++ b/data/plugins/langyo__dsh-mobile-ui-fix.yml
@@ -1,0 +1,7 @@
+url: https://github.com/langyo/dsh-mobile-ui-fix
+name: langyo/dsh-mobile-ui-fix
+category: ui
+description:
+  en: 'Mobile UI fixes for the dsh web profile: composer upload, restart row, input-modality switches, narrow-screen drawer and settings tabs, and a full-width model menu.'
+  zh: dsh web profile 的手机端体验修复：输入框上传、重启行、输入模态开关、窄屏抽屉与设置标签，以及全宽模型菜单。
+tarball: https://github.com/langyo/dsh-mobile-ui-fix/releases/latest/download/dsh-mobile-ui-fix-0.10.0.tgz

--- a/data/plugins/langyo__dsh-mobile-upgrade.yml
+++ b/data/plugins/langyo__dsh-mobile-upgrade.yml
@@ -4,4 +4,4 @@ category: ui
 description:
   en: 'Mobile UI fixes for the dsh web profile: composer upload, restart row, input-modality switches, narrow-screen drawer and settings tabs, a full-width model menu, and a stuck-request network chip.'
   zh: dsh web profile 的手机端体验修复：输入框上传、重启行、输入模态开关、窄屏抽屉与设置标签、全宽模型菜单，以及卡住请求的网络状态芯片。
-tarball: https://github.com/langyo/dsh-mobile-upgrade/releases/latest/download/dsh-mobile-upgrade-0.3.0.tgz
+tarball: https://github.com/langyo/dsh-mobile-upgrade/releases/latest/download/dsh-mobile-upgrade-0.3.1.tgz

--- a/data/plugins/langyo__dsh-mobile-upgrade.yml
+++ b/data/plugins/langyo__dsh-mobile-upgrade.yml
@@ -4,4 +4,4 @@ category: ui
 description:
   en: 'Mobile UI fixes for the dsh web profile: composer upload, restart row, input-modality switches, narrow-screen drawer and settings tabs, a full-width model menu, and a stuck-request network chip.'
   zh: dsh web profile 的手机端体验修复：输入框上传、重启行、输入模态开关、窄屏抽屉与设置标签、全宽模型菜单，以及卡住请求的网络状态芯片。
-tarball: https://github.com/langyo/dsh-mobile-upgrade/releases/latest/download/dsh-mobile-upgrade-0.2.0.tgz
+tarball: https://github.com/langyo/dsh-mobile-upgrade/releases/latest/download/dsh-mobile-upgrade-0.2.1.tgz

--- a/data/plugins/langyo__dsh-mobile-upgrade.yml
+++ b/data/plugins/langyo__dsh-mobile-upgrade.yml
@@ -4,4 +4,4 @@ category: ui
 description:
   en: 'Mobile UI fixes for the dsh web profile: composer upload, restart row, input-modality switches, narrow-screen drawer and settings tabs, and a full-width model menu.'
   zh: dsh web profile 的手机端体验修复：输入框上传、重启行、输入模态开关、窄屏抽屉与设置标签，以及全宽模型菜单。
-tarball: https://github.com/langyo/dsh-mobile-upgrade/releases/latest/download/dsh-mobile-upgrade-0.1.1.tgz
+tarball: https://github.com/langyo/dsh-mobile-upgrade/releases/latest/download/dsh-mobile-upgrade-0.1.2.tgz

--- a/data/plugins/langyo__dsh-mobile-upgrade.yml
+++ b/data/plugins/langyo__dsh-mobile-upgrade.yml
@@ -2,6 +2,6 @@ url: https://github.com/langyo/dsh-mobile-upgrade
 name: langyo/dsh-mobile-upgrade
 category: ui
 description:
-  en: 'Mobile UI fixes for the dsh web profile: composer upload, restart row, input-modality switches, narrow-screen drawer and settings tabs, and a full-width model menu.'
-  zh: dsh web profile 的手机端体验修复：输入框上传、重启行、输入模态开关、窄屏抽屉与设置标签，以及全宽模型菜单。
-tarball: https://github.com/langyo/dsh-mobile-upgrade/releases/latest/download/dsh-mobile-upgrade-0.1.2.tgz
+  en: 'Mobile UI fixes for the dsh web profile: composer upload, restart row, input-modality switches, narrow-screen drawer and settings tabs, a full-width model menu, and a stuck-request network chip.'
+  zh: dsh web profile 的手机端体验修复：输入框上传、重启行、输入模态开关、窄屏抽屉与设置标签、全宽模型菜单，以及卡住请求的网络状态芯片。
+tarball: https://github.com/langyo/dsh-mobile-upgrade/releases/latest/download/dsh-mobile-upgrade-0.2.0.tgz

--- a/data/plugins/langyo__dsh-mobile-upgrade.yml
+++ b/data/plugins/langyo__dsh-mobile-upgrade.yml
@@ -4,4 +4,4 @@ category: ui
 description:
   en: 'Mobile UI fixes for the dsh web profile: composer upload, restart row, input-modality switches, narrow-screen drawer and settings tabs, a full-width model menu, and a stuck-request network chip.'
   zh: dsh web profile 的手机端体验修复：输入框上传、重启行、输入模态开关、窄屏抽屉与设置标签、全宽模型菜单，以及卡住请求的网络状态芯片。
-tarball: https://github.com/langyo/dsh-mobile-upgrade/releases/latest/download/dsh-mobile-upgrade-0.2.1.tgz
+tarball: https://github.com/langyo/dsh-mobile-upgrade/releases/latest/download/dsh-mobile-upgrade-0.3.0.tgz

--- a/data/plugins/langyo__dsh-mobile-upgrade.yml
+++ b/data/plugins/langyo__dsh-mobile-upgrade.yml
@@ -4,4 +4,4 @@ category: ui
 description:
   en: 'Mobile UI fixes for the dsh web profile: composer upload, restart row, input-modality switches, narrow-screen drawer and settings tabs, and a full-width model menu.'
   zh: dsh web profile 的手机端体验修复：输入框上传、重启行、输入模态开关、窄屏抽屉与设置标签，以及全宽模型菜单。
-tarball: https://github.com/langyo/dsh-mobile-upgrade/releases/latest/download/dsh-mobile-upgrade-0.1.0.tgz
+tarball: https://github.com/langyo/dsh-mobile-upgrade/releases/latest/download/dsh-mobile-upgrade-0.1.1.tgz

--- a/data/plugins/langyo__dsh-mobile-upgrade.yml
+++ b/data/plugins/langyo__dsh-mobile-upgrade.yml
@@ -1,0 +1,7 @@
+url: https://github.com/langyo/dsh-mobile-upgrade
+name: langyo/dsh-mobile-upgrade
+category: ui
+description:
+  en: 'Mobile UI fixes for the dsh web profile: composer upload, restart row, input-modality switches, narrow-screen drawer and settings tabs, and a full-width model menu.'
+  zh: dsh web profile 的手机端体验修复：输入框上传、重启行、输入模态开关、窄屏抽屉与设置标签，以及全宽模型菜单。
+tarball: https://github.com/langyo/dsh-mobile-upgrade/releases/latest/download/dsh-mobile-upgrade-0.1.0.tgz


### PR DESCRIPTION
## Entry

Adds `data/plugins/langyo__dsh-mobile-upgrade.yml` — one file, as per the contributing guide.

- **Plugin**: [langyo/dsh-mobile-upgrade](https://github.com/langyo/dsh-mobile-upgrade) — mobile UI fixes for the dsh web profile: composer attachment upload (images via native paste, files to server + path), a restart row in Settings → General, input-modality switches in the native provider editor, a narrow-screen drawer and settings top tabs, a full-width model menu, and a stuck-request network chip with a liveness probe.
- **Category**: `ui`
- **npm**: published as [`dsh-mobile-upgrade@0.3.1`](https://registry.npmjs.org/dsh-mobile-upgrade) (so installs skip the build-approval step); the entry also carries an optional `tarball:` field pointing at the GitHub Release asset.
- **Install**: `dsh plugin --profile web add dsh-mobile-upgrade`

## Checklist

- [x] `dsh.bundle` manifest in package.json (`dsh.bundle.patch` + `client.platform: web`) with the `cordis.patch.yml` next to it
- [x] Real, working code — in active use on a daily-driver phone since 0.1.0
- [x] Repo is older than 1 day (created 2026-09-07)
- [x] [`dsh-plugin`](https://github.com/topics/dsh-plugin) topic set on the repository
- [x] Description states what the plugin does, no superlatives; en + zh provided
- [x] Requires `dsh` 0.1.2-rc.1+ (declared via `engines.dsh`); schemastery as peerDependency
- [x] License: SySL-1.0 (custom, full text in LICENSE); README available in 8 languages (docs/{lang}/README.md)
- [x] Screenshots referenced from the repo's `res/` folder