### PR TITLE
Add Artenx/dsh-honeybee#dshb

### DIFF
--- a/data/plugins/Artenx__dsh-honeybee--packages-dshb.yml
+++ b/data/plugins/Artenx__dsh-honeybee--packages-dshb.yml
@@ -2,5 +2,5 @@ url: https://github.com/Artenx/dsh-honeybee/tree/main/packages/dshb
 name: Artenx/dsh-honeybee#dshb
 category: remote
 description:
-  en: Run DeepSeek Harness across multiple hosts and Docker containers from one web entry, with SSH/Docker execution worlds, a node registry, an auth gate, and a mobile-aware management UI.
-  zh: 一个 Web 入口同时驱动多台主机与 Docker 容器运行 DeepSeek Harness，含 SSH/Docker 执行世界、节点注册表、认证门禁与移动端管理 UI。
+  en: Routes DSH filesystem, shell, subprocess, and PTY operations to local, SSH, and Docker execution nodes, with a node registry, an authentication gate, and a mobile-aware management UI.
+  zh: 为 DSH 提供多节点执行路由，将文件系统、Shell、子进程和 PTY 操作分发到本地、SSH 与 Docker 执行节点，并包含节点注册表、认证门禁和移动端管理 UI。

--- a/data/plugins/Artenx__dsh-honeybee--packages-dshb.yml
+++ b/data/plugins/Artenx__dsh-honeybee--packages-dshb.yml
@@ -1,0 +1,6 @@
+url: https://github.com/Artenx/dsh-honeybee/tree/main/packages/dshb
+name: Artenx/dsh-honeybee#dshb
+category: remote
+description:
+  en: Run DeepSeek Harness across multiple hosts and Docker containers from one web entry, with SSH/Docker execution worlds, a node registry, an auth gate, and a mobile-aware management UI.
+  zh: 一个 Web 入口同时驱动多台主机与 Docker 容器运行 DeepSeek Harness，含 SSH/Docker 执行世界、节点注册表、认证门禁与移动端管理 UI。


### PR DESCRIPTION
Adds DSH-HoneyBee, a single consolidated DeepSeek Harness plugin.

- **What it does:** routes DSH filesystem, shell, subprocess, and PTY operations to local-host, local-docker, remote-ssh, and remote-docker execution nodes. It also provides a node registry and REST API, workspace bindings, credential custody, a single-admin authentication gate, and a mobile-aware management UI.
- **Install:** `dsh plugin --profile web add @artenx/dshb`
- **npm:** `@artenx/dshb@0.1.2`, prebuilt and linked to `packages/dshb` through its `repository` metadata.
- **Mobile:** form controls render at 16px so iOS does not auto-zoom the page on input focus.
- **Compatibility:** verified against DeepSeek Harness `0.1.5-rc.1`; the package declares only that release as compatible.
- **Packaging:** the package ships all implementation code and client assets directly; official runtime `@deepseek-ai/*` imports are peers, while type-only `dsh-client-runtime` remains development-only.

One file added: `data/plugins/Artenx__dsh-honeybee--packages-dshb.yml`.