### PR TITLE
add Enosensu/dsh-fork-relink (session)

### DIFF
--- a/data/plugins/Enosensu__dsh-fork-relink.yml
+++ b/data/plugins/Enosensu__dsh-fork-relink.yml
@@ -1,0 +1,6 @@
+url: https://github.com/Enosensu/dsh-fork-relink
+name: Enosensu/dsh-fork-relink
+category: session
+description:
+  en: "Fork companion that auto-relinks subagent session records to the forked child: listens for the official session/created event and rewrites only the durable parentSession header frame of cold subagent children (with trash backups), so forked conversations keep their subagent panel, agent routing, and descriptors — the whole subtree follows, filtered by what the fork seed references."
+  zh: "fork 伴随插件:官方 fork 发生后,自动把原会话的直接子 agent 记录头帧 parentSession 重链到新会话(仅重写头帧,其余帧字节原样,先备份到回收站),fork 出的对话完整保留子 agent 面板、代理路由与 descriptor 信息;按 fork 子会话 seed 的引用过滤,整棵子 agent 树统一跟随。零 UI、零路由、零依赖,与 AI 结对开发。"


### PR DESCRIPTION
## Submission / 收录投稿

**Plugin / 插件**: [Enosensu/dsh-fork-relink](https://github.com/Enosensu/dsh-fork-relink) — category `session`

**What it does / 功能**: After any official fork (native branch button or other plugins), **copies** every direct subagent child of the source session onto the forked child, recursively for whole subtrees. Each copy is created through the official `ctx.agents.create` with the fork child as its `parentSession`, seeded with the original's completed-event prefix, given its own `subagent/descriptor`, minted a fresh id, and then released to a cold session so the official cold-resume path can address it. Originals are left untouched — copy, not move.

**Why / 背景**: A fork changes the parent session id while the children's durable `parentSession` still names the old session, so the forked conversation's subagent panel is empty and its children are unreachable from the new parent. The official fork exposes no children API and no listed plugin covers this. If the official fork grows native relinking, this plugin can simply be uninstalled.

**Verified / 已验证** (throwaway-fixture acceptance, 2026-09-11):
- `list_agents` on the fork child lists the copies, and a listed id is exactly the id `send_message` accepts;
- sending to a copy cold-resumes it and it answers, with the pre-fork history already in its context;
- a copy that fails delivers its settlement notice back to the fork child (outcome returns to the new parent);
- repeated opens/forks never duplicate copies (idempotence gate), and every copy is re-verified resumable after each run.

**Known limits / 已知边界**:
- it is a **fork-time copy, not a live mirror** — after the fork the two branches evolve independently;
- continuing a child from the new branch must use the **copy's id**; the original id stays with the old branch and answers `UNAUTHORIZED`;
- children with no completed turn are skipped (logged); a running child is copied through its last `turn/end`;
- the parent↔child channel keeps DSH defaults (settlement notice + `send_message`), not the child's intermediate steps.

**Checklist / 自查**:
- [x] Declares a `dsh.bundle` manifest (installs via `dsh plugin add`)
- [x] Real working code, zero dependencies, no obfuscation, no network calls
- [x] No file rewriting: official session/agent APIs only; the sole file it writes is its own log
- [x] Repo is public; README documents background, mechanism, install, tests, reachability contract, and known limits
- [x] Co-developed with AI (noted in README and repo description)

Co-developed with AI (ZCode agent, GLM model).
