### PR TITLE
Add UnknowCao/dsh-outlook - zero-credential Outlook automation (identity)

### DIFF
--- a/data/plugins/UnknowCao__dsh-outlook.yml
+++ b/data/plugins/UnknowCao__dsh-outlook.yml
@@ -1,0 +1,6 @@
+url: https://github.com/UnknowCao/dsh-outlook
+name: UnknowCao/dsh-outlook
+category: identity
+description:
+  en: 'Zero-credential Outlook automation: 13 tools that drive the local desktop Outlook client via COM — search/read mail, drafts, reply/forward, calendar, address book, rooms, free/busy — plus a sidebar new-mail badge. No Graph API registration, no SMTP passwords; anything that leaves the machine passes a three-layer human approval gate.'
+  zh: '零凭据 Outlook 自动化：13 个工具通过 COM 直接驱动本地桌面 Outlook 客户端——搜信/读信/草稿/回复转发/日历/通讯录/会议室/忙闲查询——外加侧边栏新邮件角标。无需 Graph API 注册、无需 SMTP 密码；任何外发动作都过三层人工审批门。'


### PR DESCRIPTION
Adds **UnknowCao/dsh-outlook** to the identity category (Identity & Communication).

- Install: dsh plugin --profile web add https://github.com/UnknowCao/dsh-outlook (declares dsh.bundle, installs clean)
- Windows-only by design: drives the **local desktop Outlook client via COM**, so it works on locked-down corporate machines where Graph API app registration is impossible - no credentials, no tenant admin rights.
- Claimed 13 tools: countable in [index.js](https://github.com/UnknowCao/dsh-outlook/blob/main/index.js) (outlook_check_new, search_mail, read_mail, account, draft_mail, send_mail, reply_mail, calendar_query, calendar_create, search_people, freebusy, search_rooms, save_attachment) plus a sidebar new-mail badge.
- Sends (mail / meeting invite) go through a two-call confirmation + content-hash binding + bridge token - documented in the README security section.
- Shipped as v2.6.1 with 33 test cases (TESTCASES.md) and a changelog; repo freshly released and maintained.

One YAML file only, per contributing.md; READMEs regenerate after merge.