### PR TITLE
catalog: refresh Odai DSH compatibility

### DIFF
--- a/data/added-dates.json
+++ b/data/added-dates.json
@@ -445,5 +445,8 @@
  "https://github.com/Tabbit-Browser/dsh-tabbit": "2026-08-21",
  "https://github.com/omdsh-dev/stent": "2026-08-13",
  "https://github.com/moguiyu/dsh-tavily/tree/main/packages/dsh-tavily": "2026-08-15",
- "https://github.com/polaris-smart/dsh-devices": "2026-08-19"
+ "https://github.com/polaris-smart/dsh-devices": "2026-08-19",
+ "https://github.com/wwweljf/dsh-plugins/tree/master/plugins/dsh-ding-sound": "2026-09-08",
+ "https://github.com/wwweljf/dsh-plugins/tree/master/plugins/dsh-wx-push": "2026-09-08",
+ "https://github.com/wwweljf/dsh-plugins/tree/master/plugins/dsh-wx-remote": "2026-09-08"
 }

--- a/data/plugins/orziz__odai--dsh-plugin.yml
+++ b/data/plugins/orziz__odai--dsh-plugin.yml
@@ -2,5 +2,5 @@ url: https://github.com/orziz/odai/tree/main/dsh/plugin
 name: orziz/odai#odai-dsh-plugin
 category: workflow
 description:
-  en: 'Profile-wide DSH governance and routing bundle with configurable responsibility dispatch, compaction, scoped semantic memory, safety continuity, and verified completion; compatible with DSH 0.1.1-rc.2.'
-  zh: 面向整个 DSH profile 的治理与路由 bundle，提供可配置的职责调度、压缩、本地作用域语义记忆、安全连续性与真实验收；兼容 DSH 0.1.1-rc.2。
+  en: 'Profile-wide DSH governance and routing with a Web Control Center for responsibility and evidence inspection, plus compaction, scoped semantic memory, safety continuity, and verified delivery; compatible with DSH 0.1.5-rc.1.'
+  zh: 面向整个 DSH profile 的治理与路由 bundle，提供用于职责与证据检查的 Web Control Center，以及压缩、本地作用域语义记忆、安全连续性与真实验收；兼容 DSH 0.1.5-rc.1。


### PR DESCRIPTION
## Summary

Refreshes the existing Odai metadata to reflect the published DSH contract and the included Web Control Center for responsibility and evidence inspection. The catalog now records exact compatibility with `@deepseek-ai/dsh@0.1.5-rc.1` instead of `0.1.1-rc.2`.

The substantive Odai change is limited to its existing YAML source of truth; generated READMEs remain omitted per the contribution workflow. At the maintainer's request, this branch also temporarily carries the same three `data/added-dates.json` pins as #4821/#4687 so the repository-wide build can run. Once #4821 lands, that shared hunk can drop out on rebase.

Disclosure: I maintain Odai.

## Verification

- npm registry verified `odai-dsh-plugin@0.2.29` with exact peer `@deepseek-ai/dsh@0.1.5-rc.1`
- published tarball verified to contain canonical Odai `0.3.11`, runtime contract `6`, and the Web client export
- repository catalog parser found exactly one Odai entry with no validation problems
- `data/added-dates.json` parses with 450 keys and the three merge-introduced entries pinned to `2026-09-08`, exactly matching #4821
- disposable-worktree reproduction: `node scripts/generate-readme.mjs` and `SKIP_PUBLISH_CHECKS=1 node scripts/build-site.mjs` pass for 3,431 entries across both locales
- `git diff --check`