### PR TITLE
Add yindf/taskfold (session)

### DIFF
--- a/data/plugins/yindf__taskfold.yml
+++ b/data/plugins/yindf__taskfold.yml
@@ -1,0 +1,7 @@
+url: https://github.com/yindf/taskfold
+name: yindf/taskfold
+category: session
+tarball: https://github.com/yindf/taskfold/releases/download/v0.31.1/dsh-taskfold-0.31.1.tgz
+description:
+  en: 'Wraps work in named tasks and, once a task closes, folds its whole span of messages into one summary at the next step boundary; the original content can be restored on demand.'
+  zh: '用命名任务包住工作过程；任务结束后，在下一个步骤边界把整段消息折叠成一段摘要，原文可随时还原。'


### PR DESCRIPTION
Adds [yindf/taskfold](https://github.com/yindf/taskfold) to **Sessions & Messages**.

**What it does.** Wraps work in named tasks (`task_begin("…")` / `task_end("…")`). When a task closes, its whole span of messages is folded into one titled summary at the next step boundary, and `fold_recall({ fold: N })` regenerates the original content from an on-disk archive at any time.

**Category.** `session` — it operates on the session transcript (message spans), not on a UI surface, a model route, or a tool capability.

**Requirements.**
- `package.json` declares `dsh.bundle.patch: ./cordis.patch.yml` at the repo root.
- Real, working code: 9 offline test files, `npm test` green.
- Repo created 2026-09-02 (older than the 1-day floor), not archived.
- `dsh-plugin` topic present.
- Prebuilt tarball attached to the GitHub Release: `dsh-taskfold-0.31.1.tgz` (the `tarball:` field above).

**Accuracy note.** The summary is written once, while the original span is still in context, so it is not a summary of a summary. Archival is queued on close and drains at the next step boundary — that is why the description says "at the next step boundary" rather than "immediately". Nothing is discarded: the original messages are written to a JSONL archive that `fold_recall` reads back verbatim.
