### PR TITLE
add zgrajdnhj7806-svg/dsh-deepseek-web (model)

### DIFF
--- a/data/plugins/zgrajdnhj7806-svg__dsh-deepseek-web.yml
+++ b/data/plugins/zgrajdnhj7806-svg__dsh-deepseek-web.yml
@@ -1,0 +1,6 @@
+url: https://github.com/zgrajdnhj7806-svg/dsh-deepseek-web
+name: zgrajdnhj7806-svg/dsh-deepseek-web
+category: model
+description:
+  en: "Calls your own chat.deepseek.com account as a second model from DSH: ask a question, analyze a file's line range, and check login state, plus a runtime skill and a settings-page login panel."
+  zh: "把你自己的 chat.deepseek.com 账号当作第二个模型接入 DSH：提问、按文件行区间分析、查看登录状态，附带运行时技能与设置页登录面板。"


### PR DESCRIPTION
<!-- Thanks for contributing! Quick checklist / 提交前快速自查 -->
- [x] I added **one file** at `data/plugins/zgrajdnhj7806-svg__dsh-deepseek-web.yml` — the READMEs are untouched. / 仅新增一个 `data/plugins/zgrajdnhj7806-svg__dsh-deepseek-web.yml` 文件，未改动 README。
- [x] My repo's `package.json` declares **`dsh.bundle`** (not just `dsh.client`), with `cordis.patch.yml` at the repo root. / 仓库已声明 `dsh.bundle`，且根目录有 `cordis.patch.yml`。
- [ ] My repo is at least **1 day old** — see the note below. / 仓库创建满 1 天——见下方说明。
- [x] `category` is `model`, one of the allowed values. / `category` 取值为 `model`，在允许清单内。
- [x] Description states what the plugin does, no superlatives. / 描述只说功能，不带营销词。
- [x] My repo has the `dsh-plugin` topic. / 仓库已打 `dsh-plugin` topic。

**Recommended / 推荐项**: official `@deepseek-ai/*` packages are declared as `peerDependencies`, not `dependencies`.

## What this adds / 新增内容

**Plugin**: [dsh-deepseek-web](https://github.com/zgrajdnhj7806-svg/dsh-deepseek-web)

Calls the user's own chat.deepseek.com web account as a second model from inside DSH — three tools (`deepseek_web_ask`, `deepseek_web_analyze_lines`, `deepseek_web_status`), one runtime skill, and a settings-page login panel. Pure Node.js, MIT.
把用户自己的 chat.deepseek.com 网页版账号当作第二个模型接进 DSH——三个工具、一个运行时技能、一个设置页登录面板。纯 Node.js，MIT。

Why `model`: the plugin's job is to make an external model endpoint callable from DSH through the PoW challenge and SSE streaming; the settings panel exists only to capture the login token. / 为何选 `model`：核心职责是让 DSH 能调用一个外部模型端点（PoW 挑战 + SSE 流式），设置面板仅为获取登录态而存在。

## Note on repo age / 关于仓库年龄

The repo was created at `2026-09-12T05:16:41Z`, about an hour before this PR, so it does not yet clear the 1-day floor and CI may reject this submission. Per contributing.md, a resubmission is not held against the plugin, so I am opening it now so the entry is in front of maintainers, and will resubmit once the age floor is cleared. Everything else on the checklist is satisfied.
仓库创建于 `2026-09-12T05:16:41Z`，距本 PR 约一小时，尚未满 1 天，CI 可能拒绝本提交。按 contributing.md，重新提交不会对插件有任何影响，因此我先提交以便维护者看到条目，满 1 天后会重新提交。清单其余项均已满足。

## Not a duplicate / 非重复条目

Existing entries that mention chat.deepseek.com are `wqx-txdsyl/dsh-ds-attach` (attachment UI), `wpc0323/deepseek-web-import` (imports web conversations as sessions) and `zerorigin-studio/dsh-deepseek-chat` (opens the site in a window). None of them call the web account as a model; this one does. / 现有提及 chat.deepseek.com 的条目分别是附件 UI、会话导入与窗口入口，均非把网页版账号作为模型调用。