### PR TITLE
Add dsh-api-dashboard (usage)

### DIFF
--- a/data/plugins/133563825as-ai__dsh-api-dashboard.yml
+++ b/data/plugins/133563825as-ai__dsh-api-dashboard.yml
@@ -1,0 +1,6 @@
+url: https://github.com/133563825as-ai/dsh-api-dashboard
+name: 133563825as-ai/dsh-api-dashboard
+category: usage
+description:
+  en: 'Multi-platform API balance and usage dashboard for the DSH web GUI: balances for DeepSeek, Zhipu GLM, Kimi, StepFun, SiliconFlow, MiniMax, OpenRouter, Novita and xAI under the composer, estimated per-session and per-subagent cost with DeepSeek peak/off-peak pricing, automatic discovery of relays configured in DSH settings, and an optional draggable whale widget.'
+  zh: 'DSH Web GUI 的多平台 API 余额与用量看板：在输入框下方显示 DeepSeek、智谱 GLM、Kimi、阶跃星辰、硅基流动、MiniMax、OpenRouter、Novita、xAI 的余额，估算本会话与子代理消耗并按 DeepSeek 峰谷计价，自动发现 DSH 设置里已配置的中转站，另有一个可拖拽的大肥鱼挂件。'


### PR DESCRIPTION
Add dsh-api-dashboard (usage)

Adds one entry file: `data/plugins/133563825as-ai__dsh-api-dashboard.yml`. No README edits, no other entries touched.

**What it is / 这是什么**

A multi-platform API balance and usage dashboard for the DSH web GUI. It renders under the composer (`conversation.composer.dock`) and has three layers: a balance bar → a dashboard drawer → per-platform detail. It shows balances for DeepSeek, Zhipu GLM, Kimi, StepFun, SiliconFlow, MiniMax, OpenRouter, Novita and xAI; estimates the current session's cost and each subagent's cost separately; applies DeepSeek peak/off-peak pricing; and discovers relays already configured in DSH's `settings.yaml` so they don't have to be re-entered by hand. Platforms that expose no balance API (OpenAI, Claude, Gemini, Qwen, MiMo, Doubao, Hunyuan) are shown as "no balance API" rather than being filled with a fabricated number.

**Category / 分类**

`usage` — the plugin's job is account balance and usage/cost accounting.

**Checklist / 对照要求**

- `package.json` declares `dsh.bundle.patch` (root `cordis.patch.yml`) and `dsh.client.platform: web` — the repo is installable with `dsh plugin add`.
- `dsh-plugin` topic is set on the repository.
- Repo created 2026-08-25 (well past the 1-day bar), actively maintained, MIT.
- Real working code: `src/index.js` (2,755 lines) plus `client/client.js` (2,676 lines), zero runtime dependencies, 17 test files / 553 assertions.
- Official `@deepseek-ai/*` packages are declared as `peerDependencies`, not `dependencies`.
- The description states only what the code does — no superlatives, no numbers that aren't in the source.
- Adds exactly one file and nothing else.

---

为 DSH Web GUI 增加多平台 API 余额与用量看板条目。只新增 `data/plugins/133563825as-ai__dsh-api-dashboard.yml` 一个文件，不改 README、不动其它条目。
