### PR TITLE
Add weibaohui/dsh-git-server

### DIFF
--- a/data/plugins/weibaohui__dsh-git-server.yml
+++ b/data/plugins/weibaohui__dsh-git-server.yml
@@ -1,0 +1,6 @@
+url: https://github.com/weibaohui/dsh-git-server
+name: weibaohui/dsh-git-server
+category: git
+description:
+  en: "Git server: embeds ts-gogs (a TypeScript reimplementation of Gogs) and serves a full Git service on its own port — HTTP clone/push, web UI, issues/PRs/wiki — reusing user-management credentials, start/stop from the settings page."
+  zh: Git 服务器：内嵌 ts-gogs（Gogs 的 TypeScript 平替），独立端口跑完整 Git 服务（HTTP clone/push、网页端、issue/PR/wiki），可复用 user-management 的用户名密码，设置页一键启停。


### PR DESCRIPTION
Adds **weibaohui/dsh-git-server**.

- 📦 npm: [@weibaohui/dsh-git-server](https://www.npmjs.com/package/@weibaohui/dsh-git-server) (v0.1.0) → `dsh plugin add @weibaohui/dsh-git-server`
- ✅ `package.json` declares `dsh.bundle` (+ `cordis.patch.yml`), web client included
- ✅ Repo has the `dsh-plugin` topic (plus `dsh`, `deepseek-harness`)
- 🖼️ Demo: https://github.com/weibaohui/dsh-git-server/blob/main/docs/demo-tour.webm

Checklist / 自查:
- [x] I added **one file** at `data/plugins/weibaohui__dsh-git-server.yml` — that single file is the whole submission
- [x] My repo's `package.json` declares **`dsh.bundle`**
- [x] My repo is at least **1 day old**
- [x] `category` is one of the valid values — using `git`
- [x] Description states what the plugin does, no superlatives
- [x] My repo has the `dsh-plugin` topic
- [x] 📦 Published to npm
