### PR TITLE
Add GooDAnDReaDY plugins batch B

### DIFF
--- a/data/plugins/GooDAnDReaDY__dsh-cron.yml
+++ b/data/plugins/GooDAnDReaDY__dsh-cron.yml
@@ -1,0 +1,6 @@
+url: https://github.com/GooDAnDReaDY/dsh-cron
+name: GooDAnDReaDY/dsh-cron
+category: workflow
+description:
+  en: "Scheduled cron tasks, background automation and agent execution for DeepSeek Harness."
+  zh: "为 DeepSeek Harness 提供定时任务、后台自动化与 Agent 执行。"

--- a/data/plugins/GooDAnDReaDY__dsh-kanban.yml
+++ b/data/plugins/GooDAnDReaDY__dsh-kanban.yml
@@ -1,0 +1,6 @@
+url: https://github.com/GooDAnDReaDY/dsh-kanban
+name: GooDAnDReaDY/dsh-kanban
+category: workflow
+description:
+  en: "Visual Kanban board for DeepSeek Harness with Gitea-backed tasks, workflow columns and a dedicated agent session per task."
+  zh: "为 DeepSeek Harness 提供可视化看板，支持 Gitea 任务、工作流列和每任务独立 Agent 会话。"

--- a/data/plugins/GooDAnDReaDY__dsh-time-machine.yml
+++ b/data/plugins/GooDAnDReaDY__dsh-time-machine.yml
@@ -1,0 +1,6 @@
+url: https://github.com/GooDAnDReaDY/dsh-time-machine
+name: GooDAnDReaDY/dsh-time-machine
+category: security
+description:
+  en: "Smart checkpoints, workspace safety guards and instant rollback for DeepSeek Harness."
+  zh: "为 DeepSeek Harness 提供智能检查点、工作区安全防护和即时回滚。"


### PR DESCRIPTION
## Problem / goal
Publish the missing public GooDAnDReaDY DSH plugins in the curated index so they are discoverable by DSH marketplaces.

## Why
These are public GitHub repositories and public npm packages. Each repository declares the DSH bundle metadata and has the `dsh-plugin` topic.

## Change
Add three factual generated-source entries:
- GooDAnDReaDY/dsh-cron
- GooDAnDReaDY/dsh-kanban
- GooDAnDReaDY/dsh-time-machine

## Scope / limitations
Catalog metadata only; no plugin source, npm package, or runtime configuration is changed.

## Checks
The entries are split into batches of no more than three because the repository submission gate enforces that limit. Supersedes the corresponding entries from #4647.