### PR TITLE
Add youqu68/dsh-delete-chat

### DIFF
--- a/data/plugins/youqu68__dsh-delete-chat.yml
+++ b/data/plugins/youqu68__dsh-delete-chat.yml
@@ -1,0 +1,6 @@
+url: https://github.com/youqu68/dsh-delete-chat
+name: youqu68/dsh-delete-chat
+category: session
+description:
+  en: Archive, unarchive, and delete sessions from a settings page.
+  zh: 在设置页中归档、恢复并删除会话。


### PR DESCRIPTION
Adds one entry: `youqu68/dsh-delete-chat` (category `session`).

- Repo: https://github.com/youqu68/dsh-delete-chat
- npm: https://www.npmjs.com/package/dsh-delete-chat
- The package declares `dsh.bundle` (`cordis.patch.yml`) and `dsh.client` (web), and exports `./typert` for its Host Remote surface.
- It adds a settings page that lists every session, archives/unarchives them (hide/restore), and permanently deletes a non-live session's persistence log behind a two-step confirmation.

Only this one YAML file is added; no other entry is touched.