### PR TITLE
Add dsh-token-use (usage)

### DIFF
--- a/data/plugins/huangyuheng__dsh-token-use.yml
+++ b/data/plugins/huangyuheng__dsh-token-use.yml
@@ -1,0 +1,6 @@
+url: https://github.com/huangyuheng/dsh-token-use
+name: huangyuheng/dsh-token-use
+category: usage
+description:
+  en: 'Settings section that reports token usage: totals for input, output, cache read, cache write, reasoning and call count, with breakdowns by model, day, month and project plus a per-day trend chart for the last 30 days; history is rebuilt once on a worker thread and then kept current from live session events.'
+  zh: '设置中的 Token 用量面板：总量（输入/输出/缓存读/缓存写/推理/调用次数），按模型、按天、按月、按项目的明细，以及最近 30 天的按日趋势折线图；历史在 Worker 线程上一次性重建，之后由会话事件实时累加。'


### PR DESCRIPTION
Adds `dsh-token-use` under **Usage & Billing**.

A settings section (**Settings → Token usage**) that reports token usage: totals for input / output / cache read / cache write / reasoning / call count, with breakdowns by model, day, month and project, plus a per-day trend chart for the last 30 days.

What it does that the other usage entries do not: history is rebuilt once on a worker thread (host event loop never blocked), and after that the numbers come from folding live `session/event` usage records — no log rescan per refresh, no polling, no writes. The filter set (model / day / month / project) is served from in-memory buckets.

Checks relevant to this list:

- `package.json` declares `dsh.bundle` (`./cordis.patch.yml`); `dsh.client` ships the settings UI.
- Install verified from this repository: `dsh plugin --profile web add github:huangyuheng/dsh-token-use`.
- Reads `$DSH_HOME/sessions` (multi-frame `session.jsonl.zstd` and plaintext `session.jsonl`); the JSON endpoint is read-only and loopback-only by default.
- The `dsh-plugin` topic is set on the repository.
