### PR TITLE
Update LoopX DSH plugin to beta.5

### DIFF
--- a/data/plugins/huangruiteng__loopx--packages-dsh-loopx-plugin.yml
+++ b/data/plugins/huangruiteng__loopx--packages-dsh-loopx-plugin.yml
@@ -4,4 +4,4 @@ category: workflow
 description:
   en: 'LoopX, a provider-neutral, local-first state kernel and control plane for long-horizon agents: keeps Goal, Todo, gate, evidence, quota, recovery, and handoff state above DeepSeek Harness, while the plugin bootstraps the CLI and skills, admits bounded same-session continuation, and adds a loopback GoalBar for the exact bound loop.'
   zh: 'LoopX——面向长周期 Agent 的提供商中立、本地优先状态内核与控制平面：在 DeepSeek Harness 执行层之上持久化 Goal、Todo、门禁、证据、配额、恢复与交接状态；插件负责引导安装 CLI 与技能、准入有界的同会话续跑，并为精确绑定的工作循环提供本地 GoalBar。'
-tarball: https://github.com/huangruiteng/loopx/releases/download/dsh-loopx-plugin-v0.1.1-beta.4/dsh-loopx-plugin-0.1.1-beta.4.tgz
+tarball: https://github.com/huangruiteng/loopx/releases/download/dsh-loopx-plugin-v0.1.1-beta.5/dsh-loopx-plugin-0.1.1-beta.5.tgz


### PR DESCRIPTION
## Summary

Update the existing LoopX marketplace entry from beta.4 to beta.5. This release restores GoalBar compatibility on DSH 0.1.5 through its authenticated shared API carrier, while preserving the supported legacy carrier.

## Validation

- Release asset resolves successfully (HTTP 200)
- Downloaded release asset matches the locally packed artifact by SHA-256
- `node scripts/generate-readme.mjs --check`
- `git diff --check`

Only the existing LoopX entry YAML is changed; generated READMEs are untouched.
