### PR TITLE
Add hutao562/dsh-remote-dsh (remote)

### DIFF
--- a/data/plugins/hutao562__dsh-remote-dsh.yml
+++ b/data/plugins/hutao562__dsh-remote-dsh.yml
@@ -1,0 +1,6 @@
+url: https://github.com/hutao562/dsh-remote-dsh
+name: hutao562/dsh-remote-dsh
+category: remote
+description:
+  en: 'Adds a row at the top of the sidebar that switches the whole Web GUI to another DSH host reached over a loopback port, and shows that host''s session state on the row (running, unread activity, or waiting for your answer).'
+  zh: '在侧边栏顶部加一行，点击后整页切换成另一台 DSH 主机的 Web GUI（通过回环端口访问），并在该行显示那台主机的会话状态（运行中、有新活动、正等你回答）。'


### PR DESCRIPTION
Adds `data/plugins/hutao562__dsh-remote-dsh.yml` — one new entry, category `remote`.

**Plugin:** [hutao562/dsh-remote-dsh](https://github.com/hutao562/dsh-remote-dsh) — a row at the top of the sidebar that switches the whole Web GUI to another DSH host reached over a loopback port, with that host's session state on the row (blue while it runs, green for activity since you last looked, amber while it waits on an approval or question).

**Requirements:**

- `package.json` declares `dsh.bundle: { patch: "./cordis.patch.yml" }` (plus `dsh.client: { platform: "web" }`), and `cordis.patch.yml` is committed at the repository root.
- The repository carries the `dsh-plugin` topic.
- This PR adds exactly one file — the entry — and nothing else.

Note on the age gate: the repository was created 2026-09-10T13:35Z, so at submission time the 1-day floor has not elapsed yet. Per the comment in `scripts/check-submission.mjs` that check re-runs on its own, so I am leaving the PR untouched rather than pushing anything to force it.
