### PR TITLE
docs: update bbqisbbq/dsh-tiddlywiki description

### DIFF
--- a/data/plugins/bbqisbbq__dsh-tiddlywiki.yml
+++ b/data/plugins/bbqisbbq__dsh-tiddlywiki.yml
@@ -2,5 +2,5 @@ url: https://github.com/bbqisbbq/dsh-tiddlywiki
 name: bbqisbbq/dsh-tiddlywiki
 category: memory
 description:
-  en: 'Runs TiddlyWiki 5 as the DSH persistent knowledge base: ten tiddlywiki_* agent tools (filtered search, read/write/batch/rename/delete, recent, tags, plus git sync with conflict resolve), a full TiddlyWiki editor embedded in the GUI center column, and a quick-note widget with draft auto-save — all backed by an auto-committing git repository.'
-  zh: '把 TiddlyWiki 5 变成 DSH 的持久知识库：十个 tiddlywiki_* 智能体工具（带过滤的检索、读写/批量/改名/删除、最近、标签，以及 git 同步与冲突解决），GUI 中央栏内嵌完整 TiddlyWiki 编辑器，快速笔记卡片支持草稿自动保存——全部由自动提交的 git 仓库支撑。'
+  en: 'Runs TiddlyWiki 5 as the DSH persistent knowledge base: ten tiddlywiki_* agent tools (filtered search, read/write/batch/rename/delete, recent, tags, git sync with conflict resolve), a full TiddlyWiki editor embedded in the GUI center column over a same-origin proxy, a right-side wiki tab, a per-session tab summarizing the notes a session read or wrote, a quick-note card with draft auto-save, and an optional clip bookmarklet with image attachment — all backed by an auto-committing git repository.'
+  zh: '把 TiddlyWiki 5 变成 DSH 的持久知识库：十个 tiddlywiki_* 智能体工具（带过滤的检索、读写/批量/改名/删除、最近、标签，以及 git 同步与冲突解决），GUI 中央栏经同源代理内嵌完整 TiddlyWiki 编辑器，右侧栏知识库 Tab，会话级汇总本会话读写过的笔记，快速笔记卡片支持草稿自动保存，另可选剪藏书签（选中图片一并存为二进制附件）——全部由自动提交的 git 仓库支撑。'


### PR DESCRIPTION
Updates only my own entry — `data/plugins/bbqisbbq__dsh-tiddlywiki.yml`.

The current line was written when the plugin was v0.13.0. It is now v0.17.0 and also ships:

- a right-side TiddlyWiki tab (registered as a right-pane tab type)
- a per-session "knowledge" tab that summarizes the notes a session read or wrote
- an optional local clip bridge + bookmarklet that also saves selected images as binary attachments
- unchanged claims kept as-is: ten `tiddlywiki_*` agent tools, embedded TiddlyWiki editor in the GUI center column, quick-note card with draft auto-save, auto-committing git repository

No other entry file is touched, and the generated READMEs are left to `sync-readme` on `main` (PR is yml-only).

---

只改了自己这一条 entry（简介从 v0.13.0 时期的文案更新到 v0.17.0：补上右侧栏知识库 Tab、会话级汇总 Tab、可选剪藏书签/图片附件）；未触碰其他条目，README 由 main 上的 sync-readme 流程重新生成。
