### PR TITLE
Add PerryLink/dsh-autotier, dsh-team-rooms, dsh-plugin-upgrade-015

### DIFF
--- a/data/plugins/PerryLink__dsh-autotier.yml
+++ b/data/plugins/PerryLink__dsh-autotier.yml
@@ -1,0 +1,6 @@
+url: https://github.com/PerryLink/dsh-autotier
+name: PerryLink/dsh-autotier
+category: model
+description:
+  en: 'Automatic model-tier routing for DeepSeek Harness: one user instruction enters, one tier decision comes out — complex intent is planned on the strong tier and implemented on the cheap tier, simple intent stays cheap throughout, with a deterministic guard and a TTL escalation fallback.'
+  zh: 自动模型档位路由：一条用户指令进入、一个档位决策出来——复杂意图由强档规划、廉价档执行，简单意图全程廉价档，确定性护栏 + TTL 升级回退。

--- a/data/plugins/PerryLink__dsh-plugin-upgrade-015.yml
+++ b/data/plugins/PerryLink__dsh-plugin-upgrade-015.yml
@@ -1,0 +1,6 @@
+url: https://github.com/PerryLink/dsh-plugin-upgrade-015
+name: PerryLink/dsh-plugin-upgrade-015
+category: skill
+description:
+  en: 'Merged, version-locked plugin upgrade skill for DeepSeek Harness (0.1.3-alpha.1 to 0.1.5-rc.1 as two closed legs): an evidence-bound version card plus a zero-dependency 20-seam scanner, shipped as a bundle skill and an npx CLI.'
+  zh: 合并后的版本锁定插件升级技能（0.1.3-alpha.1 → 0.1.5-rc.1，两条闭环腿）：证据绑定版本卡 + 零依赖 20 接缝扫描器，以 bundle 技能 + npx CLI 两种形态发布。

--- a/data/plugins/PerryLink__dsh-team-rooms.yml
+++ b/data/plugins/PerryLink__dsh-team-rooms.yml
@@ -1,0 +1,6 @@
+url: https://github.com/PerryLink/dsh-team-rooms
+name: PerryLink/dsh-team-rooms
+category: workflow
+description:
+  en: Persistent, cross-session multi-agent team rooms for DeepSeek Harness — members, a message bus, a shared task board, and a shared timeline that survive restarts.
+  zh: 持久化、跨会话的多 Agent 团队房间：成员、消息总线、共享任务板与共享时间线，重启后仍然保留。


### PR DESCRIPTION
Three new entries, one YAML file each — the READMEs are not touched (they regenerate on main).

| Entry | Category | What it does |
|---|---|---|
| [PerryLink/dsh-autotier](https://github.com/PerryLink/dsh-autotier) | model | Automatic model-tier routing: one user instruction enters, one tier decision comes out — complex intent is planned on the strong tier and implemented on the cheap tier, with a deterministic guard and TTL escalation fallback. |
| [PerryLink/dsh-team-rooms](https://github.com/PerryLink/dsh-team-rooms) | workflow | Persistent, cross-session multi-agent team rooms: members, a message bus, a shared task board, and a shared timeline that survive restarts. |
| [PerryLink/dsh-plugin-upgrade-015](https://github.com/PerryLink/dsh-plugin-upgrade-015) | skill | Merged, version-locked plugin upgrade skill (0.1.3-alpha.1 → 0.1.5-rc.1 as two closed legs): an evidence-bound version card plus a zero-dependency 20-seam scanner (bundle skill + npx CLI). |

Submission checklist:

- [x] I added one file at `data/plugins/<owner>__<repo>.yml` per entry — those files are the whole submission
- [x] Each repo's `package.json` declares `dsh.bundle` (`{"bundle":{"patch":"./cordis.patch.yml"}}`), not just `dsh.client`
- [x] Each repo is at least 1 day old (dsh-team-rooms was created 2026-09-10 and released 1.0.0/1.0.1; the age check re-runs automatically if it is still under the bar)
- [x] `category` values come from the live enum in contributing.md: `model`, `workflow`, `skill`
- [x] Descriptions state what each plugin does, no superlatives — each line was drafted from and fact-checked against the plugin's README at HEAD
- [x] Each repo carries the `dsh-plugin` topic
- [x] Descriptions containing `: ` are single-quoted so the YAML parses as a string

Notes for reviewers:

- All three ship `dsh.bundle` with `cordis.patch.yml`, publish to npm (`dsh-autotier`, `dsh-team-rooms`, `dsh-plugin-upgrade-015`), and carry CI + five-language READMEs.
- dsh-team-rooms is a 2026-09-11 extraction from dsh-background-agents into its own plugin; dsh-plugin-upgrade-015 supersedes the two retired version-locked packages `dsh-plugin-upgrade` (leg A) and `dsh-plugin-upgrade-rc1` (leg B).

---
*Prepared with AI assistance; every description and file path was fact-checked against the live repositories before drafting.*
