### PR TITLE
Add Aafff623/dsh-callout and Aafff623/dsh-keyboard-manager

### DIFF
--- a/data/plugins/Aafff623__dsh-callout.yml
+++ b/data/plugins/Aafff623__dsh-callout.yml
@@ -1,0 +1,6 @@
+url: https://github.com/Aafff623/dsh-callout
+name: Aafff623/dsh-callout
+category: ui
+description:
+  en: 'GitHub-style alert cards for DSH assistant Markdown: a qualifying `> [!NOTE]`, TIP, IMPORTANT, WARNING, or CAUTION blockquote becomes a theme-aware card. Stored session content is left unchanged.'
+  zh: 把 DSH 助手 Markdown 里合格的 `> [!NOTE]`、TIP、IMPORTANT、WARNING、CAUTION 块引用渲染成跟随主题的 GitHub 风格提示卡片，不改会话存档。

--- a/data/plugins/Aafff623__dsh-keyboard-manager.yml
+++ b/data/plugins/Aafff623__dsh-keyboard-manager.yml
@@ -1,0 +1,6 @@
+url: https://github.com/Aafff623/dsh-keyboard-manager
+name: Aafff623/dsh-keyboard-manager
+category: ui
+description:
+  en: 'Keyboard shortcuts for the DSH Web UI: Ctrl+Q toggles the left sidebar, Ctrl+E toggles the right panel, and Ctrl+S opens Settings. Physical key codes can be overridden in the profile patch.'
+  zh: 为 DSH Web UI 提供快捷键：Ctrl+Q 切换左侧栏，Ctrl+E 切换右侧栏，Ctrl+S 打开设置。物理键码可在 profile 补丁中覆盖。


### PR DESCRIPTION
Adds two UI entries. READMEs left untouched.

- [Aafff623/dsh-callout](https://github.com/Aafff623/dsh-callout) — GitHub-style NOTE / TIP / IMPORTANT / WARNING / CAUTION cards from assistant Markdown blockquotes.
- [Aafff623/dsh-keyboard-manager](https://github.com/Aafff623/dsh-keyboard-manager) — Ctrl+Q left sidebar, Ctrl+E right panel, Ctrl+S Settings; key codes overridable in the profile patch.

Both have `dsh.bundle`, `cordis.patch.yml`, the `dsh-plugin` topic, and `lib/` committed. Created 2026-09-06.