### PR TITLE
Add nirvanaslash/dsh-artifact-preview

### DIFF
--- a/data/plugins/nirvanaslash__dsh-artifact-preview.yml
+++ b/data/plugins/nirvanaslash__dsh-artifact-preview.yml
@@ -1,0 +1,6 @@
+url: https://github.com/nirvanaslash/dsh-artifact-preview
+name: nirvanaslash/dsh-artifact-preview
+category: ui
+description:
+  en: 'Adds a produced-files card row to the chat and a resizable split-screen preview panel for workspace artifacts (Markdown, source code, CSV, JSON, images, HTML), plus a localhost port preview.'
+  zh: '在对话中新增产出文件卡片行，并提供可拖拽分屏的产物预览面板，支持 Markdown、源码、CSV、JSON、图片、HTML，以及本地端口预览。'


### PR DESCRIPTION
Adds one entry for `nirvanaslash/dsh-artifact-preview` (category: `ui`).

**Why it qualifies**

- `package.json` declares `dsh.bundle` (`"bundle": { "patch": "./cordis.patch.yml" }`), so it installs with `dsh plugin add dsh-artifact-preview`.
- Also declares `dsh.client.platform: web` for its browser surface.
- Real, working code: a host entry plus a prebuilt browser bundle. Repo created 2026-08-15, MIT licensed, carries the `dsh-plugin` topic, last push 2026-08-18.
- Published to npm as `dsh-artifact-preview`, and the published package's `repository` field points back at this repository.

**What it does** — adds a produced-files card row to the chat, and a resizable split-screen side preview panel for workspace artifacts (Markdown, source code, CSV, JSON, images, HTML), plus a localhost port preview.

One file added, no other entry touched.
