### PR TITLE
Add yakoylp/dsh-localnotify to notify section

### DIFF
--- a/data/plugins/yakoylp__dsh-localnotify.yml
+++ b/data/plugins/yakoylp__dsh-localnotify.yml
@@ -1,0 +1,6 @@
+url: https://github.com/yakoylp/dsh-localnotify
+name: yakoylp/dsh-localnotify
+category: notify
+description:
+  en: 'In-app local notification center for DSH: a sidebar Notifications entry with unread badge, full-screen center with level color coding (info/success/warn/error), time/source filters, sorting, title/content search, read/unread, delete, detail popup with one-click copy, and pagination; written by the notify_add agent tool or the dsh-localnotify CLI (with auto-cleanup retention), page refreshes live, UI follows dsh web language (zh/en).'
+  zh: 'DSH 本地通知栏：侧边栏【通知】入口 + 未读徽标、全屏通知中心（级别视觉分级 info/success/warn/error、时间/来源筛选、排序、标题内容搜索、未读已读、删除、详情弹层一键复制、分页），notify_add agent 工具与 CLI 写入本地 JSON 文件（支持自动清理），页面实时刷新，界面跟随 dsh web 语言切换。'


### PR DESCRIPTION
## Add [yakoylp/dsh-localnotify](https://github.com/yakoylp/dsh-localnotify) — category: notify

A local in-app notification center plugin for DSH (DeepSeek Harness):

- Sidebar **Notifications** entry with unread badge; full-screen notification center (level color coding info/success/warn/error, time & source filters, sorting, title/content search, read/unread, delete with confirm, detail popup with one-click copy, pagination, i18n zh/en)
- Written via the 
otify_add agent tool or the dsh-localnotify CLI into a local JSON file; optional auto-cleanup retention; page refreshes live
- Real, working code (v1.4.0, MIT); 27 tests across store / HTTP API / CLI, GitHub Actions CI green on Node 18/20/22
- Single entry file, no hand-edited README

Checklist:
- [x] New YAML only under data/plugins/
- [x] Repo contains real working code
- [x] Tests + CI in the target repo