### PR TITLE
Add liu3734/jira-tasks-dsh-plugin (ui): JIRA task panel under the composer

### DIFF
--- a/data/plugins/liu3734__jira-tasks-dsh-plugin--profile-package.yml
+++ b/data/plugins/liu3734__jira-tasks-dsh-plugin--profile-package.yml
@@ -1,0 +1,6 @@
+url: https://github.com/liu3734/jira-tasks-dsh-plugin/tree/main/profile-package
+name: liu3734/jira-tasks-dsh-plugin#profile-package
+category: ui
+description:
+  en: 'JIRA task panel under the DSH composer: per-workspace project key and optional JQL, listing the issues assigned to the current user with status, priority and issue-type chips, a total count, collapse and refresh, links to JIRA, plus a settings card for the base URL and token with a connection probe.'
+  zh: 'DSH 输入框下方的 JIRA 任务面板：按工作区配置项目 Key 与可选 JQL，展示指派给当前用户的问题，带状态、优先级与类型标签、总数徽标、收起与刷新、跳转 JIRA，并在设置页卡片配置 JIRA 地址与令牌（含连接测试）。'


### PR DESCRIPTION
<!-- Thanks for contributing! Quick checklist / 提交前快速自查 -->

- [x] I added **one file** at `data/plugins/liu3734__jira-tasks-dsh-plugin.yml` — the generated READMEs are left to `sync-readme.yml`
- [x] My repo's `package.json` declares **`dsh.bundle`**, at the repository root
- [x] My repo is at least **1 day old** (created 2026-08-17)
- [x] `category` is `ui`
- [x] Description states what the plugin does, no superlatives
- [x] My repo has the `dsh-plugin` topic

**What it does**

A JIRA task panel under the DSH composer. Per-workspace project key and optional JQL (persisted in the browser), listing the issues assigned to the current user with status / priority / issue-type chips, a total-count badge, collapse and refresh, and links that open the issue in JIRA.

- **Host half** registers `POST /jira/api/search` and `POST /jira/api/test` on `webServer`; the query goes to `/rest/api/2/search` via `subprocess` + `curl` with the auth header passed on stdin, so the token never lands in the argv.
- **Client half** registers `conversation.composer.dock`, `conversation.input.dock` (blank-session hero) and a `settings.plugin.item` card: the base URL is written to the `jira-tasks` settings namespace, the token to the credentials store and is never returned to the front end. The card probes `/rest/api/2/myself` and shows a connection status light.

**Install**: published to npm as `dsh-jira-tasks` → `dsh plugin --profile web add dsh-jira-tasks`; from GitHub → `dsh plugin --profile web add github:liu3734/jira-tasks-dsh-plugin`.
