### PR TITLE
Add xiongyishun666-alt/dsh-archived-sessions

### DIFF
--- a/data/plugins/xiongyishun666-alt__dsh-archived-sessions.yml
+++ b/data/plugins/xiongyishun666-alt__dsh-archived-sessions.yml
@@ -1,0 +1,6 @@
+url: https://github.com/xiongyishun666-alt/dsh-archived-sessions
+name: xiongyishun666-alt/dsh-archived-sessions
+category: session
+description:
+  en: 'Archived sessions settings page that lists every archived session and restores one with a single click.'
+  zh: '设置面板新增「已归档会话」页：列出全部已归档会话，每条可一键恢复。'


### PR DESCRIPTION
Adds **`xiongyishun666-alt/dsh-archived-sessions`** — a settings page listing archived sessions with one-click restore.

### Checklist

- [x] One file at `data/plugins/xiongyishun666-alt__dsh-archived-sessions.yml` — the whole submission
- [x] Repo `package.json` declares **`dsh.bundle`** (`{ "bundle": { "patch": "./cordis.patch.yml" }, "client": { "platform": "web" } }`)
- [ ] Repo is at least 1 day old — created `2026-09-09T16:38Z`, so this one is still red; per the check's own message it re-runs by itself and clears in ~24h
- [x] `category: session` (manages the session archive state and adds a settings page)
- [x] Description states what the plugin does, no superlatives
- [x] Repo has the `dsh-plugin` topic

### Notes

- Verified against DSH `0.1.2-rc.1` (`dsh-plugin-desktop` 2.0.5).
- Official `@deepseek-ai/*` packages are declared as `peerDependencies`.
- Not published to npm yet; installs from the repo work as-is.
- The plugin calls the workspace registry's internal `setState`/`requireState`/`enqueueOperation` because this DSH version exposes no public unarchive API. This is guarded with `typeof` checks (a changed internal only produces an error, never a data change) and documented in the repo README.
