### PR TITLE
add vitas/dsh-model-pricing

### DIFF
--- a/data/plugins/vitas__dsh-model-pricing.yml
+++ b/data/plugins/vitas__dsh-model-pricing.yml
@@ -1,0 +1,13 @@
+# Ready-to-submit entry for https://github.com/awesome-dsh-plugin/awesome-dsh-plugin
+# Open a PR that adds this file to the list repo as:
+#   data/plugins/vitas__dsh-model-pricing.yml
+# (READMEs in that repo are generated from data/plugins/*.yml — do not edit them.)
+# Submission gate: the list's CI requires the target repo to be >= 1 day old;
+# vitas/dsh-model-pricing was created 2026-09-09T16:36Z, so submit from
+# 2026-09-10T17:00Z onward.
+url: https://github.com/vitas/dsh-model-pricing
+name: vitas/dsh-model-pricing
+category: model
+description:
+  en: 'Model pricing for the DSH settings page: per-1M-token prices from models.dev with the harness catalog overlaid, capability tags, cross-provider comparison, and a community promotion feed.'
+  zh: 'DSH 设置页中的模型价格表：基于 models.dev 的每 100 万 token 价格并叠加本地目录，含能力标签、跨供应商比价和社区促销信息源。'

--- a/data/plugins/vitas__dsh-model-pricing.yml
+++ b/data/plugins/vitas__dsh-model-pricing.yml
@@ -1,10 +1,3 @@
-# Ready-to-submit entry for https://github.com/awesome-dsh-plugin/awesome-dsh-plugin
-# Open a PR that adds this file to the list repo as:
-#   data/plugins/vitas__dsh-model-pricing.yml
-# (READMEs in that repo are generated from data/plugins/*.yml — do not edit them.)
-# Submission gate: the list's CI requires the target repo to be >= 1 day old;
-# vitas/dsh-model-pricing was created 2026-09-09T16:36Z, so submit from
-# 2026-09-10T17:00Z onward.
 url: https://github.com/vitas/dsh-model-pricing
 name: vitas/dsh-model-pricing
 category: model


### PR DESCRIPTION
Adds `vitas/dsh-model-pricing` (category: model). The repo declares the full `dsh.bundle` manifest (plus a web `dsh.client`), is published to npm (`dsh-model-pricing@0.2.0`), carries the `dsh-plugin` topic, and the entry description matches the code — the stats it cites are the live snapshot numbers (213 providers, 7,178 priced rows). `description.zh` included. Thanks!