### PR TITLE
Fix added-date lookup for entries introduced in merges

### DIFF
--- a/scripts/build-site.mjs
+++ b/scripts/build-site.mjs
@@ -238,8 +238,15 @@ if (ordered.some((e) => !dates[e.url])) {
       try {
         // Oldest "added" commit for that path. Not `-1`, which git applies
         // before --reverse and would hand back the newest instead.
-        const out = execSync(`git log --diff-filter=A --format=%cI -- ${JSON.stringify(file)}`,
+        let out = execSync(`git log --diff-filter=A --format=%cI -- ${JSON.stringify(file)}`,
           { encoding: 'utf8' }).trim().split('\n').filter(Boolean)
+        // A canonical filename can first appear in a merge, whose diff the
+        // default log hides. Retry only missing dates so existing dates stay
+        // unchanged and ordinary entries do not pay for merge diff traversal.
+        if (!out.length) {
+          out = execSync(`git log --diff-merges=first-parent --no-patch --diff-filter=A --format=%cI -- ${JSON.stringify(file)}`,
+            { encoding: 'utf8' }).trim().split('\n').filter(Boolean)
+        }
         const iso = out[out.length - 1]
         if (iso) dates[e.url] = new Date(iso).toISOString()
       } catch { /* not committed yet — falls through to the error below */ }


### PR DESCRIPTION
Site builds currently stop on the three `wwweljf/dsh-plugins` entries because their canonical filenames were introduced by merge commit `5599809cf0e63ef2249d923c805c134d6b73e9ca`. The entry-date fallback uses `git log --diff-filter=A`, which does not include merge diffs by default, so it finds no addition even with full Git history. This also fails the site-build check in #4708: [CI failure](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/actions/runs/34314817518/job/102348716964).

When the existing lookup finds no date, retry with merge diffs against the first parent and suppress patch output so the parser still receives only timestamps. Successful lookups keep their existing dates, and ordinary entries avoid the extra merge-history traversal. The frozen date baseline and README history lookup retain their current behavior.

Validation:

- Reproduced missing dates for `dsh-ding-sound`, `dsh-wx-push`, and `dsh-wx-remote`; the merge-aware query returns `2026-09-08T23:01:39+08:00` for all three.
- Checked ordinary entry histories, including the new advisor submission; their resolved dates are unchanged.
- `node --check scripts/build-site.mjs` passes.
- `node scripts/generate-readme.mjs` and `SKIP_PUBLISH_CHECKS=1 node scripts/build-site.mjs` pass for all 3,431 entries in both locales. The generated catalog recovers the three affected dates and preserves all 432 currently listed entries covered by the frozen date baseline.

This PR only changes the date lookup in `scripts/build-site.mjs`; it adds or modifies no plugin entries.


The identical fix is now also included in #4708 as a separate cherry-picked commit so that submission can run a successful base build before its normal age recheck. This PR remains the infrastructure-only option for maintainers; neither branch changes the submission rules or other plugin entries.
