### PR TITLE
Add ShawnKung/dsh-balance-monitor

### DIFF
--- a/data/plugins/ShawnKung__dsh-balance-monitor.yml
+++ b/data/plugins/ShawnKung__dsh-balance-monitor.yml
@@ -1,0 +1,6 @@
+url: https://github.com/ShawnKung/dsh-balance-monitor
+name: ShawnKung/dsh-balance-monitor
+category: usage
+description:
+  en: Shows selectable DeepSeek, Kimi, Zhipu GLM, and TeamoRouter balances in the DSH Web sidebar, with per-provider details, usage data, and refresh controls.
+  zh: 在 DSH Web 侧边栏展示可选的 DeepSeek、Kimi、智谱 GLM 和 TeamoRouter 余额，并提供渠道详情、用量数据与刷新控制。


### PR DESCRIPTION
## English

Adds `ShawnKung/dsh-balance-monitor` to the `usage` category.

The plugin displays selectable balances for DeepSeek, Kimi, Zhipu GLM, and TeamoRouter in the DSH Web sidebar. Its popup provides per-channel details, provider-reported usage where available, and individual or combined refresh controls.

Credentials are resolved host-side from environment variables, configured model providers, or user credential references, and are not exposed to the browser.

## 中文

将 `ShawnKung/dsh-balance-monitor` 添加到 `usage` 分类。

该插件在 DSH Web 侧边栏展示可选择的 DeepSeek、Kimi、智谱 GLM 和 TeamoRouter 余额。弹窗提供各渠道详情、渠道支持的用量数据，以及单渠道和全部刷新能力。

凭据仅在 Host 侧解析，依次复用环境变量、模型 Provider 配置或用户凭据引用，不会传入浏览器。

## Submission checklist / 提交检查

- Adds one bilingual YAML entry only / 仅新增一个中英双语 YAML 条目
- Declares an installable `dsh.bundle` with a Web client / 声明了包含 Web 客户端的可安装 `dsh.bundle`
- Published as `@shawnkung/dsh-balance-monitor@0.1.14` / 已发布至 npm
- Declares `@deepseek-ai/schemastery` as a peer dependency / 将官方 Schemastery 声明为 peer dependency
- Includes interface screenshots and the `dsh-plugin` topic / 仓库包含界面截图和 `dsh-plugin` Topic
- Passes the current submission gate / 已通过当前 Submission Gate 检查