### PR TITLE
Add andregoncalves/dsh-balance

### DIFF
--- a/data/plugins/andregoncalves__dsh-balance.yml
+++ b/data/plugins/andregoncalves__dsh-balance.yml
@@ -1,0 +1,6 @@
+url: https://github.com/andregoncalves/dsh-balance
+name: andregoncalves/dsh-balance
+category: usage
+description:
+  en: 'Provider-aware account balance chip for the DSH sidebar, showing the active model provider balance for DeepSeek, OpenRouter, Moonshot/Kimi, Zhipu/GLM, and MiniMax, plus DeepSeek peak/off-peak status.'
+  zh: 'DSH 侧边栏的账户余额胶囊，跟随当前模型的服务商显示余额，支持 DeepSeek、OpenRouter、Moonshot/Kimi、Zhipu/GLM 与 MiniMax，并显示 DeepSeek 高峰/空闲时段。'


### PR DESCRIPTION
Adds `andregoncalves/dsh-balance` to **Usage & Billing**.

- Repo: https://github.com/andregoncalves/dsh-balance
- npm: [`@andrecgoncalves/dsh-balance`](https://www.npmjs.com/package/@andrecgoncalves/dsh-balance)
- Declares `dsh.bundle` (`cordis.patch.yml`); installs with `dsh plugin --profile web add @andrecgoncalves/dsh-balance`
- Real, working code: a dual-face Cordis package (host route + browser chip), zero runtime dependencies, MIT, bilingual README
- Repo created 2026-08-16; topic `dsh-plugin` added
- `screenshots.json` declared in the repo for storefront screenshots

What it does: shows the active model provider's account balance in the sidebar footer for DeepSeek, OpenRouter, Moonshot/Kimi, Zhipu/GLM, and MiniMax, and marks DeepSeek's peak/off-peak billing window.