### PR TITLE
Add vclike/dsh-github-companion (Git & Code Review)

### DIFF
--- a/data/plugins/vclike__dsh-github-companion.yml
+++ b/data/plugins/vclike__dsh-github-companion.yml
@@ -1,0 +1,6 @@
+url: https://github.com/vclike/dsh-github-companion
+name: vclike/dsh-github-companion
+category: git
+description:
+  en: '33 github_* tools covering REST reads, issue writes, Git data writes, private repo creation, and clone; in-process permission gate and cost-discipline companion skill; no gh CLI required.'
+  zh: '33 个 github_* 工具，覆盖 REST 读取、Issue 写入、Git 数据写入、私有仓库创建与克隆；附带进程内权限门与成本纪律伴生 skill，无需 gh CLI。'


### PR DESCRIPTION
# 一键开 PR 操作指引

## URL

```
https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/compare/main...vclike:add-vclike-dsh-github-companion?expand=1
```

浏览器打开后，GitHub 会自动比较 `vclike/add-vclike-dsh-github-companion:main` 与 `awesome-dsh-plugin/awesome-dsh-plugin:main`，显示 1 file changed（你刚提交的 `data/plugins/vclike__dsh-github-companion.yml`）。

## PR 标题

```
Add vclike/dsh-github-companion (Git & Code Review)
```

## PR 正文（完整复制）

````markdown
## Summary

Adds `vclike/dsh-github-companion` to the Git & Code Review category of the awesome list. One file: `data/plugins/vclike__dsh-github-companion.yml`.

The plugin ships 33 native GitHub REST tools (read / issue-write / git-data-write / private-repo-creation), an in-process permission gate, a cost-discipline companion skill, and an Actions-cost guard — all wrapped behind a single `dsh plugin add` install. No `gh` CLI dependency.

## Why Git & Code Review

The plugin's primary surface is Git operations: branch / commit / push / PR / release / fork-sync / clone. The companion skill's job is push discipline, release flows, incident playbook, and CI hardening. Putting the entry under Git & Code Review matches the plugin's actual purpose.

## Plugin facts

- **Repository:** https://github.com/vclike/dsh-github-companion
- **Latest release:** [v1.0.5](https://github.com/vclike/dsh-github-companion/releases/tag/v1.0.5)
- **DSH compatibility:** `^0.1.0-rc.7 || ^0.1.1-rc.1 || ^0.1.2-rc.1 || ^0.1.5-rc.1`
- **Bundle mount points (3):** `github-tools` (the 33 tools), `github-permission-gate` (the gate), `dsh-github-usage` (the on-demand skill). All declared in the package's own `cordis.patch.yml`.
- **No `gh` CLI dependency** — direct REST + GraphQL over `fetch`/`undici`. Atomic multi-file commit via the git-data API. Clone uses the system `git` with env-injected `http.<host>/.extraheader` so the PAT never touches argv / the remote URL / `.git/config` / logs.
- **Test coverage:** 83 vitest tests + `scripts/verify-load.mjs` runtime smoke script.

## Description accuracy (audited against the code)

- **"33 github_* tools"** — README's `Tool surface` table enumerates exactly 33 (21 read + 3 issue-write + 8 git-data-write + 1 private-repo-creation).
- **"private repo creation"** — `github_create_repository` sends `private: true` unconditionally; defaults to off (`enableRepoCreation`) and requires an Admin-RW PAT.
- **"in-process permission gate"** — `src/gate.ts` registers a `tools/pre-execute` listener scoped to `github_*`. Three modes (off / writes / all), two actions (ask / deny), `excludeTools` for per-tool opt-out.
- **"cost-discipline companion skill"** — package's `SKILL.md` ships at the package root and is auto-registered as on-demand by `dsh-github-usage`; the user-level `skill/dsh-github-companion/` directory holds four router reference files.
- **"no gh CLI required"** — explicit design choice; see README "Why this plugin does not wrap the gh CLI".

## Checklist

- [x] `package.json` declares `dsh.bundle` manifest (`patch: ./cordis.patch.yml`)
- [x] `cordis.patch.yml` is at the repo root
- [x] `dsh-plugin` topic added to the repository
- [x] Repo age > 1 day (created 2026-08-23)
- [x] Latest release describes tool counts matching the README
- [x] No superlatives or marketing language in the description
- [x] No existing entry covers this surface (closest neighbours are Codex/WorkBuddy OAuth bridges in the Models & Providers category, which are not Git-tooling plugins)
````

## 步骤

1. 打开上面那个 URL
2. GitHub 会自动展开一个"compare"页面，显示 vclike/add-vclike-dsh-github-companion:main → awesome-dsh-plugin:main，diff 是 1 个新文件
3. 点 "Create pull request" 绿色按钮
4. 粘贴上面的标题和正文
5. 再点 "Create pull request" 提交

## 另一种方式（如果你想用 fine-grained PAT）

在 GitHub Settings → Personal access tokens → Fine-grained tokens，新建一个 PAT：
- Resource owner: awesome-dsh-plugin
- Repository access: awesome-dsh-plugin (only)
- Permissions: Pull requests: Read and write

把 token 给 me（通过环境变量或 secret），我可以用 GitHub REST API 直接开 PR。
