### PR TITLE
Add MaRi23333/dsh-serverchan-watchdog

### DIFF
--- a/data/plugins/MaRi23333__dsh-serverchan-watchdog.yml
+++ b/data/plugins/MaRi23333__dsh-serverchan-watchdog.yml
@@ -1,0 +1,6 @@
+url: https://github.com/MaRi23333/dsh-serverchan-watchdog
+name: MaRi23333/dsh-serverchan-watchdog
+category: notify
+description:
+  en: 'Unofficial host-side ServerChan alerts for DeepSeek Harness: sends a mobile reminder when an approval, plan review, or question stays unanswered past a configurable threshold, even with the browser closed.'
+  zh: 'DeepSeek Harness 的第三方 Server酱提醒插件：在主机端监控审批、计划评审和问答，超过设定时间仍未处理时发送手机提醒，无需保持浏览器打开。'


### PR DESCRIPTION
Adds `MaRi23333/dsh-serverchan-watchdog` under `notify`.

The plugin monitors pending approvals, plan reviews, and questions on the DeepSeek Harness host and sends an alert through ServerChan after a configurable threshold. It works without an open browser tab and requires the user's own ServerChan SendKey. It is an unofficial community plugin.

This submission adds one bilingual YAML entry. The repository is public, MIT-licensed, older than one day, has the `dsh-plugin` topic, and declares `dsh.bundle` with a checked-in patch. The published npm package is `dsh-serverchan-watchdog` and points back to the same repository.
