### PR TITLE
add dsh-tauri-turnrewind (git): turn-level /undo with an in-card confirm step and conflict refusal

### DIFF
--- a/data/plugins/yingtianlan__dsh-tauri-turnrewind.yml
+++ b/data/plugins/yingtianlan__dsh-tauri-turnrewind.yml
@@ -1,0 +1,6 @@
+url: https://github.com/yingtianlan/dsh-tauri-turnrewind
+name: yingtianlan/dsh-tauri-turnrewind
+category: git
+description:
+  en: 'Turn-level workspace undo for Git worktrees: every agent turn gets a private snapshot, /undo previews a red/green diff card that is confirmed in place, files changed after the turn are refused with a conflict diff unless --force or --skip-conflicts is passed, and HEAD, index, stash and commit history of the user repository are never written.'
+  zh: 'Git worktree 的 turn 级工作区撤销：每个 turn 建私有快照，/undo 先出红绿 diff 预览卡、卡内确认；turn 之后被改过的文件拒绝用冲突 diff 覆盖，只有显式 --force 或 --skip-conflicts 才继续；不写用户仓库的 HEAD、index、stash 与提交历史。'


### PR DESCRIPTION
**Single plugin** — `dsh-tauri-turnrewind` (npm `0.3.1`, repo https://github.com/yingtianlan/dsh-tauri-turnrewind).

Turn-level workspace undo for Git worktrees. Every agent turn gets a private snapshot; `/undo` previews the exact file changes as a red/green diff card that the user confirms in place, refuses to overwrite a file that changed after the turn (showing a conflict diff, with `--force` / `--skip-conflicts` as explicit opt-ins), and never writes the user repository HEAD, index, stash or commit history.

- install: `dsh plugin add dsh-tauri-turnrewind`
- category: `git` — it restores workspace files inside a Git worktree; `session` would also be defensible.

Why this is not a duplicate of the rewind entries already listed (`Anionex/dsh-turn-rewind`, `PerryLink/dsh-checkpoint-rewind`):

- two-phase `/undo`: the preview parks a pending plan that must be confirmed from the card; the plan is bound to the previewed snapshot refs and re-validated on confirm (drift -> fresh preview);
- conflict refusal is the default; a forced overwrite requires `--force` / `--skip-conflicts`;
- Git-worktree only: non-Git directories are explicitly skipped (`TURNREWIND_GIT_REQUIRED`);
- a private snapshot repository per worktree that borrows the source objects through `alternates`, with self-heal (rebuilds a self-contained baseline after the source repository is gc/pruned); the user repository is never written;
- cross-process workspace lock plus a `needs-recovery` fence and an in-app recovery panel for interrupted undo/redo;
- `/undo --doctor` read-only diagnostics, ledger `quick_check` + daily rolling backup, retention caps, and a 64 MB per-file restore limit with per-path failure reporting.

Manifest: `dsh.bundle.patch` -> `./cordis.patch.yml` is present next to `package.json`; no official `@deepseek-ai/*` runtime dependencies. Repository created 2026-08-30; `dsh-plugin` topic added.