### PR TITLE
Add sueqet/dsh-todo-board

### DIFF
--- a/data/plugins/sueqet__dsh-todo-board.yml
+++ b/data/plugins/sueqet__dsh-todo-board.yml
@@ -1,0 +1,6 @@
+url: https://github.com/sueqet/dsh-todo-board
+name: sueqet/dsh-todo-board
+category: ui
+description:
+  en: 'Cross-session TODO board as a draggable floating panel: tasks are grouped by working directory and reorderable by drag, each one carries a run mode (remind only, continue in the current session, or open a new session in the same directory), up to four attached images sent to the model as real image attachments, and an optional local time it may run at; two checkboxes track AI-done and user-verified, and the agent picks up the next unfinished task in that directory when it finishes one.'
+  zh: 跨会话 TODO 板：可拖动浮窗按工作目录分组、拖拽排序，每条待办带一个执行模式（仅提醒 / 在当前会话续跑 / 在同目录新开会话）、可附最多 4 张图片（派发时作为真正的图片附件发给模型）、以及一个可选的定时执行时间；两个勾选框分别记录 AI 已完成与用户已验收，AI 完成一项后自动接续该目录下一条未完成待办。


### PR DESCRIPTION
Adds `sueqet/dsh-todo-board` — a cross-session TODO board for DSH.

**What it does**

- A draggable floating panel (`shell.overlay`) groups tasks by working directory; rows are drag-reorderable and the on-screen top-to-bottom order is the dispatch order.
- Each task carries one run mode: `remind` only, `resume` (inject into the current session at turn end), or `newSession` (create a session in the same directory). A `newSession` task binds the session it creates and reuses that binding instead of opening another one.
- Each task can carry up to 4 images. They are admitted through the harness `attachments` service and dispatched as real `image` content blocks alongside the prompt.
- Each task can carry an optional local time (`YYYY-MM-DDTHH:mm`); it is not dispatched before that minute.
- Two checkboxes: the model ticks "AI done" via the `todo_board` tool, only the user ticks "verified".

**Manifest**

`package.json` declares `dsh.bundle.patch → ./cordis.patch.yml`, with `cordis.patch.yml` in the repo root. `@deepseek-ai/cordis` is a `peerDependency`; there are no runtime `dependencies`.

**Checklist**

- [x] `dsh.bundle` declared (plus `dsh.client` for the web panel)
- [x] Repo contains working code (`lib/index.js` host half, `client/client.js` web half, `tools/smoke.mjs` self-test)
- [x] Repo is more than a day old
- [x] Repo carries the `dsh-plugin` topic
- [x] One entry added, no other entry touched
