### PR TITLE
Add chromoany/dsh-notify-me (notify)

### DIFF
--- a/data/plugins/chromoany__dsh-notify-me.yml
+++ b/data/plugins/chromoany__dsh-notify-me.yml
@@ -1,0 +1,6 @@
+url: https://github.com/chromoany/dsh-notify-me
+name: chromoany/dsh-notify-me
+category: notify
+description:
+  en: Desktop notifications, sounds and a tab-title marker when the agent needs your input or a reply finishes in the background.
+  zh: 模型需要你操作或后台回复完成时，弹出系统通知、提示音并标记标签页标题。


### PR DESCRIPTION
Adds one entry file: `data/plugins/chromoany__dsh-notify-me.yml`.

- repo declares `dsh.bundle.patch` → `./cordis.patch.yml` (committed at root) and `dsh.client.platform: web`
- `dsh-plugin` topic set; repo created 2026-09-08, npm package `dsh-notify-me@1.1.2` published

What it does: web client plugin — desktop notification, sound and tab-title marker when the agent needs input (approval, plan review, question) or a reply finishes in the background; toggled from the Settings page with zh/en notification language.