### PR TITLE
Add X1A0BAN/dsh-survival-mode

### DIFF
--- a/data/plugins/X1A0BAN__dsh-survival-mode.yml
+++ b/data/plugins/X1A0BAN__dsh-survival-mode.yml
@@ -4,3 +4,4 @@ category: fun
 description:
   en: 'Survival mode: all sessions share one satiety/health pool — each model step burns satiety, starvation freezes tool calls until fed, with an MC mini-game for gathering food.'
   zh: 生存模式：全局共享一条饱食度与生命，模型每步思考消耗饱食度，饿死后全局工具被冻结，通过 MC 采集小游戏获取食物喂食复活。
+tarball: https://github.com/X1A0BAN/dsh-survival-mode/releases/latest/download/dsh-survival-mode.tgz

--- a/data/plugins/X1A0BAN__dsh-survival-mode.yml
+++ b/data/plugins/X1A0BAN__dsh-survival-mode.yml
@@ -1,0 +1,6 @@
+url: https://github.com/X1A0BAN/dsh-survival-mode
+name: X1A0BAN/dsh-survival-mode
+category: fun
+description:
+  en: 'Survival mode: all sessions share one satiety/health pool — each model step burns satiety, starvation freezes tool calls until fed, with an MC mini-game for gathering food.'
+  zh: 生存模式：全局共享一条饱食度与生命，模型每步思考消耗饱食度，饿死后全局工具被冻结，通过 MC 采集小游戏获取食物喂食复活。


### PR DESCRIPTION
Adds [X1A0BAN/dsh-survival-mode](https://github.com/X1A0BAN/dsh-survival-mode) to `fun`.

Survival mode for DSH: all sessions share one satiety/health pool — each model step burns satiety, starvation freezes tool calls until fed, with an MC mini-game for gathering food (apple / bread / golden apple).

- `dsh.bundle` manifest in package.json + `cordis.patch.yml` at repo root
- `dsh-plugin` topic set, repo older than 1 day
- Published on npm (`dsh-survival-mode@0.1.0`); `tarball:` points at a version-free release asset