### PR TITLE
Add greyoak111/siyuan-codex-bridge (memory)

### DIFF
--- a/data/plugins/greyoak111__siyuan-codex-bridge.yml
+++ b/data/plugins/greyoak111__siyuan-codex-bridge.yml
@@ -1,0 +1,6 @@
+url: https://github.com/greyoak111/siyuan-codex-bridge
+name: greyoak111/siyuan-codex-bridge
+category: memory
+description:
+  en: 'Connects DeepSeek Harness to a local SiYuan (思源笔记) desktop app: bridges its own MCP endpoint, registers its note tools as mcp__siyuan__<tool>, ships a notes skill, and enforces a readonly/authoring/full profile on every call.'
+  zh: '把 DeepSeek Harness 接到本机思源笔记桌面端：桥接它自带的 MCP 端点，把笔记工具注册为 mcp__siyuan__<tool>，附带笔记使用技能，并在每次调用上执行只读/创作/完整三级策略。'


### PR DESCRIPTION
<!-- Thanks for contributing! Quick checklist / 提交前快速自查 -->

- [x] I added **one file** at `data/plugins/<owner>__<repo>.yml` — that single file is the whole submission / 我新增了一个 `data/plugins/<owner>__<repo>.yml` 文件
- [x] My repo's `package.json` declares **`dsh.bundle`** (not just `dsh.client`) — patch: `./cordis.patch.yml`
- [x] My repo is at least **1 day old** (created 2026-09-08)
- [x] `category` is `memory` — it exposes the user's own local note vault to the agent, the same shape as the Obsidian-vault entries in that category
- [x] Description states what the plugin does, no superlatives
- [x] My repo has the `dsh-plugin` topic

**Recommended / 推荐：** `@deepseek-ai/dsh-mcp-client` is declared as a `peerDependencies` entry with an explicit prerelease branch (`>=0.0.1-rc.1 <0.1.0 || >=0.1.0-rc.1 <0.2.0-0`), so the profile keeps one copy. No npm package; no `screenshots.json` yet.

## What it does / 这个插件做什么

Connects DeepSeek Harness to a **local SiYuan (思源笔记) desktop app**. `cordis.patch.yml` points `@deepseek-ai/dsh-mcp-client` at `bridge/mcp-stdio.mjs` — a dependency-free Node bridge to the MCP endpoint the SiYuan app already serves on loopback — so the agent gets SiYuan's official note tools as `mcp__siyuan__<tool>`, plus a `siyuan` skill contributed from this package's `skills/` directory.

- **No configuration in the normal case.** The API token is resolved from the environment, then `~/.config/dsh-siyuan/config.json`, then SiYuan's own workspace settings (`~/.config/siyuan/workspace.json` → `<workspace>/conf/conf.json`), which is where the user's token already lives.
- **One of three operation profiles is enforced on every `tools/call`** — `readonly`, `authoring` (default) or `full`. An action outside the active profile is refused with a clear error instead of being forwarded, and `full`-only actions (delete, move, notebook administration, file, SQL, import/export, history, repository, sync, HTTP) are named as such in the skill.
- **State stays out of the package.** Config and the append-only audit log (`~/.config/dsh-siyuan/`, mode 600, no arguments and no note content) live in the user's config directory, because an installed plugin directory is immutable.
- `node node_modules/.bin/dsh-siyuan-bridge --doctor` reports the endpoint, where the token came from, and the active profile — without printing the token.
- The same repository also carries the Codex/CLI half of this bridge (`bin/`, Python). The two halves are independent: separate bridge code, token source, policy and audit.

## Verification / 验证

Installed in a clean isolated profile exactly as a plugin (`node_modules/dsh-siyuan` linked and added to the profile's bundles) and booted a headless session:

- `mcp__siyuan__system {"action":"version"}` → `3.8.3`
- `mcp__siyuan__search {"action":"fulltext","query":"思源"}` → returned a real document path, snippet and block id
- a skill named `siyuan` appeared in the agent's skill catalog
- `mcp__siyuan__sql {"action":"query"}` was refused under the default `authoring` profile (`-32003`) while `mcp__siyuan__notebook {"action":"list"}` succeeded
