### PR TITLE
Add dsh-skill-dossier (skill)

### DIFF
--- a/data/plugins/JeffreySuen-x__dsh-skill-dossier.yml
+++ b/data/plugins/JeffreySuen-x__dsh-skill-dossier.yml
@@ -1,0 +1,6 @@
+url: https://github.com/JeffreySuen-x/dsh-skill-dossier
+name: JeffreySuen-x/dsh-skill-dossier
+category: skill
+description:
+  en: 'Skill dossier + work report for DSH: browse, search and archive each skill (direction, scope, boundaries, scenarios), review or delete it, and roll daily briefs into daily, weekly and monthly reports.'
+  zh: DSH 技能档案与工作汇报：浏览、搜索并为每个技能建档（方向/使用范围/能力边界/应用场景），复审与删除技能，并把每日简报汇成日报/周报/月报。


### PR DESCRIPTION
Adds `dsh-skill-dossier` under `category: skill`.

**What it does** — a skill dossier + work report plugin for DSH. It browses and searches the skills installed across `~/.dsh/skills`, `.dsh/skills` and `~/.agents/skills`; writes one dossier per skill (direction / scope / boundaries / scenarios); records call counts; reviews and deletes folder skills; and rolls daily briefs into daily, weekly and monthly reports.

**Checklist**
- [x] `package.json` declares `dsh.bundle.patch` → `./cordis.patch.yml`, and that file is at the repo root
- [x] Browser half declared via `dsh.client` (`platform: web`)
- [x] Real, working code — the four gates pass (`test` / `typecheck` / `build` / `pack`)
- [x] Repo created 2026-08-21 (>= 1 day)
- [x] `dsh-plugin` topic is set
- [x] Actively maintained (pushed today)
- [x] `url` matches the repo exactly

Zero runtime dependencies; the client bundle is ~59 KB and no chart library was added.
