### PR TITLE
add dsh-team-cost (usage): per-member team cost metering, budgets, dashboard

### DIFF
--- a/data/plugins/1569126506-sudo__dsh-team-cost.yml
+++ b/data/plugins/1569126506-sudo__dsh-team-cost.yml
@@ -1,0 +1,6 @@
+url: https://github.com/1569126506-sudo/dsh-team-cost
+name: 1569126506-sudo/dsh-team-cost
+category: usage
+description:
+  en: 'Team cost captain: meters every model call (subagents included), attributes each call to a member by workspace rules, prices it with the built-in DeepSeek 2026-09 catalog (peak/off-peak, CNY/USD) or user overrides, and appends it to a local JSONL ledger. Adds hot-reloadable member budgets, 80%/100% webhook alerts, optional over-budget enforcement, a team_cost_report tool with CSV export, and a settings-page team dashboard served over a Typert RPC service.'
+  zh: '团队成本管家：按成员/工作空间计量每次模型调用的 token 与费用（含子代理），内置 DeepSeek 2026-09 价目表与自定义价格覆盖，成员预算热更新、阈值 Webhook 告警、可选超支拦截，提供成本报表工具与 CSV 导出，并在设置页提供团队成本看板。'


### PR DESCRIPTION
Adds data/plugins/1569126506-sudo__dsh-team-cost.yml (one new file, no other entries touched).

Repo: https://github.com/1569126506-sudo/dsh-team-cost — public, declares a dsh.bundle manifest (cordis.patch.yml, one host row) plus dsh.client (web), add-script installable.

What the plugin does (all claims verifiable in the repo): meters every model call from the session/event firehose (assistant/message carries TokenUsage; subagent sessions metered too), attributes each call to a member via workspace-prefix rules, prices with the built-in DeepSeek 2026-09 catalog (peak/off-peak, CNY/USD) or price-overrides.json, and appends to a local monthly JSONL ledger. Hot-reloadable member budgets (members.json), 80%/100% threshold alerts with optional webhook, optional over-budget enforcement (off by default), a team_cost_report agent tool with CSV export, and a「团队成本」settings dashboard served via a Typert RPC service (./typert manifest + ctx.provide('teamCost')). Category: usage.

Verification: boots clean on DSH 0.1.5-rc.1 with the typert-loader registering the teamCost service; dashboard screenshot at docs/dashboard-demo.png; 23/23 unit smoke tests via node test/smoke.mjs. No conversation content leaves the machine.