### PR TITLE
Add yihe-packs-dsh (data/plugins/ljc6413__yihe-packs-dsh.yml)

### DIFF
--- a/data/plugins/ljc6413__yihe-packs-dsh.yml
+++ b/data/plugins/ljc6413__yihe-packs-dsh.yml
@@ -1,0 +1,6 @@
+url: https://github.com/ljc6413/yihe-packs-dsh
+name: ljc6413/yihe-packs-dsh
+category: dev
+description:
+  en: 'YiHe pkg-dev knowledge packs for DeepSeek Harness: 52 domain packs and 90 RFB experience files for coding cognition.'
+  zh: '缁?DeepSeek Harness 瑁呬細杩涘寲鐨勭紪绋嬭鐭ョ煡璇嗗簱锛?2 涓鍩熷寘涓?90 涓?RFB 缁忛獙鏂囦欢锛岃鐩?11 闂ㄨ瑷€鏍堜笌鍓嶆部鏂瑰悜銆?


### PR DESCRIPTION
Add [yihe-packs-dsh](https://github.com/ljc6413/yihe-packs-dsh) 鈥?YiHe pkg-dev knowledge packs for DeepSeek Harness.

- One file: `data/plugins/ljc6413__yihe-packs-dsh.yml`
- Repo declares a `dsh.bundle` manifest (`dsh.bundle.patch` -> `cordis.patch.yml`), installable via `dsh plugin add yihe-packs-dsh`
- npm package published: [yihe-packs-dsh@0.1.0](https://www.npmjs.com/package/yihe-packs-dsh) (Apache-2.0)
- Contents: 52 domain packs (JSON) + 90 RFB experience files (language stacks & frontier fields), served through a catalog plugin; executable/installer included.
