### PR TITLE
Add Mlte0907/dsh-teams-x and Mlte0907/dsh-remote-x

### DIFF
--- a/data/plugins/Mlte0907__dsh-remote-x.yml
+++ b/data/plugins/Mlte0907__dsh-remote-x.yml
@@ -1,0 +1,6 @@
+url: https://github.com/Mlte0907/dsh-remote-x
+name: Mlte0907/dsh-remote-x
+category: remote
+description:
+  en: 'Remote control and mobile overlay for DeepSeek Harness: LAN and public (cloudflared) tunnels with QR-code access, a phone-first mobile UI under 768px, and a LAN reverse-proxy CLI.'
+  zh: 'DeepSeek Harness 的远程控制与移动端覆盖层：局域网与公网（cloudflared）隧道 + 二维码接入、768px 以下的手机端界面，附局域网反向代理 CLI。'

--- a/data/plugins/Mlte0907__dsh-teams-x.yml
+++ b/data/plugins/Mlte0907__dsh-teams-x.yml
@@ -1,0 +1,6 @@
+url: https://github.com/Mlte0907/dsh-teams-x
+name: Mlte0907/dsh-teams-x
+category: workflow
+description:
+  en: 'Orchestrates durable multi-agent teams from one DSH session: a captain spawns member subagents, drives a dependency-aware task DAG with quality gates, and coordinates through persistent mailboxes, with a live activity panel.'
+  zh: '把单个 DSH 会话编排成持久化多智能体团队：captain 生成成员子代理、驱动带质量门的依赖感知任务 DAG、通过持久邮箱协调，附带实时活动面板。'


### PR DESCRIPTION
Two entries, both mine. One PR (2 entries, under the 3-entry limit).

| entry | category | what it does |
| --- | --- | --- |
| `Mlte0907/dsh-teams-x` | `workflow` | Turns one DSH session into a durable multi-agent team: a captain spawns member subagents, drives a dependency-aware task DAG with quality gates (objective/acceptance/inScope/verify), and coordinates through persistent mailboxes; a live activity panel shows the team. |
| `Mlte0907/dsh-remote-x` | `remote` | Remote control and mobile overlay: LAN and public (cloudflared) tunnels with QR-code access, a phone-first UI under 768px, and a LAN reverse-proxy CLI. |

Both repositories:

- declare `dsh.bundle` in `package.json`, with `cordis.patch.yml` alongside;
- ship real, working code (not placeholder or README-only);
- are past the 1-day age bar — created 2026-09-04 (`dsh-remote-x`) and 2026-09-06 (`dsh-teams-x`);
- carry the `dsh-plugin` topic.

Only the two entry files are added. The generated READMEs are untouched, as the contribution guide asks.

Category notes: `dsh-teams-x` orchestrates tasks across subagents, so I filed it under `workflow`; `agi` was the other candidate. `dsh-remote-x` is remote access plus a mobile overlay, which is what `remote` is for. Happy to move either if a better fit exists.