### PR TITLE
Add OTTTTTO/dsh-scheduled-send (workflow)

### DIFF
--- a/data/added-dates.json
+++ b/data/added-dates.json
@@ -445,5 +445,9 @@
  "https://github.com/Tabbit-Browser/dsh-tabbit": "2026-08-21",
  "https://github.com/omdsh-dev/stent": "2026-08-13",
  "https://github.com/moguiyu/dsh-tavily/tree/main/packages/dsh-tavily": "2026-08-15",
- "https://github.com/polaris-smart/dsh-devices": "2026-08-19"
+ "https://github.com/polaris-smart/dsh-devices": "2026-08-19",
+ "https://github.com/OTTTTTO/dsh-scheduled-send": "2026-09-09",
+ "https://github.com/wwweljf/dsh-plugins/tree/master/plugins/dsh-ding-sound": "2026-08-22",
+ "https://github.com/wwweljf/dsh-plugins/tree/master/plugins/dsh-wx-push": "2026-08-22",
+ "https://github.com/wwweljf/dsh-plugins/tree/master/plugins/dsh-wx-remote": "2026-08-22"
 }

--- a/data/plugins/OTTTTTO__dsh-scheduled-send.yml
+++ b/data/plugins/OTTTTTO__dsh-scheduled-send.yml
@@ -1,0 +1,6 @@
+url: https://github.com/OTTTTTO/dsh-scheduled-send
+name: OTTTTTO/dsh-scheduled-send
+category: workflow
+description:
+  en: 'Scheduled send: fire a drafted message into the bound conversation as a normal user bubble at a set time. Runs host-side, so the browser can stay closed; per-session isolation and restart-safe redelivery.'
+  zh: '定时发送：到点将拟好的消息以正常用户气泡发送到绑定的会话。调度在服务端执行，关闭浏览器不影响发送；会话隔离、重启自动补发。'


### PR DESCRIPTION
Scheduled send for DSH Web: fire a drafted composer message into the bound conversation as a normal user bubble at a set time. Delivery runs host-side, so the browser can stay closed; tasks are bound to their session, survive restarts, and are redelivered on recovery. 63 tests, MIT, published to npm as @ottttto/dsh-scheduled-send.

<!-- Thanks for contributing! Quick checklist / 提交前快速自查 -->

- [x] I added **one file** at `data/plugins/<owner>__<repo>.yml` — that single file is the whole submission. The READMEs are regenerated on `main` after merge: don't edit them by hand, and you don't need to commit them either / 我新增了一个 `data/plugins/<owner>__<repo>.yml` 文件——**这一个文件就是全部投稿**。README 会在合并后由 `main` 自动重新生成：不要手工编辑，也不需要提交
- [x] My repo's `package.json` declares **`dsh.bundle`** (not just `dsh.client`) — [example](../blob/main/contributing.md) / 仓库 `package.json` 已声明 `dsh.bundle`（只有 `dsh.client` 无法安装）
- [x] My repo is at least **1 day old** / 仓库创建满 1 天
- [x] `category` is one of `agi ui usage theme model identity session memory tools wsl browser vision voice docs skill workflow git notify dev security remote market fun` ([full list with descriptions](../blob/main/contributing.md)), and themes/skins go under `theme` / `category` 取值正确（完整清单见 contributing.md），主题/皮肤类请用 `theme`
- [x] Description states what the plugin does, no superlatives / 描述只说功能，不带营销词
- [x] My repo has the `dsh-plugin` topic / 仓库已打 `dsh-plugin` topic

**Recommended (not required) / 推荐但不强制：**

- 📦 Publish to npm — npm installs are prebuilt and skip the `allowBuilds` approval, so users get a one-command install / 发布 npm 包：预构建产物免 `allowBuilds` 授权，用户一条命令装好
  ✅ Published: `@ottttto/dsh-scheduled-send@0.3.9+`（`repository` field points back at this repo）
- 🔗 Declare official `@deepseek-ai/*` packages as `peerDependencies` (not `dependencies`) — avoids duplicate runtimes inside the profile / 官方 `@deepseek-ai/*` 包用 `peerDependencies` 声明（而非 `dependencies`），避免 profile 里出现重复运行时
  ✅ N/A — no `@deepseek-ai/*` runtime dependencies (capabilities are implemented inline)
- 🖼️ Screenshots go in **your own repository** now: a `screenshots.json` beside your `package.json`（[how](../blob/main/contributing.md#screenshots--截图optional-recommended--可选推荐)）
  ✅ Done — `screenshots.json` at repo root, 3 screenshots in `assets/`