### PR TITLE
Add GodCC6/dsh-updater

### DIFF
--- a/data/plugins/GodCC6__dsh-claude-memory.yml
+++ b/data/plugins/GodCC6__dsh-claude-memory.yml
@@ -1,0 +1,6 @@
+url: https://github.com/GodCC6/dsh-claude-memory
+name: GodCC6/dsh-claude-memory
+category: memory
+description:
+  en: 'Read-only bridge that surfaces Claude Code''s existing project memory in DSH — git-root-aware resolution, credential redaction before injection, and an on-demand recall tool. Zero runtime dependencies.'
+  zh: '只读桥接 Claude Code 已有项目记忆到 DSH：按 git 仓库根解析、注入前脱敏、按需检索工具，零依赖。'

--- a/data/plugins/GodCC6__dsh-updater.yml
+++ b/data/plugins/GodCC6__dsh-updater.yml
@@ -1,0 +1,6 @@
+url: https://github.com/GodCC6/dsh-updater
+name: GodCC6/dsh-updater
+category: dev
+description:
+  en: Auto-update plugin for DeepSeek Harness — checks and updates a git-checkout or npm-global dsh plus integration repos, with ff-only pulls, automatic rollback, cancel, and an optional idle-aware auto-apply mode.
+  zh: DeepSeek Harness 自动更新插件：检查并更新 git checkout 或 npm 全局形态的 dsh 本体与 integrations 仓，仅快进合并、失败自动回滚、可随时取消，可选空闲感知自动应用。


### PR DESCRIPTION
Adds [GodCC6/dsh-updater](https://github.com/GodCC6/dsh-updater) to **Development & Runtime** (`dev`).

- Auto-update plugin for DSH: install-shape detection (git checkout / npm global), harness + `~/.dsh/integrations` repo checks, `dsh_update_status` / `dsh_update_run` / `dsh_update_cancel` agent tools, optional idle-aware auto-apply (off by default).
- `dsh.bundle` manifest: root `package.json` declares `"dsh": {"bundle": {"patch": "./cordis.patch.yml"}}`, with `cordis.patch.yml` present.
- Install verified end-to-end from this repo: `dsh plugin --profile <scratch> add github:GodCC6/dsh-updater` → package installs from GitHub and `dsh-updater` joins the profile's `dsh.profile.bundles` layer with the patch in place.
- MIT licensed, CI green on Node 20/22/24, v0.1.0 release published, repo topic `dsh-plugin` added.
- Zero third-party dependencies (Node built-ins only). Entry descriptions state features only; every claim is covered by the README and code.

Single entry file added, nothing else touched.
