### PR TITLE
add yjh051108/dsh-routing-suite (dev)

### DIFF
--- a/data/plugins/yjh051108__dsh-routing-suite.yml
+++ b/data/plugins/yjh051108__dsh-routing-suite.yml
@@ -1,0 +1,6 @@
+url: https://github.com/yjh051108/dsh-routing-suite
+name: yjh051108/dsh-routing-suite
+category: dev
+description:
+  en: 'One repository, three parts: a runtime injector for DSH plugin packages (inject, hot-reload, unload, promote a dev staging tool to the front, route self-heal, plus a settings-page plugin manager that lists, unloads and drags folders in to internalize), a task-aware reasoning-mode router agent preset (router-standard / router-spec / router-react), and a graded two-level task protocol whose six tools (commit_star, lock_stage, revise_do, edit_plan, mark_task, redteam_verdict) pin task state to disk. The injector implementation ships in-tree, so the install carries its own behaviour rather than a dependency list.'
+  zh: '一个仓库三件套：DSH 插件包的运行时注入器（注入、热重载、卸载、开发侧挂区一键转正、路由自愈，外带设置页插件管理：列出、卸载、拖入文件夹内化）、任务感知的思维模式路由 agent 预设（router-standard / router-spec / router-react）、以及分级两级任务协议（commit_star / lock_stage / revise_do / edit_plan / mark_task / redteam_verdict 六个工具，任务状态落盘）。注入器实现直接在库内，安装的是它自己的行为而不是一份依赖清单。'


### PR DESCRIPTION
<!-- Thanks for contributing! Quick checklist / 提交前快速自查 -->

> **Third-party nomination / 第三方提名** — I am not the author of [`yjh051108/dsh-routing-suite`](https://github.com/yjh051108/dsh-routing-suite). The checklist below is filled in about the **nominated** repository rather than one of mine, and every item in it was checked against that repository. If you would rather hear from the author first, say so and I will step back.

- [x] The submission is **one file** at `data/plugins/<owner>__<repo>.yml` — that single file is the whole submission. The READMEs are regenerated on `main` after merge: nothing here edits them by hand / 本次投稿只有一个文件，未手工编辑 README
- [x] The nominated repo's `package.json` declares **`dsh.bundle`** (not just `dsh.client`) — root `package.json` → `"dsh": { "bundle": { "patch": "./cordis.patch.yml" } }`, and `cordis.patch.yml` is present at the root / 仓库根 `package.json` 已声明 `dsh.bundle`
- [x] The nominated repo is at least **1 day old** — created 2026-08-14, about 28 days old at the time of writing / 仓库创建满 1 天
- [x] `category` is one of the valid values — `dev` / `category` 取值为 `dev`
- [x] Description states what the plugin does, no superlatives / 描述只说功能，不带营销词
- [x] The nominated repo has the `dsh-plugin` topic — topics: `ai-agents, cordis, deepseek-harness, dsh, dsh-plugin` / 仓库已打 `dsh-plugin` topic

### Why this one / 为什么提它

7,168 stars, last push 2026-09-04, not archived, MIT `LICENSE`.

I checked whether it is already covered: searching `data/plugins/` for `routing-suite`, for the owner name, and for `super-injector` turns up no entry for this repository.

**Not a meta-package (review point 7).** The root `package.json` *is* the suite's own package (`@dsh-external/dsh-super-injector`), its `files` list ships `injector/lib` + `injector/scripts`, and its `cordis.patch.yml` inserts a single row that resolves to that in-tree implementation. It carries behaviour of its own, not a dependency list.

### Every claim in the entry, and where it comes from / 描述逐句对应源码

| Claim | Source |
| --- | --- |
| Inject / hot-reload / unload / promote a dev staging tool / route self-heal | `injector/package.json` description; the `dev_*` tools registered in `injector/src/index.ts` |
| Settings-page plugin manager: list, unload, drag a folder in to internalize | `injector/src/client/index.ts` — the settings page builds 插件管理（dsh-super-injector）, 内化（AI 造插件）, 直接注入 |
| `router-standard` / `router-spec` / `router-react` presets | `preset/` subdirectories; `preset/router-standard/preset.yml` |
| The graded protocol's six tools | `graded/src/tools.js` registers exactly `commit_star`, `lock_stage`, `revise_do`, `edit_plan`, `mark_task`, `redteam_verdict` |

Local verification before opening this PR / 提交前本地验证：`node scripts/generate-readme.mjs --check` → 0；`SKIP_PUBLISH_CHECKS=1 node scripts/build-site.mjs` → 0 (`3562 rows × 2 locales + sitemap + count badge`)；the entry shows up in `docs/index.html`, `docs/zh/index.html`, `docs/plugins.json`, `docs/sitemap.xml`, `docs/dev/index.html` and `docs/p/yjh051108/dsh-routing-suite/index.html`；the commit adds exactly one file.

### Notes / 备注

- The suite ships three parts in one repository. I listed it as **one** entry because it installs as one unit (`dsh plugin --profile web add github:yjh051108/dsh-routing-suite`) and the root manifest is the injector itself. If you would rather have a component listed on its own, tell me which and I will re-cut the entry.
- Observed upstream, for the author's attention rather than as a blocker: the root `LICENSE` is MIT while the root `package.json` declares `BSD-3-Clause`, and `graded/` is Apache-2.0.
- No `tarball:` field — the `.tgz` files in that repository are committed artifacts, not GitHub Release assets, and the guide asks for release-hosted https `.tgz`. Installing from source works (that is the command in its README).
- No screenshots declared: `screenshots.json` can only be added inside a repository I do not control; the guide says storefronts fall back to images extracted from the README.