### PR TITLE
Add duoduoqian708/dsh-voice-talk

### DIFF
--- a/data/plugins/duoduoqian708__dsh-voice-talk.yml
+++ b/data/plugins/duoduoqian708__dsh-voice-talk.yml
@@ -2,5 +2,5 @@ url: https://github.com/duoduoqian708/dsh-voice-talk
 name: duoduoqian708/dsh-voice-talk
 category: voice
 description:
-  en: "Full-screen voice conversation for the DSH Web GUI: talk hands-free and hear each reply read aloud as it streams - prose only, code and reasoning skipped."
-  zh: "DSH Web 的全屏语音对话：点麦克风边说边听，AI 回复边生成边念正文，只念正文、略过代码与推理；支持千问 / 讯飞 / 系统语音。"
+  en: "Voice conversation mode for the DSH Web GUI: tap the mic to start a full-screen call, talk hands-free, and hear each reply read aloud as it streams. Bilingual (Chinese/English) UI, light and dark themes, adjustable speech rate, and switchable voices."
+  zh: "DSH Web 的语音对话模式：点一下麦克风进入全屏通话，边说边听，AI 回复边生成边朗读。界面中英双语，适配明暗主题，支持语速调节与音色切换。"

--- a/data/plugins/duoduoqian708__dsh-voice-talk.yml
+++ b/data/plugins/duoduoqian708__dsh-voice-talk.yml
@@ -1,0 +1,6 @@
+url: https://github.com/duoduoqian708/dsh-voice-talk
+name: duoduoqian708/dsh-voice-talk
+category: voice
+description:
+  en: "Full-screen voice conversation for the DSH Web GUI: talk hands-free and hear each reply read aloud as it streams - prose only, code and reasoning skipped."
+  zh: "DSH Web 的全屏语音对话：点麦克风边说边听，AI 回复边生成边念正文，只念正文、略过代码与推理；支持千问 / 讯飞 / 系统语音。"


### PR DESCRIPTION
Adds **duoduoqian708/dsh-voice-talk** to the `voice` category.

- Repo: https://github.com/duoduoqian708/dsh-voice-talk
- package.json declares `dsh.bundle` (`cordis.patch.yml`) and `dsh.client`; installable via `dsh plugin --profile web add dsh-voice-talk`
- Published on npm as `dsh-voice-talk@0.1.1` (prebuilt install, no build approval needed)
- Repo has the `dsh-plugin` topic
- What it does: voice conversation mode for the DSH Web GUI - tap the mic to start a full-screen call, talk hands-free, and hear each reply read aloud as it streams. Bilingual (Chinese/English) UI, light and dark themes, adjustable speech rate, and switchable voices.