### PR TITLE
Add icanfinish11/dsh-context-mode

### DIFF
--- a/data/plugins/icanfinish11__dsh-context-mode.yml
+++ b/data/plugins/icanfinish11__dsh-context-mode.yml
@@ -1,0 +1,6 @@
+url: https://github.com/icanfinish11/dsh-context-mode
+name: icanfinish11/dsh-context-mode
+category: session
+description:
+  en: 'DeepSeek Harness adapter for Context Mode: in-process ctx_* tools for sandboxed code execution and an FTS5 knowledge base, plus context-window routing guidance.'
+  zh: '为 DeepSeek Harness 适配 Context Mode：进程内 ctx_* 工具（沙箱代码执行与 FTS5 知识库），并注入上下文窗口路由指引。'


### PR DESCRIPTION
- [x] I added **one file** at `data/plugins/icanfinish11__dsh-context-mode.yml` — that single file is the whole submission. The READMEs are regenerated on `main` after merge: don't edit them by hand, and you don't need to commit them either / 我新增了一个 `data/plugins/icanfinish11__dsh-context-mode.yml` 文件——**这一个文件就是全部投稿**。README 会在合并后由 `main` 自动重新生成：不要手工编辑，也不需要提交
- [x] My repo's `package.json` declares **`dsh.bundle`** (not just `dsh.client`) — [example](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/main/contributing.md) / 仓库 `package.json` 已声明 `dsh.bundle`（只有 `dsh.client` 无法安装）
- [x] My repo is at least **1 day old** / 仓库创建满 1 天
- [x] `category` is one of `agi ui usage theme model identity session memory tools wsl browser vision voice docs skill workflow git notify dev security remote market fun` ([full list with descriptions](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/main/contributing.md)), and themes/skins go under `theme` / `category` 取值正确（完整清单见 contributing.md），主题/皮肤类请用 `theme`
- [x] Description states what the plugin does, no superlatives / 描述只说功能，不带营销词
- [x] My repo has the `dsh-plugin` topic / 仓库已打 `dsh-plugin` topic

---

### What it does

`dsh-context-mode` is a DeepSeek Harness adapter for [Context Mode](https://github.com/mksglu/context-mode) — the context-window server by Mert Koseoğlu (`mksglu`). It loads the engine library **in-process** (no MCP child process, no `mcp__` prefix) and registers the `ctx_*` tools natively in dsh's `tools` registry, then contributes the context-window routing guidance as the `context-mode:routing` system-prompt section.

Tools registered by default: `ctx_execute`, `ctx_execute_file`, `ctx_batch_execute`, `ctx_index`, `ctx_search`, `ctx_fetch_and_index`, `ctx_stats`, `ctx_doctor`, `ctx_purge`, `ctx_insight`. `ctx_upgrade` exists but defaults to **off** (it rewrites host hook configs that dsh does not use).

Category: **`session`** — the plugin's subject is the context window of a session (keeping tool output out of it), which is where the other context-curation entries (`EvilIrving/dsh-context-proxy`, `Icstick/dsh-context-maid`) also sit. It is not the same as those: they trim context already in the session, this one sandboxes the work that would have produced it and keeps a searchable store outside the window.

### Every claim in the description, checked against the source (repo root)

- **in-process** — `index.js` imports the engine's `build/server.js` through Node resolution and registers each tool definition directly into `ctx.tools`; `CONTEXT_MODE_EMBEDDED_PLUGIN_TOOLS=1` is set around the import so the engine skips its stdio transport and process-wide handlers. No MCP transport is started.
- **sandboxed code execution** — the execution tools are context-mode's own executor implementations, reached through the engine's `REGISTERED_CTX_TOOLS` registry.
- **FTS5 knowledge base** — `ctx_index` / `ctx_search` / `ctx_fetch_and_index` use the engine's SQLite FTS5 store, rooted at `$DSH_HOME/context-mode` by default and overridable via the plugin's `storageDir` config.
- **routing guidance** — `ctx.systemPrompt.section({ name: 'context-mode:routing' })`, verified present in a real boot (`D:\...\plugins\ctx-local` probe: 10 `ctx_*` tools + section).

### Dependencies point at the original

The engine is a runtime dependency that resolves to the original author's published npm package: `"context-mode": "^1.0.169"`, published by `mksglu` (author: Mert Koseoğlu), repository `mksglu/context-mode`. This repository contains **no engine code** and does not re-publish it — it ships only the dsh adapter (≈400 lines), and `README.md` has a Credits section naming the original author, repository and license (Elastic-2.0, dual copyright line).

### Notes for the reviewer

- The PR adds exactly one file; nothing else is touched.
- Not published to npm yet, so there is no npm mapping and no `tarball:` field — it installs from the repository: `dsh plugin --profile web add icanfinish11/dsh-context-mode`.
- No `@deepseek-ai/*` package is declared at all (the plugin uses Node builtins plus the engine dependency), so there is no duplicate-runtime concern to address.
- `screenshots.json` is not declared; the storefront can fall back to images in the README as usual.

### 中文简介

`dsh-context-mode` 把 Context Mode（原作者 Mert Koseoğlu / mksglu）的引擎以**进程内**方式接入 DeepSeek Harness：原生注册 `ctx_*` 工具（沙箱代码执行、FTS5 知识库、知识库管理），并注入上下文窗口路由指引；引擎以运行时依赖指向**原作者发布的 npm 包**（`context-mode@^1.0.169`），仓库内不含引擎代码、不重传他人作品。分类选 `session`（与现有 context 类条目同类，但思路不同：那些是"剪掉已进上下文的垃圾"，本插件是"让活在外面干、记忆存在外面"）。
