### PR TITLE
Add Wedomizing/Dsh_genshin_nicole_skin (theme)

### DIFF
--- a/data/plugins/Wedomizing__Dsh_genshin_nicole_skin.yml
+++ b/data/plugins/Wedomizing__Dsh_genshin_nicole_skin.yml
@@ -1,0 +1,6 @@
+url: https://github.com/Wedomizing/Dsh_genshin_nicole_skin
+name: Wedomizing/Dsh_genshin_nicole_skin
+category: theme
+description:
+  en: Genshin Nicole PV wallpaper skin for the DSH web GUI — 14 subtitle-free frames rotate on a timed crossfade queue with pause and manual switching.
+  zh: 原神·尼可 PV 背景皮肤：14 张去字幕画面定时轮播淡入淡出，支持暂停与上一张/下一张切换。


### PR DESCRIPTION
Adds one theme entry: **dsh-skin-genshin-nicole** ??a Genshin Nicole PV wallpaper skin for the DSH web GUI (14 subtitle-free frames on a timed crossfade queue with pause and manual switching).

- `package.json` declares `dsh.bundle` (`cordis.patch.yml`) plus `dsh.client` ??installable via `dsh plugin add`.
- Repository: https://github.com/Wedomizing/Dsh_genshin_nicole_skin (topic `dsh-plugin` added).
- Screenshots declared in the repo's `screenshots.json`.