### PR TITLE
Add wx-yss/dsh-composer-enter

### DIFF
--- a/data/plugins/wx-yss__dsh-composer-enter.yml
+++ b/data/plugins/wx-yss__dsh-composer-enter.yml
@@ -1,0 +1,6 @@
+url: https://github.com/wx-yss/dsh-composer-enter
+name: wx-yss/dsh-composer-enter
+category: session
+description:
+  en: Makes Enter insert a newline in the DSH 0.1.5 Web composer while Cmd/Ctrl+Enter keeps submitting messages.
+  zh: 让 DSH 0.1.5 Web 输入框使用 Enter 换行，同时保留 Cmd/Ctrl+Enter 提交消息。


### PR DESCRIPTION
## 内容

新增 `wx-yss/dsh-composer-enter` 条目。该插件让 DSH 0.1.5 Web 输入框使用 Enter 换行，同时保留 Cmd/Ctrl+Enter 提交。

## 自查

- [x] 只新增一个 `data/plugins/<owner>__<repo>.yml` 文件
- [x] 插件根目录 `package.json` 已声明 `dsh.bundle`
- [ ] 仓库创建满 1 天（年龄门禁会在达到条件后自动重跑）
- [x] 分类使用 `session`
- [x] 描述只陈述实际功能
- [x] 仓库已添加 `dsh-plugin` topic

## 验证

- 插件仓库 `npm run check` 通过
- 已在 DSH CLI `0.1.5-rc.1`、Web 客户端组件 `0.1.5-rc.2` 实测 Enter 换行
- 投稿门禁除仓库年龄外均通过