### PR TITLE
Add Missher12/dsh-missher-memory

### DIFF
--- a/data/plugins/Missher12__dsh-missher-memory.yml
+++ b/data/plugins/Missher12__dsh-missher-memory.yml
@@ -1,0 +1,7 @@
+url: https://github.com/Missher12/dsh-missher-memory
+name: Missher12/dsh-missher-memory
+category: memory
+description:
+  en: Project-scoped local memory with review-before-recall, source references, reversible consolidation, and a portable Cordis service; the Harness adapter provides search and settings, with optional Brain integration.
+  zh: 按项目隔离的本地记忆，支持审核后检索、来源追溯、可回滚整理与通用 Cordis 服务；Harness 适配提供搜索和设置页，可选接入 Brain。
+tarball: https://github.com/Missher12/dsh-missher-memory/releases/download/v0.3.0-cordis.0/dsh-missher-memory-0.3.0-cordis.0.tgz


### PR DESCRIPTION
Adds only `Missher12/dsh-missher-memory` to the memory category, with English and Chinese descriptions and a pinned prebuilt GitHub Release tarball.

The plugin stores reviewed local project memory with source references and reversible consolidation. It exposes a portable Cordis service and keeps a Harness adapter for search and settings; Brain integration is optional. Candidate creation does not authorize approval or promote rules.

The linked version is the `0.3.0-cordis.0` prerelease. Compatible hosts must explicitly bind projects; other Agents need their own service-to-tool mapping. Real model invocation and Desktop UI acceptance are not claimed.

Validation: the entry passes the repository's `validateEntries`, README generation, and site build. Only one YAML entry is committed; no existing entries or generated READMEs are changed. The public plugin repository declares `dsh.bundle`, includes MIT-licensed source, and has the `dsh-plugin` topic.

Release: https://github.com/Missher12/dsh-missher-memory/releases/tag/v0.3.0-cordis.0
Package and lifecycle verification: https://github.com/Missher12/dsh-missher-memory/actions/runs/34241169065

Current check status: **Submission gate passed**. The PR check reaches the site build, which fails on three existing upstream entries: `wwweljf/dsh-plugins/tree/master/plugins/dsh-ding-sound`, `dsh-wx-push`, and `dsh-wx-remote`, with `no added-date derivable`. This PR changes none of those entries. Entry validation, regeneration and lint completed before that failure. The standalone site build on the submission base also passed locally.

Failing site-build run: https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/actions/runs/34242256495

Please review this single memory entry once the unrelated added-date issue is resolved. The prebuilt release and its public download checks are complete.
