### PR TITLE
Add idoall/dsh-update-status

### DIFF
--- a/data/plugins/idoall__dsh-update-status.yml
+++ b/data/plugins/idoall__dsh-update-status.yml
@@ -1,0 +1,7 @@
+url: https://github.com/idoall/dsh-update-status
+name: idoall/dsh-update-status
+category: ui
+tarball: https://github.com/idoall/dsh-update-status/releases/download/v0.1.1/dsh-update-status-0.1.1.tgz
+description:
+  en: Read-only DeepSeek Harness Web sidebar version chip that shows the running DSH version, npm latest/next/alpha channels, compatibility labels, and a copy-only upgrade command.
+  zh: 只读的 DeepSeek Harness Web 侧栏版本芯片，显示当前运行版本、npm latest/next/alpha 通道、兼容性标识，以及仅复制的升级命令。


### PR DESCRIPTION
## Summary

Add [idoall/dsh-update-status](https://github.com/idoall/dsh-update-status) as a UI plugin.

- Read-only sidebar version chip for DeepSeek Harness Web
- Shows the running DSH version, npm `latest` / `next` / `alpha` channels, and compatibility labels
- Generates a copy-only upgrade command (never installs or restarts DSH)
- Declares `dsh.bundle` + `cordis.patch.yml`, published as `dsh-update-status@0.1.1`
- Verified against DeepSeek Harness `0.1.5-rc.1`

Entry file only: `data/plugins/idoall__dsh-update-status.yml` (READMEs not edited).

## Test plan

- [ ] CI entry-count / `dsh.bundle` / repo-age / generate-readme checks pass
- [ ] Category `ui` is acceptable
- [ ] Description matches the plugin behavior