### PR TITLE
Add CAI-MH/dsh-sysbrief, CAI-MH/dsh-plugin-forge, CAI-MH/dsh-agent-bridge

### DIFF
--- a/data/plugins/CAI-MH__dsh-agent-bridge.yml
+++ b/data/plugins/CAI-MH__dsh-agent-bridge.yml
@@ -1,0 +1,6 @@
+url: https://github.com/CAI-MH/dsh-agent-bridge
+name: CAI-MH/dsh-agent-bridge
+category: notify
+description:
+  en: 'Bridge a Feishu bot to a DSH session: open a real session in a workspace, run tasks with the existing model and plugins, and report results back.'
+  zh: '飞书机器人 → DSH 会话桥：在指定工作区开真会话，用 DSH 现有模型+插件执行任务并回传结论。'

--- a/data/plugins/CAI-MH__dsh-plugin-forge.yml
+++ b/data/plugins/CAI-MH__dsh-plugin-forge.yml
@@ -1,0 +1,6 @@
+url: https://github.com/CAI-MH/dsh-plugin-forge
+name: CAI-MH/dsh-plugin-forge
+category: dev
+description:
+  en: 'Scaffold DSH local bundles in the dph format from any workspace and keep a pitfall experience library to steer later development.'
+  zh: '在任意工作区按 dph 格式脚手架 DSH 本地插件，并维护踩坑经验库持续修正开发。'

--- a/data/plugins/CAI-MH__dsh-sysbrief.yml
+++ b/data/plugins/CAI-MH__dsh-sysbrief.yml
@@ -1,0 +1,6 @@
+url: https://github.com/CAI-MH/dsh-sysbrief
+name: CAI-MH/dsh-sysbrief
+category: workflow
+description:
+  en: 'Parse PRDs and PDFs, ask clarifying questions in batches, consolidate a BRIEF.md system brief, and package deliverables for upload.'
+  zh: '解析 PRD/PDF、分批追问澄清目标系统并沉淀 BRIEF.md，最终打包可上传交付物。'


### PR DESCRIPTION
- CAI-MH/dsh-sysbrief (workflow): Parse PRDs and PDFs, ask clarifying questions in batches, consolidate a BRIEF.md system brief, and package deliverables for upload.
- CAI-MH/dsh-plugin-forge (dev): Scaffold DSH local bundles in the dph format from any workspace and keep a pitfall experience library.
- CAI-MH/dsh-agent-bridge (notify): Bridge a Feishu bot to a DSH session to run tasks with the existing model and plugins, then report results back.

All three declare `dsh.bundle`, carry the `dsh-plugin` topic, and include `description.en` + `description.zh`.