### PR TITLE
Update guhanfei-ai/dsh-grafana and dsh-mindmap descriptions

### DIFF
--- a/data/plugins/guhanfei-ai__dsh-grafana.yml
+++ b/data/plugins/guhanfei-ai__dsh-grafana.yml
@@ -2,5 +2,5 @@ url: https://github.com/guhanfei-ai/dsh-grafana
 name: guhanfei-ai/dsh-grafana
 category: tools
 description:
-  en: 'Grafana dashboard editor: paste a dashboard URL, edit the JSON through conversation, and push it back over the HTTP API.'
-  zh: 'Grafana 大盘编辑器：粘贴大盘 URL，通过对话修改 JSON，再经 HTTP API 推回 Grafana。'
+  en: 'Conversational Grafana operations: inspect live dashboard data across named sources, then make safe, reviewable dashboard changes with approval and version checks.'
+  zh: '对话式 Grafana 运维：跨多个命名源站查看实时大盘数据，再通过审批与版本校验安全、可审阅地修改大盘。'

--- a/data/plugins/guhanfei-ai__dsh-mindmap.yml
+++ b/data/plugins/guhanfei-ai__dsh-mindmap.yml
@@ -2,5 +2,5 @@ url: https://github.com/guhanfei-ai/dsh-mindmap
 name: guhanfei-ai/dsh-mindmap
 category: ui
 description:
-  en: 'Markdown mindmap panel: a plain markdown file in the working directory is the mindmap; the chat edits it step by step and the side panel follows live.'
-  zh: 'Markdown 思维脑图面板：工作目录里一个普通 md 文件就是脑图，对话逐步编辑，侧栏面板实时跟随。'
+  en: 'Conversational Markdown mindmap workspace: edit complete documents step by step, keep a live right-side visualization synchronized, and open, manage, and export mindmaps from the working directory.'
+  zh: '对话式 Markdown 思维脑图工作台：逐步编辑完整文档，实时同步右侧可视化，并在工作目录中打开、管理和导出脑图。'


### PR DESCRIPTION
Refreshes both entry descriptions to match current functionality:

- **dsh-grafana**: conversational operations across multiple named Grafana sources, with approval and version checks for dashboard changes.
- **dsh-mindmap**: reworded as a conversational Markdown mindmap workspace (step-by-step editing, live side-panel visualization, open/manage/export).

yml-only change (2 entry files), no README edits.