### PR TITLE
Add lovvvve/dsh-quick-actions#composer-quick-actions

### DIFF
--- a/data/plugins/lovvvve__dsh-quick-actions--packages-composer-quick-actions.yml
+++ b/data/plugins/lovvvve__dsh-quick-actions--packages-composer-quick-actions.yml
@@ -1,0 +1,6 @@
+url: https://github.com/lovvvve/dsh-quick-actions/tree/main/packages/composer-quick-actions
+name: lovvvve/dsh-quick-actions#composer-quick-actions
+category: ui
+description:
+  en: Global Quick Actions beside every session-backed composer in DSH. One press sends a preset or your own saved text, with per-action send confirmation.
+  zh: 在 DSH 每个由会话支持的消息编辑器旁提供全局快捷动作。一键发送预置或你自己保存的文本，每个动作可单独设置发送确认。


### PR DESCRIPTION
Adds one entry: **lovvvve/dsh-quick-actions#composer-quick-actions** (`ui`).

Global Quick Actions beside every session-backed composer in DSH. One press loads a preset or a saved custom action into the draft and submits it through the official `setDraft` → `submit` path, with per-action send confirmation. Presets ship with the package and can be hidden or cloned; custom actions belong to the user, and everything persists through DSH's local Settings.

The entry points at the subpackage, because that is where the `dsh.bundle` manifest lives:

- `dsh.bundle.patch` → `./cordis.patch.yml`, whose single `insert` row names this package itself
- `dsh.client.platform` → `web`

`scripts/check-submission.mjs --base <upstream/main>` passes locally on this branch (`checking 1 entry` → `ok`).

Notes for review:

- Text is static, with no variables or templates, and the plugin never parses or rewrites command semantics — a `/`-prefixed action is handed to DSH's own adjudication.
- The description claims nothing about capability detection or DSH version tiering; the plugin detects neither.
- The npm package is not published at the moment of opening this PR. Listing does not depend on it, and it will be published shortly.
