### PR TITLE
Add yunxiyang/dsh-loop-continue

### DIFF
--- a/data/added-dates.json
+++ b/data/added-dates.json
@@ -445,5 +445,8 @@
  "https://github.com/Tabbit-Browser/dsh-tabbit": "2026-08-21",
  "https://github.com/omdsh-dev/stent": "2026-08-13",
  "https://github.com/moguiyu/dsh-tavily/tree/main/packages/dsh-tavily": "2026-08-15",
- "https://github.com/polaris-smart/dsh-devices": "2026-08-19"
+ "https://github.com/polaris-smart/dsh-devices": "2026-08-19",
+ "https://github.com/wwweljf/dsh-plugins/tree/master/plugins/dsh-ding-sound": "2026-09-08",
+ "https://github.com/wwweljf/dsh-plugins/tree/master/plugins/dsh-wx-push": "2026-09-08",
+ "https://github.com/wwweljf/dsh-plugins/tree/master/plugins/dsh-wx-remote": "2026-09-08"
 }

--- a/data/plugins/yunxiyang__dsh-loop-continue.yml
+++ b/data/plugins/yunxiyang__dsh-loop-continue.yml
@@ -1,0 +1,6 @@
+url: https://github.com/yunxiyang/dsh-loop-continue
+name: yunxiyang/dsh-loop-continue
+category: agi
+description:
+  en: 'Resumes an agent turn that ended after narrating its next action without calling a tool: the guard replays the turn log on agent/turn-stopping, asks a judge model one true/false question, and steers the same turn to run one more step.'
+  zh: '续跑「叙述了下一步动作却没调用工具」就结束的 agent 轮次：插件在 agent/turn-stopping 回放该轮日志，让裁判模型回答一次 true/false，命中的话把同一轮再推进一步。'


### PR DESCRIPTION
Adds `yunxiyang/dsh-loop-continue`.

## What it does

The agent loop closes a turn as `completed` the moment a step emits text and no tool call. A model that writes "now I will re-apply the change" and stops therefore looks *finished* to the loop, even though the work is half done.

`dsh-loop-continue` listens on `agent/turn-stopping`, replays the stopping turn's own session log, and asks a judge model one strict `true`/`false` question — but only when the turn shape matches that failure mode:

1. the turn ended on a text-only step (no tool call), **and**
2. it called at least one tool earlier.

So an ordinary finished answer, or a one-shot reply that never used a tool, never spends a judge call. On `true` the guard steers the same turn to run one more step; on `false` (or an unparseable answer) the turn closes as usual.

## Bounds

Steering is not free, so it is capped two ways:

- a hard per-turn budget (`maxContinuations`, default 10), and
- an **ignored-steer check**: the guard records the session-log position at each steer and, the next time the turn stops, verifies that some step in between actually called a tool. A steer the model ignored ends the turn instead of spending the rest of the budget on the same refusal.

The judge follows the conversation's own provider/model and is advisory — a judge failure never wedges a turn.

## Manifest

`package.json` declares `dsh.bundle` with `./cordis.patch.yml`, which ships a plain `id` + `name` insert (no `config`, no expressions), and the repo has the `dsh-plugin` topic. Published to npm as `dsh-loop-continue` (0.1.1).

## Entry

Adds one file, `data/plugins/yunxiyang__dsh-loop-continue.yml`. `scripts/check-submission.mjs` passes for it locally.

## Relationship to nearby entries

Three entries already act on `agent/turn-stopping`; none of them covers this failure mode.

- `Milbaxter/dsh-critique-loop` intercepts **every** completed turn to force a critique round. This plugin is narrower: it fires only when the turn's shape shows the model announced an action and never took it, so a finished turn is left alone.
- `pavangupta352/stalegreen` (#dsh-plugin-stalegreen) steers when a test/lint/build *claim* has a stale or failed receipt — a freshness check on verification claims. This one never looks at claim freshness; it looks at whether a described action was ever performed.
- `CAI-MH/dsh-quality-review` audits the *quality* of a reply (accuracy, completeness, consistency).

The distinguishing case here is a control-flow defect, not a review: the loop closes the turn as `completed` because the step carried text and no tool call, and the promise inside that text is silently dropped.
