### PR TITLE
Update the dsh-vision-plugin entry for v1.2.0 (selectable API key auth scheme)

### DIFF
--- a/data/plugins/bug-huntter__dsh-vision-plugin.yml
+++ b/data/plugins/bug-huntter__dsh-vision-plugin.yml
@@ -2,5 +2,5 @@ url: https://github.com/bug-huntter/dsh-vision-plugin
 name: bug-huntter/dsh-vision-plugin
 category: vision
 description:
-  en: 'Configurable image recognition for text-only DSH models: image messages are first transcribed by any OpenAI-compatible vision model (Base URL, model ID and key configured in a Settings section), then passed to the main model as text; image-input support is advertised while enabled.'
-  zh: 为纯文本 DSH 模型增加可配置识图能力：开启后图片消息先由任意 OpenAI 兼容视觉模型转写为文字描述，再交给主模型处理；设置页可配置 Base URL、Model ID 与密钥。
+  en: 'Configurable image recognition for text-only DSH models: image messages are first transcribed by an OpenAI-compatible vision model (Base URL, model ID and API key set in a Settings section) and then passed to the main model as text, while image-input support is advertised. The API key auth scheme is selectable — OpenAI, Anthropic, Gemini or Azure style request headers — and a missing key is reported before any request is sent.'
+  zh: 为纯文本 DSH 模型增加可配置识图能力：开启后图片消息先由任意 OpenAI 兼容视觉模型转写为文字描述，再交给主模型处理；设置页可配置 Base URL、Model ID 与密钥，并可选择密钥的鉴权方式（OpenAI / Anthropic / Gemini / Azure 风格请求头）；未填写密钥时会在发起请求前明确提示。


### PR DESCRIPTION
Updates the existing entry for `bug-huntter/dsh-vision-plugin` so its one-line claim matches v1.2.0. **Entry file only** — no other entry touched, no `npm:` key, no README edits.

### What the plugin changed in v1.2.0

- **The API key auth scheme is now selectable**: OpenAI (`Authorization: Bearer`), Anthropic (`x-api-key` + `anthropic-version`), Gemini (`x-goog-api-key`) or Azure (`api-key`). The endpoint stays the OpenAI-compatible `{baseUrl}/chat/completions` — only the auth header changes.
- **A missing API key is reported before any request is sent** (`未携带 API Key`, naming the field to fill), instead of being silently replaced by the credential of whichever LLM route shares the Base URL.

Both claims in the new description are verifiable in the repo: `src/authHeaders.ts` holds the four header mappings (shared by the host and the settings-page test), and the empty-key notice is raised in `transcribeImage()` before any network call.

### What changed here

`description.en` / `description.zh` in `data/plugins/bug-huntter__dsh-vision-plugin.yml` only. `node scripts/generate-readme.mjs` regenerates the list line from the yml, so this PR is committed yml-only.

### Checks run locally

- `node scripts/generate-readme.mjs` — our line regenerates from the yml (diff is exactly that one line, both locales)
- `SKIP_PUBLISH_CHECKS=1 node scripts/build-site.mjs` — 3431 entries × 2 locales, exit 0

The repo declares `dsh.bundle`, carries the `dsh-plugin` topic, and `@lp181818/dsh-vision-plugin@1.2.0` is published on npm with its `repository` field pointing back at the listed repository.

---

更新 `bug-huntter/dsh-vision-plugin` 的条目，使其一句话描述与 v1.2.0 一致；**只改这一个条目文件**，不动其它条目、不加 `npm:` 字段、不手工编辑 README。

v1.2.0 起可选密钥鉴权方式（OpenAI / Anthropic / Gemini / Azure 风格请求头，端点仍是 OpenAI 兼容的 `{baseUrl}/chat/completions`，只换鉴权头）；未填写密钥时会在发请求前明确提示「未携带 API Key」，不再复用其它路由的密钥。两处表述都可在仓库中核对：`src/authHeaders.ts`（四种请求头映射，主机端与设置页测试共用）与 `transcribeImage()` 中发请求前的空密钥判定。

本地已跑 `node scripts/generate-readme.mjs`（仅提交 yml，README 由生成器产出）与 `SKIP_PUBLISH_CHECKS=1 node scripts/build-site.mjs`（3431 条 × 2 语言，exit 0）。
