### PR TITLE
Add ShadowMiner/hermes-dsh-bridge and ShadowMiner/hermes-web-mcp

### DIFF
--- a/data/plugins/ShadowMiner__hermes-dsh-bridge.yml
+++ b/data/plugins/ShadowMiner__hermes-dsh-bridge.yml
@@ -1,0 +1,6 @@
+url: https://github.com/ShadowMiner/hermes-dsh-bridge
+name: ShadowMiner/hermes-dsh-bridge
+category: tools
+description:
+  en: "Bidirectional bridge between Hermes Agent and DeepSeek Harness: dispatch_task with UI-visible sessions in the DSH sidebar, session mirroring, and 10 DSH-to-Hermes tools."
+  zh: "Hermes Agent 与 DeepSeek Harness 的双向桥：派单任务以 UI 可见会话出现在 DSH 侧边栏，支持会话镜像与 10 个 DSH→Hermes 工具。"

--- a/data/plugins/ShadowMiner__hermes-web-mcp.yml
+++ b/data/plugins/ShadowMiner__hermes-web-mcp.yml
@@ -1,0 +1,6 @@
+url: https://github.com/ShadowMiner/hermes-web-mcp
+name: ShadowMiner/hermes-web-mcp
+category: browser
+description:
+  en: "Keyless web powers for any MCP client: web_search, JS-rendered web_extract over dual CDP Chrome with proxy failover, and 7 real-browser page_* tools in an isolated context."
+  zh: "免密钥上网 MCP server：web_search、基于双 CDP Chrome 的 JS 渲染抓取（代理自动互备），以及 7 个隔离上下文真实浏览器 page_* 工具。"


### PR DESCRIPTION
Two new plugins from ShadowMiner: hermes-dsh-bridge (bidirectional Hermes<->DSH bridge, UI-visible dispatch) and hermes-web-mcp (keyless web MCP server, 9 tools). Both declare dsh.bundle manifest. Category: tools + browser.