### PR TITLE
Add VAST-AI-Research/Tripo3D-Plugin-dsh#plugin

### DIFF
--- a/data/plugins/VAST-AI-Research__Tripo3D-Plugin-dsh--plugin.yml
+++ b/data/plugins/VAST-AI-Research__Tripo3D-Plugin-dsh--plugin.yml
@@ -1,0 +1,6 @@
+url: https://github.com/VAST-AI-Research/Tripo3D-Plugin-dsh/tree/master/plugin
+name: VAST-AI-Research/Tripo3D-Plugin-dsh#plugin
+category: skill
+description:
+  en: 'Tripo 3D generation skills driving the tripo-cli through the shell: text-to-3D, image-to-3D, rigging with locomotion clips, decimation and LOD chains, and export to GLB/FBX/OBJ/STL/USDZ/3MF, with headless device login for both China-mainland and international accounts; installable as `tripo-dsh`.'
+  zh: 通过 shell 驱动 tripo-cli 的 Tripo 3D 生成 Skill：文生 3D、图生 3D、绑骨与走跑动画、减面与 LOD 链，导出 GLB/FBX/OBJ/STL/USDZ/3MF，支持国内站与海外站账号的无头设备码登录；npm 包名 `tripo-dsh`。

--- a/data/plugins/VAST-AI-Research__Tripo3D-Plugin-dsh.yml
+++ b/data/plugins/VAST-AI-Research__Tripo3D-Plugin-dsh.yml
@@ -1,6 +1,0 @@
-url: https://github.com/VAST-AI-Research/Tripo3D-Plugin-dsh
-name: VAST-AI-Research/Tripo3D-Plugin-dsh
-category: skill
-description:
-  en: 'Tripo 3D generation skills driving the tripo-cli through the shell: text-to-3D, image-to-3D, rigging with locomotion clips, decimation and LOD chains, and export to GLB/FBX/OBJ/STL/USDZ/3MF, with headless device login for both China-mainland and international accounts; installable as `tripo-dsh`.'
-  zh: 通过 shell 驱动 tripo-cli 的 Tripo 3D 生成 Skill：文生 3D、图生 3D、绑骨与走跑动画、减面与 LOD 链，导出 GLB/FBX/OBJ/STL/USDZ/3MF，支持国内站与海外站账号的无头设备码登录；npm 包名 `tripo-dsh`。

--- a/data/plugins/VAST-AI-Research__Tripo3D-Plugin-dsh.yml
+++ b/data/plugins/VAST-AI-Research__Tripo3D-Plugin-dsh.yml
@@ -1,0 +1,6 @@
+url: https://github.com/VAST-AI-Research/Tripo3D-Plugin-dsh
+name: VAST-AI-Research/Tripo3D-Plugin-dsh
+category: skill
+description:
+  en: 'Tripo 3D generation skills driving the tripo-cli through the shell: text-to-3D, image-to-3D, rigging with locomotion clips, decimation and LOD chains, and export to GLB/FBX/OBJ/STL/USDZ/3MF, with headless device login for both China-mainland and international accounts; installable as `tripo-dsh`.'
+  zh: 通过 shell 驱动 tripo-cli 的 Tripo 3D 生成 Skill：文生 3D、图生 3D、绑骨与走跑动画、减面与 LOD 链，导出 GLB/FBX/OBJ/STL/USDZ/3MF，支持国内站与海外站账号的无头设备码登录；npm 包名 `tripo-dsh`。


### PR DESCRIPTION
Adds `data/plugins/VAST-AI-Research__Tripo3D-Plugin-dsh.yml` (category: skill).

Tripo's official skills-only plugin for DeepSeek Harness. Two bundled skills (`tripo-3d`, `tripo-game-asset`) drive the `tripo-cli` through the shell tool: text-to-3D, image-to-3D, rigging with locomotion clips, decimation / LOD chains, export to GLB/FBX/OBJ/STL/USDZ/3MF, headless device login for both China-mainland and international accounts.

- Repo: https://github.com/VAST-AI-Research/Tripo3D-Plugin-dsh (`dsh.bundle` manifest in `plugin/package.json`, `dsh-plugin` topic set)
- npm: https://www.npmjs.com/package/tripo-dsh (`repository` field points back at the repo above)
- Install: `dsh plugin --profile web add tripo-dsh`

Made with [Cursor](https://cursor.com)