### PR TITLE
Repoint MoneyPal entry at its dsh-moneypal subpackage

### DIFF
--- a/data/plugins/ding112__MoneyPal--packages-dsh-moneypal.yml
+++ b/data/plugins/ding112__MoneyPal--packages-dsh-moneypal.yml
@@ -1,5 +1,5 @@
-url: https://github.com/ding112/MoneyPal
-name: ding112/dsh-moneypal
+url: https://github.com/ding112/MoneyPal/tree/main/packages/dsh-moneypal
+name: ding112/MoneyPal#dsh-moneypal
 category: tools
 description:
   en: Personal finance plugin for DSH with structured Beancount ledger tools.


### PR DESCRIPTION
## What

Repoints the MoneyPal entry at its DSH subpackage and renames the file accordingly:

```yaml
url: https://github.com/ding112/MoneyPal/tree/main/packages/dsh-moneypal
name: ding112/MoneyPal#dsh-moneypal
```

`data/plugins/ding112__MoneyPal.yml` → `data/plugins/ding112__MoneyPal--packages-dsh-moneypal.yml`. Category and both descriptions are unchanged. No other entry is touched; the generated READMEs are left to `sync-readme.yml` as the contribution guide asks.

## Why

The listed repository root is a **private npm workspace named `moneypal-workspace`** whose package name is not the published plugin name. With the repo-root URL the market install target is `github:ding112/MoneyPal`, which installs `moneypal-workspace`; validation then removes it (`no dsh manifest`) and reports `nothing installable survived validation`. The published package is `dsh-moneypal`, declared in `packages/dsh-moneypal/package.json` — the subdirectory this entry now points at, so the automatic npm probe can find the name.

Upstream `ding112/MoneyPal` main now carries both files the probe reads:

- `packages/dsh-moneypal/package.json` (HTTP 200 on `raw.githubusercontent.com/ding112/MoneyPal/HEAD/...`, `name: "dsh-moneypal"`, no `version` field)
- `packages/dsh-moneypal/cordis.patch.yml` (HTTP 200; the root copy was moved here)

No `npm:` key is added — the mapping is left to `probe-npm.mjs`, exactly as the guide requires.

## Verification (isolated checkout of this branch)

- `readEntries()` + `validateEntries()`: 0 problems across 3431 entries; the MoneyPal entry validates, `slugFor()` returns `ding112__MoneyPal--packages-dsh-moneypal`, and it is the only MoneyPal entry (the old file is gone).
- `node scripts/generate-readme.mjs`: emits
  `- [ding112/MoneyPal#dsh-moneypal](https://github.com/ding112/MoneyPal/tree/main/packages/dsh-moneypal) - …` in both locales.
- `node scripts/probe-npm.mjs` (real script, other rows pre-seeded as already-checked so it probes only this URL): verdict
  `{"npm":"dsh-moneypal","version":"1.0.0-rc.3","checkedAt":"2026-09-09"}`. The existing npm `latest` (`1.0.0-rc.3`) already links back to `ding112/MoneyPal`, so nothing has to be republished.
- `node scripts/build-site.mjs` with that probe output: the catalog row is
  `"npm": "dsh-moneypal"`, `"install": "dsh plugin --profile web add dsh-moneypal"`.
- Fed to dsh-market's real `installTargetFor`, the row resolves to `dsh-moneypal` (the previous entry resolved to `github:ding112/MoneyPal`).
- Nothing generated is committed: `git status` is clean and the diff against `main` is one renamed entry file.

Note for the maintainers: on a local full clone, `node scripts/build-site.mjs` also reports three pre-existing undated entries (`wwweljf/dsh-plugins/tree/master/plugins/dsh-ding-sound`, `-dsh-wx-push`, `-dsh-wx-remote`) unrelated to this PR; their add commits are merges, which the added-date pass cannot see without `-m`. I stubbed those three dates locally only to let the build finish and inspect the MoneyPal row, and reverted the stub.
