### PR TITLE
Add dsh-dock-bridge: publishes the running server's PID, port and tokenized URL for a Dock app

### DIFF
--- a/data/plugins/wjingshan__dsh-dock-launcher--plugins-dsh-dock-bridge.yml
+++ b/data/plugins/wjingshan__dsh-dock-launcher--plugins-dsh-dock-bridge.yml
@@ -1,0 +1,7 @@
+url: https://github.com/wjingshan/dsh-dock-launcher/tree/main/plugins/dsh-dock-bridge
+name: wjingshan/dsh-dock-launcher#dsh-dock-bridge
+category: ui
+tarball: https://github.com/wjingshan/dsh-dock-launcher/releases/download/v0.15.0/dsh-dock-bridge-0.1.0.tgz
+description:
+  en: Publishes the running dsh Web server's PID, port and tokenized URL to a runtime file for the DeepSeek Harness Switch Dock app, and removes it on shutdown.
+  zh: 为「DeepSeek Harness 开关」程序坞应用写出运行中 dsh Web 服务的 PID、端口与带 token 的地址（运行时文件权限 0600），并在退出时删除。


### PR DESCRIPTION
Adds one entry: **`wjingshan/dsh-dock-launcher#dsh-dock-bridge`**.

### What it is

`plugins/dsh-dock-bridge` is a host plugin (plain ESM, no build step, zero dependencies) that publishes the running dsh Web server's PID, bound port and **tokenized** URL to `~/.config/dsh-dock-launcher/runtime.json` (mode `0600`), and removes the file on shutdown.

It exists because the Web surface authenticates every Host RPC method and WebSocket with a per-process launch token, and the only ways to get a working URL are to parse the server's startup log or to have the process publish it. This plugin publishes it.

### Requirements

- `package.json` declares `dsh.bundle` → [`plugins/dsh-dock-bridge/package.json`](https://github.com/wjingshan/dsh-dock-launcher/blob/main/plugins/dsh-dock-bridge/package.json) (`"bundle": { "patch": "./cordis.patch.yml" }`), with the patch next to it: [`cordis.patch.yml`](https://github.com/wjingshan/dsh-dock-launcher/blob/main/plugins/dsh-dock-bridge/cordis.patch.yml) inserting one host row.
- `tarball:` points at a prebuilt `.tgz` on the v0.15.0 release, pinned to the tag, because the package lives in a subdirectory and the repository has no root `package.json` — so a build-from-source command is not a usable install path for a user.
- The `dsh-plugin` topic is added to the repository.
- Verified locally, not just written: the plugin was installed into a throwaway `DSH_HOME` via `dsh plugin add` (both from the checkout and from the built tarball), the harness then reported `pid/port/url` for a real server on a non-default port, `curl` returned `303` for that URL and `401` for the bare origin, and a `SIGTERM` shutdown removed the file. One detail worth flagging: a `dispose`-only cleanup left a stale file behind on the SIGTERM path, so cleanup also runs from `process.on('exit')`.

### About the parent repository

The rest of `wjingshan/dsh-dock-launcher` is a native macOS Dock app (Swift) that the plugin serves; this entry deliberately points at the plugin subdirectory, not at the app. The description above states only what the plugin itself does.

On category: the plugin has no UI of its own, so `ui` is a judgement call based on its peers (desktop launcher / shell integrations such as `dsh-dock` and `dsh-clean-desktop-shell`). Happy to move it to `tools` or `notify` if you prefer.
