### PR TITLE
Add dingyi222666/dsh-wakatime

### DIFF
--- a/data/plugins/dingyi222666__dsh-wakatime.yml
+++ b/data/plugins/dingyi222666__dsh-wakatime.yml
@@ -1,0 +1,6 @@
+url: https://github.com/dingyi222666/dsh-wakatime
+name: dingyi222666/dsh-wakatime
+category: usage
+description:
+  en: Tracks DSH's file reads, image views, and code edits in WakaTime, including exact counts of lines added and deleted by AI. Keeps activity tracking running while DSH responds, batches updates across files, and coordinates per-project reporting limits across parallel DSH processes. Automatically installs and updates wakatime-cli.
+  zh: 在 WakaTime 中记录 DSH 读取文件、查看图片和编辑代码的活动，并准确统计 AI 新增和删除的代码行数。DSH 回复期间持续记录活动，多个文件的记录批量上报，并在并行运行的 DSH 进程间统一控制各项目的上报频率。自动安装和更新 wakatime-cli。


### PR DESCRIPTION
新增一个条目文件：`data/plugins/dingyi222666__dsh-wakatime.yml`。

**插件：** [dingyi222666/dsh-wakatime](https://github.com/dingyi222666/dsh-wakatime) —— DeepSeek Harness 的 WakaTime 活动记录插件。它把 fs 工具持久化的 `tool/result` 事件（`edit`、`write`、`read`、`read_image`、`str_replace_editor`）转成 WakaTime heartbeat，`--ai-line-changes` 按 diff hunk 精确计算；turn 流式输出期间通过 `agent/status` 与 `agent/assistant-stream` 持续发送实时活动心跳；多文件编辑合并为一次 `wakatime-cli --extra-heartbeats` 调用；按项目限流，并把限流预算持久化到磁盘，供并行运行的 DSH 进程共享。

<!-- Thanks for contributing! Quick checklist / 提交前快速自查 -->

- [x] I added **one file** at `data/plugins/<owner>__<repo>.yml` — that single file is the whole submission. The READMEs are regenerated on `main` after merge: don't edit them by hand, and you don't need to commit them either / 我新增了一个 `data/plugins/<owner>__<repo>.yml` 文件——**这一个文件就是全部投稿**。README 会在合并后由 `main` 自动重新生成：不要手工编辑，也不需要提交
- [x] My repo's `package.json` declares **`dsh.bundle`** (not just `dsh.client`) — [example](../blob/main/contributing.md) / 仓库 `package.json` 已声明 `dsh.bundle`（只有 `dsh.client` 无法安装）
- [x] My repo is at least **1 day old** / 仓库创建满 1 天
- [x] `category` is one of `agi ui usage theme model identity session memory tools wsl browser vision voice docs skill workflow git notify dev security remote market fun` ([full list with descriptions](../blob/main/contributing.md)), and themes/skins go under `theme` / `category` 取值正确（完整清单见 contributing.md），主题/皮肤类请用 `theme`
- [x] Description states what the plugin does, no superlatives / 描述只说功能，不带营销词
- [x] My repo has the `dsh-plugin` topic / 仓库已打 `dsh-plugin` topic

**Recommended (not required) / 推荐但不强制：**

- [x] 📦 Publish to npm — npm installs are prebuilt and skip the `allowBuilds` approval, so users get a one-command install / 发布 npm 包：预构建产物免 `allowBuilds` 授权，用户一条命令装好 —— 已发布 `@dingyi222666/dsh-wakatime`（v0.2.2），`repository` 字段指回本仓库
- [x] 🔗 Declare official `@deepseek-ai/*` packages as `peerDependencies` (not `dependencies`) — avoids duplicate runtimes inside the profile / 官方 `@deepseek-ai/*` 包用 `peerDependencies` 声明（而非 `dependencies`），避免 profile 里出现重复运行时
- [ ] 🖼️ Screenshots go in **your own repository** now: a `screenshots.json` beside your `package.json`, listing image paths. Nothing to add here, and you can change them later without another pull request ([how](../blob/main/contributing.md#screenshots--截图optional-recommended--可选推荐)) / 截图现在放在**你自己的仓库**里：在 `package.json` 旁边放一个 `screenshots.json`，列出图片路径。这个 PR 里不用加任何东西，以后想换也不必再提 PR（[说明](../blob/main/contributing.md#screenshots--截图optional-recommended--可选推荐)）—— 暂未提供
