### PR TITLE
fix(build): derive added dates through merge commits (unblocks main + PR queue)

### DIFF
--- a/data/added-dates.json
+++ b/data/added-dates.json
@@ -445,5 +445,8 @@
  "https://github.com/Tabbit-Browser/dsh-tabbit": "2026-08-21",
  "https://github.com/omdsh-dev/stent": "2026-08-13",
  "https://github.com/moguiyu/dsh-tavily/tree/main/packages/dsh-tavily": "2026-08-15",
- "https://github.com/polaris-smart/dsh-devices": "2026-08-19"
+ "https://github.com/polaris-smart/dsh-devices": "2026-08-19",
+ "https://github.com/wwweljf/dsh-plugins/tree/master/plugins/dsh-ding-sound": "2026-09-08",
+ "https://github.com/wwweljf/dsh-plugins/tree/master/plugins/dsh-wx-push": "2026-09-08",
+ "https://github.com/wwweljf/dsh-plugins/tree/master/plugins/dsh-wx-remote": "2026-09-08"
 }

--- a/scripts/build-site.mjs
+++ b/scripts/build-site.mjs
@@ -238,8 +238,27 @@ if (ordered.some((e) => !dates[e.url])) {
       try {
         // Oldest "added" commit for that path. Not `-1`, which git applies
         // before --reverse and would hand back the newest instead.
-        const out = execSync(`git log --diff-filter=A --format=%cI -- ${JSON.stringify(file)}`,
-          { encoding: 'utf8' }).trim().split('\n').filter(Boolean)
+        //
+        // --diff-merges=first-parent is what makes a merge-introduced entry
+        // visible. A maintainer's merge resolution can create both halves of an
+        // entry inside the merge commit — #2662 renamed the three
+        // wwweljf__dsh-plugins entries to their slug (…--plugins-dsh-*.yml)
+        // and wrote their README lines while merging — and `git log` shows no
+        // diff for a merge by default. So this lookup found nothing, README
+        // history had nothing either (those lines are in no non-merge commit),
+        // and the build refused to run for every entry that merge introduced:
+        // main was red from the moment it landed, and so was every pull
+        // request whose merge ref was built on top of it. With this flag the
+        // merge counts as the commit that added the path, which is exactly the
+        // date the ledger wants.
+        //
+        // The flag also makes merges emit their patch here, so the date lines
+        // have to be picked out instead of assuming every line is one:
+        // `new Date('+url: …')` throws, the catch below swallows it, and the
+        // entry lands back in "no added-date derivable" looking exactly like a
+        // shallow clone does.
+        const out = execSync(`git log --diff-merges=first-parent --diff-filter=A --format=%cI -- ${JSON.stringify(file)}`,
+          { encoding: 'utf8' }).split('\n').map((l) => l.trim()).filter((l) => /^\d{4}-\d{2}-\d{2}T/.test(l))
         const iso = out[out.length - 1]
         if (iso) dates[e.url] = new Date(iso).toISOString()
       } catch { /* not committed yet — falls through to the error below */ }


### PR DESCRIPTION
## What this fixes

`Build (locale parity, date derivation, templates)` has been failing on **main** since 2026-09-08, on every pull request whose merge ref was built after that, e.g. #4687 ([job log](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/actions/runs/34519562721/job/103013388550)):

```
3433 entries parsed across 2 locales
no added-date derivable for: https://github.com/wwweljf/dsh-plugins/tree/master/plugins/dsh-ding-sound, …/dsh-wx-push, …/dsh-wx-remote
need full git history (fetch-depth: 0) and committed entries — refusing to build
```

Those three entries were introduced **by the merge commit itself**. #2662 was merged as `5599809cf` (2026-09-08T15:01:39Z, `parents=2`), whose resolution renamed the entry files to their slug and wrote the README lines:

| | branch commits | on main |
|---|---|---|
| entry file | `wwweljf__dsh-plugins--dsh-ding-sound.yml` (now 404 on main) | `wwweljf__dsh-plugins--plugins-dsh-ding-sound.yml` |
| README line | none of the 4 branch commits touches a README | added by the merge commit (`README.md` `+3`) |

```
$ gh api "repos/awesome-dsh-plugin/awesome-dsh-plugin/commits?path=data/plugins/wwweljf__dsh-plugins--plugins-dsh-ding-sound.yml"
5599809cf  2026-09-08T15:01:39Z  parents=2   Add wwweljf/dsh-plugins: dsh-ding-sound, dsh-wx-push, dsh-wx-remote (#2662)
```

`git log` does not diff a merge by default, so both passes of the derivation come up empty — README history has no `+` line for those URLs, and the entry file's only commit is the merge. Neither URL is in `data/added-dates.json`, so the build refuses, by design.

## Changes

**`data/added-dates.json`** — pins the three entries to `2026-09-08` (the day they landed, matching the merge commit). This is the manual-migration path the file already exists for, and it makes the published dates independent of how the history is shaped later.

**`scripts/build-site.mjs`** — `--diff-merges=first-parent` on the yml lookup, so a merge counts as the commit that added the path. Verified against a reproduction of this exact history shape:

| | current code | with the flag |
|---|---|---|
| `git log --diff-filter=A -- <entry file>` | `''` | `2026-09-08T15:01:39+08:00` |
| README walk, for the same URL | `<NONE>` | (unchanged — see below) |

Two deliberate limits:

- The date lines are filtered (`/^\d{4}-\d{2}-\d{2}T/`) before `out[out.length - 1]`, because `--diff-merges=first-parent` also makes merges emit their patch. Without the filter `new Date('+url: …')` throws, the surrounding `catch` swallows it, and the entry lands back in "no added-date derivable".
- Only the yml lookup gets the flag. The README walk keeps its current output so that every date already published keeps the value it has; the yml is the better ledger anyway (one file per entry, added once).

## Verification

- `node -e "JSON.parse(…added-dates.json)"` — 450 keys, the three new ones present.
- `node --check scripts/build-site.mjs` — clean.
- Both lookups exercised against a local reproduction of the merge-introduced-entry shape (branch commit adds file under the old name, merge resolution renames it and rewrites the README line): current code → empty, patched code → the merge date.
- CI on this PR: `check` should be green, which is itself the end-to-end test — this branch changes no entry and no generated README.

A maintainer who would rather not take the script change can cherry-pick `data/added-dates.json` alone: the three dates are what unblocks main and the queue, and the script change is only what stops the next merge-introduced entry from needing this again.
