### PR TITLE
Update dsh-mneme description & demo screenshots

### DIFF
--- a/data/plugins/modusensus__dsh-mneme.yml
+++ b/data/plugins/modusensus__dsh-mneme.yml
@@ -2,5 +2,5 @@ url: https://github.com/modusensus/dsh-mneme
 name: modusensus/dsh-mneme
 category: memory
 description:
-  en: "Cross-session memory plugin for DeepSeek Harness: remembers across sessions, consolidates in the background (autoDream), and manages everything through an interactive memory library panel — SQLite storage with human-editable Markdown mirrors, offline semantic search, and a standalone external API and CLI."
-  zh: "DeepSeek Harness 跨会话记忆插件：跨会话记住用户与项目、后台 autoDream 自动巩固记忆、交互式记忆库面板统一管理（浏览/搜索/编辑/导入导出）——SQLite 存储配可人工编辑的 Markdown 镜像，支持离线语义检索、独立外部 API 与 CLI。"
+  en: "The memory that dreams — cross-session memory for DeepSeek Harness: remembers you across sessions, auto-consolidates in its sleep (autoDream), parks conflicting memories for your review, and keeps a replayable audit trail. Offline-first: local semantic search, SQLite with human-editable Markdown mirrors, entity graph & an interactive memory panel plus an external API and CLI."
+  zh: "会做梦的记忆 — DeepSeek Harness 跨会话记忆插件：跨会话记住用户与项目、深夜 autoDream 自动巩固记忆、矛盾记忆自动挂起等你裁决、全程可回放审计。默认离线：本地语义检索，SQLite 配可人工编辑的 Markdown 镜像，支持实体图谱、交互式记忆库面板及独立外部 API 与 CLI。"

--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -1,4 +1,11 @@
 {
+ "https://github.com/modusensus/dsh-mneme": [
+  "https://raw.githubusercontent.com/modusensus/dsh-mneme/main/images/screenshot-memories-en.png",
+  "https://raw.githubusercontent.com/modusensus/dsh-mneme/main/images/screenshot-entities-en.png",
+  "https://raw.githubusercontent.com/modusensus/dsh-mneme/main/images/screenshot-status-en.png",
+  "https://raw.githubusercontent.com/modusensus/dsh-mneme/main/images/screenshot-settings-en.png",
+  "https://raw.githubusercontent.com/modusensus/dsh-mneme/main/images/screenshot-help-en.png"
+ ],
  "https://github.com/anweat/dsh-context-console": [
   "https://raw.githubusercontent.com/anweat/dsh-context-console/main/docs/images/context-console-trajectory.png",
   "https://raw.githubusercontent.com/anweat/dsh-context-console/main/docs/images/context-console-inventory.png",


### PR DESCRIPTION
## What changed / 改了什么

Two files in `data/`:

1. **`data/plugins/modusensus__dsh-mneme.yml`** — rewrote the en/zh `description` to align with the refreshed project pitch ("the memory that dreams"): freezes conflicting memories for human review, keeps a replayable audit trail, offline-first semantic search over SQLite with human-editable Markdown mirrors, entity graph, interactive memory panel, plus an external API and CLI.
2. **`data/screenshots.json`** — new `modusensus/dsh-mneme` entry pointing to the English UI screenshots (memories / entities / status / settings / help).

## Why / 为什么

- Sync the awesome-list entry with the current feature set and the new project pitch.
- Showcase the plugin with real UI screenshots on the listing site.

No name / url / category changes.

## Note

This supersedes the earlier #4685 (which only touched the description); this PR also adds the demo screenshots.