### PR TITLE
Add wuwaka/dsh-clipboard-menu

### DIFF
--- a/data/plugins/wuwaka__dsh-clipboard-menu.yml
+++ b/data/plugins/wuwaka__dsh-clipboard-menu.yml
@@ -1,0 +1,6 @@
+url: https://github.com/wuwaka/dsh-clipboard-menu
+name: wuwaka/dsh-clipboard-menu
+category: ui
+description:
+  en: 'Adds a right-click menu to DeepSeek Harness inside desktop shells that ship no context menu: cut, copy, paste and select all in the composer, copy and copy-as-plain-text on selected text elsewhere, and a search entry that opens the default browser with a configurable engine.'
+  zh: '在没有自带右键菜单的桌面外壳中为 DeepSeek Harness 补上右键菜单：输入框内的剪切、复制、粘贴、全选，别处选中文字的复制与复制为纯文本，以及用可配置引擎在默认浏览器中搜索。'


### PR DESCRIPTION
Adds `wuwaka/dsh-clipboard-menu` (category `ui`).

- Repo: https://github.com/wuwaka/dsh-clipboard-menu
- Release: https://github.com/wuwaka/dsh-clipboard-menu/releases/tag/v0.3.0

### Checklist from contributing.md

- [x] `package.json` declares `dsh.bundle` (plus `dsh.client`, since it ships browser UI)
- [x] `cordis.patch.yml` sits in the repo root
- [x] Real, working code — no placeholders
- [x] Repo is more than 1 day old
- [x] `dsh-plugin` topic added
- [x] Description states what it does, no superlatives

### What it does

Electron ships no context menu and the DSH Desktop shell does not add one, so
right-clicking the composer did nothing. This plugin renders its own menu in the
renderer: cut / copy / paste / select all in the composer, copy and
copy-as-plain-text on selected text elsewhere, and a search entry that hands the
selection to the default browser.

The search engine is configurable, because a page cannot read the browser's own
default engine — no web API exposes it. The pick is stored in `localStorage` and
falls back to a guess from the UI language (Chinese → Baidu, otherwise Google).
Custom engines can be added by name and URL template, as many as wanted, each
removable from its row.

It installs its listener only inside shells that have no native menu — detected
through DSH Desktop's `dsh-desktop-*` renderer markers, its preload bridge,
Electron's user agent, or Tauri globals — so a plain browser keeps its own menu
rather than getting a downgraded one.

Paste is editor-aware: the composer is a Lexical editor, so the plugin dispatches
a synthetic `ClipboardEvent('paste')` carrying a `DataTransfer`, while
React-controlled inputs go through the native value setter plus an `input` event.

### Test

`node test/smoke.cjs` — 83 assertions, all passing. CI runs them on node 22 and
24 across ubuntu and windows.
