### PR TITLE
Add stadeummwt/dsh-supreme (security)

### DIFF
--- a/data/plugins/stadeummwt__dsh-supreme.yml
+++ b/data/plugins/stadeummwt__dsh-supreme.yml
@@ -1,0 +1,6 @@
+url: https://github.com/stadeummwt/dsh-supreme
+name: stadeummwt/dsh-supreme
+category: security
+description:
+  en: 'Governance suite of seven host-side policy plugins: cost and execution-class policy gates on model calls with UNKNOWN-cost hard denial, benchmark-informed routing with RM0-first cost-class selection, deterministic verification with evidence checks, a bounded note-ledger memory policy, and workflow limits — enforced through one dsh.bundle patch layer, with the pinned upstream harness left unpatched.'
+  zh: '七个宿主侧策略插件组成的治理套件：模型调用的成本与执行级策略门禁（UNKNOWN 成本硬拒绝）、基于基准证据的路由与 RM0-first 成本类选择、带证据检查的确定性验证、有界笔记账本记忆策略与工作流限制——通过单一 dsh.bundle 补丁层强制执行，上游 harness 本体保持零补丁。'


### PR DESCRIPTION
Adds `stadeummwt/dsh-supreme` to the **Security & Permissions** category.

**What it is:** a governance suite of seven host-side policy plugins for DeepSeek Harness, shipped as one `dsh.bundle` patch layer (`dsh plugin --profile <name> add github:stadeummwt/dsh-supreme`).

- Cost / execution-class policy gates on model calls (UNKNOWN cost hard-denied; PAID/TRIAL LAB-only)
- Benchmark-informed deterministic routing (8 hard gates + weighted scoring, RM0-first cost-class selection, verifier-failure-driven effort escalation)
- Deterministic verification with evidence checks; memory selection policy with a bounded note ledger; workflow limits with surgical path scoping
- Unicode-taint detection/denial on tool arguments and a reasoning-trace presence audit via the official `tools/pre-execute` seam
- Upstream pinned at deepseek-ai/deepseek-harness `d347e703908d` — zero upstream patches

**Bundle manifest:** `package.json` declares `dsh.bundle.patch` → `cordis.patch.yml` (submission-gate requirement).

**Verification evidence (all runnable from the repo):** `bun run suite` (61/61 Level-A checks + 5 real-loader boots, VERDICT COMPLETE), `bun run bundle:verify` (BUNDLE_E2E_COMPLETE via the real CLI install), `bun run composition:verify`, `bun run v12:verify` (every v1.2 config key asserted at its service). CI runs the keyless + full suite on push.

One entry file only: `data/plugins/stadeummwt__dsh-supreme.yml` (nothing else touched). Repository topics include `dsh-plugin`.