### PR TITLE
entry(dsh-remote-web): track latest release in tarball URL

### DIFF
--- a/data/plugins/mrRisega__dsh-remote--packages-dsh-remote-web.yml
+++ b/data/plugins/mrRisega__dsh-remote--packages-dsh-remote-web.yml
@@ -1,7 +1,7 @@
 url: https://github.com/mrRisega/dsh-remote/tree/main/packages/dsh-remote-web
 name: mrRisega/dsh-remote#dsh-remote-web
 category: remote
-tarball: https://github.com/mrRisega/dsh-remote/releases/download/v0.6.0/dsh-remote-web.tgz
+tarball: https://github.com/mrRisega/dsh-remote/releases/latest/download/dsh-remote-web.tgz
 description:
   en: 'Remote control for dsh web from a phone browser, from anywhere (no public IP needed): hosted cloud relay works over 4G, or self-host the router; one command installs the desktop bridge and this in-harness Settings panel (cloud/self-hosted tabs, account login, bridge start/stop, feedback); the tunnel data plane is end-to-end encrypted (E2EE phone↔desktop, with a QR / one-time-link desktop grant so you never re-type the password), with HTTP/WebSocket pass-through, access-key auth, a live device list and optional traffic quotas.'
   zh: '手机浏览器远程控制 dsh web，人在哪都能用（免公网 IP）：官方托管中继 4G 即用，也可自建 relay；一条命令安装电脑端 bridge 与设置页「远程控制」面板（云端/自建切换、账号登录、bridge 启停、反馈）；隧道数据面端到端加密（E2EE：手机↔电脑端正文与 WS 内容加密，中继只见路由元数据；支持扫码/一次性链接桌面授权，免重复输密码）；HTTP/WebSocket 全量透传，访问密钥认证、实时设备列表、可选流量配额。'


### PR DESCRIPTION
The entry's declared `tarball` was pinned to a versioned URL (`releases/download/v0.6.0/…`), so storefronts would keep offering the 0.6.0 build after every new release — the plugin is already at 0.6.2.

This points it at `releases/latest/download/dsh-remote-web.tgz`. The asset name is version-free (as the contributing rules require for `latest/download/`), so the URL always resolves to the newest build and cannot rot. Verified locally: `latest/download/dsh-remote-web.tgz` currently serves the 0.6.2 build; every future release attaches these version-free assets (`dsh-remote-web.tgz` / `dsh-remote-ui.tgz`).

Only my own entry's `tarball` line changes.