### PR TITLE
Add tmeeli/dsh-auto-goal-resume

### DIFF
--- a/data/plugins/tmeeli__dsh-auto-goal-resume.yml
+++ b/data/plugins/tmeeli__dsh-auto-goal-resume.yml
@@ -1,0 +1,6 @@
+url: https://github.com/tmeeli/dsh-auto-goal-resume
+name: tmeeli/dsh-auto-goal-resume
+category: session
+description:
+  en: "Automatically resumes active goal sessions after DSH restart; long-running tasks continue without a manual nudge."
+  zh: DSH 重启后自动续跑有活跃目标的会话,无需人工说「继续」。


### PR DESCRIPTION
Submit the dsh-auto-goal-resume plugin: automatically resumes active goal sessions after DSH restart (real-time + cold scan, idempotent, zero-dep). Repo: https://github.com/tmeeli/dsh-auto-goal-resume