### PR TITLE
Add GodCC6/dsh-claude-memory

### DIFF
--- a/data/plugins/GodCC6__dsh-claude-memory.yml
+++ b/data/plugins/GodCC6__dsh-claude-memory.yml
@@ -1,0 +1,6 @@
+url: https://github.com/GodCC6/dsh-claude-memory
+name: GodCC6/dsh-claude-memory
+category: memory
+description:
+  en: 'Read-only bridge that surfaces Claude Code''s existing project memory in DSH — git-root-aware resolution, credential redaction before injection, and an on-demand recall tool. Zero runtime dependencies.'
+  zh: '只读桥接 Claude Code 已有项目记忆到 DSH：按 git 仓库根解析、注入前脱敏、按需检索工具，零依赖。'


### PR DESCRIPTION
Adds one plugin entry — `data/plugins/GodCC6__dsh-claude-memory.yml`, category `memory`.

**Repo:** https://github.com/GodCC6/dsh-claude-memory
**npm:** https://www.npmjs.com/package/dsh-claude-memory
**Install:** `dsh plugin --profile web add dsh-claude-memory`

A read-only bridge that surfaces Claude Code's existing project memory inside DSH, so a task can continue after a Claude Code quota runs out. It injects the resolved project's `MEMORY.md` index plus the user-global `~/.claude/CLAUDE.md`, and registers one `claude_memory` tool for on-demand reads. It declares `dsh.bundle` (`./cordis.patch.yml`) and has no runtime dependencies — it imports only `node:*`.

Published as `dsh-claude-memory@0.1.0` (verified: clean install in an empty project resolves the entry; registry metadata carries the `dsh.bundle` manifest). Verified on DSH 0.1.2-rc.1: the row composes into the profile tree (`--dump-config`), the plugin loads, and a headless run showed the injected memory block reaching the model with the tool call executing and returning real file content. `npm test` is 76 assertions with no network or model calls, green on Node 22 and 24 (CI included).

Two findings that may be useful to other plugin authors, both written up in the README:

- **Prompt providers are synchronous.** `dsh-system-prompt` resolves section/context `text` without awaiting it (`lib/index.js:330,337`), so an `async () => string` provider yields a `Promise` and the interpolator fails on `text.indexOf` (`:152`). The plugin keeps a synchronously refreshed cache instead.
- **Claude Code files memory under the git repository root, not the raw cwd.** A directory that has no `.git` of its own files its memories under the enclosing repo's key. Measured evidence is in the README's case study.

The `en` description matches what the plugin actually does; the `zh` line is my own, happy to have it corrected.