### PR TITLE
Add CAI-MH/dsh-agent-group-panel, CAI-MH/dsh-gpt-image

### DIFF
--- a/data/plugins/CAI-MH__dsh-agent-group-panel.yml
+++ b/data/plugins/CAI-MH__dsh-agent-group-panel.yml
@@ -1,0 +1,6 @@
+url: https://github.com/CAI-MH/dsh-agent-group-panel
+name: CAI-MH/dsh-agent-group-panel
+category: ui
+description:
+  en: 'Feishu multi-agent robot console: start, stop and reconnect the daemon, view status and recent activity, and jump to the task workspace.'
+  zh: '飞书多助手机器人控制台：开启/关闭/重连守护进程、状态与最近动态、直达任务工作区。'

--- a/data/plugins/CAI-MH__dsh-gpt-image.yml
+++ b/data/plugins/CAI-MH__dsh-gpt-image.yml
@@ -1,0 +1,6 @@
+url: https://github.com/CAI-MH/dsh-gpt-image
+name: CAI-MH/dsh-gpt-image
+category: vision
+description:
+  en: 'Generate images through a logged-in web ChatGPT session and download them to a local directory.'
+  zh: '控制已登录的网页版 ChatGPT 生成图片并下载到本地。'


### PR DESCRIPTION
- CAI-MH/dsh-agent-group-panel (ui): Feishu multi-agent robot console — start, stop and reconnect the daemon, view status and recent activity, and jump to the task workspace.
- CAI-MH/dsh-gpt-image (vision): Generate images through a logged-in web ChatGPT session and download them to a local directory.

Both declare `dsh.bundle`, carry the `dsh-plugin` topic, and include `description.en` + `description.zh`.