### PR TITLE
Add jarvislee90s-dot/dsh-foxbell-pet

### DIFF
--- a/data/plugins/jarvislee90s-dot__dsh-foxbell-pet.yml
+++ b/data/plugins/jarvislee90s-dot__dsh-foxbell-pet.yml
@@ -1,0 +1,17 @@
+url: https://github.com/jarvislee90s-dot/dsh-foxbell-pet
+name: jarvislee90s-dot/dsh-foxbell-pet
+category: fun
+tarball: https://github.com/jarvislee90s-dot/dsh-foxbell-pet/releases/latest/download/dsh-foxbell-pet-2.0.0.tgz
+description:
+  zh: >-
+    多宠物桌宠系统：四盏状态灯实时监控所有活跃会话（红待审批/黄运行/绿完成未读/深红错误），点卡片直达对应会话；
+    四组状态语音随事件播报，字幕与音频时长对齐；外部宠物四来源导入（本地文件夹/zip/Codex 目录/Petdex 在线仓库），
+    卡片式热切换即时生效，激活守卫自动校验图集与语音完整性；五场景动作绑定、拖拽物理、三档缩放；
+    内置小狐狸 Foxbell 随包自带，装上即用。
+  en: >-
+    Multi-pet desktop companion: four MAM status lights watch every active session
+    (approval / running / done-unread / error) and each card click-through to its conversation;
+    four voice groups speak on state changes with duration-timed subtitles; import pets from
+    four sources (folder / zip / Codex dir / Petdex registry) with card-style hot-swap and an
+    integrity guard; five action bindings, drag physics, three scales. The built-in fox Foxbell
+    ships in the package — install and go.


### PR DESCRIPTION
## Plugin

**[jarvislee90s-dot/dsh-foxbell-pet](https://github.com/jarvislee90s-dot/dsh-foxbell-pet)** — a multi-pet desktop companion for the dsh web GUI.

- **Status monitor**: four MAM-semantics lights (approval / running / done-unread / error) over every active session; cards are click-through to the conversation and confirm-on-open
- **Voice groups**: general / approval / error / done speak on state changes, subtitles = voice filenames, durations probed and enforced (1–20s, ≤10MB)
- **External pet system**: on-disk store with manifest v2, 4-source import (local folder / zip with extraction caps / Codex dir / Petdex registry proxied host-side with domain allowlist), card-style hot-swap, integrity guard with a repair dialog, safe delete to a trash dir
- **Five action bindings** (double-click / red / yellow / dark-red / green) with live preview, drag physics, three scales, zh/en copy
- Built-in pet (Foxbell the fox) ships in the package — sprite + 31 voices + manifest

## Submission checklist

- Declares a complete `dsh.bundle` manifest (`cordis.patch.yml` + web client) — installs with `dsh plugin add`
- Prebuilt tarball on the release, declared via `tarball:` (no `allowBuilds` approval needed on installs)
- Repo created 2026-08-16; actively maintained (v2.0.0 line merged this week, runtime-tested against dsh 0.1.5-alpha.1 web profile)
- `dsh-plugin` topic added
- Category `fun`, matching whale-on-desk / pet-sprite / desk-pet entries
- Screenshots declared author-side (`screenshots.json` in the plugin repo, three shots: hot-swap dialog, context menu, codex import) — picked up by the probe automatically

Line accuracy: every claim above is implemented and runtime-tested; the five bindings and four import sources can be verified against `src/client/PetMenu.tsx` and `src/host/staging.js`.