### PR TITLE
Add Jackson-chen97/dsh-devops

### DIFF
--- a/data/plugins/Jackson-chen97__dsh-devops.yml
+++ b/data/plugins/Jackson-chen97__dsh-devops.yml
@@ -2,5 +2,5 @@ url: https://github.com/Jackson-chen97/dsh-devops
 name: Jackson-chen97/dsh-devops
 category: dev
 description:
-  en: GitLab and Kubernetes monitoring for DSH: merge request and pipeline management, deployment and pod status with logs and events, webhook-triggered alerts, and a dashboard UI.
+  en: 'GitLab and Kubernetes monitoring for DSH: merge request and pipeline management, deployment and pod status with logs and events, webhook-triggered alerts, and a dashboard UI.'
   zh: 面向 DSH 的 GitLab 与 Kubernetes 监控：合并请求与流水线管理、部署与 Pod 状态（含日志与事件）、Webhook 告警，以及仪表盘界面。

--- a/data/plugins/Jackson-chen97__dsh-devops.yml
+++ b/data/plugins/Jackson-chen97__dsh-devops.yml
@@ -1,0 +1,6 @@
+url: https://github.com/Jackson-chen97/dsh-devops
+name: Jackson-chen97/dsh-devops
+category: dev
+description:
+  en: GitLab and Kubernetes monitoring for DSH: merge request and pipeline management, deployment and pod status with logs and events, webhook-triggered alerts, and a dashboard UI.
+  zh: 面向 DSH 的 GitLab 与 Kubernetes 监控：合并请求与流水线管理、部署与 Pod 状态（含日志与事件）、Webhook 告警，以及仪表盘界面。


### PR DESCRIPTION
Adds `data/plugins/Jackson-chen97__dsh-devops.yml`.

- Repo: https://github.com/Jackson-chen97/dsh-devops (GitLab + Kubernetes DevOps monitoring plugin for DSH)
- `dsh.bundle` manifest declared in `package.json` with `cordis.patch.yml` at the repo root
- Repo has the `dsh-plugin` topic
- Category: `dev`
- Description states only features verified against the source (GitLab MR/pipeline APIs, K8s deployment/pod status with logs and events, webhook + alert engine, dashboard UI with i18n)
