### PR TITLE
add xain/ui-beep (notify): Web Audio agent-heartbeat cues for the DSH web GUI

### DIFF
--- a/data/added-dates.json
+++ b/data/added-dates.json
@@ -445,5 +445,8 @@
  "https://github.com/Tabbit-Browser/dsh-tabbit": "2026-08-21",
  "https://github.com/omdsh-dev/stent": "2026-08-13",
  "https://github.com/moguiyu/dsh-tavily/tree/main/packages/dsh-tavily": "2026-08-15",
- "https://github.com/polaris-smart/dsh-devices": "2026-08-19"
+ "https://github.com/polaris-smart/dsh-devices": "2026-08-19",
+ "https://github.com/wwweljf/dsh-plugins/tree/master/plugins/dsh-ding-sound": "2026-08-22",
+ "https://github.com/wwweljf/dsh-plugins/tree/master/plugins/dsh-wx-push": "2026-08-22",
+ "https://github.com/wwweljf/dsh-plugins/tree/master/plugins/dsh-wx-remote": "2026-08-22"
 }

--- a/data/plugins/xain__ui-beep.yml
+++ b/data/plugins/xain__ui-beep.yml
@@ -1,0 +1,6 @@
+url: https://github.com/xain/ui-beep
+name: xain/ui-beep
+category: notify
+description:
+  en: 'Web Audio agent-heartbeat cues for the DSH web GUI: a low working hum while an agent is busy, ticks on streaming output, and a chime when a session awaits input or work finishes, with per-voice volume, mute toggle, and optional local audio files.'
+  zh: 为 DSH 网页界面提供 Web Audio 智能体心跳提示：Agent 忙碌时低频心跳、流式输出时滴答声、会话等待输入或工作完成时提示音；支持分音色音量、静音开关与本地音频文件替换。


### PR DESCRIPTION
Add [xain/ui-beep](https://github.com/xain/ui-beep) to the **notify** category.

- url: https://github.com/xain/ui-beep
- category: `notify`
- description.en + description.zh included
- Repo declares `dsh.bundle` manifest, published on npm as `@xain_npm/dsh-client-ui-beep@0.4.0` and installable via `dsh plugin add @xain_npm/dsh-client-ui-beep`
- `dsh-plugin` topic on repo — verified
- Repo is > 1 day old — verified

What it does: Web Audio agent-heartbeat cues for the DSH web GUI — a low working hum while an agent is busy, ticks on streaming output, and a chime when a session awaits input or work finishes. Per-voice volume (0–200%), a composer mute toggle, and optional local audio files per voice (whole-filesystem picker; unreadable files fall back to the built-in tones).
