### PR TITLE
add dsh-lint-loop (tools): zero-config lint feedback loop (eslint / biome / ruff)

### DIFF
--- a/data/plugins/lemonxiny55__dsh-lint-loop.yml
+++ b/data/plugins/lemonxiny55__dsh-lint-loop.yml
@@ -1,0 +1,6 @@
+url: https://github.com/lemonxiny55/dsh-lint-loop
+name: lemonxiny55/dsh-lint-loop
+category: tools
+description:
+  en: 'Zero-config lint feedback loop: lint_diagnostics / lint_workspace_errors / lint_fix tools driven by the eslint / biome / ruff already present in the repo (auto-detected from config files, repo-local node_modules/.bin resolved first, nothing bundled), plus an auto-injected post-edit findings delta wired to the harness fs/observed event — edit → lint → auto-repair with one lint_fix call for dsh agents.'
+  zh: '零配置 lint 反馈闭环：由仓库已有的 eslint / biome / ruff 驱动（从配置文件自动探测、优先解析仓库本地 node_modules/.bin、不捆绑任何 linter）提供 lint_diagnostics / lint_workspace_errors / lint_fix 工具，并订阅 harness 的 fs/observed 事件自动注入「本次编辑引入的发现增量」——为 dsh Agent 带来编辑→lint→一键自动修复的闭环体验。'


### PR DESCRIPTION
Single DSH plugin **dsh-lint-loop** (npm, repo now carries **v0.2.0**): the edit → lint → fix loop via the repo's own linters — zero-config auto-detection of eslint / biome / ruff from config files (eslint.config.*, .eslintrc.*, biome.json[c], ruff.toml / [tool.ruff]; JS-family routes to eslint by default, biome only without eslint config; .py/.pyi to ruff), repo-local node_modules/.bin resolved before PATH, nothing bundled.

**Tools** — `lint_diagnostics` (rule, file:line:col, message, fixable flag; severity filter + cap) — call right after editing a file; `lint_workspace_errors` (session-wide error view); `lint_fix` (eslint --fix / biome check --write / ruff check --fix on one file, then re-lint: returns fixed flag, +added/-removed line summary, remaining findings). Tools accept `file_path` (native fs convention) or the `file` alias.

**v0.2.0 loop upgrades**
- **Completion gate** on the harness `agent/turn-stopping` seam: while files edited during the turn still carry errors, the plugin steers the agent for another step instead of letting it finish. Self-limiting — each file is evaluated once per stopping, each turn forces at most `gateMaxSteers` (default 2) continuations, and `lint_fix` re-arms the check after it rewrites a file (the linter process bypasses `fs/observed`). `gate: false` disables.
- **Source code frames** on rendered findings (offending line marked █ plus a line of context) via `codeFrames` / `frameLines` / `frameLimit` — the model fixes without re-reading the file.
- **Errors-only injected section** (`sectionSeverity`, default error) with a configurable settle window (`settleMs`), so warnings stay out of the prompt by default.

Plus the auto-injected `lint:findings` system-prompt section (order 75, right after `lsp:diagnostics`) wired to the harness `fs/observed` event — only the NEW/CHANGED findings per edit, top 5, TTL-expiring. Serial per-(root, linter) runner lanes with 10s timeout degradation; every failure returns a friendly message (missing linter → exact install command; unconfigured repo → init hints) — never throws to the model.

**Verification** — 94 vitest cases (marker-driven fake linter emitting each real linter's JSON; real-captured biome 2.5 reporter-shape regression tests; no real linter needed in CI). Validated against real eslint 10 / biome 2.5 / ruff 0.16. **End-to-end on the real Windows harness (dsh 0.1.1-rc.2, web + headless targets)**: model edits a file with 3 real eslint errors, the completion gate fires (`agent/turn-stopping` steer carrying the findings), the model calls `lint_fix`, the file is rewritten (`var`→`let`, `==`→`===`), the gate re-checks and admits the turn — final file verified clean by a direct eslint run. Two bugs surfaced and were fixed during that live run (the turn-stopping listener must return its async handler to be awaited; tools must accept `file_path`), each with a regression test.

Repo: https://github.com/lemonxiny55/dsh-lint-loop · npm: https://www.npmjs.com/package/dsh-lint-loop · install: `dsh plugin add dsh-lint-loop`. Coexists with dsh-lsp-diagnostics (order 75 vs 70). Category: tools.