### PR TITLE
Update Mandarin715/dsh-autostart (dev): resident supervisor, accurate 0.2.0 description

### DIFF
--- a/data/plugins/Mandarin715__dsh-autostart.yml
+++ b/data/plugins/Mandarin715__dsh-autostart.yml
@@ -1,0 +1,6 @@
+url: https://github.com/Mandarin715/dsh-autostart
+name: Mandarin715/dsh-autostart
+category: dev
+description:
+  en: 'Windows boot autostart and one-click restart for the DSH service, from inside DSH: a resident supervisor that outlives the host, so a failed restart cannot leave DSH down; DSH spawned attached to a hidden console the supervisor owns, so no console window appears; plus a restart button, the current tokenised access URL and an optional post-start hook.'
+  zh: Windows 平台的 DSH 服务开机自启与一键重启(都在 DSH 设置页内):由常驻看护进程启动 DSH,它活得比 DSH 久,因此重启失败不会让 DSH 停摆;DSH 依附在看护进程的隐藏控制台上,不再每条命令弹一个控制台窗口;另有设置页重启按钮、当前带 token 的访问地址与可选的服务启动后钩子。


### PR DESCRIPTION
Updates the existing entry for `Mandarin715/dsh-autostart` so the description matches what 0.2.0 does. Only `data/plugins/Mandarin715__dsh-autostart.yml` is touched; the READMEs regenerate on merge. Category unchanged (`dev`).

What changed in the plugin, all of it verifiable in the repository:

- The restart path is now a **resident supervisor** that outlives the DSH host. Before the host is allowed to exit, the plugin confirms a supervisor is alive and writes the restart request to disk, then reads it back; if either step fails it refuses the restart and leaves DSH running. So a failed restart can no longer leave DSH down.
- DSH is spawned **attached to the hidden console the supervisor owns**, so tool commands no longer create a Windows Terminal window per call.
- The supervisor is deliberately **not a watchdog**: it starts a replacement only for a restart the user asked for, and steps aside when DSH exits on its own.

`docs/ACCEPTANCE.md` records the real-machine acceptance run (window enumeration, process lineage, `service.log` sequences). Release: https://github.com/Mandarin715/dsh-autostart/releases/tag/v0.2.0
