### PR TITLE
Add AlienGene/dsh-llm-balance-siderbar

### DIFF
--- a/data/plugins/AlienGene__dsh-llm-balance-siderbar.yml
+++ b/data/plugins/AlienGene__dsh-llm-balance-siderbar.yml
@@ -1,0 +1,6 @@
+url: https://github.com/AlienGene/dsh-llm-balance-siderbar
+name: AlienGene/dsh-llm-balance-siderbar
+category: usage
+description:
+  en: 'DeepSeek Harness plugin for querying LLM service provider usage: reads DeepSeek and Moonshot balances plus Kimi For Coding and OpenCode Go quota windows on the host and shows them in an always-visible card with three view modes, edge docking and a collapsed letter bubble.'
+  zh: 'DeepSeek Harness 服务提供商用量查询插件：在宿主侧读取 DeepSeek、Moonshot 余额与 Kimi For Coding、OpenCode Go 的配额窗口，在常驻卡片中展示，支持三种视图、边缘磁吸与收起为字母气泡。'


### PR DESCRIPTION
- [x] I added **one file** at `data/plugins/AlienGene__dsh-llm-balance-siderbar.yml` — that single file is the whole submission. READMEs are regenerated on `main` after merge, so I did not touch them.
- [x] My repo's `package.json` declares **`dsh.bundle`** (`cordis.patch.yml`, one plain insert row `llm-balance`).
- [x] My repo is at least **1 day old** (created 2026-09-11).
- [x] `category` is `usage`.
- [x] The description states what the plugin does — no superlatives. It reads DeepSeek / Moonshot balances and Kimi For Coding / OpenCode Go quota windows on the host and shows them in a card with three view modes, edge docking and a collapsed letter bubble.
- [x] My repo has the `dsh-plugin` topic.

Recommended:
- [x] Published to npm as `dsh-llm-balance@0.7.1` — prebuilt `lib/` and `client/client.js` ship in the tarball, and its `repository` field points back at this repo, so the npm probe will pick it up.
- [x] Official `@deepseek-ai/*` runtime is declared as an optional `peerDependencies` entry, not a `dependencies` one.
- [ ] Screenshots will be added as `screenshots.json` in my own repository.