### PR TITLE
add dsh-plan-plus (ui): inline plan-review replies, plan version history, line diff and editing

### DIFF
--- a/data/plugins/lsdt45__dsh-plan-plus.yml
+++ b/data/plugins/lsdt45__dsh-plan-plus.yml
@@ -1,0 +1,6 @@
+url: https://github.com/lsdt45/dsh-plan-plus
+name: lsdt45/dsh-plan-plus
+category: ui
+description:
+  en: 'Plan review enhancement for DeepSeek Harness Web: reply to the plan-review card inline to have the model revise the plan, and browse, compare, edit and archive every plan version in a full-screen overlay.'
+  zh: 'DeepSeek Harness Web 的计划评审增强：在评审卡片内直接回复意见让模型修订计划，并在全屏浮层中回看、对比、编辑和留档每一版计划。'


### PR DESCRIPTION
<!-- Thanks for contributing! Quick checklist / 提交前快速自查 -->

- [x] I added **one file** at `data/plugins/<owner>__<repo>.yml` — that single file is the whole submission. The READMEs are regenerated on `main` after merge: don't edit them by hand, and you don't need to commit them either / 我新增了一个 `data/plugins/<owner>__<repo>.yml` 文件——**这一个文件就是全部投稿**。README 会在合并后由 `main` 自动重新生成：不要手工编辑，也不需要提交
- [x] My repo's `package.json` declares **`dsh.bundle`** (not just `dsh.client`) — [example](../blob/main/contributing.md) / 仓库 `package.json` 已声明 `dsh.bundle`（只有 `dsh.client` 无法安装）
- [x] My repo is at least **1 day old** / 仓库创建满 1 天
- [x] `category` is one of `agi ui usage theme model identity session memory tools wsl browser vision voice docs skill workflow git notify dev security remote market fun` ([full list with descriptions](../blob/main/contributing.md)), and themes/skins go under `theme` / `category` 取值正确（完整清单见 contributing.md），主题/皮肤类请用 `theme`
- [x] Description states what the plugin does, no superlatives / 描述只说功能，不带营销词
- [x] My repo has the `dsh-plugin` topic / 仓库已打 `dsh-plugin` topic

**Recommended (not required) / 推荐但不强制：**

- 📦 Publish to npm — npm installs are prebuilt and skip the `allowBuilds` approval, so users get a one-command install / 发布 npm 包：预构建产物免 `allowBuilds` 授权，用户一条命令装好
- 🔗 Declare official `@deepseek-ai/*` packages as `peerDependencies` (not `dependencies`) — avoids duplicate runtimes inside the profile / 官方 `@deepseek-ai/*` 包用 `peerDependencies` 声明（而非 `dependencies`），避免 profile 里出现重复运行时
- 🖼️ Screenshots go in **your own repository** now: a `screenshots.json` beside your `package.json`, listing image paths. Nothing to add here, and you can change them later without another pull request ([how](../blob/main/contributing.md#screenshots--截图optional-recommended--可选推荐)) / 截图现在放在**你自己的仓库**里：在 `package.json` 旁边放一个 `screenshots.json`，列出图片路径。这个 PR 里不用加任何东西，以后想换也不必再提 PR（[说明](../blob/main/contributing.md#screenshots--截图optional-recommended--可选推荐)）

---

Adds `data/plugins/lsdt45__dsh-plan-plus.yml` — one new file, exactly one level deep under `data/plugins/`. No other entry is touched, and the generated READMEs are not committed here.

**Repo:** https://github.com/lsdt45/dsh-plan-plus — the root `package.json` declares `dsh.bundle` (`{ "patch": "./cordis.patch.yml" }`) with `cordis.patch.yml` beside it, plus `dsh.client` (`platform: "web"`) because it ships browser UI. Zero-build: a plain ESM host half and a hand-written client bundle, with no `dependencies` and no `prepare`/`postinstall`, so a source install needs no build approval. No `@deepseek-ai/*` package is declared as either dependency kind — `dsh.client.inject` names `@deepseek-ai/dsh-client-locale` and `@deepseek-ai/dsh-client-ui-conversation`, which the host resolves at runtime rather than from npm.

**Category: `ui`** — this is plan-review UI inside the existing conversation surface, not an orchestration change.

**What the plugin does** (each claim is checkable in the repo):

- **Reply inside the review card.** Registers `conversation.composer` at `priority: -5` and narrows to the pending plan review with the rule the native `planReviewOf` uses (`wait.kind` of `question` / `plan-review`, exactly one question). The card gains a multi-line input and send button — Enter sends, Shift+Enter inserts a newline, IME composition is handled. The text returns through the native custom-answer channel, so the model revises the plan and the card re-appears. Approve / reject / go-to-chat keep their meaning, and a failed narrowing falls back to the stock UI.
- **Versions are read from the session log, not from memory.** The host half registers the exact `webServer` route `GET /planx-latest-plan?sessionId=…`, which scans the session's `tool/call` events for `exit_plan_mode` and returns them as a version array — so the history survives a page refresh.
- **Overlay and entry button.** `conversation.input.left` carries the 「查看计划」 button (it appears once a session has a plan); `shell.overlay` carries the overlay, which lists v1…vN with timestamps, renders the plan through the plugin's own small markdown renderer (headings, lists, code fences, tables) and diffs adjacent versions with a hand-written LCS (`DIFF_MAX_LINES = 500`; identical versions read 与上一版无改动, and the compare toggle is disabled on v1).
- **Direct editing, archived as a version.** Edit mode takes markdown source and saves it as a new version — badged 已编辑, present in the version dropdown, diffable against its predecessor — persisted to `localStorage` under `dsh.planPlus.v1.edits`. It is a user-owned copy for review: approving still runs the model's original plan.
- **Expand to the conversation area** from the review card's title bar or the overlay toolbar.

**Verification:** `node scripts/generate-readme.mjs` adds exactly one line per locale for this entry; I ran it, confirmed the two lines, and reverted both READMEs so the diff here is the yml alone.

**Screenshots:** 3 images are declared in the plugin's own repository (`screenshots.json` + `assets/`), following the current convention — nothing screenshot-related is added here.

**On overlap,** since the list already carries plan-review plugins: `titanwings/dsh-plannotator` also returns plan feedback to the agent, and `eightHundreds/dsh-plannotator` opens the external Plannotator app. This one works inside the stock review card rather than a separate annotation surface, and adds version history, line diff and local editing of the plan. If you read that overlap differently, re-file it or say so — better that than a merge that looks like a duplicate later.
