### PR TITLE
Add Missher Evolution workflow rules plugin

### DIFF
--- a/data/plugins/Missher12__dsh-missher-evolution.yml
+++ b/data/plugins/Missher12__dsh-missher-evolution.yml
@@ -1,0 +1,7 @@
+url: https://github.com/Missher12/dsh-missher-evolution
+name: Missher12/dsh-missher-evolution
+category: workflow
+description:
+  en: Records scoped workflow rules and correction reminders with bounded evidence, local settings, and optional Brain Hub integration.
+  zh: 根据有界证据记录限定范围的工作流规则与纠错提醒，提供本地设置并支持可选 Brain Hub 集成。
+tarball: https://github.com/Missher12/dsh-missher-evolution/releases/download/v0.7.0/dsh-missher-evolution-0.7.0.tgz


### PR DESCRIPTION
Adds one workflow entry for `dsh-missher-evolution`, the public Harness distribution of MSE 0.7.0. It records scoped workflow rules and correction reminders using bounded local evidence, exposes a settings page, and supports optional Brain Hub integration. The TypeScript core is bundled, so users do not install another SDK.

The entry uses the fixed-tag prebuilt GitHub Release tarball, avoiding source-build installation. The repository declares `dsh.bundle` and has the `dsh-plugin` topic. Source is MIT; the existing distribution and trademark notices are retained.

Validation:
- [Public release and checksum](https://github.com/Missher12/dsh-missher-evolution/releases/tag/v0.7.0): original 228410-byte archive, SHA-256 `339702ea314c20d464fb27511d897f13aac6e2001681275da5ac9b5b9298412a`; anonymously downloaded and matched byte-for-byte.
- [Source CI](https://github.com/Missher12/dsh-missher-evolution/actions/runs/34242121130): 238 tests, Host/Client type checks, build and archive verification on Intel Mac, Apple Silicon Mac, Windows and Linux.
- Actual installed Desktop CLI/Electron: isolated DSH_HOME install, restart and uninstall; controlled lifecycle events exercised Brain/native contribution and persistence, with neighboring data preserved.
- The catalog generator parsed the single new YAML and generated exactly one added line in each README. Generated READMEs are intentionally not part of this PR.

Limitations are documented: no claim of measured model improvement or full Desktop UI acceptance from these checks, and no per-rule approval/restore API in 0.7.0. Other host adapters and live learning state are not included.
