### PR TITLE
Add AaronandWork/dsh-evidence-gate

### DIFF
--- a/data/plugins/AaronandWork__dsh-evidence-gate.yml
+++ b/data/plugins/AaronandWork__dsh-evidence-gate.yml
@@ -1,0 +1,7 @@
+url: https://github.com/AaronandWork/dsh-evidence-gate
+name: AaronandWork/dsh-evidence-gate
+category: dev
+description:
+  en: Evidence-first conclusion gate that cross-checks first-hand claims against a durable per-session tool-activity index, blocks unverified guesses and tracks blocked-versus-converted metrics.
+  zh: 实证门——按会话将第一手结论与持久工具活动索引交叉核验、拦截未验证猜测并以台账统计拦截与转化，中英双语界面。
+tarball: https://github.com/AaronandWork/dsh-evidence-gate/releases/latest/download/dsh-evidence-gate.tgz


### PR DESCRIPTION
Adds `AaronandWork/dsh-evidence-gate` under **dev**.

**What it does.** A conclusion gate for dsh agents. Before a load-bearing claim is stated, the `evidence_gate` tool checks its basis: a first-hand claim (tested / measured / read directly) is cross-checked against a durable per-session tool-activity index (`$DSH_HOME/evidence-gate/store.json`), and a claim that cannot be matched is blocked instead of stated. Verdicts are per claim: verified, cited, or blocked. A per-session switch and report (`/evidence-gate on|off|status|report`, plus the `evidence_gate_switch` tool) carries a ledger whose counters include blocked-versus-converted. The web UI is bilingual (en / zh).

**Checklist**

- [x] One file added: `data/plugins/AaronandWork__dsh-evidence-gate.yml`
- [x] `package.json` declares `dsh.bundle` (`{"patch": "./cordis.patch.yml"}`, with `cordis.patch.yml` at the repo root) - not only `dsh.client`
- [x] Repo is at least 1 day old
- [x] `category: dev` - it gates agent conclusions; not a theme or a skin
- [x] Description says what the plugin does, is checked against the source, and carries no superlatives
- [x] Repo has the `dsh-plugin` topic

**Optional install extras already in place**

- Published to npm as `@aaronandwork/dsh-evidence-gate`; the package `repository` field points back at this repo
- Prebuilt tarball on GitHub Releases with a version-free asset name, so `latest/download/` cannot rot: `https://github.com/AaronandWork/dsh-evidence-gate/releases/latest/download/dsh-evidence-gate.tgz`
- `screenshots.json` at the repo root declares 4 GIFs under `assets/`

**Branch base.** This branch was cut from an older `main` (this token cannot push `.github/workflows` changes without the `workflow` scope). The submission itself is exactly +1 file under `data/plugins/` and touches nothing else.