### PR TITLE
Update fewoot/dsh-whale-particles: refresh description and point tarball at v0.3.0

### DIFF
--- a/data/plugins/fewoot__dsh-whale-particles.yml
+++ b/data/plugins/fewoot__dsh-whale-particles.yml
@@ -2,7 +2,6 @@ url: https://github.com/fewoot/dsh-whale-particles
 name: fewoot/dsh-whale-particles
 category: ui
 description:
-  en: 'Interactive dot-matrix background for the DSH web UI: particles form the DeepSeek whale or your transparent-PNG photo, each dot carries its own smooth force; mouse disturbs them and an auto screensaver mode sweeps 360-degree waves and full-screen breathing. '
-  zh: '给 DSH Web 加一个点阵互动背景:点阵可组成鲸鱼或你上传的透明 PNG 照片,每颗粒子有自己独立的平滑外力;既能手动随鼠标扰动,也能切换自动屏保模式(360° 任意方向扫波 + 全屏呼吸躁动),参数面板支持恢复默认。'
-# 非 npm 分发时加这行(tag 与 Release 一致):
-# tarball: https://github.com/fewoot/dsh-whale-particles/releases/download/v0.1.0/dsh-whale-particles-0.1.0.tgz
+  en: 'Dot-matrix backdrop for the DSH Web UI: the dots form the DeepSeek whale or a transparent PNG you import (alpha-masked), each dot carries its own low-frequency force and follows the cursor in manual mode, while an auto screensaver mode sweeps 360-degree waves and full-screen breathing across the artwork; sliders and toggles live under Settings > Plugins.'
+  zh: '给 DSH Web 加一层点阵背景:点阵可组成鲸鱼剪影,或导入透明 PNG 按 alpha 取主体;每颗粒子各自持有低频外力,手动模式下跟随光标扰动,自动屏保模式则用 360° 任意方向的扫波与全屏呼吸带动整幅图案;鼠标/自动与鲸鱼/照片在参数面板里切换,入口在 设置 → 插件。'
+tarball: https://github.com/fewoot/dsh-whale-particles/releases/download/v0.3.0/dsh-whale-particles-0.3.0.tgz


### PR DESCRIPTION
…all at v0.3.0

The tarball link still pointed at the v0.1.1 asset, so the entry offered an outdated download. It now points at the v0.3.0 release asset.

The description is also refreshed to match the current UI. The plugin now ships its parameter panel as its own tab under Settings > Plugins (it used to be a row inside General settings), so the previous wording no longer said where the controls live. Everything claimed in the new text is in the client bundle: per-dot low-frequency forces, cursor following in manual mode, 360-degree waves and full-screen breathing in the auto mode, and alpha-masked PNG import.

<!-- Thanks for contributing! Quick checklist / 提交前快速自查 -->

- [ ] I added **one file** at `data/plugins/<owner>__<repo>.yml` — that single file is the whole submission. The READMEs are regenerated on `main` after merge: don't edit them by hand, and you don't need to commit them either / 我新增了一个 `data/plugins/<owner>__<repo>.yml` 文件——**这一个文件就是全部投稿**。README 会在合并后由 `main` 自动重新生成：不要手工编辑，也不需要提交
- [ ] My repo's `package.json` declares **`dsh.bundle`** (not just `dsh.client`) — [example](../blob/main/contributing.md) / 仓库 `package.json` 已声明 `dsh.bundle`（只有 `dsh.client` 无法安装）
- [ ] My repo is at least **1 day old** / 仓库创建满 1 天
- [ ] `category` is one of `agi ui usage theme model identity session memory tools wsl browser vision voice docs skill workflow git notify dev security remote market fun` ([full list with descriptions](../blob/main/contributing.md)), and themes/skins go under `theme` / `category` 取值正确（完整清单见 contributing.md），主题/皮肤类请用 `theme`
- [ ] Description states what the plugin does, no superlatives / 描述只说功能，不带营销词
- [ ] My repo has the `dsh-plugin` topic / 仓库已打 `dsh-plugin` topic

**Recommended (not required) / 推荐但不强制：**

- 📦 Publish to npm — npm installs are prebuilt and skip the `allowBuilds` approval, so users get a one-command install / 发布 npm 包：预构建产物免 `allowBuilds` 授权，用户一条命令装好
- 🔗 Declare official `@deepseek-ai/*` packages as `peerDependencies` (not `dependencies`) — avoids duplicate runtimes inside the profile / 官方 `@deepseek-ai/*` 包用 `peerDependencies` 声明（而非 `dependencies`），避免 profile 里出现重复运行时
- 🖼️ Screenshots go in **your own repository** now: a `screenshots.json` beside your `package.json`, listing image paths. Nothing to add here, and you can change them later without another pull request ([how](../blob/main/contributing.md#screenshots--截图optional-recommended--可选推荐)) / 截图现在放在**你自己的仓库**里：在 `package.json` 旁边放一个 `screenshots.json`，列出图片路径。这个 PR 里不用加任何东西，以后想换也不必再提 PR（[说明](../blob/main/contributing.md#screenshots--截图optional-recommended--可选推荐)）
