### PR TITLE
Restore wwweljf added-date pins lost to a stale-base merge

### DIFF
--- a/data/added-dates.json
+++ b/data/added-dates.json
@@ -445,5 +445,8 @@
  "https://github.com/Tabbit-Browser/dsh-tabbit": "2026-08-21",
  "https://github.com/omdsh-dev/stent": "2026-08-13",
  "https://github.com/moguiyu/dsh-tavily/tree/main/packages/dsh-tavily": "2026-08-15",
- "https://github.com/polaris-smart/dsh-devices": "2026-08-19"
+ "https://github.com/polaris-smart/dsh-devices": "2026-08-19",
+ "https://github.com/wwweljf/dsh-plugins/tree/master/plugins/dsh-ding-sound": "2026-09-08T15:01:39.000Z",
+ "https://github.com/wwweljf/dsh-plugins/tree/master/plugins/dsh-wx-push": "2026-09-08T15:01:39.000Z",
+ "https://github.com/wwweljf/dsh-plugins/tree/master/plugins/dsh-wx-remote": "2026-09-08T15:01:39.000Z"
 }


### PR DESCRIPTION
9bee1da31 pinned the added dates for the three #2662 entries (merge-commit introductions the git-history derivation can't see). That pin is **gone from current main**: a later merge whose branch predated 9bee1da31 rewrote `data/added-dates.json` from a stale base, dropping the three keys. The reversal hides inside a merge commit, so the path-filtered history shows nothing after 09-07.

Effect: every PR based on current main fails the Build step with `no added-date derivable for: …/dsh-ding-sound, …/dsh-wx-push, …/dsh-wx-remote` — #4682, #4683 and the rest of the open pile.

This PR restores the exact file content from 9bee1da31 (verified: the only delta between that commit and main on this path is the three lost keys). `SKIP_PUBLISH_CHECKS=1 node scripts/build-site.mjs` passes locally on this branch and fails on main.

Possible prevention (not included here): the added-dates.json write path could assert it never drops existing keys, or the derivation walk could expand merges (`-m`) — either would make this class of reversal loud instead of silent.