### PR TITLE
Add AHIOSUZ/dsh-workspace-tools (security)

### DIFF
--- a/data/plugins/AHIOSUZ__dsh-workspace-tools.yml
+++ b/data/plugins/AHIOSUZ__dsh-workspace-tools.yml
@@ -1,0 +1,6 @@
+url: https://github.com/AHIOSUZ/dsh-workspace-tools
+name: AHIOSUZ/dsh-workspace-tools
+category: security
+description:
+  en: Applies per-workspace default Agent and permission presets to new root sessions automatically (Settings - Workspace defaults), using only official extension points.
+  zh: 按工作区规则为新建根会话自动应用 Agent 预设与权限预设（设置 - 工作区默认设置），仅使用官方扩展点。


### PR DESCRIPTION
Adds [AHIOSUZ/dsh-workspace-tools](https://github.com/AHIOSUZ/dsh-workspace-tools) under **Security & Permissions**.

- What it does: applies per-workspace default Agent and permission presets to new root sessions automatically (a "Workspace defaults" settings page), using only official extension points - `agent/created`, `agentPresets.select`, `permissionPresets`, `settings.installSection`, `remote.workspace.follow`. No DSH patches required; works on official 0.1.5-rc.1+.
- Manifest: `dsh.bundle` declared in the root `package.json` (bundle patch + web client half for the settings page).
- Rules are stored keyed by workspace id (path kept for display), matching the session cwd through `workspaceRegistry.resolveByPath` with a path-prefix fallback.
- Official `@deepseek-ai/*` packages are declared as `peerDependencies`; npm publish pending, so source install applies for now (built `lib/` is committed).