### PR TITLE
Add prebuilt tarball for Angelyeye/dsh-cost-tracker

### DIFF
--- a/data/plugins/Angelyeye__dsh-cost-tracker.yml
+++ b/data/plugins/Angelyeye__dsh-cost-tracker.yml
@@ -4,3 +4,4 @@ category: usage
 description:
   en: Tracks DeepSeek Harness LLM token usage and cost (CNY, peak/off-peak pricing) with a settings dashboard, agent tools, HTTP API and persistent storage.
   zh: 统计 DeepSeek Harness 的 LLM Token 用量与花费（人民币、峰谷计价），提供设置面板、Agent 工具、HTTP 接口与持久化存储。
+tarball: https://github.com/Angelyeye/dsh-cost-tracker/releases/latest/download/dsh-cost-tracker.tgz


### PR DESCRIPTION
## What

Adds the optional `tarball:` field to my existing entry — `data/plugins/Angelyeye__dsh-cost-tracker.yml`, which is the only file this PR touches.

```yaml
tarball: https://github.com/Angelyeye/dsh-cost-tracker/releases/latest/download/dsh-cost-tracker.tgz
```

- Release: https://github.com/Angelyeye/dsh-cost-tracker/releases/tag/v1.6.0 — published (not a draft, not a prerelease)
- The asset name is version-free (`dsh-cost-tracker.tgz`), so `/releases/latest/download/` will not rot on my next release
- A ranged GET on that URL returns `206`
- The archive is ~67 KB and contains `package.json`, `index.js`, `client.js`, `store.js`, `pricing.js`, `config.js` and `cordis.patch.yml`
- The package declares no lifecycle scripts, so a prebuilt install does not hit pnpm's build-approval prompt

## Scope

Only my own entry, only one documented field. No other entry is touched and the generated READMEs are untouched — `tarball` is not rendered into them.

## Also in that release

The same release brings my repository in line with the submission rules: both READMEs now lead with the marketplace install command (`dsh plugin --profile web add github:Angelyeye/dsh-cost-tracker`), the repository-layout section documents `dsh.bundle` and `cordis.patch.yml`, and the version badge matches `package.json`. Unit tests: 218 passing.
