### PR TITLE
fix: derive merge-added entry dates and remove stale image-viewer Beta label

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -120,6 +120,8 @@ jobs:
           fi
       - name: awesome-lint
         run: npx awesome-lint
+      - name: Added-date regression tests
+        run: node --test scripts/added-dates.test.mjs
       - name: Build (locale parity, date derivation, templates)
         # probes are skipped on purpose: the build tolerates missing probe
         # data, and this keeps the check token-free and fork-safe.

--- a/data/plugins/WSL043__dsh-image-viewer.yml
+++ b/data/plugins/WSL043__dsh-image-viewer.yml
@@ -2,5 +2,5 @@ url: https://github.com/WSL043/dsh-image-viewer
 name: WSL043/dsh-image-viewer
 category: vision
 description:
-  en: Upgrades DSH image viewing with pointer-centered zoom, pan, galleries, downloads, keyboard support, and inline region notes (Beta).
-  zh: 增强 DSH 原生图片查看体验，支持指针中心缩放、拖动、画廊、下载、键盘操作和图片区域备注（Beta）。
+  en: Upgrades DSH image viewing with pointer-centered zoom, pan, galleries, downloads, keyboard support, and inline region notes.
+  zh: 增强 DSH 原生图片查看体验，支持指针中心缩放、拖动、画廊、下载、键盘操作和图片区域备注。

--- a/scripts/added-dates.test.mjs
+++ b/scripts/added-dates.test.mjs
@@ -1,0 +1,56 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { firstAddedDate } from './lib/added-dates.mjs'
+
+function repository(t) {
+  const cwd = mkdtempSync(join(tmpdir(), 'awesome-added-date-'))
+  t.after(() => rmSync(cwd, { recursive: true, force: true }))
+  const git = (...args) => execFileSync('git', args, { cwd, encoding: 'utf8', windowsHide: true })
+  git('init', '-q', '-b', 'main')
+  git('config', 'user.name', 'Date fixture')
+  git('config', 'user.email', 'fixture@example.invalid')
+  const commit = (date) => execFileSync('git', ['commit', '-qm', 'fixture'], {
+    cwd, windowsHide: true,
+    env: { ...process.env, GIT_AUTHOR_DATE: date, GIT_COMMITTER_DATE: date },
+  })
+  writeFileSync(join(cwd, 'base'), 'base')
+  git('add', 'base')
+  commit('2026-08-01T00:00:00Z')
+  return { cwd, git, commit }
+}
+
+test('finds an entry renamed to its canonical path in a merge resolution', t => {
+  const { cwd, git, commit } = repository(t)
+  git('switch', '-qc', 'topic')
+  writeFileSync(join(cwd, 'old.yml'), 'url: https://github.com/owner/repo')
+  git('add', 'old.yml')
+  commit('2026-08-02T00:00:00Z')
+  git('switch', '-q', 'main')
+  git('merge', '--no-ff', '--no-commit', 'topic')
+  git('mv', 'old.yml', 'canonical.yml')
+  commit('2026-08-03T00:00:00Z')
+  assert.equal(git('log', '--diff-filter=A', '--format=%cI', '--', 'canonical.yml').trim(), '')
+  assert.equal(firstAddedDate('canonical.yml', cwd), '2026-08-03T00:00:00.000Z')
+})
+
+test('keeps the original topic-branch date for a normal merged addition', t => {
+  const { cwd, git, commit } = repository(t)
+  git('switch', '-qc', 'topic')
+  writeFileSync(join(cwd, 'plugin.yml'), 'entry')
+  git('add', 'plugin.yml')
+  commit('2026-08-02T00:00:00Z')
+  git('switch', '-q', 'main')
+  git('merge', '--no-ff', '--no-commit', 'topic')
+  commit('2026-08-03T00:00:00Z')
+  assert.equal(firstAddedDate('plugin.yml', cwd), '2026-08-02T00:00:00.000Z')
+})
+
+test('does not invent dates for uncommitted files', t => {
+  const { cwd } = repository(t)
+  writeFileSync(join(cwd, 'pending.yml'), 'entry')
+  assert.equal(firstAddedDate('pending.yml', cwd), null)
+})

--- a/scripts/build-site.mjs
+++ b/scripts/build-site.mjs
@@ -16,6 +16,7 @@ import { Marked } from 'marked'
 import LOCALES from '../site/locales.mjs'
 import COMMENTS from '../site/comments.mjs'
 import { CAT_IDS as ENTRY_CAT_IDS, readEntries } from './lib/entries.mjs'
+import { firstAddedDate } from './lib/added-dates.mjs'
 
 const ORIGIN = 'https://awesome-dsh-plugin.com'
 const DATES_FILE = 'data/added-dates.json'
@@ -238,10 +239,11 @@ if (ordered.some((e) => !dates[e.url])) {
       try {
         // Oldest "added" commit for that path. Not `-1`, which git applies
         // before --reverse and would hand back the newest instead.
-        const out = execSync(`git log --diff-filter=A --format=%cI -- ${JSON.stringify(file)}`,
-          { encoding: 'utf8' }).trim().split('\n').filter(Boolean)
-        const iso = out[out.length - 1]
-        if (iso) dates[e.url] = new Date(iso).toISOString()
+        // Merge resolutions can introduce a path absent from both parents
+        // (e.g. #2662 renamed its entry files while merging). Default git log
+        // omits merge diffs and reports no addition even with full history.
+        const iso = firstAddedDate(file)
+        if (iso) dates[e.url] = iso
       } catch { /* not committed yet — falls through to the error below */ }
     }
     stillUndated = ordered.filter((e) => !dates[e.url])

--- a/scripts/lib/added-dates.mjs
+++ b/scripts/lib/added-dates.mjs
@@ -1,0 +1,14 @@
+import { execFileSync } from 'node:child_process'
+
+/** Oldest addition of the current entry path, including merge resolutions.
+ * Do not restrict traversal to the first-parent chain: ordinary additions on
+ * a topic branch must keep their original date rather than the merge date.
+ */
+export function firstAddedDate(file, cwd = process.cwd()) {
+  const out = execFileSync('git', [
+    'log', '--diff-merges=first-parent', '--no-patch', '--diff-filter=A',
+    '--format=%cI', '--', file.replaceAll('\\', '/'),
+  ], { cwd, encoding: 'utf8', windowsHide: true }).trim().split(/\r?\n/).filter(Boolean)
+  const oldest = out.at(-1)
+  return oldest ? new Date(oldest).toISOString() : null
+}


### PR DESCRIPTION
This PR removes the stale Beta suffix from the English and Chinese dsh-image-viewer descriptions and fixes the added-date derivation bug blocking this and other submissions.

The build fails on the three `wwweljf/dsh-plugins` entries even with full Git history. Their canonical YAML paths were introduced by the resolution of merge commit `5599809cf0e63ef2249d923c805c134d6b73e9ca` (#2662), not by either parent. Default `git log --diff-filter=A` omits merge diffs, so the fallback cannot find an addition. The README-history pass also does not find these entries.

The entry-file fallback now includes first-parent merge diffs while still traversing topic history. Existing frozen dates and README-derived dates retain precedence; ordinary merged entries retain their original topic-commit dates. The three affected entries resolve to `2026-09-08T15:01:39.000Z`. No dates are fabricated and `data/added-dates.json` is not changed.

Validation:

- Reproduced the original build failure locally with exactly the same three undated URLs.
- Real temporary Git repository tests cover a rename performed during merge resolution, an ordinary merged addition, and an uncommitted entry. All three pass; the PR workflow now runs them.
- Full site build validation is recorded in the PR checks.

Image-viewer references: [npm 0.1.0](https://www.npmjs.com/package/dsh-image-viewer/v/0.1.0), [stable release](https://github.com/WSL043/dsh-image-viewer/releases/tag/v0.1.0). I maintain dsh-image-viewer. Generated READMEs are not committed.
