### PR TITLE
Add weibaohui/dsh-process

### DIFF
--- a/data/plugins/weibaohui__dsh-process.yml
+++ b/data/plugins/weibaohui__dsh-process.yml
@@ -1,0 +1,6 @@
+url: https://github.com/weibaohui/dsh-process
+name: weibaohui/dsh-process
+category: workflow
+description:
+  en: "Process management: brings ntd-style processes (multi-stage, multi-step agent workflow templates) into the dsh web UI — browse, edit, validate, import/export and AI-generate processes; the built-in library is read-only while the personal library is writable with live file sync, and agents read the library through process_* tools and advance work stage by stage."
+  zh: 工艺管理：把 ntd 的「工艺」（多阶段·多环节 agent 工作流模板）接进 dsh web——浏览/编辑/校验/导入导出/AI 生成工艺，内置库只读、我的库可写，文件改动实时同步；agent 可通过 process_* 工具读工艺库、按工艺分阶段推进。


### PR DESCRIPTION
Adds **weibaohui/dsh-process** (工艺管理 / Process management) to **workflow**.

Process management: brings ntd-style processes (multi-stage, multi-step agent workflow templates) into the dsh web UI — browse, edit, validate, import/export and AI-generate processes; the built-in library is read-only while the personal library is writable with live file sync, and agents read the library through process_* tools and advance work stage by stage.

按评审清单自查 / Checklist:

- [x] Adds **one new file only**: `data/plugins/weibaohui__dsh-process.yml` — no existing entries touched, READMEs not hand-edited
- [x] `dsh.bundle` manifest declared in `package.json` (`dsh.bundle.patch = ./cordis.patch.yml`, patch file at repo root)
- [x] Published to npm as [@weibaohui/dsh-process](https://www.npmjs.com/package/@weibaohui/dsh-process) (v0.5.0, MIT); repo carries the `dsh-plugin` topic (also `dsh`, `deepseek-harness`) and is older than 1 day
- [x] Category `workflow` — the plugin manages multi-stage, multi-step agent workflow templates
- [x] `description.en` is quoted (contains `: `) and ends with a period; `zh` included

Demo: https://github.com/weibaohui/dsh-process/blob/main/docs/demo-process.gif

Install: `dsh plugin add @weibaohui/dsh-process`
