### PR TITLE
Add leetom314/dsh-risk-gate (security)

### DIFF
--- a/data/plugins/leetom314__dsh-risk-gate.yml
+++ b/data/plugins/leetom314__dsh-risk-gate.yml
@@ -1,0 +1,5 @@
+url: https://github.com/leetom314/dsh-risk-gate
+name: leetom314/dsh-risk-gate
+category: security
+description:
+  en: 'Semantic risk grading and progressive authorization: classifies tool calls into safe/risky/redline, asks before irreversible actions, auto-allows only approved-and-succeeded signatures.'


### PR DESCRIPTION
Adds [dsh-risk-gate](https://github.com/leetom314/dsh-risk-gate): semantic risk grading + progressive authorization for DeepSeek Harness. Declares dsh.bundle.patch (cordis.patch.yml), MIT.