### PR TITLE
Add 99galaxy/dsh-plugin-market

### DIFF
--- a/data/plugins/99galaxy__dsh-plugin-market.yml
+++ b/data/plugins/99galaxy__dsh-plugin-market.yml
@@ -1,0 +1,6 @@
+url: https://github.com/99galaxy/dsh-plugin-market
+name: 99galaxy/dsh-plugin-market
+category: market
+description:
+  en: 'Browse the awesome-dsh-plugin catalog from a page in DSH Settings: filter by category or by installed state, search by name or description, sort by stars, downloads, name or date added, and install a plugin into the current profile. A second tab lists what is already installed, and the catalog is cached locally for an hour with a mirror, a CDN and the npm registry as fallbacks when the official source is unreachable.'
+  zh: '在 DSH 设置页浏览 awesome-dsh-plugin 目录：按分类或已安装状态筛选，按名称或简介搜索，按 Star、下载量、名称或收录时间排序，一键把插件装进当前 profile。另一个标签页列出已安装的插件；目录在本地缓存一小时，官方源不可达时依次回退到镜像、CDN 与 npm registry。'


### PR DESCRIPTION
Adds one entry: **99galaxy/dsh-plugin-market** (`market`).

### What it does

A plugin market rendered as a page inside DSH Settings. It reads the published `awesome-dsh-plugin` catalog (`plugins.json`) and lets you filter by category, search by name or description, sort by stars / downloads / name / date added, and install a plugin into the current profile. A second in-page tab lists what is already installed, and cards are marked as installed or not so the list can be filtered either way.

The catalog is cached locally for one hour. If the official domain is unreachable it falls back in order to the `gh-proxy` mirror, the jsDelivr CDN copy of `dsh-plugin-catalog`, and finally the npm registry metadata — so the page still works when the primary source is down.

### Requirements

- `package.json` declares `dsh.bundle` → `{ "patch": "./cordis.patch.yml" }`, alongside `dsh.client.platform: "web"`. `cordis.patch.yml` is at the repository root.
- The repo carries the `dsh-plugin` topic.
- Real code, no build step: `index.js` (host half), `client/client.js` (settings page), `market-core.mjs` (catalog + install helper), all committed.
- ⚠️ **The repo is under 1 day old** (created 2026-09-12T18:50:06Z), so the age check will fail on this first run. Per its own message there is nothing to change — the periodic re-gate should clear it once the repo turns 1 day old. Apologies for the timing; I would rather submit once and let it age than have it sit unsubmitted.

### On the description

Everything claimed above is what the code does, and I checked each item against it. The one-hour cache is a fixed interval (`CACHE_MS = 3600000`), not configurable, so the description says "cached locally for an hour" rather than implying a setting.

I know this lands in a category that already has entries — including the official `dsh-market/dsh-market`. It is not a wrapper around anyone else's work and it depends on nothing but the published catalog JSON, but if a maintainer judges it redundant with an existing entry, closing it is a fine outcome.