### PR TITLE
add Yur0918/dsh-soul (ui): SoulFusion personalization plugin

### DIFF
--- a/data/plugins/Yur0918__dsh-soul.yml
+++ b/data/plugins/Yur0918__dsh-soul.yml
@@ -1,0 +1,6 @@
+url: https://github.com/Yur0918/dsh-soul
+name: Yur0918/dsh-soul
+category: ui
+description:
+  en: 'SoulFusion-style personalization: 9 response styles, custom instructions, persona cards, per-session switching, long-term memory with audit trails.' 
+  zh: 'DeepSeek Harness 个性化设置：9 种回复风格、自定义指令、人设卡、会话级切换、带审计的长期记忆。'


### PR DESCRIPTION
Single DSH plugin **dsh-soul** (v2.0.0): 9 response styles (zh/en presets),
custom instructions, persona cards with per-session switching, long-term
memory with append-only audit + per-tool confirmation slots. Skeleton
assembly: best-effort systemPrompt section registration (warn-only
degradation). Repo: https://github.com/Yur0918/dsh-soul · install (after
npm publish): `dsh plugin --profile web add dsh-soul`. 62/62 tests passing.