### PR TITLE
Add WYR-233/dsh-memory-lite (memory)

### DIFF
--- a/data/plugins/WYR-233__dsh-memory-lite.yml
+++ b/data/plugins/WYR-233__dsh-memory-lite.yml
@@ -1,0 +1,7 @@
+url: https://github.com/WYR-233/dsh-memory-lite
+name: WYR-233/dsh-memory-lite
+category: memory
+description:
+  en: 'Read-only enhancer for a file-based long-term memory library (markdown cards in git): a memory_find search tool, a small budgeted memory digest injected into the system prompt, and a settings page with library overview, health-check status and toggles.'
+  zh: '面向「纯文件（markdown 卡片 + git）长期记忆库」的只读增强插件：memory_find 检索工具、一小段受预算约束的记忆库摘要注入，以及带概览/健康/开关的设置页。'
+tarball: https://github.com/WYR-233/dsh-memory-lite/releases/latest/download/dsh-memory-lite.tgz


### PR DESCRIPTION
**Plugin**: https://github.com/WYR-233/dsh-memory-lite

Adds one entry file `data/plugins/WYR-233__dsh-memory-lite.yml` (memory).

- `dsh.bundle.patch` is declared in package.json and the repo ships `cordis.patch.yml`.
- Install: `dsh plugin --profile web add github:WYR-233/dsh-memory-lite`; a prebuilt tarball is attached to the latest GitHub Release (asset name carries no version).
- `@deepseek-ai/cordis` is a peerDependency with a stable range; the plugin has zero runtime dependencies.
- `dsh-plugin` topic is set on the repository.

What it does: points at any markdown-card long-term memory library and gives the agent a `memory_find` tool plus a small, budgeted digest section in the system prompt. A settings page shows card count, body size, topics, the last health-check result, and toggles for the digest, the tool, the budget and the search limit. It never writes to the library and never rewrites conversation history; the only state is one small JSON config written atomically.