### PR TITLE
Add EIGHTfs/dsh-git-push

### DIFF
--- a/data/plugins/EIGHTfs__dsh-git-push.yml
+++ b/data/plugins/EIGHTfs__dsh-git-push.yml
@@ -1,0 +1,6 @@
+url: https://github.com/EIGHTfs/dsh-git-push
+name: EIGHTfs/dsh-git-push
+category: git
+description:
+  en: Git commit-and-push automation for DSH with pre-push auditing, rule-based quality scoring, SSH key generation, and a three-tab settings sidebar.
+  zh: DSH 的 git 提交推送自动化：提交前审计、规则质量评分、SSH 密钥生成与三选项卡设置侧边栏。


### PR DESCRIPTION
Add [EIGHTfs/dsh-git-push](https://github.com/EIGHTfs/dsh-git-push) — Git commit-and-push automation for DSH with pre-push auditing, rule-based quality scoring, SSH key generation, and a three-tab settings sidebar.

- `dsh.bundle` declared (cordis.patch.yml)
- Repo created 2026-08-18, actively maintained
- `dsh-plugin` topic added
- category: git