### PR TITLE
Update CAI-MH/dsh-feishu-task-recorder, CAI-MH/dsh-quality-review descriptions

### DIFF
--- a/data/plugins/CAI-MH__dsh-feishu-task-recorder.yml
+++ b/data/plugins/CAI-MH__dsh-feishu-task-recorder.yml
@@ -2,5 +2,5 @@ url: https://github.com/CAI-MH/dsh-feishu-task-recorder
 name: CAI-MH/dsh-feishu-task-recorder
 category: notify
 description:
-  en: 'Poll Feishu (Lark) chats through lark-cli, extract candidate tasks with a review workflow, and two-way sync them with the task-board plugin, with a floating browser panel.'
-  zh: '通过 lark-cli 轮询飞书会话，提取候选任务并逐条审核，与任务看板插件双向同步，含悬浮面板。'
+  en: 'Poll Feishu (Lark) group and direct chats through lark-cli, extract candidate tasks with a review workflow, and two-way sync them with the task-board plugin, with a floating browser panel and one-click device-flow authorization.'
+  zh: '通过 lark-cli 轮询飞书群聊与单聊，提取候选任务并逐条审核，与任务看板插件双向同步，含悬浮面板与一键授权。'

--- a/data/plugins/CAI-MH__dsh-quality-review.yml
+++ b/data/plugins/CAI-MH__dsh-quality-review.yml
@@ -2,5 +2,5 @@ url: https://github.com/CAI-MH/dsh-quality-review
 name: CAI-MH/dsh-quality-review
 category: agi
 description:
-  en: 'Audit each finished assistant turn with an independent reviewer model and steer the agent to fix failed output, with at most 2 review rounds per turn.'
-  zh: '每轮回复结束时用独立审查模型审核输出，判定不合格则引导 agent 修复，每轮最多追问 2 次。'
+  en: 'Audit each finished assistant turn with an independent reviewer model and steer the agent to fix failed output, with at most 2 review rounds per turn and SOP-folder standards injected as an extra review dimension.'
+  zh: '每轮回复结束时用独立审查模型审核输出，判定不合格则引导 agent 修复，每轮最多追问 2 次；可注入 SOP 文件夹标准作为额外审核维度。'


### PR DESCRIPTION
Updates two existing CAI-MH entries to reflect recent features:

- **CAI-MH/dsh-feishu-task-recorder** — description now mentions group *and direct* chats plus one-click device-flow authorization (v0.3.0).
- **CAI-MH/dsh-quality-review** — description now mentions SOP-folder standards injected as an extra review dimension.

Only these two files under `data/plugins/` are changed.