### PR TITLE
Add kvmem/dsh-super-advisor

### DIFF
--- a/data/plugins/kvmem__dsh-advisor.yml
+++ b/data/plugins/kvmem__dsh-advisor.yml
@@ -1,0 +1,7 @@
+url: https://github.com/kvmem/dsh-advisor
+name: kvmem/dsh-advisor
+category: workflow
+description:
+  en: On-demand second opinions through ask_advisor, with editable requests, per-call human approval, and text advice from a model configured in DSH.
+  zh: 通过 ask_advisor 按需求助顾问，支持编辑请求与逐次人工批准，由 DSH 中配置的模型返回文字建议。
+tarball: https://github.com/kvmem/dsh-advisor/releases/latest/download/dsh-tool-advisor.tgz

--- a/data/plugins/kvmem__dsh-super-advisor.yml
+++ b/data/plugins/kvmem__dsh-super-advisor.yml
@@ -1,7 +1,7 @@
-url: https://github.com/kvmem/dsh-advisor
-name: kvmem/dsh-advisor
+url: https://github.com/kvmem/dsh-super-advisor
+name: kvmem/dsh-super-advisor
 category: workflow
 description:
   en: On-demand second opinions through ask_advisor, with editable requests, per-call human approval, and text advice from a model configured in DSH.
   zh: 通过 ask_advisor 按需求助顾问，支持编辑请求与逐次人工批准，由 DSH 中配置的模型返回文字建议。
-tarball: https://github.com/kvmem/dsh-advisor/releases/latest/download/dsh-tool-advisor.tgz
+tarball: https://github.com/kvmem/dsh-super-advisor/releases/latest/download/dsh-super-advisor.tgz

--- a/scripts/build-site.mjs
+++ b/scripts/build-site.mjs
@@ -238,8 +238,15 @@ if (ordered.some((e) => !dates[e.url])) {
       try {
         // Oldest "added" commit for that path. Not `-1`, which git applies
         // before --reverse and would hand back the newest instead.
-        const out = execSync(`git log --diff-filter=A --format=%cI -- ${JSON.stringify(file)}`,
+        let out = execSync(`git log --diff-filter=A --format=%cI -- ${JSON.stringify(file)}`,
           { encoding: 'utf8' }).trim().split('\n').filter(Boolean)
+        // A canonical filename can first appear in a merge, whose diff the
+        // default log hides. Retry only missing dates so existing dates stay
+        // unchanged and ordinary entries do not pay for merge diff traversal.
+        if (!out.length) {
+          out = execSync(`git log --diff-merges=first-parent --no-patch --diff-filter=A --format=%cI -- ${JSON.stringify(file)}`,
+            { encoding: 'utf8' }).trim().split('\n').filter(Boolean)
+        }
         const iso = out[out.length - 1]
         if (iso) dates[e.url] = new Date(iso).toISOString()
       } catch { /* not committed yet — falls through to the error below */ }


### PR DESCRIPTION
Adds [DSH SuperAdvisor](https://github.com/kvmem/dsh-super-advisor) under **Workflow & Automation**. The main model calls `ask_advisor` for a focused second opinion; users can edit the request and approve each send, then receive text advice from a model configured in DSH.

The listing points at the verified [0.1.7 latest-release tarball](https://github.com/kvmem/dsh-super-advisor/releases/latest/download/dsh-super-advisor.tgz). Documented setups include a tool-capable local main model consulting a cloud advisor, and Flash consulting Pro. Quality and cost improvements are goals, not benchmarked claims. The package declares `dsh.bundle`; the repository has the `dsh-plugin` topic.

## Build failure fixed

The existing site build fails on three `wwweljf/dsh-plugins` entries because their canonical filenames were introduced in merge commit `5599809cf0e63ef2249d923c805c134d6b73e9ca`. The default `git log --diff-filter=A` query does not examine merge diffs, so it returns no addition date even with complete history. See the [failing run](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/actions/runs/34328878203/job/102392490516).

This branch includes the exact date-lookup fix from #4709, in its own cherry-picked commit. Only when the existing lookup finds no date does the build retry with first-parent merge diffs and timestamp-only output. Existing resolved dates and the frozen baseline retain their behavior. No workflow, submission rule, or other plugin entry is changed. #4709 remains available for maintainers who prefer to merge the infrastructure fix separately first.

The complete diff contains two files:

- `data/plugins/kvmem__dsh-super-advisor.yml`: the single plugin listing, 7 added lines.
- `scripts/build-site.mjs`: the necessary shared date-lookup repair, 8 added lines and 1 removed line.

Generated READMEs and site output are excluded from the PR.

## Validation and repository age

- Entry schema, duplicate checks, and README generation pass.
- The full site build passes for all 3,432 entries in both locales, including the new listing and the three previously undated entries.
- All 432 currently listed entries covered by the frozen date baseline keep their published dates.
- Plugin validation is documented in [ACCEPTANCE.md](https://github.com/kvmem/dsh-super-advisor/blob/main/ACCEPTANCE.md): 51 automated tests, actual DSH Loader checks, new installation, and upgrade/browser acceptance. This PR does not change plugin code.
- The repository was created **2026-09-09 03:13:28 UTC** and meets the one-day age requirement after **2026-09-10 03:13:28 UTC** (11:13:28 China Standard Time). The rename retains the original creation time. No gate rules or timestamps have been changed to bypass this condition.

This updates the original submission after the project was renamed from DSH Advisor to DSH SuperAdvisor; no second listing is requested.

## Current check results

The new commit's [GitHub `check` job](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/actions/runs/34330872223/job/102398888775) **passes**, including README generation, awesome-lint, and the complete site build.

The follow-up [Submission gate workflow](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/actions/runs/34331183115) failed before examining the entry: its installation token received **HTTP 403, API rate limit exceeded**, with `x-ratelimit-remaining: 0`, while resolving the PR. It did not post a submission verdict on this head. This is separate from the repaired build failure.

Running the unchanged upstream `scripts/check-submission.mjs --base origin/main` locally with authenticated GitHub access checked exactly one entry, reported no incomplete checks, and found only the one-day repository-age requirement. The bundle and other submission checks pass. The upstream workflow needs a recheck after its API budget recovers; the repository reaches the age threshold at the time above. No approval rule or check status has been bypassed or overridden.
