### PR TITLE
Add IKEASven69/dsh-plugin (dsh-trust-list) — deps trust layer with corpus-tested verdicts

### DIFF
--- a/data/plugins/IKEASven69__dsh-plugin--plugins-dsh-depsec.yml
+++ b/data/plugins/IKEASven69__dsh-plugin--plugins-dsh-depsec.yml
@@ -1,7 +1,7 @@
-url: https://github.com/IKEASven69/dsh-plugin/tree/main/plugins/dsh-depsec
-name: IKEASven69/dsh-plugin
+url: https://github.com/IKEASven69/dsh-trust-list
+name: IKEASven69/dsh-trust-list
 category: security
-tarball: https://github.com/IKEASven69/dsh-plugin/releases/download/v0.5.0/dsh-trust-list-0.5.0.tgz
+tarball: https://github.com/IKEASven69/dsh-trust-list/releases/download/v0.5.0/dsh-trust-list-0.5.0.tgz
 description:
   en: 'Dependency & plugin trust layer: when pnpm/npm block install scripts, grades every script PASS/WARN/BLOCK with file-line evidence (corpus-tested: 0 false blocks on npm top 1814 packages, 9/9 poisoning TTPs caught); four-dimension installed-plugin audit incl. SKILL.md prompt-injection content detection; version lock and post-install hash lock close the republish/tamper paths; one-click write-back to all four approval stores (pnpm 10/11, npm 12, bun); optional local classifier second pass.'
   zh: '依赖与插件的信任中间层：pnpm/npm 拦截 install 脚本时逐条证据分级放行（PASS/WARN/BLOCK + 文件行号；npm top 1814 包实测误拦截 0、九种投毒手法全拦截）；四维已装插件矩阵含 SKILL.md 提示注入内容检测；版本锁（升级换脚本即重审）与装后哈希锁（快照一键恢复）封杀重投毒路径；隔离与机械脱毒副本；一键写回 pnpm 10/11、npm 12、bun 四处放行清单；ed25519 签名规则 feed 以天级下发检测数据。'

--- a/data/plugins/IKEASven69__dsh-plugin--plugins-dsh-depsec.yml
+++ b/data/plugins/IKEASven69__dsh-plugin--plugins-dsh-depsec.yml
@@ -1,0 +1,6 @@
+url: https://github.com/IKEASven69/dsh-plugin/tree/main/plugins/dsh-depsec
+name: IKEASven69/dsh-plugin
+category: security
+description:
+  en: 'Dependency & plugin trust layer: when pnpm/npm block install scripts, grades every script PASS/WARN/BLOCK with file-line evidence (corpus-tested: 0 false blocks on npm top 1814 packages, 9/9 poisoning TTPs caught); four-dimension installed-plugin audit incl. SKILL.md prompt-injection content detection; version lock and post-install hash lock close the republish/tamper paths; one-click write-back to all four approval stores (pnpm 10/11, npm 12, bun); optional local classifier second pass.'
+  zh: '依赖与插件的信任中间层：pnpm/npm 拦截 install 脚本时逐条证据分级放行（PASS/WARN/BLOCK + 文件行号；npm top 1814 包实测误拦截 0、九种投毒手法全拦截）；四维已装插件矩阵含 SKILL.md 提示注入内容检测；版本锁（升级换脚本即重审）与装后哈希锁（快照一键恢复）封杀重投毒路径；隔离与机械脱毒副本；一键写回 pnpm 10/11、npm 12、bun 四处放行清单；ed25519 签名规则 feed 以天级下发检测数据。'

--- a/data/plugins/IKEASven69__dsh-plugin--plugins-dsh-depsec.yml
+++ b/data/plugins/IKEASven69__dsh-plugin--plugins-dsh-depsec.yml
@@ -1,6 +1,7 @@
 url: https://github.com/IKEASven69/dsh-plugin/tree/main/plugins/dsh-depsec
 name: IKEASven69/dsh-plugin
 category: security
+tarball: https://github.com/IKEASven69/dsh-plugin/releases/download/v0.5.0/dsh-trust-list-0.5.0.tgz
 description:
   en: 'Dependency & plugin trust layer: when pnpm/npm block install scripts, grades every script PASS/WARN/BLOCK with file-line evidence (corpus-tested: 0 false blocks on npm top 1814 packages, 9/9 poisoning TTPs caught); four-dimension installed-plugin audit incl. SKILL.md prompt-injection content detection; version lock and post-install hash lock close the republish/tamper paths; one-click write-back to all four approval stores (pnpm 10/11, npm 12, bun); optional local classifier second pass.'
   zh: '依赖与插件的信任中间层：pnpm/npm 拦截 install 脚本时逐条证据分级放行（PASS/WARN/BLOCK + 文件行号；npm top 1814 包实测误拦截 0、九种投毒手法全拦截）；四维已装插件矩阵含 SKILL.md 提示注入内容检测；版本锁（升级换脚本即重审）与装后哈希锁（快照一键恢复）封杀重投毒路径；隔离与机械脱毒副本；一键写回 pnpm 10/11、npm 12、bun 四处放行清单；ed25519 签名规则 feed 以天级下发检测数据。'


### PR DESCRIPTION
## What

[dsh-trust-list](https://github.com/IKEASven69/dsh-plugin/tree/main/plugins/dsh-depsec) — a dependency & plugin **trust layer** for dsh:

- **install-script approvals with evidence**: when pnpm/npm block install scripts, every script is graded PASS/WARN/BLOCK with file-line evidence; one-click write-back to all four approval stores (pnpm 10 `onlyBuiltDependencies`, pnpm 11 `allowBuilds`, npm 12 `allowScripts`, bun `trustedDependencies`)
- **quantified quality** (corpus-tested, CI-rechecked weekly): npm top 1814 packages → **0 false blocks, 7% warn rate**; 9 poisoning TTP probes → **9/9 caught**; 560 real SKILL.md files → **0 false positives**
- **four-dimension installed-plugin matrix**: supply-chain / secrets / SAST / **prompt-injection content detection** (SKILL.md/commands/agents, bilingual rules + homoglyph/zero-width/base64 de-obfuscation)
- **stateful trust**: version lock (upgrade + script change → re-verify), post-install hash lock with one-click snapshot restore, quarantine via native `disabled: true` patch row, mechanical detox copies
- **freshness**: ed25519-signed rules feed decoupled from release cadence; auto-watch triggers a scan 30s after any install command

## Manifest

`package.json` declares `dsh.bundle.patch` (monorepo subpackage, `plugins/dsh-depsec`), installable via `dsh plugin add`. Tests: 176 passing.

## Notes

- Fork of the scan-toolkits pattern: the deps lane (install-script approval fatigue, cf. pnpm#9326 / `dangerouslyAllowAllBuilds`) is unserved — plugins-lane scanners are well covered by existing entries.
- Docs with methodology: [research/2026-08-29 corpus report](https://github.com/IKEASven69/dsh-plugin/tree/main/plugins/dsh-depsec/research)