### PR TITLE
Update 01Virex/dsh-status-rotator: one-line description (v0.16.0)

### DIFF
--- a/data/plugins/01Virex__dsh-status-rotator.yml
+++ b/data/plugins/01Virex__dsh-status-rotator.yml
@@ -2,5 +2,5 @@ url: https://github.com/01Virex/dsh-status-rotator
 name: 01Virex/dsh-status-rotator
 category: ui
 description:
-  en: Replaces the "Deep diving..." turn-status label with rotating meme-worthy phrases, with typewriter and gradient effects.
-  zh: 把回合状态那句 "Deep diving..." 替换成更有梗的自定义文案，按阶段轮换，支持打字机与流动渐变。
+  en: 'Rotates the dsh turn-status label through 1059 bilingual phrases with typewriter output, an animated rainbow gradient, danmaku, 12 toggleable theme packs, live placeholders and tab-title rotation. Two star packs ship disabled by default; the stargazer pack carries one phrase per stargazer, refreshed weekly by a workflow.'
+  zh: '把 dsh 回合状态行换成 1059 条中英文案的轮播：打字机输出、流动彩虹渐变、弹幕、12 个可开关的主题词库包、实时占位符与标签页标题轮换。两个 star 包默认关闭；星标者包每位星标者一条文案，由工作流每周刷新。'


### PR DESCRIPTION
Updates the one-line description of `01Virex/dsh-status-rotator` to match what the plugin does today (v0.16.0).

Changes:
- mentions the current bank size (1059 phrases, bilingual) instead of the older feature list;
- mentions danmaku, 12 toggleable theme packs, live placeholders and tab-title rotation;
- notes that the two `star-*` packs ship disabled by default, and that the stargazer pack carries one phrase per stargazer refreshed weekly by a workflow (`star-pack.yml`).

Everything in the description is verifiable in the repo: the phrase counts come from `config.example.json` (554 zh + 505 en), the pack list from `packs[]`/`enabledPacks`, and the weekly refresh from `.github/workflows/star-pack.yml`.

Docs: https://github.com/01Virex/dsh-status-rotator#readme