### PR TITLE
Add dsh-mobile-direct (category: remote)

### DIFF
--- a/data/plugins/hajimimaodie8__dsh-mobile-direct.yml
+++ b/data/plugins/hajimimaodie8__dsh-mobile-direct.yml
@@ -1,0 +1,6 @@
+url: https://github.com/hajimimaodie8/dsh-mobile-direct
+name: hajimimaodie8/dsh-mobile-direct
+category: remote
+description:
+  en: 'Scan-once mobile entry 鈥?a QR in the top-right of the harness web UI that pairs the DSH Mobile app (device token, 30 days) or opens a one-tap browser session, always carrying a LAN address the phone can actually reach.'
+  zh: '鎵嬫満鎵爜鐩磋繛 鈥斺€?鍦?harness 鐣岄潰鍙充笂瑙掔粰鍑轰簩缁寸爜锛屾墜鏈?App 鎵竴娆″嵆瀹屾垚閰嶅锛堣澶囦护鐗岋紝榛樿 30 澶╁厤閰嶏級锛屾墜鏈烘祻瑙堝櫒鎵彟涓€涓爜鐐逛竴涓嬪嵆杩涳紱浜岀淮鐮侀噷鐨勫湴鍧€濮嬬粓鏄墜鏈虹湡姝ｅ彲杈剧殑灞€鍩熺綉 IP銆?

--- a/data/plugins/hajimimaodie8__dsh-mobile-direct.yml
+++ b/data/plugins/hajimimaodie8__dsh-mobile-direct.yml
@@ -2,5 +2,5 @@ url: https://github.com/hajimimaodie8/dsh-mobile-direct
 name: hajimimaodie8/dsh-mobile-direct
 category: remote
 description:
-  en: 'Scan-once mobile entry 鈥?a QR in the top-right of the harness web UI that pairs the DSH Mobile app (device token, 30 days) or opens a one-tap browser session, always carrying a LAN address the phone can actually reach.'
-  zh: '鎵嬫満鎵爜鐩磋繛 鈥斺€?鍦?harness 鐣岄潰鍙充笂瑙掔粰鍑轰簩缁寸爜锛屾墜鏈?App 鎵竴娆″嵆瀹屾垚閰嶅锛堣澶囦护鐗岋紝榛樿 30 澶╁厤閰嶏級锛屾墜鏈烘祻瑙堝櫒鎵彟涓€涓爜鐐逛竴涓嬪嵆杩涳紱浜岀淮鐮侀噷鐨勫湴鍧€濮嬬粓鏄墜鏈虹湡姝ｅ彲杈剧殑灞€鍩熺綉 IP銆?
+  en: 'Scan-once mobile entry — a QR in the top-right of the harness web UI that pairs the DSH Mobile app (device token, 30 days) or opens a one-tap browser session, always carrying a LAN address the phone can actually reach.'
+  zh: '手机扫码直连 —— 在 harness 界面右上角给出二维码，手机 App 扫一次即完成配对（设备令牌，默认 30 天免配），手机浏览器扫另一个码点一下即进；二维码里的地址始终是手机真正可达的局域网 IP。'


### PR DESCRIPTION
Adds one entry file, `data/plugins/hajimimaodie8__dsh-mobile-direct.yml`, per contributing.md.

`dsh-mobile-direct` puts a QR in the top-right of the harness web UI so a phone can get in without typing anything:

- the QR carries a `dsh-relay` pairing payload (`kind: dsh-relay-pair`, `v: 1`) whose `url` is the **LAN address** the phone can actually reach. The relay builds that URL from the `Host` you opened its page with, so the QR it renders on the machine running the harness says `127.0.0.1`, which no phone can use;
- the DSH Mobile app scans it and pairs via `POST /relay/pair`, receiving a device token (30 days by default);
- a second QR opens a one-tap browser session for phones without the app.

Repo: https://github.com/hajimimaodie8/dsh-mobile-direct
Requires `dsh-relay` >= 0.2.0. No build step; the package ships plain ESM.