### PR TITLE
dsh-quick-toc: update description for 0.5.0

### DIFF
--- a/data/plugins/LyaxZ__dsh-quick-toc.yml
+++ b/data/plugins/LyaxZ__dsh-quick-toc.yml
@@ -3,5 +3,5 @@ name: LyaxZ/dsh-quick-toc
 category: ui
 tarball: https://github.com/LyaxZ/dsh-quick-toc/releases/latest/download/dsh-quick-toc.tgz
 description:
-  en: 'Conversation TOC for DeepSeek Harness: turn-grouped Markdown heading outline with keyword search (title/full-text scope), in-chat match highlighting, auto-follow, and smooth jump navigation.'
-  zh: 'DeepSeek Harness 对话大纲插件：按回合分组的 Markdown 标题目录，支持关键字搜索（标题/全文范围切换）、对话内高亮定位、自动跟随、平滑跳转导航。'
+  en: 'Conversation outline plugin for DeepSeek Harness: a turn-grouped Markdown heading outline with title/full-text search, hover previews, heading-level filters, and reading-position auto-follow.'
+  zh: 'DeepSeek Harness 对话大纲插件：按回合分组的 Markdown 标题目录、支持标题/全文搜索、悬停预览、层级筛选与阅读位置自动跟随。'


### PR DESCRIPTION
Updates the `dsh-quick-toc` entry description for the 0.5.0 release (nothing else touched ? same file, two lines).

- **en**: reflects what 0.5.0 ships ? whole-session turn coverage (unloaded turns are listed and can be jumped to), title/full-text search, hover previews, heading-level filters, reading-position auto-follow.
- **zh**: the author's own wording, kept as-is.

Release: https://github.com/LyaxZ/dsh-quick-toc/releases/tag/v0.5.0 ? npm: `dsh-quick-toc@0.5.0`

Per contributing.md: `description.en` ends with a period; the value contains `: ` so it is quoted; no other entries are touched.