### PR TITLE
Add weibaohui/dsh-webdav-server

### DIFF
--- a/data/plugins/weibaohui__dsh-webdav-server.yml
+++ b/data/plugins/weibaohui__dsh-webdav-server.yml
@@ -1,0 +1,6 @@
+url: https://github.com/weibaohui/dsh-webdav-server
+name: weibaohui/dsh-webdav-server
+category: tools
+description:
+  en: "WebDAV server: turns a shared directory into a WebDAV service that Windows, macOS and Linux can mount as a local disk, with token authentication, optional read-only mode, configurable directory/port/token, and per-platform mounting guides built into the settings page."
+  zh: WebDAV 服务器：把一个共享目录变成 Windows/macOS/Linux 都能挂载成本地磁盘的 WebDAV 服务，令牌认证、可选只读、目录/端口/令牌全可配，设置页自带三平台挂载指南。


### PR DESCRIPTION
Adds **weibaohui/dsh-webdav-server**.

- 📦 npm: [@weibaohui/dsh-webdav-server](https://www.npmjs.com/package/@weibaohui/dsh-webdav-server) (v0.1.1) → `dsh plugin add @weibaohui/dsh-webdav-server`
- ✅ `package.json` declares `dsh.bundle` (+ `cordis.patch.yml`), web client included
- ✅ Repo has the `dsh-plugin` topic (plus `dsh`, `deepseek-harness`)

Checklist / 自查:
- [x] I added **one file** at `data/plugins/weibaohui__dsh-webdav-server.yml` — that single file is the whole submission
- [x] My repo's `package.json` declares **`dsh.bundle`**
- [x] My repo is at least **1 day old**
- [x] `category` is one of the valid values — using `tools`
- [x] Description states what the plugin does, no superlatives
- [x] My repo has the `dsh-plugin` topic
- [x] 📦 Published to npm
