### PR TITLE
Add whiteS18/dsh-mcp-servers-panel

### DIFF
--- a/data/plugins/whiteS18__dsh-mcp-servers-panel.yml
+++ b/data/plugins/whiteS18__dsh-mcp-servers-panel.yml
@@ -1,0 +1,6 @@
+url: https://github.com/whiteS18/dsh-mcp-servers-panel
+name: whiteS18/dsh-mcp-servers-panel
+category: ui
+description:
+  en: 'MCP server management panel in Settings: add, edit, enable/disable and delete servers across user and workspace scopes with form or JSON editing, and auto-register discovered MCP tools as native conversation tools.'
+  zh: '在设置中提供 MCP Servers 管理面板：新增、编辑、启停、删除服务器，支持用户/项目作用域与表单/JSON 双模式编辑，并自动把发现的 MCP 工具注册为对话原生工具。'


### PR DESCRIPTION
Adds [whiteS18/dsh-mcp-servers-panel](https://github.com/whiteS18/dsh-mcp-servers-panel) — an MCP server management panel in DSH Settings.

- Declares `dsh.bundle` (`cordis.patch.yml` at repo root)
- Repo is past the 1-day bar (created 2026-09-11)
- `dsh-plugin` topic set; published on npm as `dsh-mcp-servers-panel` with `repository` pointing back at the repo

Differentiators vs the existing MCP manager entry: user/workspace scope switching, form + JSON dual-mode editing (accepts `mcpServers` / Cursor / Claude Code config shapes), and automatic registration of discovered MCP tools as native conversation tools (`mcp__<server>__<tool>`).