### PR TITLE
add duyanta123/dsh-test-insight (dev): evidence-backed test plans and reviewable test drafts

### DIFF
--- a/data/plugins/duyanta123__dsh-test-insight.yml
+++ b/data/plugins/duyanta123__dsh-test-insight.yml
@@ -1,0 +1,6 @@
+url: https://github.com/duyanta123/dsh-test-insight
+name: duyanta123/dsh-test-insight
+category: dev
+description:
+  en: 'Test-insight plugin that turns repository facts and change risk into evidence-backed test plans and isolated, reviewable test drafts.'
+  zh: '测试洞察插件：把仓库事实与变更风险转化为有证据支撑的测试计划与隔离、可人工审查的测试草稿。'


### PR DESCRIPTION
Single DSH plugin **duyanta123/dsh-test-insight** (npm `dsh-test-insight`, v1.0.0-rc.3): turns repository facts and change risk into evidence-backed test plans (TEST-PLAN.md) and isolated, reviewable test drafts, with explicit-authorization allowlisted test execution (CLI + library + skill runbook).

Repo: https://github.com/duyanta123/dsh-test-insight · install: `dsh plugin add "github:duyanta123/dsh-test-insight"`

CI-gated: 39 unit tests (ubuntu/windows/macos × Node 20.11/22), packed-package smoke install, DSH 0.1.5-rc.2 compat (Windows/Ubuntu × Node 22.19, pinned exact version). `dsh.bundle` declared via `cordis.patch.yml`; topics: `dsh` `dsh-plugin`.

Category: dev.

Note: the repo is 1 day old and currently 2 commits short of the submission gate's 10-commit bar — it will cross the line shortly as the repo matures; happy to re-run the gate then.