### PR TITLE
Add Huuuuung/dsh-artifact-index plugin metadata

### DIFF
--- a/data/plugins/Huuuuung__dsh-artifact-index.yml
+++ b/data/plugins/Huuuuung__dsh-artifact-index.yml
@@ -1,0 +1,6 @@
+url: https://github.com/Huuuuung/dsh-artifact-index
+name: Huuuuung/dsh-artifact-index
+category: ui
+description:
+  en: The missing backend for the dsh-artifacts sidebar tab — serves the /report artifact index and the artifact bytes it renders.
+  zh: 为 dsh-artifacts 侧边栏补上缺失的后端，提供 /report 产物索引与预览所需的文件内容。


### PR DESCRIPTION
Adds the metadata entry for my DSH plugin.

**data/plugins/Huuuuung__dsh-artifact-index.yml** — the single-file submission.

Checklist:
- [x] One file at data/plugins/<owner>__<repo>.yml — nothing else touched
- [x] package.json declares dsh.bundle (not just dsh.client)
- [x] Repo is older than 1 day (created 2026-09-11)
- [x] category: ui — the plugin exists to make an existing sidebar tab work; it adds no UI of its own
- [x] Description states only what the code does, no superlatives
- [x] Repo carries the dsh-plugin topic

Also published to npm as dsh-artifact-index@0.1.0; the published package repository field points back at this repo, so the storefront mapping can pick up a download count.