### PR TITLE
Add WYR-233/dsh-multi-tts (voice)

### DIFF
--- a/data/plugins/WYR-233__dsh-memory-lite.yml
+++ b/data/plugins/WYR-233__dsh-memory-lite.yml
@@ -1,0 +1,7 @@
+url: https://github.com/WYR-233/dsh-memory-lite
+name: WYR-233/dsh-memory-lite
+category: memory
+description:
+  en: 'Read-only enhancer for a file-based long-term memory library (markdown cards in git): a memory_find search tool, a small budgeted memory digest injected into the system prompt, and a settings page with library overview, health-check status and toggles.'
+  zh: '面向「纯文件（markdown 卡片 + git）长期记忆库」的只读增强插件：memory_find 检索工具、一小段受预算约束的记忆库摘要注入，以及带概览/健康/开关的设置页。'
+tarball: https://github.com/WYR-233/dsh-memory-lite/releases/latest/download/dsh-memory-lite.tgz

--- a/data/plugins/WYR-233__dsh-memory-lite.yml
+++ b/data/plugins/WYR-233__dsh-memory-lite.yml
@@ -1,7 +1,0 @@
-url: https://github.com/WYR-233/dsh-memory-lite
-name: WYR-233/dsh-memory-lite
-category: memory
-description:
-  en: 'Read-only enhancer for a file-based long-term memory library (markdown cards in git): a memory_find search tool, a small budgeted memory digest injected into the system prompt, and a settings page with library overview, health-check status and toggles.'
-  zh: '面向「纯文件（markdown 卡片 + git）长期记忆库」的只读增强插件：memory_find 检索工具、一小段受预算约束的记忆库摘要注入，以及带概览/健康/开关的设置页。'
-tarball: https://github.com/WYR-233/dsh-memory-lite/releases/latest/download/dsh-memory-lite.tgz

--- a/data/plugins/WYR-233__dsh-multi-tts.yml
+++ b/data/plugins/WYR-233__dsh-multi-tts.yml
@@ -2,16 +2,7 @@ url: https://github.com/WYR-233/dsh-multi-tts
 name: WYR-233/dsh-multi-tts
 category: voice
 description:
-  en: Per-reply read-aloud with a multi-provider settings page — MiniMax or any OpenAI-compatible /audio/speech endpoint, with voice, emotion, speed and model selection plus an auto-read toggle.
-  zh: 每条回复旁的朗读按钮与输入框自动朗读开关，设置页可选服务商与音色：MiniMax 或任意 OpenAI 兼容的 /audio/speech 端点，可调音色、情绪、语速与模型。
+  en: 'Per-reply read-aloud with a multi-provider settings page — MiniMax or any OpenAI-compatible /audio/speech endpoint, with voice, emotion, speed and model selection plus an auto-read toggle.'
+  zh: '每条回复旁的朗读按钮与输入框自动朗读开关，设置页可选服务商与音色：MiniMax 或任意 OpenAI 兼容的 /audio/speech 端点，可调音色、情绪、语速与模型。'
 tarball: https://github.com/WYR-233/dsh-multi-tts/releases/latest/download/dsh-multi-tts.tgz
 
----
-
-url: https://github.com/WYR-233/dsh-memory-lite
-name: WYR-233/dsh-memory-lite
-category: memory
-description:
-  en: Read-only enhancer for a file-based long-term memory library (markdown cards in git): a memory_find search tool, a small budgeted memory digest injected into the system prompt, and a settings page with library overview, health-check status and toggles.
-  zh: 面向「纯文件（markdown 卡片 + git）长期记忆库」的只读增强插件：memory_find 检索工具、一小段受预算约束的记忆库摘要注入，以及带概览/健康/开关的设置页。
-tarball: https://github.com/WYR-233/dsh-memory-lite/releases/latest/download/dsh-memory-lite.tgz

--- a/data/plugins/WYR-233__dsh-multi-tts.yml
+++ b/data/plugins/WYR-233__dsh-multi-tts.yml
@@ -1,0 +1,7 @@
+url: https://github.com/WYR-233/dsh-multi-tts
+name: WYR-233/dsh-multi-tts
+category: voice
+description:
+  en: Per-reply read-aloud with a multi-provider settings page — MiniMax or any OpenAI-compatible /audio/speech endpoint, with voice, emotion, speed and model selection plus an auto-read toggle.
+  zh: 每条回复旁的朗读按钮与输入框自动朗读开关，设置页可选服务商与音色：MiniMax 或任意 OpenAI 兼容的 /audio/speech 端点，可调音色、情绪、语速与模型。
+tarball: https://github.com/WYR-233/dsh-multi-tts/releases/latest/download/dsh-multi-tts.tgz

--- a/data/plugins/WYR-233__dsh-multi-tts.yml
+++ b/data/plugins/WYR-233__dsh-multi-tts.yml
@@ -5,3 +5,13 @@ description:
   en: Per-reply read-aloud with a multi-provider settings page — MiniMax or any OpenAI-compatible /audio/speech endpoint, with voice, emotion, speed and model selection plus an auto-read toggle.
   zh: 每条回复旁的朗读按钮与输入框自动朗读开关，设置页可选服务商与音色：MiniMax 或任意 OpenAI 兼容的 /audio/speech 端点，可调音色、情绪、语速与模型。
 tarball: https://github.com/WYR-233/dsh-multi-tts/releases/latest/download/dsh-multi-tts.tgz
+
+---
+
+url: https://github.com/WYR-233/dsh-memory-lite
+name: WYR-233/dsh-memory-lite
+category: memory
+description:
+  en: Read-only enhancer for a file-based long-term memory library (markdown cards in git): a memory_find search tool, a small budgeted memory digest injected into the system prompt, and a settings page with library overview, health-check status and toggles.
+  zh: 面向「纯文件（markdown 卡片 + git）长期记忆库」的只读增强插件：memory_find 检索工具、一小段受预算约束的记忆库摘要注入，以及带概览/健康/开关的设置页。
+tarball: https://github.com/WYR-233/dsh-memory-lite/releases/latest/download/dsh-memory-lite.tgz

--- a/data/plugins/WYR-233__dsh-multi-tts.yml
+++ b/data/plugins/WYR-233__dsh-multi-tts.yml
@@ -5,4 +5,3 @@ description:
   en: 'Per-reply read-aloud with a multi-provider settings page — MiniMax or any OpenAI-compatible /audio/speech endpoint, with voice, emotion, speed and model selection plus an auto-read toggle.'
   zh: '每条回复旁的朗读按钮与输入框自动朗读开关，设置页可选服务商与音色：MiniMax 或任意 OpenAI 兼容的 /audio/speech 端点，可调音色、情绪、语速与模型。'
 tarball: https://github.com/WYR-233/dsh-multi-tts/releases/latest/download/dsh-multi-tts.tgz
-


### PR DESCRIPTION
**Plugin**: https://github.com/WYR-233/dsh-multi-tts

Adds one entry file `data/plugins/WYR-233__dsh-multi-tts.yml` (voice).

- `dsh.bundle.patch` is declared in package.json and the repo ships `cordis.patch.yml`.
- Install: `dsh plugin --profile web add github:WYR-233/dsh-multi-tts`; a prebuilt tarball is attached to the latest GitHub Release (asset name carries no version).
- `@deepseek-ai/*` packages are declared as peerDependencies with stable ranges.
- `dsh-plugin` topic is set on the repository.

What it does: adds a read-aloud button to every assistant reply plus an auto-read toggle in the composer, backed by a settings page where the user picks the TTS provider (MiniMax, or any OpenAI-compatible `/audio/speech` endpoint), voice, emotion, speed and model. Text is cleaned of code blocks, links, paths and Markdown markup before synthesis; API keys resolve from plugin config, environment variables or `$DSH_HOME/.env`. Config writes are atomic and keep a one-shot backup, and a corrupt config self-heals instead of being silently wiped.

_(This PR previously also carried a second plugin; that submission now lives in its own PR #4879.)_