### PR TITLE
build: date entries that a merge commit introduced (#4731)

### DIFF
--- a/data/plugins/chromoany__dsh-notify-me.yml
+++ b/data/plugins/chromoany__dsh-notify-me.yml
@@ -1,0 +1,6 @@
+url: https://github.com/chromoany/dsh-notify-me
+name: chromoany/dsh-notify-me
+category: notify
+description:
+  en: Desktop notifications, sounds and a tab-title marker when the agent needs your input or a reply finishes in the background.
+  zh: 模型需要你操作或后台回复完成时，弹出系统通知、提示音并标记标签页标题。

--- a/scripts/build-site.mjs
+++ b/scripts/build-site.mjs
@@ -238,7 +238,14 @@ if (ordered.some((e) => !dates[e.url])) {
       try {
         // Oldest "added" commit for that path. Not `-1`, which git applies
         // before --reverse and would hand back the newest instead.
-        const out = execSync(`git log --diff-filter=A --format=%cI -- ${JSON.stringify(file)}`,
+        // --diff-merges=first-parent: git log does not diff merge commits by
+        // default, so a file the merge itself introduced (a submission merged
+        // with --no-ff, or a batch merge) has no "added" commit at all and the
+        // build exited 1 for that entry, failing main and every open PR. With
+        // the flag the merge is the commit that adds the path, so %cI is the
+        // merge date — which is what the README ledger above already reports
+        // for the same entries (the merge and the README commit are seconds apart).
+        const out = execSync(`git log --diff-merges=first-parent --diff-filter=A --format=%cI -- ${JSON.stringify(file)}`,
           { encoding: 'utf8' }).trim().split('\n').filter(Boolean)
         const iso = out[out.length - 1]
         if (iso) dates[e.url] = new Date(iso).toISOString()


### PR DESCRIPTION
Implements option 2 from #4731 as a one-line change, after reproducing both date walks on a synthetic repository so the flag is not merged on faith.

## The change

`scripts/build-site.mjs`, the yml ledger (line 241):

```diff
-        const out = execSync(`git log --diff-filter=A --format=%cI -- ${JSON.stringify(file)}`,
+        const out = execSync(`git log --diff-merges=first-parent --diff-filter=A --format=%cI -- ${JSON.stringify(file)}`,
```

`git log` does not diff merge commits by default, so a path that the **merge itself** introduced has no `A` commit in that walk at all. Those entries keep a missing added-date, `build-site.mjs` reaches its `refusing to build` branch, and exit 1 fails `main` and every open PR — the state since `5599809c`.

## What the flag changes, measured

On a repository built to the same shape (yml + README line added on a side branch, merged with `--no-ff`):

```
$ git log --diff-filter=A --format=%cI -- data/plugins/b__dsh-b.yml
2026-09-01T00:00:00Z                    <- the side branch's own commit (today: found only when it is not merge-introduced)

$ git log --diff-merges=first-parent --diff-filter=A --format=%cI -- data/plugins/b__dsh-b.yml
2026-09-09T12:00:00Z                    <- the merge commit
```

With the flag the merge is the commit that adds the path, so `%cI` is the **merge** date. That is the intended semantics here and not a side effect to paper over: the other ledger already publishes the merge era for these entries — the README line for the three `wwweljf` entries comes from `5b7be0b9` (2026-09-08T15:01:48Z), nine seconds after `5599809c`. The comment added above the call records this, because `%cI` on a merge reads like a bug otherwise.

## The other walk is deliberately untouched

The README walk (line 212) does **not** get the flag. Measured on the same synthetic repo, its result is identical with and without it, and its parser cannot be polluted by merge patches: the loop only reads lines starting with `\x01` or `+` (skipping `+++`), and a merge's `-p` output for the README contains no `+- [name](url) — ` lines — such a line can only come from the side that wrote it, which the same walk already sees through `--reverse --date-order`. Adding the flag there would only widen the merge diffs it scans.

## Relationship to #4743

Independent, either can be taken alone. Worth knowing when sequencing them: with the three keys pinned, `ordered.some((e) => !dates[e.url])` is false on the publishing path, so **neither walk runs at all** — #4743 is the immediate unblock and this is the guard against the same class of failure the next time a submission is merged with `--no-ff`, or the pins are dropped again the way `#2662`'s merge dropped them.

Fixes #4731.
