### PR TITLE
Add dsh-sync-plugin: session/config sync across machines via private GitHub repo

### DIFF
--- a/data/plugins/dpskk2__dsh-sync-plugin.yml
+++ b/data/plugins/dpskk2__dsh-sync-plugin.yml
@@ -1,0 +1,6 @@
+url: https://github.com/dpskk2/dsh-sync-plugin
+name: dpskk2/dsh-sync-plugin
+category: session
+description:
+  en: Two-way sync of DSH sessions, workspace mappings, settings and patches between machines through your own private GitHub repo (API keys stay machine-local).
+  zh: 通过你自己的 GitHub 私有仓库,在多台电脑间双向同步 DSH 会话、工作区对应关系、设置与托管补丁(API 密钥留在本机)。


### PR DESCRIPTION
Adds **dpskk2/dsh-sync-plugin** under the session category (one entry, per contributing.md).

Two-way sync of DSH sessions, workspace mappings, settings and managed node_modules patches between machines through your own private GitHub repo; API keys stay machine-local (re-login or `apiKeyEnv` on each machine).

- Root `package.json` declares `dsh.bundle` (`cordis.patch.yml`) — installable via `dsh plugin add`
- Published on npm (`dsh-sync-plugin@0.11.3`) with `repository` pointing back at this repo
- Repo created 2026-09-01 (older than the 1-day bar), actively maintained
- `dsh-plugin` topic already set on the repository