### PR TITLE
Add mrSutivu/plugin-effort-slider (UI)

### DIFF
--- a/data/plugins/mrSutivu__plugin-effort-slider.yml
+++ b/data/plugins/mrSutivu__plugin-effort-slider.yml
@@ -1,0 +1,6 @@
+url: https://github.com/mrSutivu/plugin-effort-slider
+name: mrSutivu/plugin-effort-slider
+category: ui
+description:
+  en: Notched reasoning-effort slider grouped with the model picker in the composer, with theme variables and English, French and Chinese labels.
+  zh: 与模型选择器连为一体的带刻度推理强度滑杆，位于输入框内，支持主题变量与中英法三语。


### PR DESCRIPTION
Add `mrSutivu/plugin-effort-slider` under `ui`.

Notched reasoning-effort slider grouped with the model picker in the DSH composer: realtime drag, max-effort shimmer, theme variables, English, French and Chinese labels.

- `dsh.bundle` manifest declared in `package.json` (plus `dsh.client`), real working code, MIT licensed
- Repo older than 1 day, actively maintained, `dsh-plugin` topic set
- Install: `dsh plugin --profile web add github:mrSutivu/plugin-effort-slider` (also on npm as `plugin-effort-slider`)
- Description verified against the source; single file added, generated READMEs untouched
