### PR TITLE
add huangfuren/dsh-localsend (tools): LAN file transfer + no-install HTTP download links

### DIFF
--- a/data/added-dates.json
+++ b/data/added-dates.json
@@ -445,5 +445,9 @@
  "https://github.com/Tabbit-Browser/dsh-tabbit": "2026-08-21",
  "https://github.com/omdsh-dev/stent": "2026-08-13",
  "https://github.com/moguiyu/dsh-tavily/tree/main/packages/dsh-tavily": "2026-08-15",
- "https://github.com/polaris-smart/dsh-devices": "2026-08-19"
+ "https://github.com/polaris-smart/dsh-devices": "2026-08-19",
+ "https://github.com/wwweljf/dsh-plugins/tree/master/plugins/dsh-ding-sound": "2026-09-08",
+ "https://github.com/wwweljf/dsh-plugins/tree/master/plugins/dsh-wx-push": "2026-09-08",
+ "https://github.com/wwweljf/dsh-plugins/tree/master/plugins/dsh-wx-remote": "2026-09-08",
+ "https://github.com/huangfuren/dsh-localsend": "2026-09-10"
 }

--- a/data/plugins/huangfuren__dsh-localsend.yml
+++ b/data/plugins/huangfuren__dsh-localsend.yml
@@ -1,0 +1,6 @@
+url: https://github.com/huangfuren/dsh-localsend
+name: huangfuren/dsh-localsend
+category: tools
+description:
+  en: 'Send files or folders over the local network via the LocalSend v2 protocol, or generate a temporary browser download link that the receiver opens with no software installed.'
+  zh: '在 DSH 对话中通过 LocalSend v2 协议把文件/文件夹发到局域网内其它机器，或生成一次性浏览器下载链接（接收方无需安装任何软件）。零配置开箱即用，兼容 dsh 0.1.1-rc.2 与 0.1.3-alpha.1。'


### PR DESCRIPTION
Adds `huangfuren/dsh-localsend` to the **Tools & Capabilities / 工具与能力** category.

Sends files and folders to devices on the LAN over the LocalSend v2 protocol, or serves a temporary HTTP download link so the receiver needs nothing installed.

Checklist:
- `dsh.bundle` declared in root `package.json` (`cordis.patch.yml`)
- Repo created 2026-09-06, past the 1-day bar
- One entry only, no other entries touched