### PR TITLE
Add f-infinite-z/dsh-plugin-ops#dsh-plugin-ops-bundle

### DIFF
--- a/data/plugins/f-infinite-z__dsh-plugin-ops--packages-bundle.yml
+++ b/data/plugins/f-infinite-z__dsh-plugin-ops--packages-bundle.yml
@@ -3,4 +3,3 @@ name: f-infinite-z/dsh-plugin-ops#dsh-plugin-ops-bundle
 category: market
 description:
   en: 'Pre-boot health gate and repair for dsh plugin trees: seven static scan rules, fault attribution after failed boots, whitelisted reversible fixes, and a panel with plugin-row management plus a RAG knowledge base of past failures.'
-  zh: 'dsh 鎻掍欢鏍戠殑鍚姩鍓嶄綋妫€涓庝慨澶嶏細涓冩潯闈欐€佹壂鎻忚鍒欍€佸惎鍔ㄥけ璐ュ綊鍥犮€佺櫧鍚嶅崟鍙€嗕慨澶嶏紝闈㈡澘鍚彃浠惰绠＄悊涓庡巻鍙叉晠闅?RAG 鐭ヨ瘑搴撱€?

--- a/data/plugins/f-infinite-z__dsh-plugin-ops--packages-bundle.yml
+++ b/data/plugins/f-infinite-z__dsh-plugin-ops--packages-bundle.yml
@@ -1,0 +1,6 @@
+url: https://github.com/f-infinite-z/dsh-plugin-ops/tree/main/packages/bundle
+name: f-infinite-z/dsh-plugin-ops#dsh-plugin-ops-bundle
+category: market
+description:
+  en: 'Pre-boot health gate and repair for dsh plugin trees: seven static scan rules, fault attribution after failed boots, whitelisted reversible fixes, and a panel with plugin-row management plus a RAG knowledge base of past failures.'
+  zh: 'dsh 鎻掍欢鏍戠殑鍚姩鍓嶄綋妫€涓庝慨澶嶏細涓冩潯闈欐€佹壂鎻忚鍒欍€佸惎鍔ㄥけ璐ュ綊鍥犮€佺櫧鍚嶅崟鍙€嗕慨澶嶏紝闈㈡澘鍚彃浠惰绠＄悊涓庡巻鍙叉晠闅?RAG 鐭ヨ瘑搴撱€?


### PR DESCRIPTION
Adds the embedded bundle subpackage of dsh-plugin-ops to Plugin Markets & Managers.

- Repo: https://github.com/f-infinite-z/dsh-plugin-ops (`dsh-plugin` topic set, actively maintained)
- Install: `dsh plugin --profile web add dsh-plugin-ops-bundle` (npm 0.2.0 published)
- What it does: pre-boot scan/gate for the plugin tree (seven static rules), fault attribution after failed boots, whitelisted reversible fixes, and a Web panel with plugin-row management plus a RAG knowledge base of past failures.
