### PR TITLE
Add baddying/dsh-geolibre

### DIFF
--- a/data/added-dates.json
+++ b/data/added-dates.json
@@ -445,5 +445,8 @@
  "https://github.com/Tabbit-Browser/dsh-tabbit": "2026-08-21",
  "https://github.com/omdsh-dev/stent": "2026-08-13",
  "https://github.com/moguiyu/dsh-tavily/tree/main/packages/dsh-tavily": "2026-08-15",
- "https://github.com/polaris-smart/dsh-devices": "2026-08-19"
+ "https://github.com/polaris-smart/dsh-devices": "2026-08-19",
+ "https://github.com/wwweljf/dsh-plugins/tree/master/plugins/dsh-ding-sound": "2026-09-08",
+ "https://github.com/wwweljf/dsh-plugins/tree/master/plugins/dsh-wx-push": "2026-09-08",
+ "https://github.com/wwweljf/dsh-plugins/tree/master/plugins/dsh-wx-remote": "2026-09-08"
 }

--- a/data/plugins/baddying__dsh-geolibre.yml
+++ b/data/plugins/baddying__dsh-geolibre.yml
@@ -4,3 +4,4 @@ category: tools
 description:
   en: 'Render GeoJSON or vector data into an interactive GeoLibre map in a sidebar tab, and let agents operate the live map through tools: layers, styles, view, feature identification, GeoLibre processing algorithms, and the Whitebox toolbox (WASM in the browser).'
   zh: '把 GeoJSON / 矢量数据渲染成侧边栏「地图」tab 里的交互地图，并让 Agent 通过工具实时操作地图：图层、样式、视图、要素识别、GeoLibre 处理算法与 Whitebox 工具箱（浏览器端 WASM 执行）。'
+tarball: https://github.com/baddying/dsh-geolibre/releases/download/v0.1.0/dsh-geolibre-0.1.0.tgz

--- a/data/plugins/baddying__dsh-geolibre.yml
+++ b/data/plugins/baddying__dsh-geolibre.yml
@@ -1,0 +1,6 @@
+url: https://github.com/baddying/dsh-geolibre
+name: baddying/dsh-geolibre
+category: tools
+description:
+  en: 'Render GeoJSON or vector data into an interactive GeoLibre map in a sidebar tab, and let agents operate the live map through tools: layers, styles, view, feature identification, GeoLibre processing algorithms, and the Whitebox toolbox (WASM in the browser).'
+  zh: '把 GeoJSON / 矢量数据渲染成侧边栏「地图」tab 里的交互地图，并让 Agent 通过工具实时操作地图：图层、样式、视图、要素识别、GeoLibre 处理算法与 Whitebox 工具箱（浏览器端 WASM 执行）。'


### PR DESCRIPTION
Adds one entry: `data/plugins/baddying__dsh-geolibre.yml`.

**Plugin:** https://github.com/baddying/dsh-geolibre — renders GeoJSON/vector data into an interactive GeoLibre map in a sidebar tab, and lets agents operate the live map (layers, styles, view, feature identification, GeoLibre processing algorithms, Whitebox WASM toolbox) through host tools.

**Checklist (per the PR template)**
- [x] Added one file at `data/plugins/baddying__dsh-geolibre.yml` — that single file is the whole submission.
- [x] `package.json` declares `dsh.bundle` (`"dsh": { "bundle": { "patch": "./cordis.patch.yml" } }`), with `cordis.patch.yml` registering entry id `geolibre` in the repository root.
- [x] Repository created 2026-09-09, past the 1-day bar.
- [x] `category: tools` (agent-side map tools, following `HorusJiang/dsh-map-tools`).
- [x] Description states what the plugin does, no superlatives.
- [x] Repository has the `dsh-plugin` topic.

**Install** (no npm package yet): `dsh plugin --profile web add github:baddying/dsh-geolibre#v0.1.0` — the package declares `dsh.bundle`, so it joins `dsh.profile.bundles` automatically. Runtime prerequisite: a Python 3 interpreter that can `import geolibre` (documented in the README, `geolibreEnv` auto-detected or set in the profile patch).