### PR TITLE
Add idoall/dsh-quick-replies (ui)

### DIFF
--- a/data/plugins/idoall__dsh-quick-replies.yml
+++ b/data/plugins/idoall__dsh-quick-replies.yml
@@ -1,0 +1,6 @@
+url: https://github.com/idoall/dsh-quick-replies
+name: idoall/dsh-quick-replies
+category: ui
+description:
+  en: 'Manageable one-tap text chips above the session composer; idle sessions queue the message and running sessions steer at the next safe boundary without rewriting the draft.'
+  zh: 在会话输入区上方提供可管理的一点即发文本 chip；空闲时 queue、运行中 steer，不改写草稿。

--- a/data/plugins/idoall__dsh-update-status.yml
+++ b/data/plugins/idoall__dsh-update-status.yml
@@ -1,6 +1,0 @@
-url: https://github.com/idoall/dsh-update-status
-name: idoall/dsh-update-status
-category: ui
-description:
-  en: 'Read-only sidebar version chip that discovers npm latest, next, and alpha releases, shows compatibility labels, and generates copy-only upgrade commands.'
-  zh: 只读侧栏版本芯片：发现 npm latest、next、alpha 发布，显示兼容性标签，并生成仅可复制的升级命令。

--- a/data/plugins/idoall__dsh-update-status.yml
+++ b/data/plugins/idoall__dsh-update-status.yml
@@ -1,0 +1,6 @@
+url: https://github.com/idoall/dsh-update-status
+name: idoall/dsh-update-status
+category: ui
+description:
+  en: 'Read-only sidebar version chip that discovers npm latest, next, and alpha releases, shows compatibility labels, and generates copy-only upgrade commands.'
+  zh: 只读侧栏版本芯片：发现 npm latest、next、alpha 发布，显示兼容性标签，并生成仅可复制的升级命令。


### PR DESCRIPTION
## Summary

Add one installable DeepSeek Harness Web plugin under **ui**:

- [idoall/dsh-quick-replies](https://github.com/idoall/dsh-quick-replies)
  - Manageable one-tap text chips above the session composer
  - Idle → `queue`, running → `steer`; does not rewrite the draft
  - npm: `dsh-quick-replies@0.1.2`
  - install: `dsh plugin --profile web add dsh-quick-replies`

## Checklist

- [x] Added only `data/plugins/idoall__dsh-quick-replies.yml` (no hand-edited READMEs)
- [x] Repo declares `dsh.bundle` + `cordis.patch.yml`
- [x] Repo is > 1 day old
- [x] category: `ui`
- [x] Descriptions state behavior only (en + zh), no marketing
- [x] Repo has the `dsh-plugin` topic
- [x] Published on npm (prebuilt)

## Follow-up

`idoall/dsh-update-status` will be submitted in a separate PR after its repository age clears the 1-day gate (~8h from the first attempt).