### PR TITLE
docs: update runcat-tommy/dsh-panda-calendar entry (on-this-day history + timestamp converter)

### DIFF
--- a/data/plugins/runcat-tommy__dsh-panda-calendar.yml
+++ b/data/plugins/runcat-tommy__dsh-panda-calendar.yml
@@ -2,5 +2,5 @@ url: https://github.com/runcat-tommy/dsh-panda-calendar
 name: runcat-tommy/dsh-panda-calendar
 category: ui
 description:
-  en: A conversation-view tab for DeepSeek Harness Web showing solar/lunar dates, ganzhi year/month/day, Chinese zodiac, 24 solar terms, festivals, China public holidays including make-up workdays, and multi-city weather from free sources without an API key.
-  zh: '会话页头的「熊猫日历」标签页：公历/农历、干支、生肖、24 节气、传统与外国节日、中国法定节假日（含调休）与多城市天气，数据免费、无需 API Key。'
+  en: A conversation-view tab for DeepSeek Harness Web showing solar/lunar dates, ganzhi year/month/day, Chinese zodiac, 24 solar terms, festivals, China public holidays including make-up workdays, multi-city weather, an epoch↔date timestamp converter with a time-zone picker, and bundled offline "on this day" history from free sources without an API key.
+  zh: '会话页头的「熊猫日历」标签页：公历/农历、干支、生肖、24 节气、传统与外国节日、中国法定节假日（含调休）、多城市天气、时间戳转换（秒/毫秒 ↔ 年月日时分秒，可选时区）与内置离线的「历史上的今天」，数据免费、无需 API Key。'


### PR DESCRIPTION
Refreshes our own existing entry so the description matches what the plugin ships today. Exactly one file is touched — `data/plugins/runcat-tommy__dsh-panda-calendar.yml` — and no other entry is modified.

What was added to the `en` / `zh` description:

- the epoch↔date **timestamp converter** with a time-zone picker (纯前端卡片，可选时区，自动处理夏令时)
- the bundled **offline "on this day" history** (内置离线的「历史上的今天」: 大事记 + 名人诞辰)

Everything stays factual and checkable: `dsh-panda-calendar` v1.2.3 is published on npm (`latest`), the repo declares `dsh.bundle.patch: ./cordis.patch.yml`, carries the `dsh-plugin` topic, and the README documents both features. I ran the repo's own `scripts/generate-readme.mjs` locally against this YAML to confirm it parses and renders in both languages (the regenerated README files were discarded — no hand edits to generated files).

---

同步我方已有条目描述，使其与插件当前实际功能一致：**只改一个文件** `data/plugins/runcat-tommy__dsh-panda-calendar.yml`，不触碰任何其他条目。

`en` / `zh` 描述各补两项：

- **时间戳转换**（epoch ↔ 日期，可选时区、自动处理夏令时，纯前端卡片）
- **内置离线的「历史上的今天」**（大事记 + 名人诞辰）

描述只陈述事实且可核对：`dsh-panda-calendar` v1.2.3 已发布 npm（`latest`），仓库声明 `dsh.bundle.patch: ./cordis.patch.yml`、带 `dsh-plugin` topic，两项功能在 README 中有说明。我已用仓库自带的 `scripts/generate-readme.mjs` 在本地跑过这份 YAML，确认可解析且中英均能正常渲染（生成的 README 变更已丢弃，未手工改动生成文件）。
