### PR TITLE
build: date entries whose addition came in through a merge commit

### DIFF
--- a/scripts/build-site.mjs
+++ b/scripts/build-site.mjs
@@ -238,9 +238,19 @@ if (ordered.some((e) => !dates[e.url])) {
       try {
         // Oldest "added" commit for that path. Not `-1`, which git applies
         // before --reverse and would hand back the newest instead.
-        const out = execSync(`git log --diff-filter=A --format=%cI -- ${JSON.stringify(file)}`,
+        const added = execSync(`git log --diff-filter=A --format=%cI -- ${JSON.stringify(file)}`,
           { encoding: 'utf8' }).trim().split('\n').filter(Boolean)
-        const iso = out[out.length - 1]
+        // An entry that arrived through a merge commit has no --diff-filter=A
+        // row at all: `git log` does not walk a merge's diff unless asked to,
+        // so this filter cannot see the addition, and neither can the README
+        // pass above for the line that landed in the same merge. The oldest
+        // commit that touched the path IS that merge, so it answers the same
+        // question. Without this the build refuses over data it can date.
+        const touched = added.length
+          ? added
+          : execSync(`git log --format=%cI -- ${JSON.stringify(file)}`,
+            { encoding: 'utf8' }).trim().split('\n').filter(Boolean)
+        const iso = touched[touched.length - 1]
         if (iso) dates[e.url] = new Date(iso).toISOString()
       } catch { /* not committed yet — falls through to the error below */ }
     }


### PR DESCRIPTION
`main`'s site build has been failing since merge commit `5599809c` ("Add wwweljf/dsh-plugins: …", 2026-09-08), which is why **every** currently open PR's `check` job is red:

```
3432 entries parsed across 2 locales
no added-date derivable for: https://github.com/wwweljf/dsh-plugins/tree/master/plugins/dsh-ding-sound, …/dsh-wx-push, …/dsh-wx-remote
need full git history (fetch-depth: 0) and committed entries — refusing to build
```

## Why those three have no date

Both date ledgers are blind to a merge commit, because `git log` does not walk a merge's diff unless asked to:

- the README pass (`git log --reverse --date-order -p -- README.md`) never sees the `+- […]` line: grep for `dsh-ding-sound` across that entire log output returns 0 hits;
- the yml fallback (`git log --diff-filter=A --format=%cI -- <entry file>`) returns nothing: the file's only touching commit is the merge `5599809c` itself, and `--diff-filter=A` cannot see a merge's additions.

96 of the 3432 entry files have no `--diff-filter=A` row; for 93 of them the README line was committed normally, so the first ledger covers them. These three arrived entirely through the merge, so neither does — and the build refuses over data it can perfectly well date.

## The change

When `--diff-filter=A` has nothing to say, ask the same question of the same file without the filter: the **oldest commit that touched the path** is the merge that introduced it. For these three that is `5599809c` (2026-09-08T23:01:39+08:00) — the date the entries were actually added.

The `--diff-filter=A` result stays first, so an entry that already has a date keeps the exact value it has today: this only fills in what both ledgers could not. That is also why I did not reach for the wider alternatives — adding `--diff-merges=first-parent` to the README pass, or `-m`, would change which commits the primary ledger sees for every entry, and could move already-published dates.

## Verification

Ran the real build on a full clone of `main` (`5b7be0b9`), with this change applied:

```
3431 entries parsed across 2 locales
site built: 3431 rows × 2 locales + sitemap + count badge
```

Without it, the same clone stops at `no added-date derivable for: …`. All three entries resolve to `2026-09-08T23:01:39+08:00`, and no other entry's date changes (the fallback only runs where `added.length === 0`).

Once this lands on `main`, the red `check` jobs on the open PRs clear on their next run — including #4870, a plugin entry that has been waiting behind this.
