### PR TITLE
Add GooDAnDReaDY plugins batch A

### DIFF
--- a/data/plugins/GooDAnDReaDY__dsh-agent-loop-guard.yml
+++ b/data/plugins/GooDAnDReaDY__dsh-agent-loop-guard.yml
@@ -1,0 +1,6 @@
+url: https://github.com/GooDAnDReaDY/dsh-agent-loop-guard
+name: GooDAnDReaDY/dsh-agent-loop-guard
+category: security
+description:
+  en: "Fail-closed runtime tool-call loop guard for DeepSeek Harness."
+  zh: "为 DeepSeek Harness 提供故障关闭式运行时工具调用循环防护。"

--- a/data/plugins/GooDAnDReaDY__dsh-dsml-artifact-guard.yml
+++ b/data/plugins/GooDAnDReaDY__dsh-dsml-artifact-guard.yml
@@ -1,0 +1,6 @@
+url: https://github.com/GooDAnDReaDY/dsh-dsml-artifact-guard
+name: GooDAnDReaDY/dsh-dsml-artifact-guard
+category: security
+description:
+  en: "Sanitizes leaked DeepSeek DSML closing tags from model text streams."
+  zh: "清理模型文本流中泄漏的 DeepSeek DSML 闭合标签。"

--- a/data/plugins/GooDAnDReaDY__dsh-gitea.yml
+++ b/data/plugins/GooDAnDReaDY__dsh-gitea.yml
@@ -1,0 +1,6 @@
+url: https://github.com/GooDAnDReaDY/dsh-gitea
+name: GooDAnDReaDY/dsh-gitea
+category: git
+description:
+  en: "Gitea and Forgejo integration for DeepSeek Harness with issue, pull-request and worktree tools plus a Git status chip."
+  zh: "为 DeepSeek Harness 集成 Gitea 与 Forgejo，提供 issue、拉取请求和 worktree 工具及 Git 状态芯片。"


### PR DESCRIPTION
## Problem / goal
Publish the missing public GooDAnDReaDY DSH plugins in the curated index so they are discoverable by DSH marketplaces.

## Why
These are public GitHub repositories and public npm packages. Each repository declares the DSH bundle metadata and has the `dsh-plugin` topic.

## Change
Add three factual generated-source entries:
- GooDAnDReaDY/dsh-agent-loop-guard
- GooDAnDReaDY/dsh-dsml-artifact-guard
- GooDAnDReaDY/dsh-gitea

## Scope / limitations
Catalog metadata only; no plugin source, npm package, or runtime configuration is changed.

## Checks
The entries are split into batches of no more than three because the repository submission gate enforces that limit. Supersedes the corresponding entries from #4647.