### PR TITLE
Add zhang8019/dsh-permission-matrix

### DIFF
--- a/data/plugins/zhang8019__dsh-permission-matrix.yml
+++ b/data/plugins/zhang8019__dsh-permission-matrix.yml
@@ -1,6 +1,7 @@
 url: https://github.com/zhang8019/dsh-permission-matrix
 name: zhang8019/dsh-permission-matrix
 category: security
+tarball: https://github.com/zhang8019/dsh-permission-matrix/releases/latest/download/dsh-permission-matrix.tgz
 description:
   en: 'Turns DSH permissions into 9 selectable presets (3 sandbox modes x 4 approval strategies), with global and social-channel defaults, three-tier risk policies, an audit log and git checkpoints.'
   zh: '把 DSH 权限拆成 9 个可选预设(3 种沙箱 × 4 种审批),支持全局与社交渠道默认预设、三档风险策略、审计日志与 Git 快照。'

--- a/data/plugins/zhang8019__dsh-permission-matrix.yml
+++ b/data/plugins/zhang8019__dsh-permission-matrix.yml
@@ -1,0 +1,6 @@
+url: https://github.com/zhang8019/dsh-permission-matrix
+name: zhang8019/dsh-permission-matrix
+category: security
+description:
+  en: 'Turns DSH permissions into 9 selectable presets (3 sandbox modes x 4 approval strategies), with global and social-channel defaults, three-tier risk policies, an audit log and git checkpoints.'
+  zh: '把 DSH 权限拆成 9 个可选预设(3 种沙箱 × 4 种审批),支持全局与社交渠道默认预设、三档风险策略、审计日志与 Git 快照。'

--- a/data/plugins/zhang8019__dsh-permission-matrix.yml
+++ b/data/plugins/zhang8019__dsh-permission-matrix.yml
@@ -3,5 +3,5 @@ name: zhang8019/dsh-permission-matrix
 category: security
 tarball: https://github.com/zhang8019/dsh-permission-matrix/releases/latest/download/dsh-permission-matrix.tgz
 description:
-  en: 'Turns DSH permissions into 9 selectable presets (3 sandbox modes x 4 approval strategies), with global and social-channel defaults, three-tier risk policies, an audit log and git checkpoints.'
-  zh: '把 DSH 权限拆成 9 个可选预设(3 种沙箱 × 4 种审批),支持全局与社交渠道默认预设、三档风险策略、审计日志与 Git 快照。'
+  en: 'Turns DSH permissions into 9 selectable presets (3 sandbox modes x 4 approval tiers), with rule plus LLM risk classification across four risk levels, password-gated approval for high-risk operations, and a JSONL audit log.'
+  zh: '把 DSH 权限拆成 9 个可选预设（3 种沙箱 × 4 种审批），规则 + LLM 双通道四档风险分级，高风险操作需输入批准密码才放行，附 JSONL 审计日志。'


### PR DESCRIPTION
## Plugin

**zhang8019/dsh-permission-matrix** - Turns DSH permissions into 9 selectable presets (3 sandbox modes x 4 approval strategies), with global and social-channel defaults, three-tier risk policies, an audit log and git checkpoints.

- Repo: https://github.com/zhang8019/dsh-permission-matrix
- dsh.bundle manifest: yes (cordis.patch.yml)
- dsh-plugin topic: added
- Tests: node --test tests/ -> 27 passing
- Category: security (permission presets / approval policy)

Note: the repository was created 2026-09-09T11:59:07Z. If the 1-day age gate rejects this run, I will re-push to the same branch once it clears.