### PR TITLE
Add OpenWrite novel-writing workbench

### DIFF
--- a/data/plugins/LiPu-jpg__Openwrite.yml
+++ b/data/plugins/LiPu-jpg__Openwrite.yml
@@ -1,0 +1,7 @@
+url: https://github.com/LiPu-jpg/Openwrite
+name: LiPu-jpg/Openwrite
+category: workflow
+description:
+  en: 'Novel-writing workbench for DSH with an authoring preset, outline and character management, manuscript annotations, review workflows, and a managed local Python backend.'
+  zh: '面向 DSH 的小说创作工作台，提供创作预设、大纲与人物管理、正文批注、审稿流程和受管理的本地 Python 后端。'
+tarball: https://github.com/LiPu-jpg/Openwrite/releases/download/v0.2.8/dsh-openwrite-0.2.8.tgz


### PR DESCRIPTION
提交 OpenWrite 小说创作套件的完整根包，使用已发布的 npm 预编译包，避免拆分内部 bridge/panel 包或让安装用户执行源码构建。

- 仓库：https://github.com/LiPu-jpg/Openwrite
- Release：https://github.com/LiPu-jpg/Openwrite/releases/tag/v0.2.8
- 清单：根 package.json 声明 dsh.bundle.patch，cordis.patch.yml 统一挂载服务、工作台与预设。
- 推荐宿主：dsh 0.1.2-rc.1，web profile。
- 验收：https://github.com/LiPu-jpg/Openwrite/actions/runs/34368570869 （Intel 首次 15 秒超时，原样重跑通过，完整历史保留）。同一 tgz 的 SHA-256 为 3a54f30fec03a5a64338f6cbc8216cafdc733cdf3622691fdbc8f029d78e4902，六组原生环境、alpha Linux 与源码安装通过；真实模型 not-run。
- 安装会下载隔离依赖并启动本地 Python 后端；用户配置模型后，生成/评审会调用相应服务商。工具策略不是 OS 沙箱，卸载默认保留作品与历史。
- 权限与精确版本范围：https://github.com/LiPu-jpg/Openwrite/blob/main/docs/DSH_STORE.md

仅增加本项目一个目录条目。

日常安装命令：
```sh
dsh plugin --profile web add -w dsh-openwrite@latest
```
latest 仅在执行安装/升级时解析，运行中不自动更新。以上验收记录对应精确版本 0.2.8，后续版本请核对各自 Release 的宿主兼容范围。


2026-09-11 发布更新：npm `dsh-openwrite@latest` 现已指向 0.2.9；日常安装命令保持不变。v0.2.9 Release：https://github.com/LiPu-jpg/Openwrite/releases/tag/v0.2.9 。完整验收：https://github.com/LiPu-jpg/Openwrite/actions/runs/34532531326 ，全部通过，真实模型调用 0 次。npm 包与 CI/Release 包 SHA-256 一致：`2a885d03f931505432b78424922c63e7ac75c70a10ab57b7c7503d059af7b627`。编辑器同源资源加载中的 new Function 已移除，并增加严格 CSP 浏览器检查；这不代表其他扫描发现全部消失，仍请按正常流程独立复核。
