### PR TITLE
Add dsh-publish/dsh-pair-quick (settings快速配对)

### DIFF
--- a/data/plugins/dsh-publish__dsh-pair-quick.yml
+++ b/data/plugins/dsh-publish__dsh-pair-quick.yml
@@ -1,0 +1,7 @@
+url: https://github.com/dsh-publish/dsh-pair-quick
+name: dsh-publish/dsh-pair-quick
+category: remote
+description:
+  en: 'Mints a fresh remote-web-ui pairing link and shows its QR in the dsh settings page.'
+  zh: '在 dsh 设置页直接铸造 remote-web-ui 远程访问配对链接并显示二维码。'
+tarball: https://github.com/dsh-publish/dsh-pair-quick/releases/download/v0.1.0/dsh-pair-quick-0.1.0.tgz


### PR DESCRIPTION
Adds one entry: dsh-publish/dsh-pair-quick

- category: remote
- `dsh.bundle` manifest declared; prebuilt tarball attached at v0.1.0 release
- One-click pairing QR in the dsh settings page for remote-web-ui pairing

Note: the repo was created today, so the CI 1-day-repo-age check will flag this PR. Happy to resubmit tomorrow per the contributing guide; nothing else should fail (manifest, format, tarball URL are all present).