### PR TITLE
Update KongFangXun/sofagent description (MCP tools 83→84, v1.4.6)

### DIFF
--- a/data/plugins/KongFangXun__sofagent--engine-dsh-plugins-cordis-plugin-sofagent-audit.yml
+++ b/data/plugins/KongFangXun__sofagent--engine-dsh-plugins-cordis-plugin-sofagent-audit.yml
@@ -2,5 +2,5 @@ url: https://github.com/KongFangXun/sofagent/tree/main/engine/dsh-plugins/cordis
 name: KongFangXun/sofagent#cordis-plugin-sofagent-audit
 category: security
 description:
-  en: "Commit-time audit harness for AI coding agents: 24 git-diff rules (secrets, out-of-scope edits, prompt injection), HMAC-signed audit trail, snapshot rollback, and an MCP server with 83 tools. Installable via dsh plugin add."
-  zh: "面向 AI 编程 agent 的提交时审计 harness——24 条 git diff 规则（密钥泄漏、越界改动、提示注入）、HMAC 签名审计链、快照回滚、83 工具 MCP server；dsh plugin add 即装。"
+  en: "Commit-time audit harness for AI coding agents: 24 git-diff rules (secrets, out-of-scope edits, prompt injection), HMAC-signed audit trail, snapshot rollback, and an MCP server with 84 tools. Installable via dsh plugin add."
+  zh: "面向 AI 编程 agent 的提交时审计 harness——24 条 git diff 规则（密钥泄漏、越界改动、提示注入）、HMAC 签名审计链、快照回滚、84 工具 MCP server；dsh plugin add 即装。"


### PR DESCRIPTION
Updates the [KongFangXun/sofagent](https://github.com/KongFangXun/sofagent) entry: MCP tools count 83 → **84** (v1.4.6 released today, 2026-09-09).

**Disclosure: this is a self-submission.** I am the author and maintainer of sofagent.

Both `en` and `zh` description lines in the data source updated; README regenerates from data as usual. This is the third round of this entry (first listed via #4101, updated to 83 via #4507 — both merged same/next day).

Source of truth: [v1.4.6 release](https://github.com/KongFangXun/sofagent/releases/tag/v1.4.6) — "MCP 83→84 tools" in the release notes.

Single-file change to `data/plugins/KongFangXun__sofagent--engine-dsh-plugins-cordis-plugin-sofagent-audit.yml` only.
