### PR TITLE
Add XMeowchan/dsh-agent-team-model

### DIFF
--- a/data/plugins/XMeowchan__dsh-agent-team-model.yml
+++ b/data/plugins/XMeowchan__dsh-agent-team-model.yml
@@ -1,0 +1,7 @@
+url: https://github.com/XMeowchan/dsh-agent-team-model
+name: XMeowchan/dsh-agent-team-model
+category: model
+tarball: https://github.com/XMeowchan/dsh-agent-team-model/releases/latest/download/dsh-agent-team-model.tgz
+description:
+  en: Configure default and per-name provider, model, and reasoning effort for newly created Agent Teams teammates, with conversation-scoped live and restart-safe route views.
+  zh: 为新创建的 Agent Teams 队员配置默认或按名称指定的提供商、模型与推理强度，并按当前对话显示实时及重启后可恢复的路由视图。


### PR DESCRIPTION
## Summary

Adds `XMeowchan/dsh-agent-team-model` to the Models & Providers category.

The plugin configures default and per-name provider/model/reasoning-effort routes for newly created Agent Teams teammates and shows conversation-scoped live/durable route state.

## Prerequisite (worth noting during review)

This plugin writes teammate routes only; teammates come from the official experimental layer `@deepseek-ai/dsh-experimental-agent-team-profile`, which no bundled DSH profile enables by default. The repository README documents that prerequisite with install/verify/remove commands, and a profile missing the upstream layer is told which package to add (UI hint and `membersError`) instead of being asked to restart.

## Verification

- Repository declares `dsh.bundle` and `dsh.client`.
- Repository topic `dsh-plugin` is present.
- `npm test` passes (host suite: 40 assertions + 14 node:test cases).
- UI regression suite passes against DSH UI primitives 0.1.5-alpha.2.
- Screenshots captured from the running GUI and declared in `screenshots.json`.
- GitHub Release v0.3.1 carries a stable-name prebuilt tarball.

## Draft status

The plugin repository was created on 2026-09-11 at 04:06 UTC. This PR intentionally remains a draft until the registry's 24-hour repository-age requirement is satisfied; it is not ready for merge yet.