### PR TITLE
Add kp-z/dsh-mermaid-comm (docs)

### DIFF
--- a/data/plugins/kp-z__dsh-mermaid-comm.yml
+++ b/data/plugins/kp-z__dsh-mermaid-comm.yml
@@ -1,0 +1,6 @@
+url: https://github.com/kp-z/dsh-mermaid-comm
+name: kp-z/dsh-mermaid-comm
+category: docs
+description:
+  en: Makes the AI default to Mermaid diagrams in development conversations — system prompt guidance, a mermaid_validate syntax-check tool with real-parser validation, and an output gate that auto-fixes or removes broken diagrams. Rendering via dsh-mermaid.
+  zh: 让 AI 在开发交流中默认用 Mermaid 图表达——系统提示引导、mermaid_validate 真解析语法校验工具，以及自动修复或摘除坏图的输出闸。渲染交给 dsh-mermaid。


### PR DESCRIPTION
## What

Adds **kp-z/dsh-mermaid-comm** to the Docs & Rendering category.

> Makes the AI default to Mermaid diagrams in development conversations — system prompt guidance, a `mermaid_validate` syntax-check tool with real-parser validation, and an output gate that auto-fixes or removes broken diagrams. Rendering via dsh-mermaid.

## Why it belongs here

Existing mermaid entries (AKS1st/dsh-mermaid, MrmoLabs/dsh-mermaid, etc.) are *renderers* that draw fenced code blocks. This plugin is a different layer: it steers the model to output Mermaid diagrams by default (system prompt), validates syntax against the same real parser the renderer uses (`mermaid_validate` tool), and gates assistant output to auto-fix or remove broken diagrams before they reach the user. It deliberately delegates rendering to `dsh-mermaid` (MrmoLabs), so it complements rather than duplicates the renderers already listed.

- Repo: https://github.com/kp-z/dsh-mermaid-comm (public, `dsh-plugin` topic)
- npm: `dsh-mermaid-comm` v0.1.6 (published)
- Declares `dsh.bundle` manifest (patch: `cordis.patch.yml`)

> Note: the repository was created today, so the Submission gate's 1-day repo-age check will fail initially. Per the contributing guide, a brand-new repo can resubmit once it clears this — the gate can be re-run after 2026-09-13 09:06 UTC.