### PR TITLE
Add converk/dsh-tweaks plugins: prompt-history, model-capabilities, turn-file-revert

### DIFF
--- a/data/plugins/converk__dsh-tweaks--plugins-model-capabilities.yml
+++ b/data/plugins/converk__dsh-tweaks--plugins-model-capabilities.yml
@@ -1,0 +1,6 @@
+url: https://github.com/converk/dsh-tweaks/tree/main/plugins/model-capabilities
+name: converk/dsh-tweaks#model-capabilities
+category: model
+description:
+  en: Adds a reasoning-level editor with OpenAI and Anthropic protocol presets (llm-pi-ai), input-modality switches and a 1M/128K context and max-output preset to model rows in Settings.
+  zh: 在「设置 → 模型」的模型行里补上思考强度档位（llm-pi-ai，含 OpenAI / Anthropic 协议预置）、多模态开关和 1M/128K 上下文与最大输出快捷填入。

--- a/data/plugins/converk__dsh-tweaks--plugins-prompt-history.yml
+++ b/data/plugins/converk__dsh-tweaks--plugins-prompt-history.yml
@@ -1,0 +1,6 @@
+url: https://github.com/converk/dsh-tweaks/tree/main/plugins/prompt-history
+name: converk/dsh-tweaks#prompt-history
+category: ui
+description:
+  en: Recalls prompts sent earlier in the current session with the up and down keys in an empty composer, and shows a position badge while browsing.
+  zh: 在空输入框里用 ↑/↓ 翻出本会话之前发过的提示词，翻动时显示位置角标。

--- a/data/plugins/converk__dsh-tweaks--plugins-turn-file-revert.yml
+++ b/data/plugins/converk__dsh-tweaks--plugins-turn-file-revert.yml
@@ -2,5 +2,5 @@ url: https://github.com/converk/dsh-tweaks/tree/main/plugins/turn-file-revert
 name: converk/dsh-tweaks#turn-file-revert
 category: ui
 description:
-  en: Adds a changed-file summary row to finished turns and reverts or reapplies the file changes of the session latest turn.
+  en: Adds a changed-file summary row to finished turns and reverts or reapplies the file changes of the latest turn in the session.
   zh: 在每轮对话末尾补一行改动统计，并可撤回 / 重新应用本会话最后一轮的改动。

--- a/data/plugins/converk__dsh-tweaks--plugins-turn-file-revert.yml
+++ b/data/plugins/converk__dsh-tweaks--plugins-turn-file-revert.yml
@@ -1,0 +1,6 @@
+url: https://github.com/converk/dsh-tweaks/tree/main/plugins/turn-file-revert
+name: converk/dsh-tweaks#turn-file-revert
+category: ui
+description:
+  en: Adds a changed-file summary row to finished turns and reverts or reapplies the file changes of the session latest turn.
+  zh: 在每轮对话末尾补一行改动统计，并可撤回 / 重新应用本会话最后一轮的改动。


### PR DESCRIPTION
Adds three entries for [converk/dsh-tweaks](https://github.com/converk/dsh-tweaks), a monorepo whose subpackages are separately installable plugins.

| plugin | category | what it does |
|---|---|---|
| [prompt-history](https://github.com/converk/dsh-tweaks/tree/main/plugins/prompt-history) | ui | Up/Down keys in an empty composer recall prompts sent earlier in the session |
| [model-capabilities](https://github.com/converk/dsh-tweaks/tree/main/plugins/model-capabilities) | model | Reasoning levels (with OpenAI/Anthropic presets), input modalities and a 1M/128K preset button in the model editor |
| [turn-file-revert](https://github.com/converk/dsh-tweaks/tree/main/plugins/turn-file-revert) | ui | A per-turn changed-file summary with revert/reapply of the session latest turn |

Checklist:
- [x] Added three files under data/plugins/ (the 3-per-PR maximum); generated READMEs untouched
- [x] Each package declares dsh.bundle (with cordis.patch.yml), plus dsh.client for the browser half
- [x] Repo created 2026-09-10, past the 1-day bar
- [x] category values from the allowed list (ui, model, ui)
- [x] Descriptions state what each plugin does, no superlatives
- [x] Repo carries the dsh-plugin topic

Recommended extras done:
- Published to npm as dsh-tweaks-prompt-history, dsh-tweaks-model-capabilities, dsh-tweaks-turn-file-revert (0.1.0), with repository.directory pointing back at each subdirectory
- screenshots.json declared beside each package.json
- No runtime dependencies at all, so nothing needs declaring as peerDependencies
