### PR TITLE
Add two plugins by jiekesu967 (dsh-markitdown, dsh-plugin-opencode-usage)

### DIFF
--- a/data/plugins/jiekesu967__dsh-markitdown.yml
+++ b/data/plugins/jiekesu967__dsh-markitdown.yml
@@ -1,0 +1,6 @@
+url: https://github.com/jiekesu967/dsh-markitdown
+name: jiekesu967/dsh-markitdown
+category: tools
+description:
+  en: Adds a markitdown tool that converts PDF, Word, Excel, PowerPoint, HTML, CSV, EPUB and URLs to Markdown, using a real Microsoft MarkItDown installation when one is reachable and a bundled dependency-free converter otherwise.
+  zh: 提供 markitdown 工具，把 PDF、Word、Excel、PowerPoint、HTML、CSV、EPUB 与网址转成 Markdown：能找到真实的 Microsoft MarkItDown 时驱动它，否则使用内置的零依赖转换器。

--- a/data/plugins/jiekesu967__dsh-plugin-opencode-usage.yml
+++ b/data/plugins/jiekesu967__dsh-plugin-opencode-usage.yml
@@ -1,0 +1,6 @@
+url: https://github.com/jiekesu967/dsh-plugin-opencode-usage
+name: jiekesu967/dsh-plugin-opencode-usage
+category: usage
+description:
+  en: Shows OpenCode Go subscription usage (rolling, weekly and monthly used and remaining percentage with reset times) in a floating panel anchored to the bottom-left of the session window.
+  zh: 在会话窗口左下角的悬浮面板中显示 OpenCode Go 订阅用量（滚动/每周/每月的已用与剩余百分比及重置时间）。


### PR DESCRIPTION
Adds two plugins by @jiekesu967, following the one-file-per-plugin layout in `data/plugins/`.

**jiekesu967/dsh-markitdown** — `tools`
A `markitdown` model tool that converts documents to Markdown. It does not vendor Microsoft
MarkItDown: it locates a real installation (the `markitdown` CLI, `uvx markitdown`, or a Python that
already has the package), drives it, and falls back to a converter bundled in the plugin so the tool
still answers when nothing is installed. Published as
[`dsh-markitdown`](https://www.npmjs.com/package/dsh-markitdown).

**jiekesu967/dsh-plugin-opencode-usage** — `usage`
A floating panel at the bottom-left of the session window showing OpenCode Go subscription usage:
rolling, weekly and monthly used/remaining percentages with reset times. The API key is resolved
host-side and never reaches the browser. Published as
[`dsh-plugin-opencode-usage`](https://www.npmjs.com/package/dsh-plugin-opencode-usage).

Both declare `dsh.bundle.patch` and ship a `cordis.patch.yml`; both have committed `lib/` and no
build step, so they install from source directly. Neither PR touches any other entry.

Notes for the reviewer:

- `dsh-markitdown` overlaps in purpose with the existing `yakoylp/dsh-md-convert`. They are
  different implementations: that one is a self-contained CPU-first OCR pipeline, this one drives
  Microsoft MarkItDown (upstream) and adds a dependency-free fallback. Happy to hear if you would
  rather not have both — flagging it rather than leaving it for you to notice.
- `dsh-plugin-opencode-usage` is filed under `usage`; it also has a UI surface, so move it if
  `ui` fits your taxonomy better.
