### PR TITLE
add addie-ace/dsh-livebench-rankings (ui)

### DIFF
--- a/data/plugins/addie-ace__dsh-livebench-rankings.yml
+++ b/data/plugins/addie-ace__dsh-livebench-rankings.yml
@@ -1,0 +1,6 @@
+url: https://github.com/addie-ace/dsh-livebench-rankings
+name: addie-ace/dsh-livebench-rankings
+category: ui
+description:
+  en: LiveBench leaderboard for DSH — discovers the release the official site currently publishes, then reads its CSV and category JSON, and renders model rankings in an isolated same-origin iframe opened from a button beside the composer. Search, organization / open-weight / reasoning filters, per-category sorting, task-level detail, up to four models side by side, CSV export; refreshes every 60 s by default (configurable 30–3600) and caches only to the plugin's own .cache/rankings.json.
+  zh: DSH 内的 LiveBench 能力排行榜：识别官网当前发布的榜单版本，再读取其官方 CSV 与分类 JSON，在由输入框按钮打开的独立同源 iframe 中渲染模型排名。支持搜索、机构／开放权重／推理模型筛选、按能力维度排序、任务级明细、最多 4 个模型并排对比与 CSV 导出；默认每 60 秒同步（可配 30–3600），缓存只写入插件自身的 .cache/rankings.json。


### PR DESCRIPTION
<!-- Thanks for contributing! Quick checklist / 提交前快速自查 -->

- [x] I added **one file** at `data/plugins/<owner>__<repo>.yml` — that single file is the whole submission. The READMEs are regenerated on `main` after merge: don't edit them by hand, and you don't need to commit them either / 我新增了一个 `data/plugins/<owner>__<repo>.yml` 文件——**这一个文件就是全部投稿**。README 会在合并后由 `main` 自动重新生成：不要手工编辑，也不需要提交
- [x] My repo's `package.json` declares **`dsh.bundle`** (not just `dsh.client`) — [example](../blob/main/contributing.md) / 仓库 `package.json` 已声明 `dsh.bundle`（只有 `dsh.client` 无法安装）
- [x] My repo is at least **1 day old** / 仓库创建满 1 天
- [x] `category` is one of `agi ui usage theme model identity session memory tools wsl browser vision voice docs skill workflow git notify dev security remote market fun` ([full list with descriptions](../blob/main/contributing.md)), and themes/skins go under `theme` / `category` 取值正确（完整清单见 contributing.md），主题/皮肤类请用 `theme`
- [x] Description states what the plugin does, no superlatives / 描述只说功能，不带营销词
- [x] My repo has the `dsh-plugin` topic / 仓库已打 `dsh-plugin` topic

**Recommended (not required) / 推荐但不强制：**

- 📦 Publish to npm — npm installs are prebuilt and skip the `allowBuilds` approval, so users get a one-command install / 发布 npm 包：预构建产物免 `allowBuilds` 授权，用户一条命令装好
- 🔗 Declare official `@deepseek-ai/*` packages as `peerDependencies` (not `dependencies`) — avoids duplicate runtimes inside the profile / 官方 `@deepseek-ai/*` 包用 `peerDependencies` 声明（而非 `dependencies`），避免 profile 里出现重复运行时
- 🖼️ Screenshots go in **your own repository** now: a `screenshots.json` beside your `package.json`, listing image paths. Nothing to add here, and you can change them later without another pull request ([how](../blob/main/contributing.md#screenshots--截图optional-recommended--可选推荐)) / 截图现在放在**你自己的仓库**里：在 `package.json` 旁边放一个 `screenshots.json`，列出图片路径。这个 PR 里不用加任何东西，以后想换也不必再提 PR（[说明](../blob/main/contributing.md#screenshots--截图optional-recommended--可选推荐)）

---

### What the plugin does / 插件做什么

A LiveBench leaderboard inside the DSH web GUI. A button beside the composer (`conversation.input.left`, order 95, label `AI 排行`) opens a native `<dialog>` containing a same-origin `iframe` served from the plugin's own route prefix `/dsh-livebench-rankings`. The server discovers the release the official site currently publishes, then reads that release's official CSV and category JSON.

Features: model search, organization / open-weight / reasoning filters, per-category sorting, task-level detail, up to four models side by side, CSV export, manual refresh plus a default 60 s auto-sync.

### Description claim → source / 描述逐句对应源码

| Claim in the entry | Where it comes from |
| --- | --- |
| Discovers the release the official site publishes | `lib/source.js` `discoverScripts()` / `discoverData()` (reads literals from the page's own scripts, never executes them) |
| Reads official CSV and category JSON | `lib/service.js` `refresh()` → `table_<release>.csv`, `categories_<release>.json` |
| Isolated same-origin iframe | `src/client.js` (native dialog + `frame.src`), `lib/index.js` `createHandler()` (CSP + origin check) |
| Opened from a button beside the composer | `src/client.js` → `ctx.slots.register({ name: 'conversation.input.left', order: 95 })` |
| Search / organization / open-weight / reasoning filters | `src/app.js` `state.query`, `#org` select, `data-filter` segmented control |
| Per-category sorting, task-level detail | `src/app.js` `data-sort`, `showDetail()` |
| Up to four models side by side | `src/app.js` — further selection is disabled once `state.selected.size >= 4` |
| CSV export | `src/app.js` `exportCSV()` |
| Default 60 s, configurable 30–3600 | `lib/index.js` `apply()` → `Math.max(30, Math.min(3600, Number(config.refreshSeconds) \|\| 60))` |
| Caches only to `.cache/rankings.json` | `lib/index.js` `cacheFile` + atomic write in `lib/service.js` |

Local verification before submitting / 提交前本地验证：

- `node scripts/generate-readme.mjs --check` → exit 0
- `SKIP_PUBLISH_CHECKS=1 node scripts/build-site.mjs` → exit 0, `3562 rows × 2 locales + sitemap + count badge`
- the entry is present in `docs/index.html`, `docs/zh/index.html`, `docs/plugins.json`, `docs/p/addie-ace/dsh-livebench-rankings/index.html` and `docs/ui/index.html`
- the commit adds exactly one file: `data/plugins/addie-ace__dsh-livebench-rankings.yml`