### PR TITLE
Add techflag/dsh-plugin-ssh

### DIFF
--- a/data/plugins/techflag__dsh-plugin-ssh.yml
+++ b/data/plugins/techflag__dsh-plugin-ssh.yml
@@ -1,0 +1,6 @@
+url: https://github.com/techflag/dsh-plugin-ssh
+name: techflag/dsh-plugin-ssh
+category: remote
+description:
+  en: 'SSH terminals, SFTP file transfer and text editing inside DeepSeek Harness, with server troubleshooting through host models.'
+  zh: '在 DeepSeek Harness 内使用 SSH 终端、SFTP 文件传输与文本编辑，并通过宿主模型排查服务器问题。'


### PR DESCRIPTION
Adds DSH SSH to the `remote` category. It provides interactive SSH terminals, SFTP upload/download and UTF-8 text editing inside DeepSeek Harness, with server troubleshooting through the host model services.

The repository declares `dsh.bundle`, contains the Host and Client implementations, and includes actual product screenshots and a Chinese tutorial. Build, typecheck, 22 tests, and an isolated official-CLI install/bundle/page/uninstall smoke pass.

- Source: https://github.com/techflag/dsh-plugin-ssh
- Stable release: https://github.com/techflag/dsh-plugin-ssh/releases/tag/v0.1.0
- npm: https://www.npmjs.com/package/dsh-plugin-ssh
- Screenshots and README: https://github.com/techflag/dsh-plugin-ssh#readme
- Chinese tutorial: https://github.com/techflag/dsh-plugin-ssh/blob/main/docs/GETTING-STARTED.zh-CN.md
