### PR TITLE
Add TYEclipse/dsh-units

### DIFF
--- a/data/plugins/TYEclipse__dsh-units.yml
+++ b/data/plugins/TYEclipse__dsh-units.yml
@@ -1,0 +1,6 @@
+url: https://github.com/TYEclipse/dsh-units
+name: TYEclipse/dsh-units
+category: tools
+description:
+  en: 'Unit conversion toolbox covering 20 categories — length, mass, temperature, area, volume (incl. US cooking units), speed, time, data sizes (decimal MB vs binary MiB), data transfer rates (Mbps vs MB/s), acceleration incl. g-force, illumination (lux / foot-candle), pressure, energy, angle, frequency, power incl. three horsepower definitions, force, torque, typography (px/pt/em/rem), and fuel economy (mpg ↔ L/100km). Two tools — convert_unit and list_units — zero runtime dependencies, pure arithmetic; each result includes the formula applied.'
+  zh: '单位换算工具箱：覆盖 20 个类别——长度、质量、温度、面积、体积（含美制烹饪单位）、速度、时长、数据大小（十进制 MB 与二进制 MiB）、数据传输速率（Mbps 与 MB/s）、加速度（含 g-force）、照度（lux 与英尺烛光）、压强、能量、角度、频率、功率（含三种马力定义）、力、扭矩、排版（px/pt/em/rem）与油耗（mpg ↔ L/100km）。提供 convert_unit 与 list_units 两个工具；零运行时依赖，纯算术实现，结果附带所用公式。'


### PR DESCRIPTION
Adds `TYEclipse/dsh-units` — a unit conversion toolbox for dsh.

- Two tools: `convert_unit` (convert a value between two units of one category) and `list_units` (discover categories/symbols).
- 20 categories: length, mass, temperature (affine C/F/K), area, volume (incl. US cooking units), speed, time, data sizes (decimal MB vs binary MiB), data transfer rates (Mbps vs MB/s), acceleration (incl. standard gravity `g0`), illumination (lux / foot-candle), pressure, energy, angle, frequency, power (three horsepower definitions kept distinct), force, torque, typography, fuel economy (reciprocal mpg ↔ L/100km).
- Zero runtime dependencies, pure arithmetic over a static unit table — no network, no filesystem, no code execution. Rejects unknown units and cross-category pairs with clear errors.
- `dsh.bundle` manifest declared; `dsh-plugin` topic present; MIT licensed; repo created 2026-08-15.
- Install tested with an isolated profile: `dsh plugin --profile <tmp> add github:TYEclipse/dsh-units#v0.4.0`, then verified the module loads, the config layer mounts, and representative conversions run through the installed copy (e.g. `100 Mbps → 12.5 MB/s`, `1 g0 → 32.174049 ft/s²`, `1 fc → 10.76391 lx`).
