### PR TITLE
Add TianJie52009/dsh-kaomoji

### DIFF
--- a/data/plugins/TianJie52009__dsh-kaomoji.yml
+++ b/data/plugins/TianJie52009__dsh-kaomoji.yml
@@ -1,0 +1,6 @@
+url: https://github.com/TianJie52009/dsh-kaomoji
+name: TianJie52009/dsh-kaomoji
+category: fun
+description:
+  en: Adds a mood-aware Japanese kaomoji to agent replies, picked from a curated kaomojiya.org whitelist and configurable from Settings → General.
+  zh: 给 dsh 回复按情绪添加日文颜文字，词库精选自颜文字屋（kaomojiya.org），可在「设置 → 通用设置」中调整。


### PR DESCRIPTION
Adds dsh-kaomoji, a prompt-injection plugin that makes DSH replies include a mood-appropriate Japanese kaomoji from a curated kaomojiya.org whitelist.

- Host half: system-prompt section + entries/settings RPC
- Web half: a Settings -> General card
- Manifest: dsh.bundle.patch + dsh.client (installable via dsh plugin add)
- Published on npm as dsh-kaomoji; repository field points back to this repo
- Repo topic dsh-plugin added

Category: fun (same family as dsh-emoji / dsh-meme).