### PR TITLE
Add HERO476/dsh-instruction-memory (memory)

### DIFF
--- a/data/plugins/HERO476__dsh-instruction-memory.yml
+++ b/data/plugins/HERO476__dsh-instruction-memory.yml
@@ -1,0 +1,6 @@
+url: https://github.com/HERO476/dsh-instruction-memory
+name: HERO476/dsh-instruction-memory
+category: memory
+description:
+  en: Standing instructions edited in the DSH settings UI and injected into the system prompt of every subsequent turn.
+  zh: 在 DSH 设置界面维护常驻指令，自动注入此后每一轮对话的系统提示词。


### PR DESCRIPTION
条目文件：`data/plugins/HERO476__dsh-instruction-memory.yml`（本 PR 只新增这一个文件）。


- [x] I added **one file** at `data/plugins/HERO476__dsh-instruction-memory.yml` — that single file is the whole submission. The READMEs are regenerated on `main` after merge: don't edit them by hand, and you don't need to commit them either / 我新增了一个 `data/plugins/HERO476__dsh-instruction-memory.yml` 文件——**这一个文件就是全部投稿**
- [x] My repo's `package.json` declares **`dsh.bundle`** (not just `dsh.client`) / 仓库 `package.json` 已声明 `dsh.bundle`（`dsh.bundle.patch` → `./cordis.patch.yml`，位于仓库根）
- [x] My repo is at least **1 day old** / 仓库创建满 1 天 —— 创建于 2026-09-11
- [x] `category` is `memory` / `category` 取值为 `memory`
- [x] Description states what the plugin does, no superlatives / 描述只说功能，不带营销词
- [x] My repo has the `dsh-plugin` topic / 仓库已打 `dsh-plugin` topic

**What it does / 插件做什么**

dsh-instruction-memory 在 DSH 设置页提供「指令记忆」入口：用户在此增删改常驻指令条目（标题、正文、模式、优先级、启用开关），数据存于 settings.json 的 `dsh.instructionMemory` 键。此后每一轮对话，启用的条目按优先级排序、受字符预算（`budgetChars`，默认 4000）约束，作为一个段落注入系统提示词。

- 两种模式：`always` 条目注入时标注 [始终]（无条件遵守）；`auto` 条目标注 [按需]（仅与当前任务相关时生效），可附「适用场景」提示行。
- 渲染确定性：相同数据每轮生成字节一致的文本，提示词前缀在会话内可缓存。
- 纯 Node 内置模块，零依赖；`npm test`（smoke / contract / verify）无需安装依赖、无需联网。
- 卸载干净：数据只存 settings.json 的一个键，无其他文件残留。

**Why it is not already covered / 为什么与现有条目不重复**

Memory 分类现有条目绝大多数是机器侧记忆：自动从对话提取知识（auto-capture）、检索式召回（remember/recall 工具、向量/图检索）或外部记忆库桥接（Obsidian、Trilium、flomo、mem0 等）。本插件不含捕获、不含检索、也没有 agent 可写的存储——它是用户手工维护的**常驻指令清单**，唯一行为是确定性注入系统提示词。最接近的相邻形态（persona 卡片、L1 常注入层）都嵌在更大的记忆系统里；单独的「设置界面维护 + 每轮注入」轻量形态在现有列表中没有对应条目。

**Recommended items / 推荐项**

- npm：已发布 `dsh-instruction-memory@1.0.2`，`dsh plugin --profile web add dsh-instruction-memory` 即装，预构建安装免 `allowBuilds` 构建授权。
