### PR TITLE
Update bainianlaoyao/dsh-codex-harness: move to model, expand description

### DIFF
--- a/data/plugins/bainianlaoyao__dsh-codex-harness.yml
+++ b/data/plugins/bainianlaoyao__dsh-codex-harness.yml
@@ -1,6 +1,6 @@
 url: https://github.com/bainianlaoyao/dsh-codex-harness
 name: bainianlaoyao/dsh-codex-harness
-category: tools
+category: model
 description:
-  en: 'Codex-shaped coding tools and an agent preset for DeepSeek Harness: exec_command, apply_patch, view_image, DSH-native collaboration tools, and OpenAI Chat Completions and Responses API routes.'
-  zh: 面向 DeepSeek Harness 的 Codex 风格编码工具与 agent 预设：exec_command、apply_patch、view_image、DSH 原生协作工具，以及 OpenAI Chat Completions 和 Responses API 路由。
+  en: 'Codex-shaped coding tools and agent presets for GPT models on DeepSeek Harness: exec_command, write_stdin, apply_patch and view_image, plus OpenAI Chat Completions and Responses API routes, bridged to DSH-native plan, ask, approval and compaction. Long-running commands become DSH background jobs with bounded head/tail output readable through job_output, and each subagent type can be pinned to its own preset, provider, model and reasoning effort.'
+  zh: '面向 DeepSeek Harness 上 GPT 模型的 Codex 风格编码工具与 agent 预设：exec_command、write_stdin、apply_patch、view_image，以及 OpenAI Chat Completions 与 Responses API 两条路由，并桥接 DSH 原生的计划、提问、审批与压缩。长命令注册为 DSH 后台作业，输出首尾有界，可用 job_output 读取；每种子代理类型可独立指定 Preset、Provider、Model 与 Reasoning effort。'


### PR DESCRIPTION
Updates one existing entry — `data/plugins/bainianlaoyao__dsh-codex-harness.yml`. No new file, no README edits (regenerated on merge).

## `category: tools` → `model`

The package registers OpenAI Chat Completions and Responses API routes on the host plane, and both of its shipped presets (`codex 工具模式`, `codex 创造模式`) exist to drive those routes. That is what **Models & Providers** describes, and it is where the entries it actually resembles already live: `dsh-codex-connect`, `dsh-codex-subscription`, `dsh-key-rotation`. Under `tools` it sat next to nothing comparable.

## Description

Rewritten to name the surface a reader is choosing between:

- the four Codex tools — `exec_command`, `write_stdin`, `apply_patch`, `view_image`;
- the DSH-native plan / ask / approval / compaction it delegates to instead of reimplementing (no Codex-format `<environment_context>` injection);
- the background-job bridge — long commands register as DSH jobs with bounded head/tail output, read back with `job_output` / `job_list` / `job_kill`;
- per-subagent-type selection of preset, provider, model and reasoning effort.

## Note on wording

An earlier draft used "elegant", "perfectly bridges the harness" and "optimized performance and speed". Per the description rule ("states what the plugin does, no superlatives") each was replaced with the mechanism behind it — e.g. the performance claim is now the bounded head/tail output buffer and the LRU-capped session pool, stated as behaviour rather than as an adjective.

## Screenshots

Not part of this PR: they are declared in the plugin's own repository at [`screenshots.json`](https://github.com/bainianlaoyao/dsh-codex-harness/blob/main/screenshots.json) (two shots, `assets/screenshots/`), per the convention in `contributing.md`. Both were captured from a real profile boot of the published 0.3.1 and verified reachable at `HEAD` with the ranged GET `probe-screenshots.mjs` uses.

## Checklist

- [x] Only my own entry changed
- [x] READMEs untouched (regenerated by `sync-readme.yml` after merge)
- [x] `category` is one of the allowed values
- [x] Description states what the plugin does, no superlatives
- [x] Repo declares `dsh.bundle` and carries the `dsh-plugin` topic
- [x] `node scripts/check-submission.mjs` passes locally for this entry
