### PR TITLE
Add Mandarin715/dsh-autostart

### DIFF
--- a/data/plugins/Mandarin715__dsh-autostart.yml
+++ b/data/plugins/Mandarin715__dsh-autostart.yml
@@ -1,0 +1,6 @@
+url: https://github.com/Mandarin715/dsh-autostart
+name: Mandarin715/dsh-autostart
+category: dev
+description:
+  en: 'Windows boot autostart and one-click restart for the DSH service, from inside DSH: a windowless HKCU-Run bootstrap entry, a restart button in the settings card, the current tokenised access URL, and an optional post-start hook.'
+  zh: Windows 平台的 DSH 服务开机自启与一键重启（都在 DSH 设置页内）：无窗口的 HKCU Run 登录项、设置页重启按钮、显示当前带 token 的访问地址，以及可选的服务启动后钩子。


### PR DESCRIPTION
## Add `Mandarin715/dsh-autostart`

One entry file, as the contributing guide asks: `data/plugins/Mandarin715__dsh-autostart.yml` — no README edits.

**What it is.** A Windows-only DSH plugin that adds boot autostart for the DSH service and a one-click restart from inside DSH, plus the current access URL and an optional post-start hook.

**Why `dev`.** The neighbouring entries in that category are the same kind of plugin — `1123762794/dsh-web-restart` (restart button), `chenkai2/dsh-daemon` (registers `dsh web` as an auto-start service via LaunchAgent/systemd/cron), `mangomt/dsh-power` (restart / graceful shutdown). This one differs in that it is a plugin inside DSH, its autostart is a Windows HKCU-Run entry driven by a windowless `wscript` bootstrap, and it also surfaces the per-process access URL. If another category fits better, moving it is fine by me.

### Requirements checklist

- `dsh.bundle` manifest — `package.json` declares `"dsh": { "bundle": { "patch": "./cordis.patch.yml" } }`, with `cordis.patch.yml` at the repo root.
- Installable via `dsh plugin add` — installed into the web profile locally with `dsh plugin --profile web add <repo>` and run for real (see below).
- `dsh-plugin` topic — added to the repository.
- Repo at least 1 day old — this PR is opened after that (the repository was created 2026-09-10T13:25:09Z).
- Real, working code — 123 tests (`node --test`), no placeholders.
- No superlatives in the description.

### Description ↔ code (the accuracy check)

| Claim in the description | Where it lives |
|---|---|
| "Windows boot autostart" | one `HKCU\...\Run` value `DSH autostart` → `lib/registry.js` |
| "windowless HKCU-Run bootstrap entry" | `bootstrap.vbs` (UTF-16LE, run by `wscript`), generated by `lib/render-vbs.js`; the restart helper is created through WMI with `Win32_ProcessStartup.ShowWindow = 0`, so no console window appears (`lib/launch-helper.js`) |
| "one-click restart ... from inside DSH" | `POST /dsh-autostart/restart` in `index.js`; the button is in the Settings card (`client.js`, slot `settings.general.item`) |
| "the current tokenised access URL" | `buildState.accessUrl`, parsed by `lib/parse-url.js` from the captured stdout (`start-dsh-web` style log) |
| "an optional post-start hook" | `hookScript` in `config.json`, executed by `service.js` `runHook` after the port comes up |

The repository also contains `docs/ACCEPTANCE.md`: a real-machine acceptance run on DSH `0.1.5-rc.1` (M1–M7) with the evidence, including the two defects that run exposed and that were fixed afterwards.
