### PR TITLE
Add yh01010/dsh-mcp-matlab

### DIFF
--- a/data/added-dates.json
+++ b/data/added-dates.json
@@ -445,5 +445,8 @@
  "https://github.com/Tabbit-Browser/dsh-tabbit": "2026-08-21",
  "https://github.com/omdsh-dev/stent": "2026-08-13",
  "https://github.com/moguiyu/dsh-tavily/tree/main/packages/dsh-tavily": "2026-08-15",
- "https://github.com/polaris-smart/dsh-devices": "2026-08-19"
+ "https://github.com/polaris-smart/dsh-devices": "2026-08-19",
+ "https://github.com/wwweljf/dsh-plugins/tree/master/plugins/dsh-ding-sound": "2026-08-22",
+ "https://github.com/wwweljf/dsh-plugins/tree/master/plugins/dsh-wx-push": "2026-08-22",
+ "https://github.com/wwweljf/dsh-plugins/tree/master/plugins/dsh-wx-remote": "2026-08-22"
 }

--- a/data/plugins/yh01010__dsh-mcp-matlab.yml
+++ b/data/plugins/yh01010__dsh-mcp-matlab.yml
@@ -1,0 +1,6 @@
+url: https://github.com/yh01010/dsh-mcp-matlab
+name: yh01010/dsh-mcp-matlab
+category: tools
+description:
+  en: 'Bridges a local MATLAB MCP server into DSH: evaluate MATLAB code, run .m scripts and tests, and inspect installed toolboxes via mcp__matlab__* tools.'
+  zh: '将本地 MATLAB MCP server 桥接进 DSH，提供 mcp__matlab__* 工具：执行 MATLAB 代码、运行 .m 脚本与测试、查看已安装工具箱。'


### PR DESCRIPTION
Adds **data/plugins/yh01010__dsh-mcp-matlab.yml** for [yh01010/dsh-mcp-matlab](https://github.com/yh01010/dsh-mcp-matlab).

- ✅ one entry (≤ 3 allowed)
- ✅ declares `dsh.bundle.patch` in package.json
- ✅ repo is 72h old (> 1-day bar)
- ✅ `dsh-plugin` topic set on the repo
- ✅ description states what the plugin does (no superlatives)
- ✅ category: `tools` (MCP bridge registering `mcp__matlab__*` tools)

DSH plugin bridging a local MATLAB MCP server; works with the built-in `@deepseek-ai/dsh-mcp-client`.