### PR TITLE
Update dsh-mneme description: heat restored in v0.7.20 + current feature set

### DIFF
--- a/data/plugins/modusensus__dsh-mneme.yml
+++ b/data/plugins/modusensus__dsh-mneme.yml
@@ -2,5 +2,5 @@ url: https://github.com/modusensus/dsh-mneme
 name: modusensus/dsh-mneme
 category: memory
 description:
-  en: "Cross-session memory plugin for DeepSeek Harness: remembers across sessions, consolidates in the background (autoDream), and manages everything through an interactive memory library panel — SQLite storage with human-editable Markdown mirrors, offline semantic search, and a standalone external API and CLI."
-  zh: "DeepSeek Harness 跨会话记忆插件：跨会话记住用户与项目、后台 autoDream 自动巩固记忆、交互式记忆库面板统一管理（浏览/搜索/编辑/导入导出）——SQLite 存储配可人工编辑的 Markdown 镜像，支持离线语义检索、独立外部 API 与 CLI。"
+  en: "Cross-session memory plugin for DeepSeek Harness: remembers across sessions, consolidates in the background (autoDream), and manages everything through an interactive memory library panel — SQLite storage with human-editable Markdown mirrors, offline semantic search, feature-flag panel, light mode, and a standalone external API and CLI. v0.7.20 restored the heat-based self-evolving memory model (power-law decay + sleep demotion protection, opt-in)."
+  zh: "DeepSeek Harness 跨会话记忆插件：跨会话记住用户与项目、后台 autoDream 自动巩固记忆、交互式记忆库面板统一管理（浏览/搜索/编辑/导入导出）——SQLite 存储配可人工编辑的 Markdown 镜像，支持离线语义检索、功能开关面板、轻量模式、独立外部 API 与 CLI。v0.7.20 回归 heat 自进化记忆（幂律衰减 + sleep 降级保护，默认关可开）。"


### PR DESCRIPTION
## What changed / 改了什么

Only the `description` lines of `data/plugins/modusensus__dsh-mneme.yml` (en/zh).

## Why / 为什么

PR #4627 (merged today) updated the entry to reflect the v0.7.17 feature set, but heat was **restored in v0.7.20** (issue #87, backported from v0.7.10): power-law decay + sleep demotion dual protection + entity heat projection — opt-in via `heatEnabled`, off by default. The current entry omits it.

## Update

- Mention the v0.7.20 heat restoration in both en/zh descriptions
- Also surface the feature-flag panel (30 keys) + light mode, part of the current feature set
- No category/name/url changes