### PR TITLE
Update langyo/dsh-mobile-upgrade: require DSH 0.1.5-rc.1, refresh description

### DIFF
--- a/data/plugins/langyo__dsh-mobile-upgrade.yml
+++ b/data/plugins/langyo__dsh-mobile-upgrade.yml
@@ -2,6 +2,6 @@ url: https://github.com/langyo/dsh-mobile-upgrade
 name: langyo/dsh-mobile-upgrade
 category: ui
 description:
-  en: 'Mobile UI fixes for the dsh web profile: composer upload, restart row, input-modality switches, narrow-screen drawer and settings tabs, a full-width model menu, and a stuck-request network chip.'
-  zh: dsh web profile 的手机端体验修复：输入框上传、重启行、输入模态开关、窄屏抽屉与设置标签、全宽模型菜单，以及卡住请求的网络状态芯片。
+  en: 'Requires DSH 0.1.5-rc.1. Mobile UI fixes for the dsh web profile: narrow-screen drawer and settings tabs, a full-width model menu, a stuck-request network chip, and a narrow-header collector that folds the lineage, subagent and background-job chips into one tappable sheet.'
+  zh: '需要 DSH 0.1.5-rc.1。dsh web profile 的手机端体验修复：窄屏抽屉与设置标签、全宽模型菜单、卡住请求的网络状态芯片，以及把会话层级、subagent 与后台任务芯片收进一张可点开面板的窄屏头部收纳器。'
 tarball: https://github.com/langyo/dsh-mobile-upgrade/releases/latest/download/dsh-mobile-upgrade.tgz


### PR DESCRIPTION
Own entry only — single file changed: `data/plugins/langyo__dsh-mobile-upgrade.yml`.

## What changed

- **Minimum-version marker**: the entry now opens with `Requires DSH 0.1.5-rc.1.` (zh: `需要 DSH 0.1.5-rc.1。`), matching the `engines.dsh: ">=0.1.5-rc.1"` the package declares since v0.8.0 — the machine-readable contract dsh-market's discover cards and pre-install compatibility check (dsh-market#404 → #473/#522) read.
- **Description refresh**, because the plugin's composer upload feature was removed in v0.8.0 (langyo/dsh-mobile-upgrade#29): dsh 0.1.5-rc.1 ships a built-in composer attachment system, so the upload row is no longer the plugin's business. The freed slot now names what the plugin actually grew since the entry was written: the **narrow-header collector** that folds the session lineage, subagent and background-job chips into one tappable full-width sheet on phones (<1024px), verified against the shipped v0.8.1.

## Accuracy notes

- Every named feature exists in the current code: drawer + settings tabs (narrow-screen), full-width model menu (≤700px), stuck-request network chip, header collector.
- `tarball` unchanged (version-free `latest/download` asset, already fixed in #4771).
- The repo declares its own `screenshots.json` (being added in the same upstream push as this entry change); screenshot refresh lands through the nightly build without another PR here.

Screenshots of the collector feature for reference (staged on a clean profile): see the repo README after the screenshots push.