### PR TITLE
Add leetom314/dsh-tiered-memory (memory)

### DIFF
--- a/data/plugins/leetom314__dsh-tiered-memory.yml
+++ b/data/plugins/leetom314__dsh-tiered-memory.yml
@@ -1,0 +1,5 @@
+url: https://github.com/leetom314/dsh-tiered-memory
+name: leetom314/dsh-tiered-memory
+category: memory
+description:
+  en: 'Tiered persistent memory (user/env/project) with per-tier char budgets and semantic query routing; full layers refuse writes instead of silently evicting.'


### PR DESCRIPTION
Adds [dsh-tiered-memory](https://github.com/leetom314/dsh-tiered-memory): tiered persistent memory with per-tier budgets for DeepSeek Harness. Declares dsh.bundle.patch (cordis.patch.yml), MIT.