### PR TITLE
Add uigdwunm/dsh-conversation-jump

### DIFF
--- a/data/plugins/uigdwunm__dsh-conversation-jump.yml
+++ b/data/plugins/uigdwunm__dsh-conversation-jump.yml
@@ -1,0 +1,7 @@
+url: https://github.com/uigdwunm/dsh-conversation-jump
+name: uigdwunm/dsh-conversation-jump
+category: ui
+tarball: https://github.com/uigdwunm/dsh-conversation-jump/releases/download/v0.1.5/dsh-conversation-jump-0.1.5.tgz
+description:
+  en: A rail of four circular buttons in the DSH Web conversation that step to the previous or next user message, or to the top or bottom, paging older history in automatically.
+  zh: 在 DSH Web 对话区提供一组圆形按钮，逐条跳到上一条或下一条用户消息，或直接到顶部与底部，并自动翻页加载更早历史。


### PR DESCRIPTION
> **Update:** the `tarball` points at `v0.1.5` — buttons `30×26`, `18 px` chevrons, `16 px` above the composer, auto-hide now 3 s. The intermediates this PR carried earlier were withdrawn and no longer resolve; `v0.1.5` installs straight from the release asset with no build step.

Adds one entry for a DSH Web conversation navigation plugin. Category `ui`.

<!-- Thanks for contributing! Quick checklist / 提交前快速自查 -->

- [x] I added **one file** at `data/plugins/<owner>__<repo>.yml` — the READMEs are generated, don't edit them by hand / 我新增了一个 `data/plugins/<owner>__<repo>.yml` 文件（各语言 README 由脚本生成，不要手工编辑）
- [ ] I ran `node scripts/generate-readme.mjs` and committed the regenerated READMEs / 我已执行 `node scripts/generate-readme.mjs` 并提交了重新生成的 README
- [x] My repo's `package.json` declares **`dsh.bundle`** (not just `dsh.client`) — [example](../blob/main/contributing.md) / 仓库 `package.json` 已声明 `dsh.bundle`（只有 `dsh.client` 无法安装）
- [ ] My repo is at least **1 day old** with **10+ commits** / 仓库创建满 1 天且提交数 ≥ 10
- [x] `category` is one of `ui theme model session memory tools skill workflow notify dev market fun`, and themes/skins go under `theme` / `category` 取值正确，主题/皮肤类请用 `theme`
- [x] Description states what the plugin does, no superlatives / 描述只说功能，不带营销词
- [x] My repo has the `dsh-plugin` topic / 仓库已打 `dsh-plugin` topic

Two notes on the checklist, so nothing here is a blind tick:

- **Line 2** — I left it unchecked. `contributing.md` says regenerating the READMEs is preview-only and that committing the result is optional ("本地重新生成没问题"), so I did not hand-edit or commit generated files. Say the word if you'd rather have the regenerated pair in the PR and I'll push it.
- **Line 4** — the repo is **7 commits**, so it does not satisfy the literal "10+" written in this template, and I am not ticking a box that is not true. `contributing.md` and the comment block in `scripts/check-submission.mjs` both state the commit floor was dropped on 2026-09-03 (#4196) and that only the 1-day age floor remains; this repo was created 2026-08-18, so it clears the age floor. If the template is simply stale I'd suggest updating that line — if the 10+ bar is actually live, close this and I'll come back.

**Recommended (not required) / 推荐但不强制：**

- 📦 Publish to npm — not done yet; pending an npm account. Declared as a fallback path below.
- 🔗 Declare official `@deepseek-ai/*` packages as `peerDependencies` (not `dependencies`) — done: `@deepseek-ai/cordis` is a `peerDependency`, and `dependencies` is empty.
- 🖼️ Screenshots — not included in this PR. Happy to add shots to `data/screenshots.json` in a follow-up if you want them.

**Install paths.** The entry declares a `tarball` pointing at the prebuilt `v0.1.5` release asset, so users get a one-command install without a local build:

```sh
dsh plugin --profile web add https://github.com/uigdwunm/dsh-conversation-jump/releases/download/v0.1.5/dsh-conversation-jump-0.1.5.tgz
```

The repo declares no `prepare` script, so no `allowBuilds` approval is needed on the tarball or `github:` route. The package is not on npm yet.





