### PR TITLE
Add polohot/dsh-adrian-inject-context

### DIFF
--- a/data/plugins/polohot__dsh-adrian-inject-context.yml
+++ b/data/plugins/polohot__dsh-adrian-inject-context.yml
@@ -1,0 +1,5 @@
+url: https://github.com/polohot/dsh-adrian-inject-context
+name: polohot/dsh-adrian-inject-context
+category: identity
+description:
+  en: Injects your own saved context entries as a Remember row after each user message, per turn or once per session, with a Settings editor and a manager page.


### PR DESCRIPTION
## What it is

`polohot/dsh-adrian-inject-context` persists your own context entries and injects them as a standalone Remember row, per turn or once per session.

## Why the `identity` category

The plugin injects a user-authored instruction block into the conversation. The `identity` section already holds `lw-storm/dsh-plugin-masterprompt` and `PerryLink/dsh-personal-directive`, which are the same shape.

## Checks

- `package.json` declares `dsh.bundle.patch`, and `cordis.patch.yml` sits at the repo root.
- The repo carries the `dsh-plugin` topic.
- The repo is 4 days old.
- One file added. No other entry is touched.
- The description states only what the code does. Entries are stored in `~/.dsh/adrian-inject-context.json` and injected as a user-role Remember row. The Settings editor and the manager page exist.
