### PR TITLE
build: pin added dates for entries introduced by merge commits

### DIFF
--- a/data/added-dates.json
+++ b/data/added-dates.json
@@ -445,5 +445,8 @@
  "https://github.com/Tabbit-Browser/dsh-tabbit": "2026-08-21",
  "https://github.com/omdsh-dev/stent": "2026-08-13",
  "https://github.com/moguiyu/dsh-tavily/tree/main/packages/dsh-tavily": "2026-08-15",
- "https://github.com/polaris-smart/dsh-devices": "2026-08-19"
+ "https://github.com/polaris-smart/dsh-devices": "2026-08-19",
+ "https://github.com/wwweljf/dsh-plugins/tree/master/plugins/dsh-ding-sound": "2026-09-08T15:01:39.000Z",
+ "https://github.com/wwweljf/dsh-plugins/tree/master/plugins/dsh-wx-push": "2026-09-08T15:01:39.000Z",
+ "https://github.com/wwweljf/dsh-plugins/tree/master/plugins/dsh-wx-remote": "2026-09-08T15:01:39.000Z"
 }


### PR DESCRIPTION
Fixes the build break reported in #4731 (option 1 from that issue: pin the three URLs in `data/added-dates.json`).

`build-site.mjs` derives each entry's added date from two `git log` walks (README lines, then `git log --diff-filter=A -- <entry file>`). Neither sees a file that was introduced **by a merge commit**, because `git log` does not diff merges by default. The three `wwweljf/dsh-plugins` sub-package entries were introduced by merge commit `5599809c` (2026-09-08), so both sources miss them and the build exits 1:

```
no added-date derivable for: …/dsh-ding-sound, …/dsh-wx-push, …/dsh-wx-remote
need full git history (fetch-depth: 0) and committed entries — refusing to build
```

This currently fails on `main` (`build-site.yml` since 2026-09-09T03:13Z) and therefore on every contributor PR's `check` job, so no new entry can be published until it is unblocked.

Change: three keys in the frozen `data/added-dates.json` baseline, dated to that merge commit (`2026-09-08T15:01:39Z`), as verified in the #4731 comment. `data/added-dates.json` is read-only for the build and written by no script, so the pins are inert for every other entry.

Option 2 from the issue (`--diff-merges=first-parent` on both `git log` calls) fixes the class of failure rather than these three instances; this PR is the zero-risk unblock and does not preclude it.