### PR TITLE
Update vonweller/dsh-skillhub listing

### DIFF
--- a/data/added-dates.json
+++ b/data/added-dates.json
@@ -445,5 +445,8 @@
  "https://github.com/Tabbit-Browser/dsh-tabbit": "2026-08-21",
  "https://github.com/omdsh-dev/stent": "2026-08-13",
  "https://github.com/moguiyu/dsh-tavily/tree/main/packages/dsh-tavily": "2026-08-15",
- "https://github.com/polaris-smart/dsh-devices": "2026-08-19"
+ "https://github.com/polaris-smart/dsh-devices": "2026-08-19",
+ "https://github.com/wwweljf/dsh-plugins/tree/master/plugins/dsh-ding-sound": "2026-09-08T15:01:39.000Z",
+ "https://github.com/wwweljf/dsh-plugins/tree/master/plugins/dsh-wx-push": "2026-09-08T15:01:39.000Z",
+ "https://github.com/wwweljf/dsh-plugins/tree/master/plugins/dsh-wx-remote": "2026-09-08T15:01:39.000Z"
 }

--- a/data/plugins/vonweller__dsh-skillhub.yml
+++ b/data/plugins/vonweller__dsh-skillhub.yml
@@ -2,5 +2,5 @@ url: https://github.com/vonweller/dsh-skillhub
 name: vonweller/dsh-skillhub
 category: skill
 description:
-  en: Browse the public skillhub.cn catalog and install selected skills into ~/.dsh/skills.
-  zh: 浏览 skillhub.cn 公开技能目录，并将选中的技能安装到 ~/.dsh/skills。
+  en: Browse the public skillhub.cn catalog from Settings and install selected SKILL.md bundles into ~/.dsh/skills.
+  zh: 在设置页浏览 skillhub.cn 公开技能目录，并将选中的 SKILL.md 技能包安装到 ~/.dsh/skills。


### PR DESCRIPTION
Update the existing `vonweller/dsh-skillhub` listing. The plugin itself was just aligned with current DeepSeek Harness 0.1.3 plugin contracts.

This PR edits only `data/plugins/vonweller__dsh-skillhub.yml` (no generated README changes).

## Listing
- **url:** https://github.com/vonweller/dsh-skillhub
- **category:** skill (unchanged)
- **description.en:** Browse the public skillhub.cn catalog from Settings and install selected SKILL.md bundles into ~/.dsh/skills.
- **description.zh:** 在设置页浏览 skillhub.cn 公开技能目录，并将选中的 SKILL.md 技能包安装到 ~/.dsh/skills。

## Plugin (already listed)
- Declares `dsh.bundle` + `dsh.client` with `cordis.patch.yml`
- Install: `dsh plugin --profile web add github:vonweller/dsh-skillhub`
- Adds Settings → Skill Market, installs only the selected skill into `~/.dsh/skills`
- Current plugin version: 0.1.2 (Standard Schema Config, locale `t` seat, `--dsw-alias-*` tokens, `screenshots.json`)

Per contributing.md this is an update to an existing entry, not a new submission.