### PR TITLE
Add xiaomao49/dsh-model-probe (model)

### DIFF
--- a/data/plugins/xiaomao49__dsh-model-probe.yml
+++ b/data/plugins/xiaomao49__dsh-model-probe.yml
@@ -1,0 +1,6 @@
+url: https://github.com/xiaomao49/dsh-model-probe
+name: xiaomao49/dsh-model-probe
+category: model
+description:
+  en: 'Measures what an llm-pi-ai endpoint really accepts — context window from its own model list, output-token limit and reasoning levels read out of its own range errors, image support from a generated test image — then reports declared values that contradict that evidence and rewrites them only after confirmation.'
+  zh: '直接实测 llm-pi-ai 端点真正接受的能力——从它自己的模型列表取上下文窗口，从它自己的报错反推输出上限与推理档位，用生成的测试图验证图像支持——再报告与证据不符的声明值，确认后才改写。'


### PR DESCRIPTION
<!-- Thanks for contributing! Quick checklist / 提交前快速自查 -->

- [x] I added **one file** at `data/plugins/xiaomao49__dsh-model-probe.yml` — that single file is the whole submission. The READMEs are regenerated on `main` after merge: don't edit them by hand, and you don't need to commit them either / 我新增了一个 `data/plugins/xiaomao49__dsh-model-probe.yml` 文件——**这一个文件就是全部投稿**。README 会在合并后由 `main` 自动重新生成：不要手工编辑，也不需要提交
- [x] My repo's `package.json` declares **`dsh.bundle`** (not just `dsh.client`) — [example](../blob/main/contributing.md) / 仓库 `package.json` 已声明 `dsh.bundle`（只有 `dsh.client` 无法安装）
- [x] My repo is at least **1 day old** / 仓库创建满 1 天
- [x] `category` is one of `agi ui usage theme model identity session memory tools wsl browser vision voice docs skill workflow git notify dev security remote market fun` ([full list with descriptions](../blob/main/contributing.md)), and themes/skins go under `theme` / `category` 取值正确（完整清单见 contributing.md），主题/皮肤类请用 `theme`
- [x] Description states what the plugin does, no superlatives / 描述只说功能，不带营销词
- [x] My repo has the `dsh-plugin` topic / 仓库已打 `dsh-plugin` topic

**Recommended (not required) / 推荐但不强制：**

- [x] 📦 Published to npm — `dsh-model-probe@0.1.5` ([npm](https://www.npmjs.com/package/dsh-model-probe)). No build step and no runtime dependencies, so a source install works too; there are no install scripts to approve. / 已发布 npm 包。无构建步骤、无运行时依赖，源码安装同样可用，没有需要授权的 install 脚本。
- [x] 🔗 Official `@deepseek-ai/*` packages are declared as `peerDependencies`, with explicit prerelease branches / 官方包用 `peerDependencies` 声明，且带显式预发布分支
- [ ] 🖼️ Screenshots — not added / 未添加截图

---

### The plugin / 插件说明

`dsh-model-probe` audits and corrects model capability declarations for `llm-pi-ai` providers, by measuring the endpoint instead of reading a knowledge base.

`dsh-model-probe` 实测 `llm-pi-ai` 端点的真实能力，据此审计并修正模型能力声明——取证来自端点本身，而不是某个能力数据库。

- **Fields / 字段**: `contextWindow`, `maxTokens`, `reasoningEfforts`, `input` (image support).
- **Two surfaces / 两个使用面**: a settings page (模型配置实测) with a per-provider switch, a read-only scan and an explicit confirm before writing; and the agent tools `model_probe_status`, `model_probe_scan`, `model_probe_apply`.
- **Two protocols / 两种协议**: `openai-completions` and `anthropic-messages`.

**How it gets its answers / 取证方式** — three sources, plus a rule for whatever they cannot establish:

| # | Method | Fields | Cost |
| --- | --- | --- | --- |
| 1 | `GET /models` — what the endpoint says about itself | `contextWindow` | 1 request |
| 2 | Constraint elicitation — send a deliberately illegal value and read the legal range out of the endpoint's own error | `maxTokens`, `reasoningEfforts` | 0 output tokens |
| 3 | Behavioural probe — a PNG synthesized in-process, then asked to count its shapes | `input` | ~50 output tokens |
| — | Nothing readable → report `unknown` and do not write | — | 0 |

The plugin exists because a wrong declaration fails silently: a `maxTokens` above the endpoint's limit makes every request carrying it return HTTP 400, and a capability guessed from a bundled catalog is not the same as a measured one.

**Safety / 安全边界**: probing is off by default and enabled per provider; scan is read-only; writing requires an explicit confirmation and backs up `settings.yaml` first; credentials are resolved per request through the credential seam and are never cached, logged or returned over the settings API; writes go to the raw user layer so schema defaults are never baked into the config file; a field with no evidence is reported `unknown` and left alone.

**Package / 包**: plain JavaScript, `lib/` only, no build step, no runtime dependencies, MIT.

I ran `node scripts/check-submission.mjs` against this commit locally and it reports `all checked entries pass`.
