### PR TITLE
Remove dsh-file-upload (discontinued — superseded by dsh 0.1.5 built-in attachments)

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,6 @@ A listing isn't permanent either: entries whose repos go away, stop being mainta
 - [a735624258/dsh-skill-picker](https://github.com/a735624258/dsh-skill-picker) - WorkBuddy-style skill picker: a button beside the composer opens a searchable list of installed skills; picking one inserts the official /skill-name gesture, so the skill loads with your message.
 - [a792883583/dsh-chat-toc](https://github.com/a792883583/dsh-chat-toc) - Interactive chat table of contents with bookmarks, turn pinning, global shortcuts, and heading extraction.
 - [a903067276-rgb/dsh-file-mentions](https://github.com/a903067276-rgb/dsh-file-mentions) - Clickable file paths in DSH replies: Codex-style inline open, reveal in file manager, and a mentioned-files chip list at the turn tail.
-- [a903067276-rgb/dsh-file-upload](https://github.com/a903067276-rgb/dsh-file-upload) - One upload button plus drag-and-drop files into the conversation as local paths: save to the project's uploads/, path text into the input box, works with any vision tool.
 - [a903067276-rgb/dsh-hud](https://github.com/a903067276-rgb/dsh-hud) - HUD status panel: Git status, MCP servers, skills, model and token usage in a floating side panel.
 - [a903067276-rgb/dsh-plan-switch](https://github.com/a903067276-rgb/dsh-plan-switch) - One-click enter/exit Plan mode for the DSH web input bar, a quick-click shortcut for /plan.
 - [abbccdd/dsh-panel-tint](https://github.com/abbccdd/dsh-panel-tint) - Add independent opacity controls for the sidebar, message panels and composer in dsh web.

--- a/README.zh.md
+++ b/README.zh.md
@@ -104,7 +104,6 @@ dsh plugin --profile web add dshmarket
 - [a735624258/dsh-skill-picker](https://github.com/a735624258/dsh-skill-picker) — WorkBuddy 同款技能选择器：输入框旁 ⚡ 按钮弹出全部技能列表，支持搜索与最近/常用排序，点选即插入官方 `/技能名` 手势，随消息发出自动加载执行。
 - [a792883583/dsh-chat-toc](https://github.com/a792883583/dsh-chat-toc) — 对话大纲目录导航：支持书签标记、轮次置顶钉住、全局快捷键与智能标题提取。
 - [a903067276-rgb/dsh-file-mentions](https://github.com/a903067276-rgb/dsh-file-mentions) — DSH 回复中的文件路径可点击：Codex 风格行内打开、文件管理器定位、回合尾部文件 chip 列表。
-- [a903067276-rgb/dsh-file-upload](https://github.com/a903067276-rgb/dsh-file-upload) — 统一上传按钮 + 拖拽文件直进对话：文件保存到项目 uploads/，路径文本自动进输入框，可配合任意视觉工具看图。
 - [a903067276-rgb/dsh-hud](https://github.com/a903067276-rgb/dsh-hud) — HUD 状态面板：Git 状态、MCP 服务器、技能列表、模型与 token 用量，悬浮侧栏一览无余。
 - [a903067276-rgb/dsh-plan-switch](https://github.com/a903067276-rgb/dsh-plan-switch) — 输入框一键进/出 Plan 模式（/plan 的快捷点击），常驻小按钮。
 - [abbccdd/dsh-panel-tint](https://github.com/abbccdd/dsh-panel-tint) — 为 dsh web 的侧边栏、正文框和输入框提供独立的不透明度控制。

--- a/data/plugins/a903067276-rgb__dsh-file-upload.yml
+++ b/data/plugins/a903067276-rgb__dsh-file-upload.yml
@@ -1,6 +1,0 @@
-url: https://github.com/a903067276-rgb/dsh-file-upload
-name: a903067276-rgb/dsh-file-upload
-category: ui
-description:
-  en: 'One upload button plus drag-and-drop files into the conversation as local paths: save to the project''s uploads/, path text into the input box, works with any vision tool.'
-  zh: 统一上传按钮 + 拖拽文件直进对话：文件保存到项目 uploads/，路径文本自动进输入框，可配合任意视觉工具看图。


### PR DESCRIPTION
## What / 变更内容

Removes the `a903067276-rgb/dsh-file-upload` entry and regenerates both READMEs. No other entries are touched.

## Why / 为什么移除

- **Discontinued as of 2026-09-10.** dsh **0.1.5-rc.1** ships a built-in attachment system covering this plugin's core capability: attach any file type in the composer, and the model reads it on demand through the saved read-only path.
- **It breaks dsh 0.1.5+.** With the built-in attachment system present, this plugin makes the web app fail to boot ("plugin tree failed to load"). Users must disable/remove it *before* upgrading — keeping it listed invites exactly that failure.
- **Highest supported DSH version: 0.1.2.** The plugin README now carries a discontinued banner (English + Chinese), an updated maintenance policy, and a version table marking 0.1.5+ as "do not install": https://github.com/a903067276-rgb/dsh-file-upload/commit/4bfbb25

This follows the list's own policy: *"PRs fixing descriptions, moving entries between categories, or removing dead projects are equally welcome."*

### 中文说明

- 该插件已于 2026-09-10 停止维护：dsh 0.1.5-rc.1 起官方内置附件系统（输入框拖拽/粘贴任意类型文件，模型按保存的只读路径按需读取）覆盖了它的核心能力。
- 它在 dsh 0.1.5 及以上会导致 web 启动失败，用户升级前必须先停用——留在列表里会误导用户踩坑。
- 最高支持 DSH 版本为 0.1.2；仓库 README 已添加停维横幅（中英双语）与版本对照表（0.1.5+ 标注「不要安装」）。
- 本次 PR 只删除这一个条目并重新生成 README，未改动其他任何收录项。
