### PR TITLE
Add azazo1/dsh-write-protect

### DIFF
--- a/data/added-dates.json
+++ b/data/added-dates.json
@@ -445,5 +445,8 @@
  "https://github.com/Tabbit-Browser/dsh-tabbit": "2026-08-21",
  "https://github.com/omdsh-dev/stent": "2026-08-13",
  "https://github.com/moguiyu/dsh-tavily/tree/main/packages/dsh-tavily": "2026-08-15",
- "https://github.com/polaris-smart/dsh-devices": "2026-08-19"
+ "https://github.com/polaris-smart/dsh-devices": "2026-08-19",
+ "https://github.com/wwweljf/dsh-plugins/tree/master/plugins/dsh-ding-sound": "2026-09-08T15:01:39.000Z",
+ "https://github.com/wwweljf/dsh-plugins/tree/master/plugins/dsh-wx-push": "2026-09-08T15:01:39.000Z",
+ "https://github.com/wwweljf/dsh-plugins/tree/master/plugins/dsh-wx-remote": "2026-09-08T15:01:39.000Z"
 }

--- a/data/plugins/azazo1__dsh-write-protect.yml
+++ b/data/plugins/azazo1__dsh-write-protect.yml
@@ -1,0 +1,7 @@
+url: https://github.com/azazo1/dsh-write-protect
+name: azazo1/dsh-write-protect
+category: security
+tarball: https://github.com/azazo1/dsh-write-protect/releases/latest/download/dsh-write-protect.tgz
+description:
+  en: Protect declared workspace subpaths such as .git from writes, and optionally grant extra writable roots under workspace-write.
+  zh: 为工作区指定子路径提供只读保护 (例如 .git), 并支持在 workspace-write 下声明额外可写根。


### PR DESCRIPTION
Add [azazo1/dsh-write-protect](https://github.com/azazo1/dsh-write-protect).

Protects declared workspace subpaths (for example `.git`) from writes, and can grant extra writable roots under `workspace-write`. Web Settings has a page to edit those lists and preview the expanded paths.

Category: `security`.

npm: [dsh-write-protect](https://www.npmjs.com/package/dsh-write-protect)
