### PR TITLE
Add MrmoLabs/dsh-yorha-ui

### DIFF
--- a/data/plugins/MrmoLabs__dsh-yorha-ui.yml
+++ b/data/plugins/MrmoLabs__dsh-yorha-ui.yml
@@ -1,0 +1,6 @@
+url: https://github.com/MrmoLabs/dsh-yorha-ui
+name: MrmoLabs/dsh-yorha-ui
+category: theme
+description:
+  en: A NieR:Automata / YoRHa-inspired industrial terminal theme for DeepSeek Harness Web with sand-and-charcoal palettes, square geometry, and interface-wide styling.
+  zh: 一款面向 DeepSeek Harness Web 的 NieR:Automata / YoRHa 风格工业终端主题，提供沙色与炭黑配色、直角几何和全界面样式。


### PR DESCRIPTION
## Summary

Adds [MrmoLabs/dsh-yorha-ui](https://github.com/MrmoLabs/dsh-yorha-ui) to the `theme` category. It is a NieR:Automata / YoRHa-inspired industrial terminal theme for DeepSeek Harness Web.

## Checklist

- [x] Added exactly one file at `data/plugins/MrmoLabs__dsh-yorha-ui.yml`; generated READMEs are unchanged.
- [x] The plugin declares `dsh.bundle` with `cordis.patch.yml`.
- [x] The repository is more than one day old and has the `dsh-plugin` topic.
- [x] The description is factual and the category is `theme`.
- [x] The plugin is published to npm as `dsh-yorha-ui`.

## Verification

- `pnpm run check`
- `pnpm test` — 3 tests passed
- Upstream YAML parsing and README regeneration — passed
- Local site build — passed after isolating an unrelated current upstream merge-history date derivation issue affecting three existing wwweljf entries.