### PR TITLE
add 173787247/dsh-wsl-fetch (wsl): proxy-aware official web_fetch for WSL

### DIFF
--- a/data/plugins/173787247__dsh-wsl-fetch.yml
+++ b/data/plugins/173787247__dsh-wsl-fetch.yml
@@ -1,0 +1,6 @@
+url: https://github.com/173787247/dsh-wsl-fetch
+name: 173787247/dsh-wsl-fetch
+category: wsl
+description:
+  en: 'Registers a wsl-proxy ctx.web fetch provider so official web_fetch uses undici ProxyAgent through HTTP(S)_PROXY instead of connecting from WSL to a DNS-pinned public IP (the official path that produces TypeError: fetch failed behind a Windows proxy).'
+  zh: '在 ctx.web 注册 wsl-proxy 抓取后端，让官方 web_fetch 经 HTTP(S)_PROXY 用 undici ProxyAgent 出网，避免官方实现在 WSL 里 DNS 钉死后直连公网 IP，从而在 Windows 代理后出现 TypeError: fetch failed。'


### PR DESCRIPTION
## Summary

- Add `data/plugins/173787247__dsh-wsl-fetch.yml` only (category `wsl`).
- The plugin registers fetch provider `wsl-proxy` and, when `HTTP(S)_PROXY` is set, selects it so official `web_fetch` uses undici `ProxyAgent`.
- It does not add a new tool. `dsh-wsl-net` only injects proxy env into child bash/npm and cannot fix in-process `web_fetch`.

## Why this exists

On Windows + WSL, DeepSeek API can work (global `fetch` + `NODE_USE_ENV_PROXY`) while official `web_fetch` fails with `TypeError: fetch failed` on public HTTPS pages (Mattermost docs, 163, etc.).

Official `dsh-web-fetch-http` resolves DNS in WSL, then connects **directly** to that public IP with a custom undici `Agent`. That bypasses `NODE_USE_ENV_PROXY` / `HTTP(S)_PROXY`, so the request never goes through the Windows Clash/V2Ray listener.

This entry states that gap in the one-line description so WSL users can find the fix.

## Test plan

- [x] Repo has `dsh.bundle.patch` + `cordis.patch.yml`
- [x] Topic `dsh-plugin` is set
- [ ] Submission age gate: repo was created 2026-09-09 ~13:08 UTC; CI will fail until it is 1 day old. Re-run the check after 2026-09-10 ~13:08 UTC — do not change the description to work around the gate.
- [ ] Install: `dsh plugin --profile web add github:173787247/dsh-wsl-fetch`
