### PR TITLE
feat(plugin): add v0.2.0 prebuilt tarball for QuantumKuba/dsh-graphify-plugin

### DIFF
--- a/data/plugins/QuantumKuba__dsh-graphify-plugin.yml
+++ b/data/plugins/QuantumKuba__dsh-graphify-plugin.yml
@@ -1,6 +1,7 @@
 url: https://github.com/QuantumKuba/dsh-graphify-plugin
 name: QuantumKuba/dsh-graphify-plugin
 category: tools
+tarball: https://github.com/QuantumKuba/dsh-graphify-plugin/releases/download/v0.2.0/dsh-graphify-0.2.0.tgz
 description:
   en: "Native Graphify knowledge graph plugin providing 10 code intelligence tools, topological search, god nodes discovery, and PR blast radius triage."
   zh: "为 DeepSeek Harness 提供原生 Graphify 知识图谱支持，包含 10 个代码智能工具、拓扑搜索、核心节点发现与 PR 影响分析。"


### PR DESCRIPTION
Add prebuilt v0.2.0 release tarball asset for QuantumKuba/dsh-graphify-plugin so DeepSeek Harness marketplace installs skip build allowance.