### PR TITLE
Add gitroomhq/postiz-agent#dsh-postiz (tools)

### DIFF
--- a/data/plugins/gitroomhq__postiz-agent--plugins-dsh-postiz.yml
+++ b/data/plugins/gitroomhq__postiz-agent--plugins-dsh-postiz.yml
@@ -1,0 +1,6 @@
+url: https://github.com/gitroomhq/postiz-agent/tree/main/plugins/dsh-postiz
+name: gitroomhq/postiz-agent#dsh-postiz
+category: tools
+description:
+  en: 'Connects DeepSeek Harness to Postiz over MCP: list connected social media channels, fetch per-platform posting rules, and schedule, draft, or publish posts to X, LinkedIn, Instagram, Facebook, Threads, TikTok, YouTube, Reddit, Bluesky, Mastodon, Discord, Slack, Telegram and more; adds a postiz workflow skill.'
+  zh: '通过 MCP 将 DeepSeek Harness 连接到 Postiz：列出已连接的社交媒体渠道、获取各平台发帖规则，并向 X、LinkedIn、Instagram、Facebook、Threads、TikTok、YouTube、Reddit、Bluesky、Mastodon、Discord、Slack、Telegram 等平台排期、存草稿或发布帖子；附带 postiz 工作流技能。'


### PR DESCRIPTION
Adds one entry (category `tools`): **gitroomhq/postiz-agent#dsh-postiz** — a DeepSeek Harness bundle for [Postiz](https://postiz.com), the open-source social media scheduler.

- Manifest: [`plugins/dsh-postiz/package.json`](https://github.com/gitroomhq/postiz-agent/blob/main/plugins/dsh-postiz/package.json) declares `dsh.bundle` → `cordis.patch.yml`.
- What it does: mounts a `postiz` provider row plus one `@deepseek-ai/dsh-mcp-client` row (streamable HTTP to `https://mcp.postiz.com/mcp`, Bearer auth from `POSTIZ_API_KEY`, `baseUrl` overridable for self-hosted), and registers a `postiz` skill on `ctx.skills` describing the `integrationList → integrationSchema → schedulePostTool` workflow.
- Install: `dsh plugin --profile web add "github:gitroomhq/postiz-agent#path:/plugins/dsh-postiz"`
- Repo carries the `dsh-plugin` topic; created 2026-02.

Verified on dsh 0.1.5-rc: both rows compose (`--dump-config`), the MCP row activates and authenticates with the header, and without a key the plugin logs a warning naming the variable while dsh still boots.
