### PR TITLE
Update ruisenbai/dsh-annotation: require DSH 0.1.5-alpha.1 (v0.8.0)

### DIFF
--- a/data/plugins/ruisenbai__dsh-annotation.yml
+++ b/data/plugins/ruisenbai__dsh-annotation.yml
@@ -2,6 +2,6 @@ url: https://github.com/ruisenbai/dsh-annotation
 name: ruisenbai/dsh-annotation
 category: session
 description:
-  en: 'Requires DSH 0.1.3-alpha.1. Annotate selected text in finished assistant messages, then submit multiple drafts with official composer text, images, and files as one Session user message; the model answers each annotation in order with hoverable reply chips.'
-  zh: '需要 DSH 0.1.3-alpha.1。在已完成的助手消息中选中原文并添加多条注解，再与官方输入框文字、图片和文件合并为一条会话用户消息；模型按顺序逐条回答，并用可悬浮的回复芯片关联原文。'
+  en: 'Requires DSH 0.1.5-alpha.1. Annotate selected text in finished assistant messages, then submit multiple drafts with official composer text, images, and files as one Session user message; the model answers each annotation in order with hoverable reply chips.'
+  zh: '需要 DSH 0.1.5-alpha.1。在已完成的助手消息中选中原文并添加多条注解，再与官方输入框文字、图片和文件合并为一条会话用户消息；模型按顺序逐条回答，并用可悬浮的回复芯片关联原文。'
 tarball: https://github.com/ruisenbai/dsh-annotation/releases/latest/download/dsh-annotation.tgz


### PR DESCRIPTION
Updates the existing `ruisenbai__dsh-annotation.yml` entry only.

dsh-annotation v0.8.0 raises the exact host requirement from DSH `0.1.3-alpha.1` to `0.1.5-alpha.1`; the rest of the description is unchanged and still accurate. `category`, `url`, `name`, and `tarball` are untouched.

- Plugin release: https://github.com/ruisenbai/dsh-annotation/releases/tag/v0.8.0 (assets `dsh-annotation-0.8.0.tgz` + stable alias `dsh-annotation.tgz`)
- `scripts/check-submission.mjs --only-list ruisenbai__dsh-annotation.yml` passes locally against this branch.

The repo is already listed, so the new-repository age check does not apply to this update.