### PR TITLE
Add Z Research: ZA_literature, ZA_data, ZA_analysis

### DIFF
--- a/data/plugins/Z-Asset__ZA_analysis.yml
+++ b/data/plugins/Z-Asset__ZA_analysis.yml
@@ -1,0 +1,6 @@
+url: https://github.com/Z-Asset/ZA_analysis
+name: Z-Asset/ZA_analysis
+category: workflow
+description:
+  en: Model training stage — end-to-end analysis, model training, and estimation for asset pricing and machine learning research. Ships one skill.
+  zh: 模型训练与结论阶段——资产定价与机器学习研究的端到端分析、模型训练与估计。附带一个 skill。

--- a/data/plugins/Z-Asset__ZA_data.yml
+++ b/data/plugins/Z-Asset__ZA_data.yml
@@ -1,0 +1,6 @@
+url: https://github.com/Z-Asset/ZA_data
+name: Z-Asset/ZA_data
+category: workflow
+description:
+  en: Data stage — data discovery and quality assessment for asset pricing and machine learning research. Ships one skill.
+  zh: 数据处理阶段——资产定价与机器学习研究的数据发现与质量评估。附带一个 skill。

--- a/data/plugins/Z-Asset__ZA_literature.yml
+++ b/data/plugins/Z-Asset__ZA_literature.yml
@@ -1,0 +1,6 @@
+url: https://github.com/Z-Asset/ZA_literature
+name: Z-Asset/ZA_literature
+category: workflow
+description:
+  en: Literature review stage — search, synthesis, and citation-chain tracking for asset pricing and machine learning research. Ships one skill.
+  zh: 文献综述阶段——资产定价与机器学习研究的文献检索、合成与引用链追踪。附带一个 skill。


### PR DESCRIPTION
Add three Z Research plugins for asset pricing + ML/DL research workflow.

- `ZA_literature` — literature review stage (search, synthesis, citation-chain tracking)
- `ZA_data` — data stage (discovery + quality assessment)
- `ZA_analysis` — model training stage (end-to-end analysis + estimation)

Each ships one skill and is a self-contained dsh bundle (declares `dsh.bundle.patch`).