### PR TITLE
Add teethyachi/dsh-usage-mini (usage)

### DIFF
--- a/data/plugins/teethyachi__dsh-usage-mini.yml
+++ b/data/plugins/teethyachi__dsh-usage-mini.yml
@@ -1,0 +1,6 @@
+url: https://github.com/teethyachi/dsh-usage-mini
+name: teethyachi/dsh-usage-mini
+category: usage
+description:
+  en: Floating usage window for DSH Web showing Claude and Codex subscription windows with reset countdowns, plus DeepSeek API spend and balance; display-only companion to dsh-cost-meter.
+  zh: DSH Web 悬浮用量小窗，显示 Claude、Codex 订阅用量窗口与重置倒计时，以及 DeepSeek API 今日花费与余额；只展示，是 dsh-cost-meter 的伴侣。


### PR DESCRIPTION
Adds `data/plugins/teethyachi__dsh-usage-mini.yml`, category `usage`.

- Repo: https://github.com/teethyachi/dsh-usage-mini (v0.2.3, MIT). I am the author.
- Declares `dsh.bundle`; install pinned GitHub release: `dsh plugin --profile web add github:teethyachi/dsh-usage-mini#v0.2.3`.
- Display-only floating window for Claude/Codex subscription windows and DeepSeek API spend/balance. Reads dsh-cost-meter and dsh-plugin-subscriptions; a companion, not a replacement.
- Fresh v0.2.3 tarball install, full DSH 0.1.2-rc.1 web start, zh/en browser render and uninstall passed with isolated DSH_HOME. Evidence: https://github.com/teethyachi/dsh-usage-mini/blob/v0.2.3/docs/store-evidence.md
- npm `dsh-usage-mini@0.2.3` is now verified publicly available with the same artifact checksum as GitHub/HF.
