### PR TITLE
Update langyo/dsh-mobile-upgrade: version-free tarball asset name

### DIFF
--- a/data/plugins/langyo__dsh-mobile-upgrade.yml
+++ b/data/plugins/langyo__dsh-mobile-upgrade.yml
@@ -4,4 +4,4 @@ category: ui
 description:
   en: 'Mobile UI fixes for the dsh web profile: composer upload, restart row, input-modality switches, narrow-screen drawer and settings tabs, a full-width model menu, and a stuck-request network chip.'
   zh: dsh web profile 的手机端体验修复：输入框上传、重启行、输入模态开关、窄屏抽屉与设置标签、全宽模型菜单，以及卡住请求的网络状态芯片。
-tarball: https://github.com/langyo/dsh-mobile-upgrade/releases/latest/download/dsh-mobile-upgrade-0.3.1.tgz
+tarball: https://github.com/langyo/dsh-mobile-upgrade/releases/latest/download/dsh-mobile-upgrade.tgz


### PR DESCRIPTION
Updates one field of my own entry: `tarball:`.

```
-…/releases/latest/download/dsh-mobile-upgrade-0.3.1.tgz
+…/releases/latest/download/dsh-mobile-upgrade.tgz
```

The old URL is exactly the rot the contributing guide warns about — `latest/download/` resolves `latest` at request time but takes the filename literally, and mine carried the version. It still resolves today (the newest release is still v0.3.1, so it serves 0.3.1 rather than 404ing), but it stops resolving the moment the next release exists with a differently-named asset.

The plugin now publishes a **version-free** asset alongside the versioned one on every release, so the stable name above always resolves to the newest build. I attached that same version-free name to the existing v0.3.1 release as well, so this URL resolves immediately — byte-identical to the asset already there.

Only `data/plugins/langyo__dsh-mobile-upgrade.yml` is touched; no generated README.

Sequencing: my plugin PR (langyo/dsh-mobile-upgrade#17) automates the release, and tagging `v0.5.0` is what moves `latest` to a build that ships the stable asset name. This entry edit is safe to merge either side of that, since the stable name resolves on v0.3.1 today.
