### PR TITLE
add: readfish/dsh-client-theme-cyber (theme)

### DIFF
--- a/data/plugins/readfish__dsh-client-theme-cyber.yml
+++ b/data/plugins/readfish__dsh-client-theme-cyber.yml
@@ -1,0 +1,6 @@
+url: https://github.com/readfish/dsh-client-theme-cyber
+name: readfish/dsh-client-theme-cyber
+category: theme
+description:
+  en: Dark navy glass theme for DeepSeek Harness Web with a cyber-city background and holographic-cube cyan accents.
+  zh: 深海军蓝半透明面板承载赛博城市夜景背景、全息立方体青色辉光作为点缀的暗色主题。


### PR DESCRIPTION
Add **Cyber Sand** — a dark theme for DeepSeek Harness Web: navy glass panels
over a cyber-city background with holographic-cube cyan accents. Tested on
DSH Desktop. Category `theme` puts it in the market's Themes tab for one-click
install/switch. Screenshots declared in the repo's `screenshots.json`.
Install: `dsh plugin --profile web add github:readfish/dsh-client-theme-cyber`