### PR TITLE
Update dsh-mneme: refresh description & add demo screenshots

### DIFF
--- a/data/plugins/modusensus__dsh-mneme.yml
+++ b/data/plugins/modusensus__dsh-mneme.yml
@@ -2,5 +2,5 @@ url: https://github.com/modusensus/dsh-mneme
 name: modusensus/dsh-mneme
 category: memory
 description:
-  en: "The memory that dreams — cross-session memory for DeepSeek Harness: remembers you across sessions, auto-consolidates in its sleep (autoDream), parks conflicting memories for your review, and keeps a replayable audit trail. Offline-first: local semantic search, SQLite with human-editable Markdown mirrors, entity graph & an interactive memory panel plus an external API and CLI."
-  zh: "会做梦的记忆 — DeepSeek Harness 跨会话记忆插件：跨会话记住用户与项目、深夜 autoDream 自动巩固记忆、矛盾记忆自动挂起等你裁决、全程可回放审计。默认离线：本地语义检索，SQLite 配可人工编辑的 Markdown 镜像，支持实体图谱、交互式记忆库面板及独立外部 API 与 CLI。"
+  en: "The memory that dreams — cross-session memory for DeepSeek Harness: recalls you across sessions, auto-consolidates in its sleep (autoDream), freezes conflicting memories for your review, and keeps a replayable audit trail. Offline-first local semantic search over SQLite with human-editable Markdown mirrors, an entity graph, an interactive memory panel, plus an external API and CLI."
+  zh: "会做梦的记忆 — DeepSeek Harness 跨会话记忆插件：跨会话记住你与项目、深夜 autoDream 自动巩固记忆、冲突记忆先冻结待你裁决、全程可回放审计。默认离线：SQLite 配人工可编辑的 Markdown 镜像，提供本地语义检索、实体图谱、交互式记忆库面板及外部 API 与 CLI。"

--- a/data/plugins/modusensus__dsh-mneme.yml
+++ b/data/plugins/modusensus__dsh-mneme.yml
@@ -2,5 +2,5 @@ url: https://github.com/modusensus/dsh-mneme
 name: modusensus/dsh-mneme
 category: memory
 description:
-  en: "Cross-session memory plugin for DeepSeek Harness: remembers across sessions, consolidates in the background (autoDream), and manages everything through an interactive memory library panel — SQLite storage with human-editable Markdown mirrors, offline semantic search, and a standalone external API and CLI."
-  zh: "DeepSeek Harness 跨会话记忆插件：跨会话记住用户与项目、后台 autoDream 自动巩固记忆、交互式记忆库面板统一管理（浏览/搜索/编辑/导入导出）——SQLite 存储配可人工编辑的 Markdown 镜像，支持离线语义检索、独立外部 API 与 CLI。"
+  en: "The memory that dreams — cross-session memory for DeepSeek Harness: remembers you across sessions, auto-consolidates in its sleep (autoDream), parks conflicting memories for your review, and keeps a replayable audit trail. Offline-first: local semantic search, SQLite with human-editable Markdown mirrors, entity graph & an interactive memory panel plus an external API and CLI."
+  zh: "会做梦的记忆 — DeepSeek Harness 跨会话记忆插件：跨会话记住用户与项目、深夜 autoDream 自动巩固记忆、矛盾记忆自动挂起等你裁决、全程可回放审计。默认离线：本地语义检索，SQLite 配可人工编辑的 Markdown 镜像，支持实体图谱、交互式记忆库面板及独立外部 API 与 CLI。"

--- a/data/screenshots.json
+++ b/data/screenshots.json
@@ -1,4 +1,11 @@
 {
+ "https://github.com/modusensus/dsh-mneme": [
+  "https://raw.githubusercontent.com/modusensus/dsh-mneme/main/images/screenshot-memories-en.png",
+  "https://raw.githubusercontent.com/modusensus/dsh-mneme/main/images/screenshot-entities-en.png",
+  "https://raw.githubusercontent.com/modusensus/dsh-mneme/main/images/screenshot-status-en.png",
+  "https://raw.githubusercontent.com/modusensus/dsh-mneme/main/images/screenshot-settings-en.png",
+  "https://raw.githubusercontent.com/modusensus/dsh-mneme/main/images/screenshot-help-en.png"
+ ],
  "https://github.com/anweat/dsh-context-console": [
   "https://raw.githubusercontent.com/anweat/dsh-context-console/main/docs/images/context-console-trajectory.png",
   "https://raw.githubusercontent.com/anweat/dsh-context-console/main/docs/images/context-console-inventory.png",


### PR DESCRIPTION
Refreshes the curated entry for `modusensus/dsh-mneme`:

- **Description**: rewrites the en/zh copy to reflect what the plugin does today — cross-session recall, background `autoDream` consolidation, conflicting memories frozen for manual review, a replayable audit trail, offline-first local semantic search over SQLite, human-editable Markdown mirrors, an entity graph, an interactive memory panel, and an external API/CLI
- **Demo screenshots**: adds 5 screenshots (memories / entities / status / settings / help) to `data/screenshots.json` under the existing dsh-mneme key, served from the plugin repo's own `images/` folder
- **Host version requirement**: compatible with all current DeepSeek Harness (DSH) releases — the plugin's `peerDependencies` cover every published 0.1.x (0.1.0-rc.6 through 0.1.5-rc.1, incl. prereleases) plus future 0.2 prereleases, with explicit prerelease branches per awesome-dsh-plugin's peer-range convention. Verified 745 tests green against dsh 0.1.5-rc.1.

Files changed:
- `data/plugins/modusensus__dsh-mneme.yml` (+2 -2)
- `data/screenshots.json` (+7 -0)

All five screenshot URLs verified to return 200.
