### PR TITLE
Update Agent Mail to unified AI collaboration mailbox 0.2.1

### DIFF
--- a/data/plugins/dff652__deepseek-harness-community-plugins--packages-dsh-agent-mail-ui.yml
+++ b/data/plugins/dff652__deepseek-harness-community-plugins--packages-dsh-agent-mail-ui.yml
@@ -1,0 +1,7 @@
+url: https://github.com/dff652/deepseek-harness-community-plugins/tree/main/packages/dsh-agent-mail-ui
+name: dff652/deepseek-harness-community-plugins#dsh-agent-mail-ui
+category: ui
+description:
+  en: Adds an Agent Mail inbox, recipient directory and task composer to DeepSeek Harness, with an optional connection wizard requiring a separately configured authenticated management host.
+  zh: 为 DeepSeek Harness 提供 Agent Mail 收件箱、收件人目录和任务编辑器；可选连接向导需另外配置带身份验证的管理宿主。
+tarball: https://github.com/dff652/deepseek-harness-community-plugins/releases/download/dsh-agent-mail-ui-v0.1.7/dff652-dsh-agent-mail-ui-0.1.7.tgz

--- a/data/plugins/dff652__deepseek-harness-community-plugins--packages-dsh-agent-mail-ui.yml
+++ b/data/plugins/dff652__deepseek-harness-community-plugins--packages-dsh-agent-mail-ui.yml
@@ -1,7 +1,0 @@
-url: https://github.com/dff652/deepseek-harness-community-plugins/tree/main/packages/dsh-agent-mail-ui
-name: dff652/deepseek-harness-community-plugins#dsh-agent-mail-ui
-category: ui
-description:
-  en: Adds an Agent Mail inbox, recipient directory and task composer to DeepSeek Harness, with an optional connection wizard requiring a separately configured authenticated management host.
-  zh: 为 DeepSeek Harness 提供 Agent Mail 收件箱、收件人目录和任务编辑器；可选连接向导需另外配置带身份验证的管理宿主。
-tarball: https://github.com/dff652/deepseek-harness-community-plugins/releases/download/dsh-agent-mail-ui-v0.1.7/dff652-dsh-agent-mail-ui-0.1.7.tgz

--- a/data/plugins/dff652__deepseek-harness-community-plugins--packages-dsh-agent-mail.yml
+++ b/data/plugins/dff652__deepseek-harness-community-plugins--packages-dsh-agent-mail.yml
@@ -4,4 +4,4 @@ category: tools
 description:
   en: Connects DeepSeek Harness to a deployment-owned Agent Mail MCP server and exposes eleven messaging, claim, acknowledgement, diagnostics and approval-discovery tools with non-human approval execution denied.
   zh: 将 DeepSeek Harness 连接到部署方管理的 Agent Mail MCP 服务，并提供十一个消息、认领、确认、诊断与审批发现工具，同时拒绝非人类身份执行审批。
-tarball: https://github.com/dff652/deepseek-harness-community-plugins/releases/download/dsh-agent-mail-v0.1.0/dff652-dsh-agent-mail-0.1.0.tgz
+tarball: https://github.com/dff652/deepseek-harness-community-plugins/releases/download/dsh-agent-mail-v0.1.1/dff652-dsh-agent-mail-0.1.1.tgz

--- a/data/plugins/dff652__deepseek-harness-community-plugins--packages-dsh-agent-mail.yml
+++ b/data/plugins/dff652__deepseek-harness-community-plugins--packages-dsh-agent-mail.yml
@@ -2,6 +2,6 @@ url: https://github.com/dff652/deepseek-harness-community-plugins/tree/main/pack
 name: dff652/deepseek-harness-community-plugins#dsh-agent-mail
 category: tools
 description:
-  en: Connects DeepSeek Harness to a deployment-owned Agent Mail MCP server and exposes eleven messaging, claim, acknowledgement, diagnostics and approval-discovery tools with non-human approval execution denied.
-  zh: 将 DeepSeek Harness 连接到部署方管理的 Agent Mail MCP 服务，并提供十一个消息、认领、确认、诊断与审批发现工具，同时拒绝非人类身份执行审批。
-tarball: https://github.com/dff652/deepseek-harness-community-plugins/releases/download/dsh-agent-mail-v0.1.1/dff652-dsh-agent-mail-0.1.1.tgz
+  en: Connects DeepSeek Harness to a separately installed Agent Mail provider and includes one mailbox UI with send, inbox, durable sent receipts, recipient details, claim and acknowledgement. Sent receipts require provider 1.0.0-alpha.7. No automatic model wake or trusted device presence.
+  zh: 连接独立安装的 Agent Mail provider，并内置一个邮箱界面，提供发送、收件箱、持久发送回执、收件人详情、认领与确认。发送回执需要 provider 1.0.0-alpha.7。不包含自动唤醒模型或可信设备在线状态。
+tarball: https://github.com/dff652/deepseek-harness-community-plugins/releases/download/dsh-agent-mail-v0.2.0/dff652-dsh-agent-mail-0.2.0.tgz


### PR DESCRIPTION
Update the existing Agent Mail catalog entry from the old MCP-only download to the released unified 0.2.1 package. It includes MCP integration and the mailbox UI for messages, task handoffs and delivery receipts.

The final diff changes one existing YAML file: the exact Release tarball URL and English/Chinese descriptions. No separate UI entry is added. Agent Mail provider 1.0.0-alpha.7 is installed separately; automatic model wake and continuous online status are not included.

- Unified Release: https://github.com/dff652/deepseek-harness-community-plugins/releases/tag/dsh-agent-mail-v0.2.1
- Provider Release: https://github.com/dff652/agent-mail/releases/tag/v1.0.0-alpha.7
- Unified tarball SHA-256: `6ab01c2d9a287cd991aa4380f0375d89b743101c86cb2ef71f2de6ae7c58fb23`

Validation:
- The published 0.2.1 archive was downloaded anonymously and matched the accepted digest and all nine packed source files.
- The downloaded artifact passed disposable web/headless installation, one-MCP/one-UI configuration, removal and migration from the older separate packages.
- Catalog parsing and entry validation pass; dshmarket 1.41.0 source resolution selects this exact Release tarball.
- Synced upstream main at `d9a53bf020be61f21eb9a55f5a12ae7e49bf3d61`, preserving the existing PR branch history.
- Local README generation/parity and all three added-date regression tests pass on Node 22.19.0. awesome-lint passes with upstream repository metadata, with 79 existing warnings; a default fork-context run reports only the fork's missing awesome/awesome-list topics.
- Full local site build passes with the PR workflow's `SKIP_PUBLISH_CHECKS=1`: 3,632 rows across two locales, sitemap and count badge. The previous added-date errors no longer reproduce on the synced upstream code.

Existing deployments using the old separate UI must remove that UI before installing the unified package. An existing unified 0.2.0 deployment keeps its provider, mailbox, identity and connection settings. Catalog merge, refreshed market download target and live source migration are verified separately.
