### PR TITLE
Add qgx1992/dsh-ui-tools (ui): five web UI tools in one plugin

### DIFF
--- a/data/plugins/qgx1992__dsh-ui-tools.yml
+++ b/data/plugins/qgx1992__dsh-ui-tools.yml
@@ -1,0 +1,6 @@
+url: https://github.com/qgx1992/dsh-ui-tools
+name: qgx1992/dsh-ui-tools
+category: ui
+description:
+  en: 'Five web UI tools in one plugin: a provider + model two-button selector with reasoning-level control, collapse/expand-all for sidebar workspace groups, a session tab listing the files the session changed (needs kernel 0.1.2-alpha.1+, silently absent on older kernels), a workspace badge next to the session title, and a settings page that toggles them.'
+  zh: '一个插件装五个 Web UI 工具：供应商 + 模型双按钮选择器（含推理等级调节）、侧边栏工作区折叠/展开全部、会话「修改的文件」选项卡（需内核 0.1.2-alpha.1+，旧内核上静默缺席）、会话标题旁的工作区徽章，以及集中开关这些功能的设置页。'


### PR DESCRIPTION
Adds one entry for `qgx1992/dsh-ui-tools`.

**What it does** — five DSH web UI tools in one plugin, all registered through official open slots (no kernel source is patched):

1. the input model selector split into **provider + model** two-button control, with reasoning-level adjustment;
2. **collapse / expand-all** for sidebar workspace groups;
3. a **"Modified files"** session tab listing the files the session changed (needs kernel `0.1.2-alpha.1+`; on `0.1.1-rc.x` this one feature is silently absent and the other four keep working);
4. a **workspace badge** next to the session title;
5. a **"DSH UI tools" settings page** that toggles the above (preferences in `localStorage`).

**Requirements**

- `package.json` declares `dsh.bundle` (`{"patch": "./cordis.patch.yml"}`, alongside `dsh.client` for the browser half); `cordis.patch.yml` sits at the repo root.
- Repo created 2026-08-27 and actively maintained (latest commit 2026-09-10). `dsh-plugin` topic added.
- Real working code: `lib/client.js` is the hand-written bundle, no build step, nothing placeholder.
- Not published to npm — installs from GitHub source.

**Category** — `ui`: everything it ships is web UI surface (an input control, the sidebar, a session tab, a header badge, a settings page).

Heads-up for the reviewer: the list already carries an unrelated `xing-shuyin/dsh-ui-tools` (a developer tools panel — file browser / terminals / Git). Same repository *name*, different project, and the two entry files do not collide.

**Checked locally**

- `node scripts/generate-readme.mjs` adds exactly one line to each README for this entry (not committed — the entry file is the submission).
- `node scripts/check-submission.mjs --base <main sha> --only-list …` → `ok  https://github.com/qgx1992/dsh-ui-tools`.

One note on that second command, in case it is useful: on Windows it reports *"no entry files added or changed"* unless `--only-list` is passed, because `changedEntryFiles()` returns forward-slash paths from `git diff` while `e.file` is built with `path.join` and comes back with backslashes, so the `Set.has()` filter matches nothing. CI runs on Linux and is unaffected; I mention it only in case a Windows run is ever expected to gate something.
