### PR TITLE
Simplify SuCriss/dsh-leekbox description

### DIFF
--- a/data/plugins/SuCriss__dsh-leekbox.yml
+++ b/data/plugins/SuCriss__dsh-leekbox.yml
@@ -2,5 +2,5 @@ url: https://github.com/SuCriss/dsh-leekbox
 name: SuCriss/dsh-leekbox
 category: tools
 description:
-  en: 'A-share market dashboard: realtime indices and quotes, millisecond full-market search (code/name/pinyin initials with inline live quotes), market sentiment thermometer (up/down breadth, limit-up/limit-down/broken counts, consecutive-board ladder, limit-up pool), THS-style stock detail popups with candlestick K-line (forward-adjusted, MA5/10/20, volume, crosshair), persistent watchlist with realtime quotes, grouping and JSON/CSV import-export, ETF/convertible-bond/LOF boards, main-board/non-main-board pool toggles on the rank lists, dual-mode screener (weighted signal score + 7-preset multi-strategy intersection), and a tri-source 7x24 news feed (Sina/Eastmoney/Jin10) with important-item highlighting.'
-  zh: '韭菜盒子：A股看盘助手——实时行情与大盘指数、毫秒级全市场搜索（代码/名称/拼音首字母，结果带实时价格涨幅）、市场情绪温度计（涨跌家数/涨停跌停炸板/连板梯队/涨停池）、同花顺式个股详情弹窗（前复权蜡烛图K线+MA均线+成交量+十字光标）、自选股实时行情持久化（分组、JSON/CSV导入导出）、ETF/可转债/LOF榜单、行情榜单主板/非主板池切换、双模式条件选股（加权评分 + 7策略交叉选股）、新浪/东财/金十三源聚合7x24快讯（重要资讯标红）。'
+  en: 'A-share market dashboard: realtime quotes and indices, millisecond full-market search, market sentiment thermometer, candlestick K-line detail popups, watchlist, ETF/convertible-bond/LOF boards, screener, and a 7x24 aggregated news feed.'
+  zh: '韭菜盒子:A股看盘助手——实时行情与大盘指数、毫秒级全市场搜索、市场情绪温度计、同花顺式K线详情弹窗、自选股、ETF/可转债/LOF榜单、条件选股、7x24聚合快讯。'


### PR DESCRIPTION
Simplifies the existing SuCriss/dsh-leekbox entry to a one-line functional summary. Only `data/plugins/SuCriss__dsh-leekbox.yml` is touched (2 lines); no other entry is modified.

**Before:** a single ~750-character sentence enumerating sub-details — pinyin-initial search internals, MA5/10/20, crosshair, forward adjustment, the count of screener presets, three news source names, important-item highlighting, main/non-main-board pool toggles.

**After:** one line listing the plugin's main surfaces, each of which exists in the code.

Dropped as sub-detail, not as features: candlestick internals, the number of screener presets, and the news source names. Nothing new is claimed — the plugin still does everything the previous line said; the line just stops trying to say all of it at once.

Rebased onto current `upstream/main`, so the entry keeps the npm-distribution form the maintainers already moved it to (`tarball:` was dropped upstream in an earlier commit; that is untouched here).

Note: the `check` job is currently red on this branch, but for an unrelated pre-existing reason — the build refuses over three `wwweljf/dsh-plugins` subdirectory entries with no derivable added-date. The same failure hits other PRs opened around the same time (e.g. #4503), and it originates in entries this PR does not touch.