### PR TITLE
add rakibulrocky14/dsh-cli

### DIFF
--- a/data/plugins/rakibulrocky14__dsh-cli.yml
+++ b/data/plugins/rakibulrocky14__dsh-cli.yml
@@ -1,0 +1,6 @@
+url: https://github.com/rakibulrocky14/dsh-cli
+name: rakibulrocky14/dsh-cli
+category: ui
+description:
+  en: Full-screen terminal TUI for DeepSeek Harness with Web-GUI parity, live streaming, agent presets, and DeepSeek blue styling.
+  zh: DeepSeek Harness 全屏终端 TUI 界面，具备 Web GUI 级对齐能力，支持实时流式输出、智能体预设与经典蓝配色。


### PR DESCRIPTION
### Plugin Submission

- **Repository**: https://github.com/rakibulrocky14/dsh-cli
- **Category**: `ui`
- **Description (EN)**: Full-screen terminal TUI for DeepSeek Harness with Web-GUI parity, live streaming, agent presets, and DeepSeek blue styling.
- **Description (ZH)**: DeepSeek Harness 全屏终端 TUI 界面，具备 Web GUI 级对齐能力，支持实时流式输出、智能体预设与经典蓝配色。

### Checklist
- [x] Declares `dsh.bundle` manifest in `package.json` with `./cordis.patch.yml`
- [x] Includes `screenshots.json` for showcase
- [x] Added `dsh-plugin` topic
- [x] Objective, non-marketing descriptions ending with punctuation