### PR TITLE
Add tkliuxing/dsh-presets-hidden

### DIFF
--- a/data/plugins/tkliuxing__dsh-presets-hidden.yml
+++ b/data/plugins/tkliuxing__dsh-presets-hidden.yml
@@ -1,0 +1,6 @@
+url: https://github.com/tkliuxing/dsh-presets-hidden
+name: tkliuxing/dsh-presets-hidden
+category: ui
+description:
+  en: Browser-side preset visibility and ordering controls for the new-session page.
+  zh: 在新会话页控制 Agent 预设的显示与排序。


### PR DESCRIPTION
Add [tkliuxing/dsh-presets-hidden](https://github.com/tkliuxing/dsh-presets-hidden): a UI plugin for browser-side agent preset visibility and ordering controls on the new-session page.