### PR TITLE
Add yzxxy010/dsh-workspace-write-plus

### DIFF
--- a/data/plugins/yzxxy010__dsh-workspace-write-plus.yml
+++ b/data/plugins/yzxxy010__dsh-workspace-write-plus.yml
@@ -1,0 +1,6 @@
+url: https://github.com/yzxxy010/dsh-workspace-write-plus
+name: yzxxy010/dsh-workspace-write-plus
+category: security
+description:
+  en: Adds a workspace-write++ permission that keeps file tools inside the workspace while skipping the Windows process sandbox for wildcard-allowlisted executables such as Git Bash.
+  zh: 增加工作区修改++权限档，文件工具仍锁在工作区，可用通配符放行 Git Bash 等程序以跳过 Windows 进程沙箱。


### PR DESCRIPTION
Adds [yzxxy010/dsh-workspace-write-plus](https://github.com/yzxxy010/dsh-workspace-write-plus).

Installable DSH bundle (`dsh.bundle` + `cordis.patch.yml` + web client).
Inserts a fourth permission preset, `workspace-write++` / 工作区修改++:
file tools stay workspace-bound; wildcard-allowlisted executables (default `bash`, `pwsh`) skip the Windows process sandbox so Git Bash/MSYS mmap works.

Repo topic `dsh-plugin` is set. One entry only.