### PR TITLE
add yangyizhu8/dsh-unread-mark (session): session-row unread mark (persistent red dot)

### DIFF
--- a/data/plugins/yangyizhu8__dsh-unread-mark.yml
+++ b/data/plugins/yangyizhu8__dsh-unread-mark.yml
@@ -1,0 +1,7 @@
+url: https://github.com/yangyizhu8/dsh-unread-mark
+name: yangyizhu8/dsh-unread-mark
+category: session
+tarball: https://github.com/yangyizhu8/dsh-unread-mark/releases/download/v0.1.0/dsh-unread-mark-0.1.0.tgz
+description:
+  en: "Session-row unread mark for DeepSeek Harness: the session menu gains Mark unread and Unmark, pinning a red dot before the session title that survives reload and opening until cleared, both entries disabled while the built-in green finished-unopened dot is present."
+  zh: "会话行未读标记：会话菜单新增「标记未读」「取消标记」，在会话标题前钉一个刷新与点开都不会消失的红点（与系统绿点区分），绿点存在时两项禁用，标记经服务端持久化。"


### PR DESCRIPTION
Single entry: **yangyizhu8/dsh-unread-mark** (session).

A session row's "..." menu gains **Mark unread** / **Unmark**. Marking pins an 8px red dot before the session title that survives reload and opening until it is unmarked. The built-in green "finished, not yet opened" dot clears the moment you open the session, so a session you cannot get to right now can still be forgotten — this is the reminder that does not evaporate.

Disabled-state matrix: with the green dot present both entries are disabled; on an unmarked row only Mark unread is enabled; on a marked row only Unmark is enabled.

- Repo: https://github.com/yangyizhu8/dsh-unread-mark — install `dsh plugin add dsh-unread-mark`, or the prebuilt tarball attached to the v0.1.0 release (no build step).
- `package.json` declares `dsh.bundle.patch` pointing at a shipped `cordis.patch.yml`; the `dsh-plugin` topic is set.
- Host half persists marks in `~/.dsh/dsh-unread-mark-state.json` behind a loopback RPC channel (`list` / `set` / `clear`). Client half injects the two menu entries and renders the dot through light DOM polling; every host-structure probe is fail-soft, so a missing anchor drops the feature instead of throwing.
- Verification was a headless CDP probe against a live instance: menu entry order, the full disabled-state matrix, red-dot render on the marked row, and set/clear round-trips against the persisted state file.

Category: `session` — same family as the existing session-handoff entry.
