### PR TITLE
Add enteguo/dsh-plugin-quick-chat (ui)

### DIFF
--- a/data/plugins/enteguo__dsh-plugin-quick-chat.yml
+++ b/data/plugins/enteguo__dsh-plugin-quick-chat.yml
@@ -1,0 +1,6 @@
+url: https://github.com/enteguo/dsh-plugin-quick-chat
+name: enteguo/dsh-plugin-quick-chat
+category: ui
+description:
+  en: Adds a Quick Chat entry to the Web UI sidebar that opens a floating chat window with its own model and reasoning-effort picker, optionally seeded with the current session's transcript, and keeps every side conversation in a resumable, renamable, deletable history.
+  zh: 在侧边栏加入「快速会话」入口，打开一个小窗对话，可切换模型与思考强度、可选携带当前主会话全文，历史可继续、重命名、删除。


### PR DESCRIPTION
<!-- Thanks for contributing! Quick checklist / 提交前快速自查 -->

- [x] I added **one file** at `data/plugins/enteguo__dsh-plugin-quick-chat.yml` — that single file is the whole submission. The READMEs are regenerated on `main` after merge: don't edit them by hand, and you don't need to commit them either / 我新增了一个 `data/plugins/enteguo__dsh-plugin-quick-chat.yml` 文件——**这一个文件就是全部投稿**。README 会在合并后由 `main` 自动重新生成：不要手工编辑，也不需要提交
- [x] My repo's `package.json` declares **`dsh.bundle`** (not just `dsh.client`) — [example](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/main/contributing.md) / 仓库 `package.json` 已声明 `dsh.bundle`（只有 `dsh.client` 无法安装）
- [x] My repo is at least **1 day old** / 仓库创建满 1 天
- [x] `category` is one of `agi ui usage theme model identity session memory tools wsl browser vision voice docs skill workflow git notify dev security remote market fun` ([full list with descriptions](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/main/contributing.md)), and themes/skins go under `theme` / `category` 取值正确（完整清单见 contributing.md），主题/皮肤类请用 `theme`
- [x] Description states what the plugin does, no superlatives / 描述只说功能，不带营销词
- [x] My repo has the `dsh-plugin` topic / 仓库已打 `dsh-plugin` topic

**Recommended (not required) / 推荐但不强制：**

- 📦 Publish to npm — npm installs are prebuilt and skip the `allowBuilds` approval, so users get a one-command install / 发布 npm 包：预构建产物免 `allowBuilds` 授权，用户一条命令装好
- 🔗 Declare official `@deepseek-ai/*` packages as `peerDependencies` (not `dependencies`) — avoids duplicate runtimes inside the profile / 官方 `@deepseek-ai/*` 包用 `peerDependencies` 声明（而非 `dependencies`），避免 profile 里出现重复运行时
- 🖼️ Screenshots go in **your own repository** now: a `screenshots.json` beside your `package.json`, listing image paths. Nothing to add here, and you can change them later without another pull request ([how](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/main/contributing.md#screenshots--截图optional-recommended--可选推荐)) / 截图现在放在**你自己的仓库**里：在 `package.json` 旁边放一个 `screenshots.json`，列出图片路径。这个 PR 里不用加任何东西，以后想换也不必再提 PR（[说明](../blob/main/contributing.md#screenshots--截图optional-recommended--可选推荐)）

---

### What this plugin does / 插件说明

**enteguo/dsh-plugin-quick-chat** — adds a Quick Chat entry to the Web UI sidebar. It opens a small floating conversation window with its own model and reasoning-effort picker, optionally seeded with the current session's transcript, so a side question does not interrupt the main session. Every side conversation is kept in a local history that can be resumed, renamed or deleted; the history lives in `~/.dsh/quick-chat/store.json` and survives restarts.

Install / 安装：

```sh
dsh plugin --profile web add github:enteguo/dsh-plugin-quick-chat
```

Manifest / 清单（repository root `package.json`）：

```jsonc
"dsh": {
  "bundle": { "patch": "./cordis.patch.yml" },
  "client": { "platform": "web", "inject": ["@deepseek-ai/dsh-client-ui-primitives"] }
}
```

Category `ui` / 分类 `ui`. Host half mounts local `/quick-chat` routes and stores conversations in the plugin's own JSON file (they do not enter the main session list); client half adds the sidebar entry and the floating window.
