### PR TITLE
docs: update dsh-panda-calendar (add on-this-day history)

### DIFF
--- a/data/plugins/runcat-tommy__dsh-panda-calendar.yml
+++ b/data/plugins/runcat-tommy__dsh-panda-calendar.yml
@@ -2,5 +2,5 @@ url: https://github.com/runcat-tommy/dsh-panda-calendar
 name: runcat-tommy/dsh-panda-calendar
 category: ui
 description:
-  en: A conversation-view tab for DeepSeek Harness Web showing solar/lunar dates, ganzhi year/month/day, Chinese zodiac, 24 solar terms, festivals, China public holidays including make-up workdays, and multi-city weather from free sources without an API key.
-  zh: '会话页头的「熊猫日历」标签页：公历/农历、干支、生肖、24 节气、传统与外国节日、中国法定节假日（含调休）与多城市天气，数据免费、无需 API Key。'
+  en: A conversation-view tab for DeepSeek Harness Web showing solar/lunar dates, ganzhi year/month/day, Chinese zodiac, 24 solar terms, festivals, China public holidays including make-up workdays, multi-city weather and on-this-day history (events + notable births) from free sources without an API key.
+  zh: '会话页头的「熊猫日历」标签页：公历/农历、干支、生肖、24 节气、传统与外国节日、中国法定节假日（含调休）、多城市天气与历史上的今天（大事记＋名人诞辰），数据免费、无需 API Key。'


### PR DESCRIPTION
Version 1.2.0 of dsh-panda-calendar adds a collapsible **On this day** section to the today card (~3 events + 4-6 curated notable births per date; built-in 366-day offline snapshot + live enhancement from the Chinese Wikipedia, CC BY-SA). Updating the entry's en/zh descriptions to mention the new feature.