### PR TITLE
Add Imnotndesh/dsh-peak-pricing-warning

### DIFF
--- a/data/plugins/Imnotndesh__dsh-peak-pricing-warning.yml
+++ b/data/plugins/Imnotndesh__dsh-peak-pricing-warning.yml
@@ -2,5 +2,5 @@ url: https://github.com/Imnotndesh/dsh-peak-pricing-warning
 name: Imnotndesh/dsh-peak-pricing-warning
 category: ui
 description:
-  en: 'Shows a live DeepSeek peak/off-peak pricing badge beside the model selector with a countdown to the next rate change, and a session cost pill that prices the four billed token buckets at published list rates.'
-  zh: '在模型选择器旁显示 DeepSeek 峰谷定价徽标并倒计时到下一次调价，另有一个按已计费四类 token 桶与官方价格估算本次会话费用的费用胶囊。'
+  en: 'Shows DeepSeek peak/off-peak pricing status, a countdown to the next rate change, and the estimated session cost as inline text beside the model selector.'
+  zh: '在模型选择器旁以行内文字显示 DeepSeek 峰谷定价状态、距下一次调价的倒计时，以及本次会话的预估费用。'

--- a/data/plugins/Imnotndesh__dsh-peak-pricing-warning.yml
+++ b/data/plugins/Imnotndesh__dsh-peak-pricing-warning.yml
@@ -1,0 +1,6 @@
+url: https://github.com/Imnotndesh/dsh-peak-pricing-warning
+name: Imnotndesh/dsh-peak-pricing-warning
+category: ui
+description:
+  en: 'Shows a live DeepSeek peak/off-peak pricing badge beside the model selector with a countdown to the next rate change, and a session cost pill that prices the four billed token buckets at published list rates.'
+  zh: '在模型选择器旁显示 DeepSeek 峰谷定价徽标并倒计时到下一次调价，另有一个按已计费四类 token 桶与官方价格估算本次会话费用的费用胶囊。'


### PR DESCRIPTION
Adds one file: `data/plugins/Imnotndesh__dsh-peak-pricing-warning.yml`, as the contributing guide specifies.

## What the plugin does

Two client-side plugins for the DSH web GUI, both about token cost:

- **peak-pricing-warning** — a colour-coded badge beside the model selector (red = peak, yellow = weekday off-peak, green = weekend) with a live countdown to the next rate change. Off-peak is half price, so this makes the "send it now or wait" decision visible.
- **cost-estimator** — a session cost pill in the composer dock, priced from the `tokenUsage` session projection, which already exposes DeepSeek's four disjoint billing buckets (uncached input / cache read / cache write / output) at published list rates.

Both gate on the session's selected model, so they only render for DeepSeek routes.

## Checklist against the requirements

- `dsh.bundle` manifest — declared in `package.json` with `bundle.patch` → `./cordis.patch.yml`, and `client.platform: web`. The `cordis.patch.yml` is committed at the repo root.
- Real, working code — both halves are in `plugins/*/src/plugin.js`, with `lib/` generated from it by `build.mjs` so the two never drift. Both plugins are currently running in a live DSH session.
- `dsh-plugin` topic — added.
- Category — `ui`, since both are web-GUI surface additions and neither is a theme.
- Description — factual, no superlatives, ends with a period, quoted.

## One thing to flag

The repo was created **today**, so it does not yet satisfy the 1-day age CI check. I'm opening this now rather than sitting on the work; if CI fails on age alone I'll re-run it once the repo clears 24 hours. No change to the entry should be needed.

## Testing

`node test/peak.test.mjs` (8 schedule boundaries — both peak blocks, the gap between them, both weekend edges, the return to peak) and `node test/cost.test.mjs` (12 published rates asserted exactly, plus peak-is-2x-off-peak and cache-read-is->10x-cheaper invariants).