### PR TITLE
Add @dshp/mcwiki-search to tools category

### DIFF
--- a/data/plugins/Yinxe__deepseek-harness-plugins--plugins-mcwiki-search.yml
+++ b/data/plugins/Yinxe__deepseek-harness-plugins--plugins-mcwiki-search.yml
@@ -1,0 +1,7 @@
+url: https://github.com/Yinxe/deepseek-harness-plugins/tree/main/plugins/mcwiki-search
+name: Yinxe/deepseek-harness-plugins#mcwiki-search
+category: tools
+tarball: https://github.com/Yinxe/deepseek-harness-plugins/releases/latest/download/dshp-mcwiki-search-latest.tgz
+description:
+  en: 'Query Chinese Minecraft Wiki (MediaWiki API) and convert raw wiki text into clean AI-readable output — search, page intro, full-page Markdown, and random entry; templates, references, images and cross-language links are stripped before reaching the model.'
+  zh: '查询中文 Minecraft Wiki（MediaWiki API），把搜索结果与页面全文完整转换为 AI 可直接阅读的干净文本——搜索、引言、全文 Markdown、随机条目；模板、引用、图片、跨语言链接等噪声在插件内部全部清洗完毕。'

--- a/data/plugins/Yinxe__deepseek-harness-plugins--plugins-mcwiki-search.yml
+++ b/data/plugins/Yinxe__deepseek-harness-plugins--plugins-mcwiki-search.yml
@@ -1,7 +1,6 @@
 url: https://github.com/Yinxe/deepseek-harness-plugins/tree/main/plugins/mcwiki-search
 name: Yinxe/deepseek-harness-plugins#mcwiki-search
 category: tools
-tarball: https://github.com/Yinxe/deepseek-harness-plugins/releases/latest/download/dshp-mcwiki-search-latest.tgz
 description:
   en: 'Query Chinese Minecraft Wiki (MediaWiki API) and convert raw wiki text into clean AI-readable output — search, page intro, full-page Markdown, and random entry; templates, references, images and cross-language links are stripped before reaching the model.'
   zh: '查询中文 Minecraft Wiki（MediaWiki API），把搜索结果与页面全文完整转换为 AI 可直接阅读的干净文本——搜索、引言、全文 Markdown、随机条目；模板、引用、图片、跨语言链接等噪声在插件内部全部清洗完毕。'


### PR DESCRIPTION
## What

Adds [@dshp/mcwiki-search](https://github.com/Yinxe/deepseek-harness-plugins/tree/main/plugins/mcwiki-search) — query Chinese Minecraft Wiki (MediaWiki API) and convert raw wiki text into clean AI-readable output.

- Search, page intro, full-page Markdown, and random entry
- Templates, references, images and cross-language links are stripped before the text reaches the model

Monorepo subpackage: `url` points at the subdirectory and `name` is `owner/repo#subname`.

Install is the git-dependency command the site derives from the url — `dsh plugin --profile web add github:Yinxe/deepseek-harness-plugins#path:/plugins/mcwiki-search`. No `tarball` field is declared, so updates are a one-liner: `dsh plugin --profile web update @dshp/mcwiki-search`.

## Checklist

- [x] Subpackage declares `dsh.bundle` manifest (`dsh.client` also present)
- [x] `dsh-plugin` topic on the repo
- [x] Prebuilt `lib/` is committed, so install needs no build step
- [x] `screenshots.json` declared in-repo
- [x] Repo age > 1 day
- [x] Single entry; only this one file added
