### PR TITLE
Add ruisenbai/dsh-turn-fold (ui)

### DIFF
--- a/data/plugins/ruisenbai__dsh-turn-fold.yml
+++ b/data/plugins/ruisenbai__dsh-turn-fold.yml
@@ -1,0 +1,7 @@
+url: https://github.com/ruisenbai/dsh-turn-fold
+name: ruisenbai/dsh-turn-fold
+category: ui
+description:
+  en: 'Folds streaming reasoning and tool calls into collapsed step bars and collapses each finished turn into a single summary bar; step bars show native tool icons, filenames, edited line counts, and failure counts, finished turns restore duration, first-token time, token usage, generation speed, and cache hit metrics from recorded Session events, and preferences persist on the Host. Changes browser presentation only. Requires DSH 0.1.5-alpha.1.'
+  zh: '流式回复期间将推理与工具调用折叠为收起的步骤栏，回合完成后整轮收拢为一条摘要栏；步骤栏显示原生工具图标、文件名、编辑增删行数与失败计数，已完成回合从记录的 Session 事件恢复耗时、首字延迟、Token 用量、生成速度与缓存命中率，偏好由 Host 持久保存。仅改变浏览器呈现，需要 DSH 0.1.5-alpha.1。'
+tarball: https://github.com/ruisenbai/dsh-turn-fold/releases/latest/download/dsh-turn-fold.tgz


### PR DESCRIPTION
Adds `data/plugins/ruisenbai__dsh-turn-fold.yml` (new file, nothing else changed).

Two-level folding for the DSH Web client, targeting DSH `0.1.5-alpha.1` (`engines.dsh` exact):

- While a reply streams, consecutive reasoning and tool calls fold into collapsed step bars; when a turn finishes, its whole process collapses into a single summary bar. Bars reveal in two stages (turn, then step, then original reasoning/tool cards).
- Step bars show native tool-type icons, filenames, edited added/removed line counts from persisted diff metadata, and failure counts.
- Finished turns restore duration, first-token time, token usage, generation speed, and cache hit metrics from recorded Session events; preferences persist on the Host.
- Browser presentation only; no model input, tool, or Session event changes.

- Plugin release: https://github.com/ruisenbai/dsh-turn-fold/releases/tag/v0.3.0 (assets `dsh-turn-fold-0.3.0.tgz` + byte-identical stable alias `dsh-turn-fold.tgz` used by the entry's `tarball:` URL)
- Repo carries the `dsh-plugin` topic and declares `dsh.bundle` in `package.json`.
- `scripts/check-submission.mjs` run locally against this branch: the only failing item is the repository age gate — the repo was created today (0.0 days, needs 1). Per the check's own message this re-runs by itself (`regate.yml` every 6 hours) and should clear in about 24h; no resubmit, force-push, or close/reopen needed. Everything else (bundle manifest, tarball reachability, real code) passed.
- Independent implementation; does not conflict with the existing `Winter-And-You-Gone__dsh-turn-fold.yml` entry.