### PR TITLE
Update dsh-superterminal to alpha.12

### DIFF
--- a/data/plugins/Harzva__dsh-superterminal.yml
+++ b/data/plugins/Harzva__dsh-superterminal.yml
@@ -4,4 +4,4 @@ category: ui
 description:
   en: Native terminals for DSH 0.1.1-rc.2 on macOS, with terminal AI sessions, bounded Terminal Group discussions using DSH AI or independent Pi/Codex tasks, and conclusion handoffs with acceptance and rework.
   zh: 面向 macOS 上 DSH 0.1.1-rc.2 的原生终端，支持终端 AI 会话、通过 DSH AI 或独立 Pi/Codex 任务进行有限轮次群讨论，以及结论交接、验收与返工。
-tarball: https://github.com/Harzva/dsh-superterminal/releases/download/v0.1.0-alpha.11/harzva-dsh-terminal-0.1.0-alpha.11.tgz
+tarball: https://github.com/Harzva/dsh-superterminal/releases/download/v0.1.0-alpha.12/harzva-dsh-terminal-0.1.0-alpha.12.tgz


### PR DESCRIPTION
Update the existing DSH SuperTerminal entry to the verified alpha.12 release tarball. The plugin description is unchanged.

Validation: regenerated both READMEs and ran the generator check; neither README changed. The diff only updates this plugin’s tarball URL.

Release: https://github.com/Harzva/dsh-superterminal/releases/tag/v0.1.0-alpha.12
