### PR TITLE
Add PerryLink/dsh-plugin-kit, dsh-cert-mcp, dsh-plugin-doctor

### DIFF
--- a/data/plugins/PerryLink__dsh-cert-mcp.yml
+++ b/data/plugins/PerryLink__dsh-cert-mcp.yml
@@ -1,0 +1,6 @@
+url: https://github.com/PerryLink/dsh-cert-mcp
+name: PerryLink/dsh-cert-mcp
+category: dev
+description:
+  en: 'Read-only MCP server exposing the dsh-plugin-certification registry: certification grades, snapshot dates, and five-dimension evidence for DeepSeek Harness plugins, over stdio with zero runtime dependencies.'
+  zh: 只读 MCP 服务器，暴露 dsh-plugin-certification 认证注册表：认证等级、快照日期与 DeepSeek Harness 插件五维证据，stdio 传输、零运行时依赖。

--- a/data/plugins/PerryLink__dsh-plugin-doctor.yml
+++ b/data/plugins/PerryLink__dsh-plugin-doctor.yml
@@ -1,0 +1,6 @@
+url: https://github.com/PerryLink/dsh-plugin-doctor
+name: PerryLink/dsh-plugin-doctor
+category: dev
+description:
+  en: 'Zero-dependency static + sandbox smoke detector for DeepSeek Harness plugins: package-structure checks (R), a Cordis contract scan (K), dynamic sandbox smoke tests (D), and an ecosystem collection-site checklist (CC) in one run.'
+  zh: 零依赖的 DeepSeek Harness 插件「完整性 + 运行流畅」检测器：包结构静态检查（R）→ Cordis 契约扫描（K）→ 动态沙箱冒烟（D）→ 生态集合站清单校验（CC），一次运行覆盖四层。

--- a/data/plugins/PerryLink__dsh-plugin-kit.yml
+++ b/data/plugins/PerryLink__dsh-plugin-kit.yml
@@ -1,0 +1,6 @@
+url: https://github.com/PerryLink/dsh-plugin-kit
+name: PerryLink/dsh-plugin-kit
+category: dev
+description:
+  en: 'Shared zero-runtime-dependency toolkit for the PerryLink DSH plugin family: a pluggable Provider seam, fail-closed approval and adaptive session-event gates, mechanical verify scripts, and shared sanitize/pricing/judge modules in one ESM + TypeScript package.'
+  zh: PerryLink DSH 插件家族共享的零运行时依赖工具包：可插拔 Provider 接缝、fail-closed 审批门与自适应会话事件门、机械化校验脚本，以及共享的 sanitize/pricing/judge 纯模块，合为一个 ESM + TypeScript 包。


### PR DESCRIPTION
Three new dev-tooling entries, one YAML file each.

| Entry | Category | What it does |
|---|---|---|
| [PerryLink/dsh-plugin-kit](https://github.com/PerryLink/dsh-plugin-kit) | dev | Shared zero-runtime-dependency toolkit for the PerryLink DSH plugin family: a pluggable Provider seam, fail-closed approval and adaptive session-event gates, verify scripts, and shared sanitize/pricing/judge modules in one ESM + TypeScript package. |
| [PerryLink/dsh-cert-mcp](https://github.com/PerryLink/dsh-cert-mcp) | dev | Read-only MCP server exposing the dsh-plugin-certification registry: certification grades, snapshot dates, and five-dimension evidence, over stdio with zero runtime dependencies. |
| [PerryLink/dsh-plugin-doctor](https://github.com/PerryLink/dsh-plugin-doctor) | dev | Zero-dependency static + sandbox smoke detector for DSH plugins: package-structure checks (R), Cordis contract scan (K), dynamic sandbox smoke (D), ecosystem collection-site checklist (CC). |

Submission checklist:

- [x] I added one file at `data/plugins/<owner>__<repo>.yml` per entry
- [x] Each repo's `package.json` declares `dsh.bundle`, not just `dsh.client`
- [x] Each repo is at least 1 day old
- [x] `category: dev` for all three (development & runtime tooling)
- [x] Descriptions state what each tool does, no superlatives — fact-checked against each repo's README at HEAD
- [x] Each repo carries the `dsh-plugin` topic

Notes for reviewers:

- dsh-plugin-kit is **not a meta-package**: it ships no plugin dependency list and installs nothing else. It is a zero-runtime-dependency library package — a pluggable Provider seam plus shared gates and pure modules — that the PerryLink family plugins consume as their `@perrylink/dsh-plugin-kit` dependency. It carries its own `dsh.bundle` so it is installable and runs standalone.
- dsh-cert-mcp and dsh-plugin-doctor are DSH-ecosystem tooling with npm packages and CI; they are submitted under `dev` alongside similar tooling already listed in that category.
