### PR TITLE
Add levodoubt/dsh-longtext-input

### DIFF
--- a/data/plugins/levodoubt__dsh-longtext-input.yml
+++ b/data/plugins/levodoubt__dsh-longtext-input.yml
@@ -1,0 +1,7 @@
+url: https://github.com/levodoubt/dsh-longtext-input
+name: levodoubt/dsh-longtext-input
+category: ui
+description:
+  en: 'Adds a Long text button to the composer tool row: write or paste the body in an editor overlay, and on save it is written to <workspace>/.dsh-longtext/<timestamp>_<title>.md and an @ path reference to that file is appended to the composer, leaving the conversation free of the long text itself.'
+  zh: '在输入框工具栏新增「长文本」按钮：在编辑器浮层里写或粘贴正文，保存后写入 <工作区>/.dsh-longtext/<时间戳>_<标题>.md，并把该文件的 @ 路径引用追加到输入框，让正文不进入对话。'
+tarball: https://github.com/levodoubt/dsh-longtext-input/releases/download/v1.0.0/dsh-longtext-input-1.0.0.tgz


### PR DESCRIPTION
<!-- Thanks for contributing! Quick checklist / 提交前快速自查 -->

- [x] I added **one file** at `data/plugins/levodoubt__dsh-longtext-input.yml` — that single file is the whole submission. The READMEs are regenerated on `main` after merge: I have not edited or committed them / 我新增了一个 `data/plugins/levodoubt__dsh-longtext-input.yml` 文件，这一个文件就是全部投稿。README 由 `main` 自动重新生成，我没有手工编辑或提交
- [x] My repo's `package.json` declares **`dsh.bundle`** (not just `dsh.client`) — `"bundle": { "patch": "./cordis.patch.yml" }`, with `cordis.patch.yml` at the repo root / 仓库 `package.json` 已声明 `dsh.bundle`，并在仓库根放了 `cordis.patch.yml`
- [ ] My repo is at least **1 day old** — **not yet.** It was created 2026-09-12T08:12:37Z, so this is the one check currently failing. Per `check-submission.mjs` it clears by itself via `regate.yml`; no action needed and I will not resubmit. / **暂未满。** 仓库创建于 2026-09-12T08:12:37Z，目前只有这一项未过。按 `check-submission.mjs` 的说明，`regate.yml` 会自动重跑清掉它，无需操作，我不会重复提交
- [x] `category` is one of the allowed values — `ui` (composer toolbar button + editor overlay; same category as the other composer-input plugins such as `13071301808/dsh-composer-expand`) / `category` 取值 `ui`
- [x] Description states what the plugin does, no superlatives / 描述只说功能，不带营销词
- [x] My repo has the `dsh-plugin` topic / 仓库已打 `dsh-plugin` topic

**Recommended / 推荐：**

- [x] Prebuilt tarball attached to the release and declared via `tarball:` — pinned to the tag (`releases/download/v1.0.0/…`), not `latest/download/`, because the asset name carries the version and `latest/download/` takes the filename literally / 已把预构建 tarball 附到 Release 并用 `tarball:` 声明，**钉住 tag** 而非 `latest/download/`——资产名带版本号，用 `latest/download/` 会在下次发版后 404
- [x] No official `@deepseek-ai/*` packages are depended on at all — `dependencies` and `peerDependencies` are both empty / 完全没有依赖官方 `@deepseek-ai/*` 包，`dependencies` 与 `peerDependencies` 均为空
- [x] Screenshots declared in the plugin repo's own `screenshots.json` (2 images) / 截图已在自己仓库的 `screenshots.json` 声明（2 张）

## What the plugin does / 插件功能

Adds a **Long text** button to the composer tool row (`conversation.input.left`). It opens an editor overlay (`shell.overlay`); on save the body is written to `<session cwd>/.dsh-longtext/<YYYYMMDDHHmmss>[_<title>].md` by the Host half, and an `@` path reference to that file is appended to the composer.

在输入框工具栏新增「长文本」按钮，点开编辑器浮层；保存后由 Host 半把正文写入 `<会话工作目录>/.dsh-longtext/<14位本地时间>[_<标题>].md`，并把该文件的 `@` 路径引用追加到输入框。

Purpose: keeping long pasted content (stack traces, meeting notes, drafts) out of the conversation while leaving a resolvable path for the Agent.

## Notes for the review / 供评审参考

- **The description's claims map to code.** The button is registered in `conversation.input.left` and the overlay in `shell.overlay` (`lib/client.js`); the file name and the `.dsh-longtext/` directory are produced by `lib/index.js`, which takes the working directory from the Session header rather than from any client-supplied path.
- **Not covered by an existing entry.** The nearest ones grow the input in place (`13071301808/dsh-composer-expand`, `Pudge1996/dsh-composer-stretch`) or attach files that already exist (`Johnny-xuan/dsh-paste-to-path`, `WJZ-P/dsh-attachments`). This one takes text typed into an editor and writes a new file, leaving only a reference.
- **Not a meta-package.** It ships its own behaviour (a Host HTTP route that writes the file, plus two UI slot registrations) and has no runtime dependencies at all.
- **Zero build.** Both halves are hand-written plain JavaScript; `lib/client.js` is a pre-built `window.__ModuleLoader__.load({ id, factory })` bundle.
- **Replaces #4920.** That pull request was accidentally closed by my own force-push while adding the `tarball:` field: the amend kept the original commit date, so the new head was not a new commit, and GitHub treated the push as a no-op and auto-closed the PR. GitHub refuses to reopen a PR closed that way, so this is a clean branch off current `main` (6060b3c) carrying the same single entry. Apologies for the duplicate. / 本 PR 替代 #4920：我在补 `tarball:` 字段时用 force-push，但 amend 保留了原提交时间，新 head 不算新提交，GitHub 视作空推送并自动关闭了 PR；这种关闭无法重开，所以在当前 `main` 上重建了干净分支，条目内容一致。重复提交，抱歉。
