### PR TITLE
Update pn1024/dsh-skill-hub → pn1024/dsh-skill-market (repo renamed, move to market)

### DIFF
--- a/data/plugins/pn1024__dsh-skill-hub.yml
+++ b/data/plugins/pn1024__dsh-skill-hub.yml
@@ -1,6 +1,0 @@
-url: https://github.com/pn1024/dsh-skill-hub
-name: pn1024/dsh-skill-hub
-category: skill
-description:
-  en: Skill marketplace with aggregated search across SkillHub and ClawHub, in-app README preview, one-click install and uninstall, and a chat-input skill picker.
-  zh: 技能市场插件，聚合 SkillHub 与 ClawHub 双源搜索，支持站内 README 预览、一键安装卸载与聊天栏技能选择器。

--- a/data/plugins/pn1024__dsh-skill-market.yml
+++ b/data/plugins/pn1024__dsh-skill-market.yml
@@ -1,0 +1,6 @@
+url: https://github.com/pn1024/dsh-skill-market
+name: pn1024/dsh-skill-market
+category: market
+description:
+  en: Skill marketplace with unified search across SkillHub and ClawHub, in-app README preview, one-click install and uninstall, an installed-skill list, and a chat-input skill picker.
+  zh: 技能市场插件，聚合 SkillHub 与 ClawHub 双源搜索，支持站内 README 预览、一键安装与卸载、已装技能列表，以及聊天栏技能选择器。


### PR DESCRIPTION
Updates my own entry after a repository rename.

- The plugin repo `pn1024/dsh-skill-hub` was renamed to `pn1024/dsh-skill-market` (GitHub keeps the old URL as a redirect). The local package name, plugin id and panel title were renamed to match.
- Reason for the rename: `dsh-skill-hub` collides with the unrelated `cheshireez/dsh-skill-hub`; the new name is unambiguous.
- The plugin was previously listed under `skill`. It is a marketplace, so the new entry uses `market`.

Changes in this PR: removes `pn1024__dsh-skill-hub.yml`, adds `pn1024__dsh-skill-market.yml`. No other entries are touched.

Repo checks: created 2026-09-01, `dsh-plugin` topic set, `dsh.bundle` manifest declared in `package.json` (`dsh.bundle.patch` + `dsh.client`). Descriptions are limited to what the source actually implements: unified SkillHub/ClawHub search, in-app README preview (`skill-hub/readme`), install/uninstall (`skill-hub/install`, `skill-hub/uninstall`), installed list (`skill-hub/installed`), and a chat-input skill picker.
