### PR TITLE
Add bainianlaoyao/dsh-llm-api-pool

### DIFF
--- a/data/plugins/bainianlaoyao__dsh-llm-api-pool.yml
+++ b/data/plugins/bainianlaoyao__dsh-llm-api-pool.yml
@@ -1,0 +1,6 @@
+url: https://github.com/bainianlaoyao/dsh-llm-api-pool
+name: bainianlaoyao/dsh-llm-api-pool
+category: model
+description:
+  en: Pools several OpenCode Go API keys and hot-switches each request to the least-used one, with official usage and balance lookup plus a graphical settings page.
+  zh: 聚合多个 OpenCode Go API key，把每次请求热切换到用量最低的一个，并提供官方用量/余额查询与设置页图形化管理。


### PR DESCRIPTION
Adds `data/plugins/bainianlaoyao__dsh-llm-api-pool.yml` — one file, nothing else.

The plugin pools several OpenCode Go API keys and hot-switches each request to the
least-used one (routing on official `GET {baseUrl}/usage` pressure, 60s cooldown on
failure), and registers a configurable DSH provider so the pool appears as a model
provider in Settings.

- [x] One file at `data/plugins/<owner>__<repo>.yml`; READMEs untouched
- [x] `package.json` declares `dsh.bundle` (`{ "patch": "./cordis.patch.yml" }`), plus `dsh.client` for the settings page
- [x] Repo created 2026-08-23 (> 1 day old)
- [x] `category: model` — same family as the other provider/key-pool plugins (`dsh-key-rotation`, `dsh-commandcode-provider`)
- [x] Description states what it does, no superlatives
- [x] Repo carries the `dsh-plugin` topic

Recommended items: published to npm as [`dsh-llm-api-pool`](https://www.npmjs.com/package/dsh-llm-api-pool)
(latest 0.1.8), and the official `@deepseek-ai/*` packages are declared as
`peerDependencies`, not `dependencies`.
