### PR TITLE
add himeope/dsh-queue-first-enter (ui)

### DIFF
--- a/data/added-dates.json
+++ b/data/added-dates.json
@@ -445,5 +445,9 @@
  "https://github.com/Tabbit-Browser/dsh-tabbit": "2026-08-21",
  "https://github.com/omdsh-dev/stent": "2026-08-13",
  "https://github.com/moguiyu/dsh-tavily/tree/main/packages/dsh-tavily": "2026-08-15",
- "https://github.com/polaris-smart/dsh-devices": "2026-08-19"
+ "https://github.com/polaris-smart/dsh-devices": "2026-08-19",
+ "https://github.com/wwweljf/dsh-plugins/tree/master/plugins/dsh-ding-sound": "2026-08-22",
+ "https://github.com/wwweljf/dsh-plugins/tree/master/plugins/dsh-wx-push": "2026-08-22",
+ "https://github.com/wwweljf/dsh-plugins/tree/master/plugins/dsh-wx-remote": "2026-08-22",
+ "https://github.com/himeope/dsh-queue-first-enter": "2026-09-10"
 }

--- a/data/plugins/himeope__dsh-queue-first-enter.yml
+++ b/data/plugins/himeope__dsh-queue-first-enter.yml
@@ -1,0 +1,7 @@
+url: https://github.com/himeope/dsh-queue-first-enter
+name: himeope/dsh-queue-first-enter
+category: ui
+description:
+  en: Pressing Enter with an empty composer steers the first queued message into the running turn while the agent is busy.
+  zh: agent 繁忙时输入框保持空白，按 Enter 即可把队列第一条消息插话发送到正在运行的回合。
+tarball: https://github.com/himeope/dsh-queue-first-enter/releases/latest/download/dsh-queue-first-enter.tgz

--- a/data/plugins/himeope__dsh-queue-first-enter.yml
+++ b/data/plugins/himeope__dsh-queue-first-enter.yml
@@ -3,5 +3,5 @@ name: himeope/dsh-queue-first-enter
 category: ui
 description:
   en: Pressing Enter with an empty composer steers the first queued message into the running turn while the agent is busy.
-  zh: agent 繁忙时输入框保持空白，按 Enter 即可把队列第一条消息插话发送到正在运行的回合。
+  zh: agent 忙的时候，输入框空着按回车，排队的第一条消息就会插话送进当前回合，不用等它跑完。
 tarball: https://github.com/himeope/dsh-queue-first-enter/releases/latest/download/dsh-queue-first-enter.tgz

--- a/data/plugins/himeope__dsh-queue-first-enter.yml
+++ b/data/plugins/himeope__dsh-queue-first-enter.yml
@@ -3,5 +3,5 @@ name: himeope/dsh-queue-first-enter
 category: ui
 description:
   en: Pressing Enter with an empty composer steers the first queued message into the running turn while the agent is busy.
-  zh: agent 忙的时候，输入框空着按回车，排队的第一条消息就会插话送进当前回合，不用等它跑完。
+  zh: agent 正在处理任务时，输入框空着按回车，队列第一条消息就会插话送进当前回合。
 tarball: https://github.com/himeope/dsh-queue-first-enter/releases/latest/download/dsh-queue-first-enter.tgz


### PR DESCRIPTION
Adds one entry for `himeope/dsh-queue-first-enter`.

**Entry**
- `url`: `https://github.com/himeope/dsh-queue-first-enter`
- `name`: `himeope/dsh-queue-first-enter`
- `category`: `ui`
- `description.en` / `description.zh`: one line each, factual, no superlatives.
- `tarball`: prebuilt `.tgz` attached to the `v1.0.0` release — the asset name carries no version, so `latest/download/` keeps resolving after future releases.

**What it does**: while the agent is busy, dsh's composer queues the next message on Enter. This plugin adds one gesture on top of that: with an empty composer (no text, no pending images) and at least one queued item, a bare Enter calls the existing `updateQueue(itemId, { kind: 'steer' })` RPC on the first queued message, so it lands in the running turn at its next step boundary instead of waiting for the turn to end. It adds one switch — 回车立即发送队列首条 / "Enter sends the first queued message" — directly under dsh's own busy-Enter row in Settings → General. Ctrl/Cmd+Enter (steer all) and Enter with text or images are untouched.

**Boundary, stated up front**: delivery is a strict steer — it does not interrupt the running turn, and it is not "skip the current turn". dsh's queue API exposes only edit / remove / steer, and the plugin never calls `cancel`.

**About the `data/added-dates.json` hunk in this PR**

`main`'s site build has been failing since 2026-09-08 (`build-site.yml`, seven consecutive failures): three entries added by #2662 have no pin in that file, and the git fallback finds no added commit for them, so `build-site.mjs` refuses to build and every open PR inherits the red check. #4773 pinned those same three entries, which is what let its `check` go green.

This PR does the same: the three `wwweljf/dsh-plugins` entries at `2026-08-22` — the identical values #4773 used, so the two PRs agree instead of conflicting — plus this entry at `2026-09-10`. That hunk is the only reason this PR touches a file other than its own entry; happy to drop it if you'd rather pin them yourself on `main`.

**Requirements checked**
- `dsh.bundle` declared in the root `package.json` (`dsh.bundle.patch: ./cordis.patch.yml`, committed), plus `dsh.client` for the web platform. Installable via `dsh plugin --profile web add github:himeope/dsh-queue-first-enter`.
- `dsh-plugin` topic set on the repository.
- Repo created 2026-09-09 (24h+ at submission time).
- No npm package; a prebuilt tarball is attached to the release instead, and no `npm:` key is written into the entry.
- `screenshots.json` in the repo declares two GitHub-hosted paths (`assets/screenshot-settings.png`, `assets/screenshot-settings.en.png`).
- Description matches the code: the plugin registers one composer listener and one settings row; it sends no prompts of its own and makes no network calls.
