### PR TITLE
Add prebuilt tarball for dsh-whale-particles

### DIFF
--- a/data/plugins/fewoot__dsh-whale-particles.yml
+++ b/data/plugins/fewoot__dsh-whale-particles.yml
@@ -4,5 +4,4 @@ category: ui
 description:
   en: 'Interactive dot-matrix background for the DSH web UI: particles form the DeepSeek whale or your transparent-PNG photo, each dot carries its own smooth force; mouse disturbs them and an auto screensaver mode sweeps 360-degree waves and full-screen breathing. '
   zh: '给 DSH Web 加一个点阵互动背景:点阵可组成鲸鱼或你上传的透明 PNG 照片,每颗粒子有自己独立的平滑外力;既能手动随鼠标扰动,也能切换自动屏保模式(360° 任意方向扫波 + 全屏呼吸躁动),参数面板支持恢复默认。'
-# 非 npm 分发时加这行(tag 与 Release 一致):
-# tarball: https://github.com/fewoot/dsh-whale-particles/releases/download/v0.1.0/dsh-whale-particles-0.1.0.tgz
+tarball: https://github.com/fewoot/dsh-whale-particles/releases/download/v0.1.1/dsh-whale-particles-0.1.1.tgz


### PR DESCRIPTION
Adds the optional `tarball:` field, pointing at the prebuilt `.tgz` attached to the `v0.1.1` GitHub Release.

No npm package for this plugin, so listing the prebuilt asset lets storefronts offer a download instead of a build-from-source install.

The asset name is pinned together with the release tag (`v0.1.1` + `dsh-whale-particles-0.1.1.tgz`), so the URL cannot rot on a later release — the versioned-name trap only applies to `releases/latest/download/`.

Verified before opening this PR: both files download with HTTP 200 and carry the right magic bytes (gzip / zip).

This PR changes only my own entry file — no description or category edits, and the generated READMEs are untouched.