### PR TITLE
Rename my three entries after a GitHub account rename (po-et -> im-Captain)

### DIFF
--- a/data/plugins/im-Captain__dsh-http-probe.yml
+++ b/data/plugins/im-Captain__dsh-http-probe.yml
@@ -1,5 +1,5 @@
-url: https://github.com/po-et/dsh-http-probe
-name: po-et/dsh-http-probe
+url: https://github.com/im-Captain/dsh-http-probe
+name: im-Captain/dsh-http-probe
 category: tools
 description:
   en: 'Adds an http_probe tool for endpoint health checks: status code, latency and key response headers, using HEAD with GET fallback; response bodies are never downloaded.'

--- a/data/plugins/im-Captain__dsh-session-guard.yml
+++ b/data/plugins/im-Captain__dsh-session-guard.yml
@@ -1,5 +1,5 @@
-url: https://github.com/po-et/dsh-session-guard
-name: po-et/dsh-session-guard
+url: https://github.com/im-Captain/dsh-session-guard
+name: im-Captain/dsh-session-guard
 category: session
 description:
   en: 'Prevents concurrent-write session corruption: takes a per-session advisory lock on session start and every step, so a second dsh process fails loudly instead of writing a duplicate-seq gap; dead owners are taken over automatically.'

--- a/data/plugins/im-Captain__dsh-session-snapshot.yml
+++ b/data/plugins/im-Captain__dsh-session-snapshot.yml
@@ -1,5 +1,5 @@
-url: https://github.com/po-et/dsh-session-snapshot
-name: po-et/dsh-session-snapshot
+url: https://github.com/im-Captain/dsh-session-snapshot
+name: im-Captain/dsh-session-snapshot
 category: session
 description:
   en: 'Rolling, integrity-verified backups of each session at turn boundaries: verifies the log still loads before promoting a snapshot, never overwrites the last good one when a turn ends corrupt, and restores in one command even when dsh will not boot.'


### PR DESCRIPTION
## 类型 / Type

- [ ] 新增插件条目 / Add a new plugin
- [x] 更新已有条目 / Update an existing entry（GitHub 账号改名 / GitHub account renamed）

## 改动 / What changed

我的 GitHub 账号从 `po-et` 改名为 `im-Captain`（同一账号，数字 ID 未变），三个已收录插件的仓库地址随之改变：

- `po-et__dsh-http-probe.yml` → `im-Captain__dsh-http-probe.yml`
- `po-et__dsh-session-guard.yml` → `im-Captain__dsh-session-guard.yml`
- `po-et__dsh-session-snapshot.yml` → `im-Captain__dsh-session-snapshot.yml`

每个文件只改了 `url` 与 `name` 两行，`category` 和 `description`（en + zh）逐字未动。只动了我自己这三条，没有碰 README（生成物）。

## 为什么现在提 / Why now

`po-et` 这个用户名已经释放，GitHub API 现在对它返回 404 —— 没人占用。旧地址还能打开靠的是改名后的 301 跳转，而这个跳转会在有人注册 `po-et` 的那一刻失效，届时目录里这三行就会指向一个陌生人的仓库。趁还没人注册先改掉。

三个仓库自己的 README、`package.json` 和安装命令也已经同步到新地址。
