### PR TITLE
Add Z Research: ZA_report, ZA_ppt

### DIFF
--- a/data/plugins/Z-Asset__ZA_ppt.yml
+++ b/data/plugins/Z-Asset__ZA_ppt.yml
@@ -1,0 +1,6 @@
+url: https://github.com/Z-Asset/ZA_ppt
+name: Z-Asset/ZA_ppt
+category: workflow
+description:
+  en: PPT stage — presentation generation (Beamer/Quarto) from the paper for asset pricing and machine learning research. Ships one skill.
+  zh: 报告阶段（PPT）——资产定价与机器学习研究的论文演讲幻灯片生成（Beamer/Quarto）。附带一个 skill。

--- a/data/plugins/Z-Asset__ZA_report.yml
+++ b/data/plugins/Z-Asset__ZA_report.yml
@@ -1,0 +1,6 @@
+url: https://github.com/Z-Asset/ZA_report
+name: Z-Asset/ZA_report
+category: workflow
+description:
+  en: Report stage — academic paper writing for asset pricing and machine learning research. Ships one skill.
+  zh: 报告阶段（文稿）——资产定价与机器学习研究的学术论文写作。附带一个 skill。


### PR DESCRIPTION
Add two Z Research plugins for asset pricing + ML/DL research workflow.

- `ZA_report` — report stage (academic paper writing)
- `ZA_ppt` — PPT stage (presentation generation, Beamer/Quarto)

Each ships one skill and is a self-contained dsh bundle (declares `dsh.bundle.patch`).