### PR TITLE
添加 chen731215-dev/dsh-tavern-v2 与两个伴生插件条目

### DIFF
--- a/data/plugins/chen731215-dev__dsh-muv-engine.yml
+++ b/data/plugins/chen731215-dev__dsh-muv-engine.yml
@@ -1,0 +1,6 @@
+url: https://github.com/chen731215-dev/dsh-muv-engine
+name: chen731215-dev/dsh-muv-engine
+category: ui
+description:
+  en: 'MUV engine for DeepSeek Harness: runs the regex_scripts from a character card against model output, tracks variables, renders a status bar, expands macros and LaTeX, and styles tagged code blocks such as letter, terminal, newspaper and phone. Needs dsh-muv-table installed as well, which is its companion plugin.'
+  zh: 'MUV 引擎：执行角色卡的 regex_scripts 实时替换模型输出，追踪变量、渲染状态栏、展开宏与 LaTeX、为标签代码块（信纸／终端／报纸／手机）套样式。需同时安装伴生插件 dsh-muv-table。'

--- a/data/plugins/chen731215-dev__dsh-muv-table.yml
+++ b/data/plugins/chen731215-dev__dsh-muv-table.yml
@@ -1,0 +1,6 @@
+url: https://github.com/chen731215-dev/dsh-muv-table
+name: chen731215-dev/dsh-muv-table
+category: ui
+description:
+  en: 'MUV variable table editor for DeepSeek Harness: a tree view of the variables being tracked, a macro test panel for random, pick and roll, a dice shortcut bar and pick-cache management. Companion plugin for dsh-muv-engine.'
+  zh: 'MUV 变量表格编辑器：树形变量面板、宏测试浮窗（random／pick／roll）、骰子快捷栏与 pick 缓存管理。dsh-muv-engine 的伴生插件。'

--- a/data/plugins/chen731215-dev__dsh-tavern-v2.yml
+++ b/data/plugins/chen731215-dev__dsh-tavern-v2.yml
@@ -1,0 +1,6 @@
+url: https://github.com/chen731215-dev/dsh-tavern-v2
+name: chen731215-dev/dsh-tavern-v2
+category: fun
+description:
+  en: 'Tavern management panel for DeepSeek Harness: character cards, worldbooks and presets with per-session isolation, memory summaries, a character relationship web, one-click plot options and an NSFW mode. The full experience also needs the companion plugins dsh-muv-engine and dsh-muv-table, which render the status bar, the plot options and the variable tables.'
+  zh: '酒馆管理面板：多角色卡、多世界书、多预设与会话级隔离，记忆总结、角色关系网、剧情选项一键发送，另有 NSFW 模式。完整效果需同时安装伴生插件 dsh-muv-engine 与 dsh-muv-table，用于渲染状态栏、剧情选项与变量表格。'

--- a/data/plugins/chen731215-dev__dsh-tavern.yml
+++ b/data/plugins/chen731215-dev__dsh-tavern.yml
@@ -1,6 +1,0 @@
-url: https://github.com/chen731215-dev/dsh-tavern
-name: chen731215-dev/dsh-tavern
-category: fun
-description:
-  en: 'Native tavern management panel for DeepSeek Harness: character cards, worldbooks and presets with session-level isolation, memory summaries, a character relationship web, one-click plot options, and an NSFW mode.'
-  zh: 酒馆管理原生面板：多角色卡、多世界书、多预设与会话级隔离，记忆总结与角色关系网，剧情选项一键发送，另有 NSFW 成人模式。


### PR DESCRIPTION
# 新增 3 个条目 + 移除 1 个指向已归档仓库的旧条目

## 新增

| 文件 | 插件 | 分类 |
| --- | --- | --- |
| `data/plugins/chen731215-dev__dsh-tavern-v2.yml` | `chen731215-dev/dsh-tavern-v2` | fun |
| `data/plugins/chen731215-dev__dsh-muv-engine.yml` | `chen731215-dev/dsh-muv-engine` | ui |
| `data/plugins/chen731215-dev__dsh-muv-table.yml` | `chen731215-dev/dsh-muv-table` | ui |

## 移动仓库：旧条目指向已归档的仓库

列表里已有一条 `chen731215-dev/dsh-tavern`，它的 `url` 指向
`https://github.com/chen731215-dev/dsh-tavern` —— **那个仓库已归档**，
无法新建 issue、也不再接受代码。项目已迁到 `dsh-tavern-v2`，因此本 PR：

- 新增 `chen731215-dev__dsh-tavern-v2.yml`
- 删除 `chen731215-dev__dsh-tavern.yml`（同一个项目，只是换了仓库）

两个 `dsh-muv-*` 是它的伴生插件，此前未收录。删除项不是新增条目，
所以本 PR 是 3 条新增 + 1 条移除；如果 CI 只按新增计数，这里正好 3 条。

## 关于「需同时安装伴生插件」

这三个插件配套使用才完整，条目描述里已写明，避免用户只装一个后觉得功能缺失：

- `dsh-tavern` 负责角色卡 / 世界书 / 预设 / 记忆 / 关系网；
  **状态栏、剧情选项、变量表格的渲染由 `dsh-muv-engine` 与 `dsh-muv-table` 完成**。
- `dsh-muv-engine` **需要 `dsh-muv-table`** 一起安装，两者是一对。

## 自查

- 三个仓库的 `package.json` 均声明了 `dsh.bundle`（`{ "patch": "./cordis.patch.yml" }`），
  并在仓库根有对应的 `cordis.patch.yml`；带前端 UI 的另有 `dsh.client`。
- 仓库创建均已超过 1 天。
- 描述不含营销词，只陈述功能；带冒号的地方已用引号包住。
- 未改动任何其他条目。
