### PR TITLE
Add Stellum-Waq/dsh-pet-ronaldo to Fun

### DIFF
--- a/data/plugins/Stellum-Waq__dsh-pet-ronaldo.yml
+++ b/data/plugins/Stellum-Waq__dsh-pet-ronaldo.yml
@@ -1,0 +1,6 @@
+url: https://github.com/Stellum-Waq/dsh-pet-ronaldo
+name: Stellum-Waq/dsh-pet-ronaldo
+category: fun
+description:
+  en: 'Cristiano Ronaldo desktop pet for the dsh web GUI: a chibi Portugal number 7 mascot in a bottom-right overlay whose animation follows the agent state — dribbling while tools run, thinking during a turn, waiting at approvals, diving on errors — and jumping in a SIU celebration with a host-process sound when a turn completes; it can be dragged, looks at the cursor on hover, dives on a triple click, and a settings panel manages several pets and imports custom spritesheets.'
+  zh: 'DSH Web 界面右下角的 C 罗桌宠：动画随 Agent 状态切换——工具执行中颠球、回合中思考、等待审批、出错假摔——回合完成时跳起 SIU 庆祝并由宿主进程播放提示音；支持拖动、悬停注视光标、连点三次假摔，设置面板可管理多只宠物并导入自定义 spritesheet。'


### PR DESCRIPTION
Adds one entry - `data/plugins/Stellum-Waq__dsh-pet-ronaldo.yml` - for [Stellum-Waq/dsh-pet-ronaldo](https://github.com/Stellum-Waq/dsh-pet-ronaldo), category `fun`. The READMEs are untouched; regenerating locally places the line in the Fun section.

```
url: https://github.com/Stellum-Waq/dsh-pet-ronaldo
name: Stellum-Waq/dsh-pet-ronaldo
category: fun
```

**Checklist**

- [x] One file at `data/plugins/<owner>__<repo>.yml` - the READMEs are not touched
- [x] `package.json` declares `dsh.bundle` (`{"patch": "./cordis.patch.yml"}`, plus `dsh.client` with `platform: web` for the browser half) - verified on the default branch, and `cordis.patch.yml` sits at the repo root
- [x] Repo is older than 1 day (created 2026-08-15)
- [x] `category: fun` - it is a desktop pet, matching the other pet entries in that section
- [x] Description states what the plugin does, no superlatives
- [x] Repo has the `dsh-plugin` topic

**What it does**

A desktop pet for the `dsh web` GUI: a chibi Cristiano Ronaldo (Portugal number 7) sprite living in a bottom-right overlay registered on `shell.overlay`. The host half polls the `agents` service and listens for `tools/execute`, `approval/request` and `agent/request-error` to derive the pet's animation state - dribbling while tools run, thinking during a turn, waiting at approvals, diving on errors - and when a turn completes it jumps in a SIU celebration while the host process plays a sound through the system player, so it is audible regardless of the browser tab. The pet can be dragged (runs in the drag direction), looks at the cursor on hover (16 directions), and dives on a triple click. A settings section manages several pets (name, size, idle behaviour, visibility, position) and imports custom spritesheets, either from a codex project directory or from an explicit image path plus columns/rows/cell size/frames per row.

**Notes**

- Pure JavaScript + static assets, no build step, so a GitHub install needs no `allowBuilds` approval.
- No `@deepseek-ai/*` runtime dependencies at all, so nothing to declare as `peerDependencies`.
- Not published to npm.