### PR TITLE
Update seeingrain/dsh-media-inline-preview (ui): fence tags renamed to mip-*

### DIFF
--- a/data/plugins/seeingrain__dsh-media-inline-preview.yml
+++ b/data/plugins/seeingrain__dsh-media-inline-preview.yml
@@ -2,5 +2,5 @@ url: https://github.com/seeingrain/dsh-media-inline-preview
 name: seeingrain/dsh-media-inline-preview
 category: ui
 description:
-  en: All-in-one inline media previewer for img/video/audio fences with streaming playback, ffmpeg transcoding fallback, lightbox, and trust-fenced LAN/mobile access.
-  zh: 全能内联媒体预览插件，支持 img/video/audio 围栏的流式播放、ffmpeg 转码回退、灯箱浏览及信任围栏局域网/移动端访问。
+  en: All-in-one inline media previewer for mip-img/mip-video/mip-audio fences with streaming playback, ffmpeg transcoding fallback, lightbox, and trust-fenced LAN/mobile access.
+  zh: 全能内联媒体预览插件，支持 mip-img/mip-video/mip-audio 围栏的流式播放、ffmpeg 转码回退、灯箱浏览及信任围栏局域网/移动端访问。


### PR DESCRIPTION
Description-only update: this entry's text names the fence tags, and the plugin renamed them in v1.4.0.

- Fences are now `mip-img` / `mip-video` / `mip-audio`; the bare `img`/`video`/`audio` tags are no longer recognized (they are generic enough for another media plugin to claim the same block, and DSH core has no fence registry to arbitrate, so two claimants both mount and one fence renders twice).
- The tools were renamed with them (`mip_img` / `mip_media`).
- Release: https://github.com/seeingrain/dsh-media-inline-preview/releases/tag/v1.4.0 (commit 26f8117, CHANGELOG `[1.4.0]`).

Keeping the listing accurate matters here: with the old wording a reader would emit `img` fences, which now stay plain code blocks. No other entry is touched.
