### PR TITLE
Add whiteS18/dsh-image-generation (vision)

### DIFF
--- a/data/plugins/whiteS18__dsh-image-generation.yml
+++ b/data/plugins/whiteS18__dsh-image-generation.yml
@@ -1,0 +1,6 @@
+url: https://github.com/whiteS18/dsh-image-generation
+name: whiteS18/dsh-image-generation
+category: vision
+description:
+  en: Configure multiple image providers in Settings and call image_generate with the one selected model; images save under generate/image and show inline in the conversation.
+  zh: 在设置中配置多个生图供应商，对话通过 image_generate 调用当前选中的模型；图片保存到工作区 generate/image，并在对话中内联显示。


### PR DESCRIPTION
Adds one entry: `data/plugins/whiteS18__dsh-image-generation.yml`.

**[whiteS18/dsh-image-generation](https://github.com/whiteS18/dsh-image-generation)** — Configure multiple image providers in Settings and call `image_generate` with the one selected model; images save under `generate/image` and show inline in the conversation.

- Category: `vision`
- `dsh.bundle` manifest declared in package.json (`patch: ./cordis.patch.yml`, file present in repo root); `dsh.client` declared for the web UI half
- Repo has the `dsh-plugin` topic and is past the 1-day age bar (created 2026-09-09T17:49:30Z)
- Published on npm as `dsh-image-generation@0.1.0`
- Distinct from existing `dsh-image-gen` listings: this plugin adds a Settings catalog of providers plus a plugin-config card that picks exactly one model for conversation `image_generate`
- Only this one new file is touched