### PR TITLE
Add DNAlec/dsh-auto-approve

### DIFF
--- a/data/plugins/DNAlec__dsh-auto-approve.yml
+++ b/data/plugins/DNAlec__dsh-auto-approve.yml
@@ -1,0 +1,6 @@
+url: https://github.com/DNAlec/dsh-auto-approve
+name: DNAlec/dsh-auto-approve
+category: security
+description:
+  en: Auto-approves or rejects tool calls with keywords and a judge-model criteria table; uncertainty uses the original Web approval dialog.
+  zh: 用关键词和审核模型审核表自动允许或拒绝工具调用，拿不准则交给原来的网页审批框。


### PR DESCRIPTION
Adds `DNAlec/dsh-auto-approve` under `security`.

The plugin auto-approves or rejects tool calls with keywords and a judge-model criteria table, and hands uncertainty to the original Web approval dialog.

- `dsh.bundle` + `cordis.patch.yml` present
- `dsh-plugin` topic set
- `screenshots.json` in the plugin repo
- npm: `@dnalec/dsh-auto-approve@0.2.0`

There is already `Jiao-XXX/dsh-auto-approve` on the list. This is the independently maintained 0.2.0 line (Web-only human review, keywords + criteria table).