### PR TITLE
Add Limbo-137/dsh-typst-preview (docs)

### DIFF
--- a/data/plugins/Limbo-137__dsh-typst-preview.yml
+++ b/data/plugins/Limbo-137__dsh-typst-preview.yml
@@ -1,0 +1,7 @@
+url: https://github.com/Limbo-137/dsh-typst-preview
+name: Limbo-137/dsh-typst-preview
+category: docs
+tarball: https://github.com/Limbo-137/dsh-typst-preview/releases/latest/download/dsh-typst-preview.tgz
+description:
+  en: "Typst live preview as a native right-Sidebar tab: clicking a .typ file opens a tab whose toolbar switches between the tinymist-rendered page and the highlighted source, with the preview page and its WebSocket served through the app's own origin."
+  zh: "原生右侧边栏里的 Typst 实时预览：点开 .typ 文件即得一个 tab，工具栏在 tinymist 渲染的页面与高亮源码之间切换；预览页面与其 WebSocket 都经应用自身 origin 提供。"


### PR DESCRIPTION
One entry: **dsh-typst-preview** — Typst live preview in the native right Sidebar.

Repo: https://github.com/Limbo-137/dsh-typst-preview · install: `dsh plugin --profile web add github:Limbo-137/dsh-typst-preview`

- `package.json` declares `dsh.bundle` (`./cordis.patch.yml`, one insert row) next to `dsh.client` for the browser half. Host requirement is `dsh >= 0.1.5-rc.1`, because the tab type is registered on the native right Sidebar (`ctx.sidebarRightTabs` / the `sidebar.right.pane.tab` slot) rather than on better-sidebar.
- The host half runs one `tinymist preview` process per (session, file, colour mode), allocates a private port pair per instance instead of tinymist's fixed 23625/23626, and reverse-proxies the preview page and its WebSocket through `/api/typst-preview/*` on the app origin, behind a same-origin fence.
- `lib/` build artifacts are committed, so the git install runs no build script — checked locally with `pnpm add github:Limbo-137/dsh-typst-preview` (4.7s, no `prepare`, no `allowBuilds` prompt).
- Prebuilt tarball attached to the v0.2.0 release; the asset name carries no version, so the `latest/download/` URL will not rot at the next release.
- Verified against a real tinymist, not a mock: `scripts/smoke.mjs` (host half, 10 checks: process lifecycle, page proxying, WebSocket relay, reuse, reaping, cross-site refusal) and `scripts/gui-check.mjs` (headless Chrome over CDP against a running `dsh web`, 14 checks: bundle load, Sidebar tab mount, iframe proxy path, source face, face switching).
- The repository is a few hours old, so the age gate is expected to fail today and clear on the next re-gate; everything else in `scripts/check-submission.mjs` passes locally.

Category: `docs` (Docs & Rendering).
