### PR TITLE
Add longisland-icetea/dsh-lan-access

### DIFF
--- a/data/plugins/longisland-icetea__dsh-lan-access.yml
+++ b/data/plugins/longisland-icetea__dsh-lan-access.yml
@@ -1,0 +1,6 @@
+url: https://github.com/longisland-icetea/dsh-lan-access
+name: longisland-icetea/dsh-lan-access
+category: remote
+description:
+  en: 'Configurable LAN access for the DSH Web GUI: a settings tab binds the server to all interfaces, trusts only the addresses you configure, sets the browser session lifetime or removes the token login, and repairs the settings layer on non-loopback visits.'
+  zh: '可配置的 DSH Web GUI 局域网访问：设置页开启后绑定全部网卡，只信任你配置的访问地址，可调整浏览器会话有效期或去掉 token 登录，并修复非回环访问时的设置层。'


### PR DESCRIPTION
<!-- Thanks for contributing! Quick checklist / 提交前快速自查 -->

- [x] I added **one file** at `data/plugins/longisland-icetea__dsh-lan-access.yml` — that single file is the whole submission. The READMEs are regenerated on `main` after merge: don't edit them by hand, and you don't need to commit them either / 我新增了一个 `data/plugins/longisland-icetea__dsh-lan-access.yml` 文件——**这一个文件就是全部投稿**。README 会在合并后由 `main` 自动重新生成：没有手工编辑，也没有提交
- [x] My repo's `package.json` declares **`dsh.bundle`** (not just `dsh.client`) / 仓库 `package.json` 已声明 `dsh.bundle`
- [x] My repo is at least **1 day old** / 仓库创建满 1 天（created 2026-09-06）
- [x] `category` is one of `agi ui usage theme model identity session memory tools wsl browser vision voice docs skill workflow git notify dev security remote market fun`, and themes/skins go under `theme` / `category` 取值正确 — used `remote`
- [x] Description states what the plugin does, no superlatives / 描述只说功能，不带营销词
- [x] My repo has the `dsh-plugin` topic / 仓库已打 `dsh-plugin` topic

**Notes for the reviewer / 给评审的说明**

- **Name collision.** There is already an entry `Leon0555/dsh-lan-access` (a different project by another author, published on npm under the bare name `dsh-lan-access`). This entry is `longisland-icetea/dsh-lan-access`, installed from GitHub only — the collision is documented in our README. Functionally the two are not the same plugin: Leon0555's is a fixed `0.0.0.0` bind plus a `crypto.randomUUID` polyfill with no configuration surface, while this one is the configurable one (authority allowlist, session lifetime, optional removal of the browser session gate) — every claim in the description maps to a setting in `lib/index.js` / the settings tab in `lib/client.js`.
- **No npm package and no `tarball:`.** The bare npm name is taken by the unrelated project above, so we ship from GitHub. `lib/` is committed, the package has **zero runtime dependencies**, and the only peer dependency is `@deepseek-ai/cordis` (declared optional) — so `dsh plugin --profile web add github:longisland-icetea/dsh-lan-access` installs prebuilt with no build step and no `allowBuilds` approval.
- **Fence semantics described as "trusts only the addresses you configure":** that is the strict-fence path (a non-empty configuration *is* the policy). With an empty list the plugin deliberately falls back to the harness's automatic LAN trust so that "enabled but unconfigured" cannot 403 every LAN visitor — stated in the README under 严格围栏.
- I ran `node scripts/check-submission.mjs --base 5b7be0b` locally: `ok https://github.com/longisland-icetea/dsh-lan-access`, all checked entries pass.
