### PR TITLE
Add dsh-context-budget

### DIFF
--- a/data/plugins/zpis666__dsh-context-budget.yml
+++ b/data/plugins/zpis666__dsh-context-budget.yml
@@ -1,0 +1,6 @@
+url: https://github.com/zpis666/dsh-context-budget
+name: zpis666/dsh-context-budget
+category: model
+description:
+  en: Adds per-route context window and compaction threshold fields to the Models settings page and a vendor-aware thinking-effort picker to the composer, writing llm-pi-ai capacities, reasoningEfforts, and a compaction-basic patch row.
+  zh: 在模型设置页为每个 pi-ai 路由新增上下文窗口与压缩阈值字段，并在输入框右下角按厂商提供思考强度选择器，写入 llm-pi-ai 容量、reasoningEfforts 与 compaction-basic 补丁行。


### PR DESCRIPTION
Adds `dsh-context-budget`.

**What it does** — two seats on the DSH Web client:

1. A provider-card extension on the Models settings page that writes, per pi-ai route:
   - `llm-pi-ai` settings `providers.<route>.defaultContextWindow` — the capacity fallback a hand-declared route's models sit on (262144 by default);
   - the profile's `cordis.patch.yml`, a managed `compaction-basic` row with `modelPolicies[].thresholdRatio = threshold / window`, so an absolute token threshold survives a window change. The backend computes `floor(contextWindow x ratio)` and re-resolves the window on every pre-step, so the compaction engine itself is never replaced.
2. A thinking-effort picker at the composer's trailing edge (`conversation.input.right`). It reads the session model directory for the current provider/model, uses the levels the catalog already advertises, and otherwise matches the model id against a built-in vendor table (xai, openai, anthropic, deepseek, google, qwen, zai, moonshot, minimax). Picking a level on a model that has never declared one writes the profile into `models[i].reasoningEfforts` first, because the adapter rejects an unsupported effort.

**Install** — `dsh plugin --profile web add dsh-context-budget`

**Checks**
- `package.json` declares `dsh.bundle` (`./cordis.patch.yml`) and `dsh.client` (web).
- 41 tests across four suites: validation rules, patch write/rollback, the full apply flow against a mocked context, and client seat registration/rendering.
- No runtime dependency beyond `js-yaml`; `@deepseek-ai/*` packages are peer dependencies.