### PR TITLE
Add zzdhsxk/dsh-session-migration-repair

### DIFF
--- a/data/plugins/zzdhsxk__dsh-session-migration-repair.yml
+++ b/data/plugins/zzdhsxk__dsh-session-migration-repair.yml
@@ -1,0 +1,6 @@
+url: https://github.com/zzdhsxk/dsh-session-migration-repair
+name: zzdhsxk/dsh-session-migration-repair
+category: session
+description:
+  en: 'Repairs legacy DSH session logs that the current build refuses to migrate, recovering missing tool-call ids and names from the log itself and verifying each repair against the real v0 to v3 migration chain before writing.'
+  zh: '修复无法被当前 DSH 版本迁移的旧版会话日志：从日志自身恢复缺失的工具调用 id/name，写盘前先用真实 v0→v3 迁移链验证，修复前自动备份。'


### PR DESCRIPTION
## What this adds / 新增内容

One entry file: `data/plugins/zzdhsxk__dsh-session-migration-repair.yml`，分类 `session`。

**Repo**: https://github.com/zzdhsxk/dsh-session-migration-repair

DSH 0.1.5+ migrates stored session logs through v0 → v1 → v2 → v3 and validates every step. Logs written by older builds (sometimes rewritten by earlier repair tooling) can carry fields that were never validated at write time — an empty streamed tool-call id, an empty tool-call name, or a `tool/call` whose arguments no longer match the advertised call. The migration chain then refuses the whole session, which surfaces as “history unavailable”.

The plugin recovers those fields from the log itself (every streamed call is announced by an `assistant/chunk` `tool-call-delta` carrying the real id and name) and verifies the repaired log against the host’s own `sessionFormatCatalog` chain before writing. It ships a CLI (`list` / `scan` / `validate` / `fix`) and a host plugin that registers a model-callable tool plus a bundled skill.

它修复「无法被当前 DSH 版本迁移」的旧版 v0 会话日志（表现为打开老会话报「历史加载失败」）：从日志自身恢复缺失的工具调用 id/name，写盘前用宿主自带的迁移链验证；修复前自动备份，只重写真正变化的行，落盘为原子写入。

## Self-check against the requirements / 对照要求自检

- `dsh.bundle` + `cordis.patch.yml` at the repo root ✅
- `dsh-plugin` topic on the repo ✅
- Real working code, not a placeholder: zero-dependency multi-frame zstd reader/writer, the repair engine, the chain validator, a CLI, the host plugin, 12 unit tests; CI green on Node 22 and 24 ✅
- Descriptions only claim what the code does ✅

Verified on a real 59,289-line session: 160 defects repaired, 148 lines changed, output byte-identical to `zstd -dc` (120 frames), migration chain passes with 3,530 v3 events.

## Note on the repo-age check / 关于仓库年龄检查

创建时间是 `2026-09-11T18:39Z`，目前尚未满 1 天。按检查器自己的提示，这一项无需任何操作——它会自行重跑并在约 23 小时后放行，因此这里先开 PR 占位，不再做多余提交。
