### PR TITLE
Add dsh-creative-studio - portable image + video skill pack

### DIFF
--- a/data/plugins/Ylight-cpu__dsh-creative-studio.yml
+++ b/data/plugins/Ylight-cpu__dsh-creative-studio.yml
@@ -1,0 +1,23 @@
+# Submission file for the awesome-dsh-plugin list.
+#
+# Destination in the target repository:
+#   data/plugins/Ylight-cpu__dsh-creative-studio.yml
+#
+# Rules this file follows (from contributing.md):
+#   * one YAML file per plugin; the READMEs are generated — never edit them by hand
+#   * description.en is required and must be accurate (reviewers check claims against the code)
+#   * no marketing words; the sentence ends with a period
+#   * do not hand-write an `npm:` key — npm linkage is picked up automatically
+#   * `tarball:` is recommended when the plugin is not on npm; the URL must be an
+#     https .tgz on GitHub Release hosting and the asset name stays version-free
+#     so `latest/download/` does not rot on the next release
+#   * CI also checks: repo declares dsh.bundle, repo is at least 1 day old,
+#     awesome-lint passes, and at most 3 entries per PR
+
+url: https://github.com/Ylight-cpu/dsh-creative-studio
+name: Ylight-cpu/dsh-creative-studio
+category: skill
+description:
+  en: Image and video production toolkit for DeepSeek Harness - background removal with quality tiers, local inpainting retouch, headline and logo compositing, batch platform-size exports, image QA reports, plus footage inventory, frame extraction, accurate cutting, transition joins, on-screen text, subtitle burn-in, music mixing with fades, smart cover-frame selection and platform-spec video exports; it provisions its own local Python runtime through a bundled bootstrap script.
+  zh: 面向 DeepSeek Harness 的美工与视频剪辑工具包——可分档抠图、局部重绘改图、标题与 logo 合成、平台规格批量导出、图片体检报告，以及素材通览、抽帧、精确裁切、转场拼接、屏幕文案、字幕烧入、配乐淡入淡出、智能封面选帧与平台规格视频导出；通过内置引导脚本自备本地 Python 运行时。
+tarball: https://github.com/Ylight-cpu/dsh-creative-studio/releases/latest/download/dsh-creative-studio.tgz

--- a/data/plugins/Ylight-cpu__dsh-creative-studio.yml
+++ b/data/plugins/Ylight-cpu__dsh-creative-studio.yml
@@ -18,6 +18,6 @@ url: https://github.com/Ylight-cpu/dsh-creative-studio
 name: Ylight-cpu/dsh-creative-studio
 category: skill
 description:
-  en: Image and video production toolkit for DeepSeek Harness - background removal with quality tiers, local inpainting retouch, headline and logo compositing, batch platform-size exports, image QA reports, plus footage inventory, frame extraction, accurate cutting, transition joins, on-screen text, subtitle burn-in, music mixing with fades, smart cover-frame selection and platform-spec video exports; it provisions its own local Python runtime through a bundled bootstrap script.
-  zh: 面向 DeepSeek Harness 的美工与视频剪辑工具包——可分档抠图、局部重绘改图、标题与 logo 合成、平台规格批量导出、图片体检报告，以及素材通览、抽帧、精确裁切、转场拼接、屏幕文案、字幕烧入、配乐淡入淡出、智能封面选帧与平台规格视频导出；通过内置引导脚本自备本地 Python 运行时。
+  en: Image and video production toolkit for DeepSeek Harness - background removal with quality tiers, local inpainting retouch, headline and logo compositing, batch platform-size exports and image QA reports; for video, AI subject matting with background replacement (RVM ONNX, plus a chroma-key path), animated titles with fade/slide/typewriter/karaoke presets, 53 transitions with stylized variants, and light-effect and grading presets with LUT support, alongside footage inventory, accurate cutting, subtitle burn-in, music mixing and platform-spec exports; it provisions its own local Python runtime through a bundled bootstrap script.
+  zh: 面向 DeepSeek Harness 的美工与视频剪辑工具包——可分档抠图、局部重绘改图、标题与 logo 合成、平台规格批量导出与图片体检；视频侧含 AI 抠像换背景（RVM ONNX，另有绿幕色键路径）、淡入/滑入/打字机/卡拉OK 动效文字、53 种转场与风格化变体、光效与调色预设（支持 LUT），以及素材通览、精确裁切、字幕烧入、配乐混音与平台规格导出；通过内置引导脚本自备本地 Python 运行时。
 tarball: https://github.com/Ylight-cpu/dsh-creative-studio/releases/latest/download/dsh-creative-studio.tgz


### PR DESCRIPTION
Adds one entry: `data/plugins/Ylight-cpu__dsh-creative-studio.yml` (category `skill`).

## What the plugin does

`dsh-creative-studio` is a skill pack that gives the agent real image and video production capability through a bundled Python toolkit (`toolkit/cs.py`, 18 subcommands) plus two skills:

- **image-studio** — background removal with a quality policy (`fast` u2net / `auto` isnet-or-BiRefNet by image size / `best` BiRefNet), local inpainting retouch (`inpaint` with mask or box/circle regions), headline and logo compositing, multi-layer `compose`, platform-size batch exports (amazon-main, shopify, faire, 9:16 …), contact sheets, palette extraction and an image QA report (`inspect` reports subject coverage and edge transition width).
- **video-studio** — footage inventory (`video-probe`), frame extraction, accurate or stream-copy cutting, transition joins with timebase/fps/pixel-format normalisation, on-screen text, subtitle burn-in, music mixing with fades, sharpest-frame cover selection, and platform-spec exports.

The Python runtime is not bundled in the package; `scripts/bootstrap.ps1` provisions it per machine (Pillow, OpenCV, rembg, ONNX Runtime, imageio-ffmpeg) and `scripts/install-as-plugin.ps1` registers the plugin.

## Checks

- `package.json` declares `dsh.bundle.patch` → `./cordis.patch.yml`; the patch inserts the plugin row.
- Installs from the published source: `dsh plugin --profile web add github:Ylight-cpu/dsh-creative-studio` was run against a throwaway profile and completed, with `dsh-creative-studio` reconciled into `dsh.profile.bundles`.
- Prebuilt tarball attached to the v0.1.0 release and referenced from the entry with a version-free asset name; `https://github.com/Ylight-cpu/dsh-creative-studio/releases/latest/download/dsh-creative-studio.tgz` was fetched and verified (62.3 KB).
- Repository topic `dsh-plugin` added.
- Official `@deepseek-ai/*` packages are declared as `peerDependencies` with an explicit prerelease branch (`>=0.1.1-rc.2 <0.1.2 || >=0.1.2-rc.1 <0.2.0-0`), verified with semver against `0.1.2-rc.1`.

The repository was created today, so the age check may report "repository is 0.x days old (needs 1)" on the first run — flagging it here so it is not read as something to fix; the entry itself is ready.