### PR TITLE
Add GooDAnDReaDY plugins batch C

### DIFF
--- a/data/plugins/GooDAnDReaDY__dsh-usage-guard.yml
+++ b/data/plugins/GooDAnDReaDY__dsh-usage-guard.yml
@@ -1,0 +1,6 @@
+url: https://github.com/GooDAnDReaDY/dsh-usage-guard
+name: GooDAnDReaDY/dsh-usage-guard
+category: usage
+description:
+  en: "Normalizes malformed token-usage samples so broken session histories remain loadable."
+  zh: "规范化异常的 Token 用量样本，使损坏的会话历史仍可加载。"


### PR DESCRIPTION
## Problem / goal
Publish the missing public GooDAnDReaDY DSH plugin in the curated index so it is discoverable by DSH marketplaces.

## Why
This is a public GitHub repository and public npm package. The repository declares the DSH bundle metadata and has the `dsh-plugin` topic.

## Change
Add the factual generated-source entry:
- GooDAnDReaDY/dsh-usage-guard

## Scope / limitations
Catalog metadata only; no plugin source, npm package, or runtime configuration is changed.

## Checks
The entries are split into batches of no more than three because the repository submission gate enforces that limit. Supersedes the corresponding entry from #4647.