### PR TITLE
Add dsh-archive-sessions (archived-session manager)

### DIFF
--- a/data/plugins/jujiujiang222-cell__dsh-archive-sessions.yml
+++ b/data/plugins/jujiujiang222-cell__dsh-archive-sessions.yml
@@ -1,0 +1,10 @@
+# Copy this file into the awesome-dsh-plugin/awesome-dsh-plugin catalog repo as:
+#   data/plugins/jujiujiang222-cell__dsh-archive-sessions.yml
+# then open a PR (one file per PR). CI requires the listed repository to be at
+# least 1 day old before it accepts the submission.
+url: https://github.com/jujiujiang222-cell/dsh-archive-sessions
+name: jujiujiang222-cell/dsh-archive-sessions
+category: session
+description:
+  en: 'Archived-session manager: an "Archived Sessions" settings page that lists archived sessions and lets you restore or permanently delete each one (two-step confirmation).'
+  zh: '归档会话管理：在设置页新增“归档会话”，列出所有已归档会话，支持恢复与二次确认后的永久删除。'


### PR DESCRIPTION
## 收录插件 / Add plugin: dsh-archive-sessions

Repository: https://github.com/jujiujiang222-cell/dsh-archive-sessions

**What it does / 功能**
归档会话管理：在 DSH 设置页新增“归档会话”页面，列出所有仍保留磁盘日志的已归档会话，支持恢复与二次确认后的永久删除（删除真实会话日志文件并清理工作区归属，运行中的会话先请求停止）。

An “Archived Sessions” settings page that lists archived sessions (disk is the source of truth), and lets you restore a session or permanently delete it with an in-page two-step confirmation. A running session is asked to stop first; deletion removes the durable session log and detaches workspace accounting.

**Package manifest**: declares `dsh.bundle.patch` (cordis.patch.yml) and a web client half (`dsh.client`), matching the installable-plugin convention (`dsh plugin --profile web add github:jujiujiang222-cell/dsh-archive-sessions`).

**Safety note / 安全说明**: the permanent-delete action removes session log files from the app's own data directory (`~/.dsh/sessions/...`) and runs that removal with an explicit full-access shell policy, because the sandboxed default shell cannot delete files there. Review `src/index.js` before merging.
