### PR TITLE
Add @dshp/token-meter to usage category

### DIFF
--- a/data/plugins/Yinxe__deepseek-harness-plugins--plugins-token-meter.yml
+++ b/data/plugins/Yinxe__deepseek-harness-plugins--plugins-token-meter.yml
@@ -1,0 +1,7 @@
+url: https://github.com/Yinxe/deepseek-harness-plugins/tree/main/plugins/token-meter
+name: Yinxe/deepseek-harness-plugins#token-meter
+category: usage
+tarball: https://github.com/Yinxe/deepseek-harness-plugins/releases/latest/download/dshp-token-meter-latest.tgz
+description:
+  en: 'Unified token quota and usage statistics for dsh: multi-vendor rolling/payg quota with sidebar cards and provider ops, plus session-log token aggregation with trends, heatmap, and per-model breakdown.'
+  zh: 'DSH 额度与用量统计统一视图：多供应商滚动/按量额度（侧边栏卡片 + 供应商运维），外加会话日志 token 聚合（趋势、热力图、按模型拆分）。'

--- a/data/plugins/Yinxe__deepseek-harness-plugins--plugins-token-meter.yml
+++ b/data/plugins/Yinxe__deepseek-harness-plugins--plugins-token-meter.yml
@@ -1,7 +1,6 @@
 url: https://github.com/Yinxe/deepseek-harness-plugins/tree/main/plugins/token-meter
 name: Yinxe/deepseek-harness-plugins#token-meter
 category: usage
-tarball: https://github.com/Yinxe/deepseek-harness-plugins/releases/latest/download/dshp-token-meter-latest.tgz
 description:
   en: 'Unified token quota and usage statistics for dsh: multi-vendor rolling/payg quota with sidebar cards and provider ops, plus session-log token aggregation with trends, heatmap, and per-model breakdown.'
   zh: 'DSH 额度与用量统计统一视图：多供应商滚动/按量额度（侧边栏卡片 + 供应商运维），外加会话日志 token 聚合（趋势、热力图、按模型拆分）。'


### PR DESCRIPTION
## What

Adds [@dshp/token-meter](https://github.com/Yinxe/deepseek-harness-plugins/tree/main/plugins/token-meter) — unified token quota and usage statistics for dsh.

- Multi-vendor rolling/payg quota with sidebar cards and provider ops
- Session-log token aggregation with trends, heatmap, and per-model breakdown

Monorepo subpackage: `url` points at the subdirectory and `name` is `owner/repo#subname`.

Install is the git-dependency command the site derives from the url — `dsh plugin --profile web add github:Yinxe/deepseek-harness-plugins#path:/plugins/token-meter`. No `tarball` field is declared, so updates are a one-liner: `dsh plugin --profile web update @dshp/token-meter`.

## Checklist

- [x] Subpackage declares `dsh.bundle` manifest (`dsh.client` also present)
- [x] `dsh-plugin` topic on the repo
- [x] Prebuilt `lib/` is committed, so install needs no build step
- [x] `screenshots.json` declared in-repo
- [x] Repo age > 1 day
- [x] Single entry; only this one file added
