### PR TITLE
Add lcestou/dsh-oh-my-claude

### DIFF
--- a/data/plugins/lcestou__dsh-oh-my-claude.yml
+++ b/data/plugins/lcestou__dsh-oh-my-claude.yml
@@ -1,0 +1,5 @@
+url: https://github.com/lcestou/dsh-oh-my-claude
+name: lcestou/dsh-oh-my-claude
+category: model
+description:
+  en: "Claude Code CLI as an LLM provider for dsh: live model list, per-session resume, approval relay, images, a memory/rewind/changes panel, and workspaces on remote SSH boxes."


### PR DESCRIPTION
- [x] I added **one file** at `data/plugins/lcestou__dsh-oh-my-claude.yml`
- [x] My repo's `package.json` declares **`dsh.bundle`** (`"bundle": { "patch": "./cordis.patch.yml" }`)
- [x] My repo is at least **1 day old** (created 2026-09-11)
- [x] `category` is `model`
- [x] Description states what the plugin does, no superlatives
- [x] My repo has the `dsh-plugin` topic

Published to npm as `dsh-oh-my-claude` 1.0.0, with the `repository` field pointing back at the repo. `@deepseek-ai/*` packages are peer dependencies.

The plugin drives the logged-in Claude Code CLI over stream-json and registers it as a dsh provider. Same category as katsos/dsh-claude-cli and zhangjunjesse/dsh-claude-driver.
