### PR TITLE
Add Beatther-c/dsh-api-client — agent-native API client (Postman-like UI + api_client_* agent tools)

### DIFF
--- a/data/plugins/Beatther-c__dsh-api-client.yml
+++ b/data/plugins/Beatther-c__dsh-api-client.yml
@@ -1,0 +1,6 @@
+url: https://github.com/Beatther-c/dsh-api-client
+name: Beatther-c/dsh-api-client
+category: tools
+description:
+  en: 'Agent-native API client for DeepSeek Harness: Postman-like debugging UI (request tree with context menus and full keyboard navigation, resizable sidebar, layered auto-generated header preview with per-item suppression and constant secret masking), six api_client_* agent tools sharing the same request core, redaction and audit chain with the human UI, Postman Collection v2.1 import with a migration report, environment variables with SecretRef indirection, and a fail-closed SSRF network policy.'
+  zh: DeepSeek Harness 的 Agent 原生 API Client：Postman 级调试 UI（右键菜单与完整键盘导航的请求树、可调宽侧栏、自动生成 Header 分层预览——逐项可停用、敏感值恒脱敏），六个 api_client_* Agent 工具与 Human UI 共用同一请求核心、脱敏与审计链，Postman Collection v2.1 导入附迁移报告，环境变量经 SecretRef 间接引用，SSRF 网络策略默认 fail-closed。


### PR DESCRIPTION
## What is this plugin / 这是什么插件

**dsh-api-client** is an agent-native API client for DeepSeek Harness — a Postman-like debugging UI for humans and a set of `api_client_*` HTTP tools for agents, **sharing the same request core, redaction pipeline and audit chain**. Published on npm as [`dsh-api-client@0.2.0`](https://www.npmjs.com/package/dsh-api-client) (MIT).

**dsh-api-client** 是 DeepSeek Harness 的 Agent 原生 API Client——给人用的 Postman 级调试 UI 与给 Agent 用的 `api_client_*` HTTP 工具**共用同一请求核心、脱敏管线与审计链**。已以 MIT 协议发布 npm `dsh-api-client@0.2.0`。

## Highlights / 亮点

- **Human/Agent dual track, one core / 人机双轨同核**：UI 里调好的请求可一键「交给 Agent」（出域前经确认弹窗+脱敏投影）；Agent 执行的请求进同一 History 与审计。高风险方法默认进 Approval。
- **Desktop-grade request tree / 桌面级请求树**：right-click context menus (create/rename/copy/cut/paste/copy-as-cURL/delete), full keyboard contract (arrows, F2, Shift+F10, Cmd+C/X/V…), inline rename, search with isolated transient expansion.
- **Transparent auto-generated headers / 自动 Header 透明化**：layered preview of what Body/Auth/client defaults/runtime will actually send, with per-item suppression, source labels, override status, and a canonical `buildRequestPlan` shared by preview and send — no more "not shown in UI but sent on the wire".
- **Security by default / 默认安全**：secrets via SecretRef indirection, constant `••••••••` masking in every surface (DOM/aria/tooltip/History/Agent context), safe cURL with `<redacted>`, fail-closed SSRF network policy (localhost/private network denied by default, per-hop redirect re-evaluation, DNS-rebinding protection).
- **Postman Collection v2.1 import** with compatibility scan + migration report (scripts kept but never executed).
- **Zero added runtime deps for the latest release; client bundle verified free of server-only code.**

## Quality bar / 质量证据

- 30 spec files / **589 automated tests** green (unit + integration + real local echo-server wire-consistency tests pinning actual undici behavior); `tsc --noEmit` clean.
- Architecture boundary enforced by a source-scanning test (client never imports DSH internals; all mutations go hook → Host API → service/core → storage).
- Verified in a real DSH 0.1.2-rc.1 runtime via browser-driven acceptance (40+ assertions with evidence screenshots), plus an independent full-code review loop.

## Install / 安装

```bash
dsh plugin --profile web add dsh-api-client
```

Requires DSH `>=0.1.2-rc.1`. An **API Client** entry appears in the sidebar.

## Submission checklist / 投稿自查

- [x] `dsh.bundle` manifest in `package.json` + `cordis.patch.yml` at repo root
- [x] Real, working code (48+ source files across a pnpm monorepo: shared/core/postman-adapter packages + host + client)
- [x] Repo older than 1 day (created 2026-09-07)
- [x] `dsh-plugin` topic added
- [x] Actively maintained (v0.2.0 released 2026-09-10)
- [x] Description states features only, no superlatives
