### PR TITLE
dsh-think-translate: drop the stale prebuilt tarball

### DIFF
--- a/data/plugins/UncleK__dsh-think-translate.yml
+++ b/data/plugins/UncleK__dsh-think-translate.yml
@@ -1,0 +1,6 @@
+url: https://github.com/UncleK/dsh-think-translate
+name: UncleK/dsh-think-translate
+category: ui
+description:
+  en: Display-layer translation for the DSH Web UI — thinking chains, task cards and answers in 8 target languages via local Ollama or Google/Bing, originals preserved.
+  zh: DSH Web 界面显示层翻译：将思考链、任务卡片与回答正文翻译为 8 种目标语言之一（本地 Ollama 或 Google/Bing，自动选择），原文完整保留。


### PR DESCRIPTION
## What

Drops the `tarball:` line from this entry.

## Why

The entry pins a prebuilt from **v1.0.10**:

```yaml
tarball: https://github.com/UncleK/dsh-think-translate/releases/download/v1.0.10/dsh-think-translate-1.0.10.tgz
```

The plugin has shipped on npm since 1.1.0 (now **1.2.4**), and v1.0.10 predates a long list of fixes — including a credentials leak in two routes and a DSH provider-discovery bug. Since the market already prefers repo-verified npm packages over author tarballs, this line only matters when that npm path fails — and in exactly that case it would install the old build.

I have not been attaching prebuilt tarballs to releases since v1.0.10, so the field cannot stay current on its own; removing it lets npm be the single source of truth for installs.

Entry is otherwise unchanged. Nothing else in the file is touched.
