### PR TITLE
Add nirvanaslash/dsh-bat2exe

### DIFF
--- a/data/plugins/nirvanaslash__dsh-bat2exe.yml
+++ b/data/plugins/nirvanaslash__dsh-bat2exe.yml
@@ -1,0 +1,6 @@
+url: https://github.com/nirvanaslash/dsh-bat2exe
+name: nirvanaslash/dsh-bat2exe
+category: dev
+description:
+  en: 'Compiles a Windows .bat/.cmd launcher into a real .exe from inside DSH: renders an icon from a built-in bitmap font, emits a C# wrapper that runs the batch file next to it, compiles with csc.exe (or dotnet build), and can write Start Menu / Desktop shortcuts.'
+  zh: '在 DSH 内把 Windows .bat/.cmd 启动器编译成真正的 .exe：用内置位图字体生成图标，生成调用同目录批处理的 C# 薄壳，经 csc.exe（或 dotnet build）编译，并可选写入开始菜单/桌面快捷方式。'


### PR DESCRIPTION
Adds one entry for `nirvanaslash/dsh-bat2exe` (category: `dev`).

**Why it qualifies**

- `package.json` declares `dsh.bundle` (`"bundle": { "patch": "./cordis.patch.yml" }`), so it installs with `dsh plugin --profile web add dsh-bat2exe`.
- Real, working code: a Cordis host entry registering two tools (`bat2exe_build`, `bat2exe_probe`) plus a `bat2exe` settings namespace. The icon renderer is dependency-free (zlib + an embedded 5x7 bitmap font); the compile step uses the .NET Framework `csc.exe` with a `dotnet build` fallback.
- Repo has the `dsh-plugin` topic and is MIT licensed.

**What it does** - compiles a Windows `.bat`/`.cmd` launcher into a real `.exe`: renders an icon from a built-in bitmap font, emits a C# wrapper that runs the batch file next to it, compiles it with `csc.exe` (or `dotnet build`), and can write Start Menu / Desktop shortcuts.

**Not yet on npm** - published only after review if that is preferred; the two tools and the settings namespace are what the entry claims.

One file added, no other entry touched.
