### PR TITLE
Add dsh-task-time: session-based task time management and reminders

### DIFF
--- a/data/added-dates.json
+++ b/data/added-dates.json
@@ -445,5 +445,8 @@
  "https://github.com/Tabbit-Browser/dsh-tabbit": "2026-08-21",
  "https://github.com/omdsh-dev/stent": "2026-08-13",
  "https://github.com/moguiyu/dsh-tavily/tree/main/packages/dsh-tavily": "2026-08-15",
- "https://github.com/polaris-smart/dsh-devices": "2026-08-19"
+ "https://github.com/polaris-smart/dsh-devices": "2026-08-19",
+ "https://github.com/wwweljf/dsh-plugins/tree/master/plugins/dsh-ding-sound": "2026-09-09",
+ "https://github.com/wwweljf/dsh-plugins/tree/master/plugins/dsh-wx-push": "2026-09-09",
+ "https://github.com/wwweljf/dsh-plugins/tree/master/plugins/dsh-wx-remote": "2026-09-09"
 }

--- a/data/plugins/Flandern1211__dsh-task-time.yml
+++ b/data/plugins/Flandern1211__dsh-task-time.yml
@@ -2,5 +2,5 @@ url: https://github.com/Flandern1211/dsh-task-time
 name: Flandern1211/dsh-task-time
 category: notify
 description:
-  en: Session-based task time management and reminders for DeepSeek Harness: plan time per session, continuous countdown (model-only runtime), interval reminders with system toast and UI cards, decision alerts when the model needs user input, task board with session jumping, and persistent local records.
+  en: 'Session-based task time management and reminders for DeepSeek Harness: plan time per session, continuous countdown (model-only runtime), interval reminders with system toast and UI cards, decision alerts when the model needs user input, task board with session jumping, and persistent local records.'
   zh: DeepSeek Harness 会话级任务用时管理与提醒：为每个会话设置计划用时，仅模型运行时连续计时，定时提醒（系统通知 + 界面提醒卡），需要你决策时红色常驻提醒，任务面板支持点击跳转会话，本地记录持久化。

--- a/data/plugins/Flandern1211__dsh-task-time.yml
+++ b/data/plugins/Flandern1211__dsh-task-time.yml
@@ -1,0 +1,6 @@
+url: https://github.com/Flandern1211/dsh-task-time
+name: Flandern1211/dsh-task-time
+category: notify
+description:
+  en: Session-based task time management and reminders for DeepSeek Harness: plan time per session, continuous countdown (model-only runtime), interval reminders with system toast and UI cards, decision alerts when the model needs user input, task board with session jumping, and persistent local records.
+  zh: DeepSeek Harness 会话级任务用时管理与提醒：为每个会话设置计划用时，仅模型运行时连续计时，定时提醒（系统通知 + 界面提醒卡），需要你决策时红色常驻提醒，任务面板支持点击跳转会话，本地记录持久化。


### PR DESCRIPTION
## Add dsh-task-time plugin

URL: https://github.com/Flandern1211/dsh-task-time
Category: notify (Notifications & Integrations)

### Description

Session-based task time management and reminders for DeepSeek Harness: plan time per session, continuous countdown, interval reminders, decision alerts, task board with session jumping, and persistent local records.

### Checklist

- [x] The repo declares \dsh.bundle\ in \package.json\
- [x] Repo is older than 1 day
- [x] Single entry PR