### PR TITLE
Add SmailPang/dsh-effort-slider

### DIFF
--- a/data/plugins/SmailPang__dsh-effort-slider.yml
+++ b/data/plugins/SmailPang__dsh-effort-slider.yml
@@ -1,0 +1,7 @@
+url: https://github.com/SmailPang/dsh-effort-slider
+name: SmailPang/dsh-effort-slider
+category: ui
+description:
+  en: Replaces the native DSH reasoning-level option list in place with a draggable Off, Low, High, and Max slider while preserving the official model-selection flow.
+  zh: 在原位置将 DSH 原生推理等级选项替换为可拖动的 Off、Low、High、Max 滑块，并保留官方模型选择流程。
+tarball: https://github.com/SmailPang/dsh-effort-slider/releases/download/v0.1.1/dsh-effort-slider-0.1.1.tgz


### PR DESCRIPTION
## Summary`n`nAdds `SmailPang/dsh-effort-slider` to the UI category.`n`n## Difference from the existing similarly named entry`n`nThe existing `2768651338/dsh-effort-slider` intercepts the Effort row and opens a separate plugin-owned panel that writes `reasoningEffort` directly. This plugin instead enters the native DSH reasoning-level submenu, replaces its native option list in place, and activates the hidden native options so the official model-selection flow, back navigation, and persistent submenu behavior are preserved.`n`n## Validation`n`n- Repository declares `dsh.bundle`.`n- Repository has the `dsh-plugin` topic.`n- A prebuilt GitHub Release tarball is provided.`n- `node scripts/generate-readme.mjs` completed successfully locally.